### PR TITLE
Add Chaos 2026-11-01 stable API version

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ActionVersions_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ActionVersions_Get.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "actionName": "microsoft-compute-shutdown",
+    "versionName": "1.0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "1.0",
+        "type": "Microsoft.Chaos/locations/actions/versions",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions/microsoft-compute-shutdown/versions/1.0",
+        "properties": {
+          "displayName": "Shutdown Virtual Machine",
+          "description": "Shuts down a virtual machine to test application resilience to infrastructure failures.",
+          "canonicalId": "microsoft-compute-shutdown/1.0",
+          "actionName": "Shutdown",
+          "version": "1.0.0",
+          "actionType": "Discrete",
+          "supportedTargetTypes": [
+            {
+              "targetType": "Microsoft.Compute/virtualMachines",
+              "requiredPermissions": [
+                "Microsoft.Compute/virtualMachines/powerOff/action",
+                "Microsoft.Compute/virtualMachines/start/action"
+              ]
+            }
+          ],
+          "parametersSchema": {
+            "type": "object",
+            "properties": {
+              "abruptShutdown": {
+                "type": "boolean",
+                "description": "Whether to perform an abrupt shutdown."
+              }
+            },
+            "required": []
+          },
+          "recommendedRoles": [
+            "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.000Z",
+          "lastModifiedAt": "2025-01-01T00:00:00.000Z"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionVersions_Get",
+  "title": "Get an Action Version for westus2 location"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ActionVersions_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ActionVersions_List.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "actionName": "microsoft-compute-shutdown"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions/microsoft-compute-shutdown/versions?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "1.0",
+            "type": "Microsoft.Chaos/locations/actions/versions",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions/microsoft-compute-shutdown/versions/1.0",
+            "properties": {
+              "displayName": "Shutdown Virtual Machine",
+              "description": "Shuts down a virtual machine to test application resilience to infrastructure failures.",
+              "canonicalId": "microsoft-compute-shutdown/1.0",
+              "actionName": "Shutdown",
+              "version": "1.0.0",
+              "actionType": "Discrete",
+              "supportedTargetTypes": [
+                {
+                  "targetType": "Microsoft.Compute/virtualMachines",
+                  "requiredPermissions": [
+                    "Microsoft.Compute/virtualMachines/powerOff/action",
+                    "Microsoft.Compute/virtualMachines/start/action"
+                  ]
+                }
+              ],
+              "parametersSchema": {
+                "type": "object",
+                "properties": {
+                  "abruptShutdown": {
+                    "type": "boolean",
+                    "description": "Whether to perform an abrupt shutdown."
+                  }
+                },
+                "required": []
+              },
+              "recommendedRoles": [
+                "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+              ]
+            },
+            "systemData": {
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "lastModifiedAt": "2025-01-01T00:00:00.000Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionVersions_List",
+  "title": "List all Action Versions for a given action."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Actions_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Actions_Get.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "actionName": "microsoft-compute-shutdown"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "microsoft-compute-shutdown",
+        "type": "Microsoft.Chaos/locations/actions",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions/microsoft-compute-shutdown",
+        "properties": {
+          "displayName": "Shutdown Virtual Machine",
+          "description": "Shuts down a virtual machine to test application resilience to infrastructure failures.",
+          "canonicalId": "microsoft-compute-shutdown/1.0",
+          "actionName": "Shutdown",
+          "version": "1.0.0",
+          "actionType": "Discrete",
+          "supportedTargetTypes": [
+            {
+              "targetType": "Microsoft.Compute/virtualMachines",
+              "requiredPermissions": [
+                "Microsoft.Compute/virtualMachines/powerOff/action",
+                "Microsoft.Compute/virtualMachines/start/action"
+              ]
+            }
+          ],
+          "parametersSchema": {
+            "type": "object",
+            "properties": {
+              "abruptShutdown": {
+                "type": "boolean",
+                "description": "Whether to perform an abrupt shutdown."
+              }
+            },
+            "required": []
+          },
+          "recommendedRoles": [
+            "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.000Z",
+          "lastModifiedAt": "2025-01-01T00:00:00.000Z"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Actions_Get",
+  "title": "Get an Action for westus2 location"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Actions_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Actions_List.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "microsoft-compute-shutdown",
+            "type": "Microsoft.Chaos/locations/actions",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions/microsoft-compute-shutdown",
+            "properties": {
+              "displayName": "Shutdown Virtual Machine",
+              "description": "Shuts down a virtual machine to test application resilience to infrastructure failures.",
+              "canonicalId": "microsoft-compute-shutdown/1.0",
+              "actionName": "Shutdown",
+              "version": "1.0.0",
+              "actionType": "Discrete",
+              "supportedTargetTypes": [
+                {
+                  "targetType": "Microsoft.Compute/virtualMachines",
+                  "requiredPermissions": [
+                    "Microsoft.Compute/virtualMachines/powerOff/action",
+                    "Microsoft.Compute/virtualMachines/start/action"
+                  ]
+                }
+              ],
+              "parametersSchema": {
+                "type": "object",
+                "properties": {
+                  "abruptShutdown": {
+                    "type": "boolean",
+                    "description": "Whether to perform an abrupt shutdown."
+                  }
+                },
+                "required": []
+              },
+              "recommendedRoles": [
+                "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+              ]
+            },
+            "systemData": {
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "lastModifiedAt": "2025-01-01T00:00:00.000Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Actions_List",
+  "title": "List all Actions for westus2 location."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Capabilities_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Capabilities_CreateOrUpdate.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "resource": {
+      "properties": {}
+    },
+    "capabilityName": "Shutdown-1.0",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Shutdown-1.0",
+        "type": "Microsoft.Chaos/targets/capabilities",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0",
+        "properties": {
+          "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+          "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+          "publisher": "Microsoft",
+          "targetType": "VirtualMachine",
+          "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+        },
+        "systemData": {
+          "createdAt": "2020-05-14T05:08:38.4662189Z",
+          "lastModifiedAt": "2020-05-14T05:08:38.4662189Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "Shutdown-1.0",
+        "type": "Microsoft.Chaos/targets/capabilities",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0",
+        "properties": {
+          "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+          "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+          "publisher": "Microsoft",
+          "targetType": "VirtualMachine",
+          "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+        },
+        "systemData": {
+          "createdAt": "2020-05-14T05:08:38.4662189Z",
+          "lastModifiedAt": "2020-05-14T05:08:38.4662189Z"
+        }
+      }
+    }
+  },
+  "operationId": "Capabilities_CreateOrUpdate",
+  "title": "Create/update a Capability that extends a virtual machine Target resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Capabilities_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Capabilities_Delete.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "capabilityName": "Shutdown-1.0",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Capabilities_Delete",
+  "title": "Delete a Capability that extends a virtual machine Target resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Capabilities_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Capabilities_Get.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "capabilityName": "Shutdown-1.0",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Shutdown-1.0",
+        "type": "Microsoft.Chaos/targets/capabilities",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0",
+        "properties": {
+          "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+          "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+          "publisher": "Microsoft",
+          "targetType": "VirtualMachine",
+          "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+        },
+        "systemData": {
+          "createdAt": "2020-05-14T05:08:38.4662189Z",
+          "lastModifiedAt": "2020-05-14T05:08:38.4662189Z"
+        }
+      }
+    }
+  },
+  "operationId": "Capabilities_Get",
+  "title": "Get a Capability that extends a virtual machine Target resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Capabilities_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Capabilities_List.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine/capabilities?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "Shutdown-1.0",
+            "type": "Microsoft.Chaos/targets/capabilities",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0",
+            "properties": {
+              "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+              "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+              "publisher": "Microsoft",
+              "targetType": "VirtualMachine",
+              "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+            },
+            "systemData": {
+              "createdAt": "2020-05-14T05:08:38.4662189Z",
+              "lastModifiedAt": "2020-05-14T05:08:38.4662189Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Capabilities_List",
+  "title": "List all Capabilities that extend a virtual machine Target resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/CapabilityTypes_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/CapabilityTypes_Get.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "capabilityTypeName": "Shutdown-1.0",
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetTypeName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Shutdown-1.0",
+        "type": "Microsoft.Chaos/locations/targetTypes/capabilityTypes",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes/Microsoft-VirtualMachine/capabilityTypes/Shutdown-1.0",
+        "properties": {
+          "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+          "displayName": "Shutdown VM",
+          "kind": "fault",
+          "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+          "publisher": "Microsoft",
+          "azureRbacActions": [
+            "Microsoft.Compute/virtualMachines/powerOff/action",
+            "Microsoft.Compute/virtualMachines/read"
+          ],
+          "azureRbacDataActions": [],
+          "requiredAzureRoleDefinitionIds": [
+            "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+          ],
+          "runtimeProperties": {
+            "kind": "continuous"
+          },
+          "targetType": "VirtualMachine",
+          "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+        }
+      }
+    }
+  },
+  "operationId": "CapabilityTypes_Get",
+  "title": "Get a Capability Type for a virtual machine Target resource on westus2 location."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/CapabilityTypes_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/CapabilityTypes_List.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetTypeName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes/Microsoft-VirtualMachine/capabilityTypes?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "Shutdown-1.0",
+            "type": "Microsoft.Chaos/locations/targetTypes/capabilityTypes",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes/Microsoft-VirtualMachine/capabilityTypes/Shutdown-1.0",
+            "properties": {
+              "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+              "displayName": "Shutdown VM",
+              "kind": "fault",
+              "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+              "publisher": "Microsoft",
+              "azureRbacActions": [
+                "Microsoft.Compute/virtualMachines/powerOff/action",
+                "Microsoft.Compute/virtualMachines/read"
+              ],
+              "azureRbacDataActions": [],
+              "requiredAzureRoleDefinitionIds": [
+                "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+              ],
+              "runtimeProperties": {
+                "kind": "continuous"
+              },
+              "targetType": "VirtualMachine",
+              "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CapabilityTypes_List",
+  "title": "List all Capability Types for a virtual machine Target resource on westus2 location."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_CreateOrUpdate.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "connectionName": "aksClusterConnection",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "resource": {
+      "properties": {
+        "kind": "AksExtension",
+        "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+        "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+        "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/connections/aksClusterConnection",
+        "name": "aksClusterConnection",
+        "type": "Microsoft.Chaos/workspaces/connections",
+        "properties": {
+          "kind": "AksExtension",
+          "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "status": "Connected",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/connections/aksClusterConnection",
+        "name": "aksClusterConnection",
+        "type": "Microsoft.Chaos/workspaces/connections",
+        "properties": {
+          "kind": "AksExtension",
+          "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+          "status": "Pending",
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Connections_CreateOrUpdate",
+  "title": "Create or update a connection."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "connectionName": "aksClusterConnection",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Connections_Delete",
+  "title": "Delete a connection in a workspace."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_Get.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "connectionName": "aksClusterConnection",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/connections/aksClusterConnection",
+        "name": "aksClusterConnection",
+        "type": "Microsoft.Chaos/workspaces/connections",
+        "properties": {
+          "kind": "AksExtension",
+          "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "status": "Connected",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Connections_Get",
+  "title": "Get a connection."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Connections_ListAll.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/connections/aksClusterConnection",
+            "name": "aksClusterConnection",
+            "type": "Microsoft.Chaos/workspaces/connections",
+            "properties": {
+              "kind": "AksExtension",
+              "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+              "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+              "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+              "status": "Connected",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2025-01-15T10:30:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/connections/csfiConnection",
+            "name": "csfiConnection",
+            "type": "Microsoft.Chaos/workspaces/connections",
+            "properties": {
+              "kind": "Csfi",
+              "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVm",
+              "principalId": "9f8e7d6c-5b4a-3c2d-1e0f-9a8b7c6d5e4f",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+              "certificateSubjectName": "CN=chaos-csfi.dsts.core.windows.net",
+              "certificateIssuer": "CN=Microsoft Azure TLS Issuing CA",
+              "dstsPrincipal": "chaos-csfi.dsts.core.windows.net",
+              "status": "Pending",
+              "provisioningState": "Creating"
+            },
+            "systemData": {
+              "createdAt": "2025-01-16T09:00:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-16T09:00:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ],
+        "nextLink": null
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Connections_ListAll",
+  "title": "Get a list of connections."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/DiscoveredResources_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/DiscoveredResources_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "discoveredResourceName": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/discoveredResources/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "name": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "type": "Microsoft.Chaos/workspaces/discoveredResources",
+        "properties": {
+          "namespace": "Microsoft.Compute",
+          "resourceName": "myVirtualMachine",
+          "resourceType": "virtualMachines",
+          "fullyQualifiedIdentifier": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/myVirtualMachine",
+          "discoveredAt": "2025-01-15T10:30:00.000Z",
+          "scope": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG"
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "system",
+          "createdByType": "Application",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "system",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DiscoveredResources_Get",
+  "title": "Get a discovered resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/DiscoveredResources_ListByWorkspace.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/DiscoveredResources_ListByWorkspace.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/discoveredResources/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "name": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "Microsoft.Chaos/workspaces/discoveredResources",
+            "properties": {
+              "namespace": "Microsoft.Compute",
+              "resourceName": "myVirtualMachine",
+              "resourceType": "virtualMachines",
+              "fullyQualifiedIdentifier": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/myVirtualMachine",
+              "discoveredAt": "2025-01-15T10:30:00.000Z",
+              "scope": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG"
+            },
+            "systemData": {
+              "createdAt": "2025-01-15T10:30:00.000Z",
+              "createdBy": "system",
+              "createdByType": "Application",
+              "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+              "lastModifiedBy": "system",
+              "lastModifiedByType": "Application"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/discoveredResources/b2c3d4e5-f6a7-8901-bcde-f12345678901",
+            "name": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+            "type": "Microsoft.Chaos/workspaces/discoveredResources",
+            "properties": {
+              "namespace": "Microsoft.Storage",
+              "resourceName": "mystorageaccount",
+              "resourceType": "storageAccounts",
+              "fullyQualifiedIdentifier": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/mystorageaccount",
+              "discoveredAt": "2025-01-15T11:00:00.000Z",
+              "scope": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG"
+            },
+            "systemData": {
+              "createdAt": "2025-01-15T11:00:00.000Z",
+              "createdBy": "system",
+              "createdByType": "Application",
+              "lastModifiedAt": "2025-01-15T11:00:00.000Z",
+              "lastModifiedBy": "system",
+              "lastModifiedByType": "Application"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/discoveredResources/c3d4e5f6-a7b8-9012-cdef-123456789012",
+            "name": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+            "type": "Microsoft.Chaos/workspaces/discoveredResources",
+            "properties": {
+              "namespace": "Microsoft.Network",
+              "resourceName": "myVirtualNetwork",
+              "resourceType": "virtualNetworks",
+              "fullyQualifiedIdentifier": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork",
+              "discoveredAt": "2025-01-15T11:15:00.000Z",
+              "scope": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG"
+            },
+            "systemData": {
+              "createdAt": "2025-01-15T11:15:00.000Z",
+              "createdBy": "system",
+              "createdByType": "Application",
+              "lastModifiedAt": "2025-01-15T11:15:00.000Z",
+              "lastModifiedBy": "system",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ],
+        "nextLink": null
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DiscoveredResources_ListByWorkspace",
+  "title": "Get a list of discovered resources for a workspace."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_Cancel.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_Cancel.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Experiments_Cancel",
+  "title": "Cancel a running Experiment."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_CreateOrUpdate.json
@@ -1,0 +1,208 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "resource": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "tags": {
+        "key7131": "ryohwcoiccwsnewjigfmijz",
+        "key2138": "fjaeecgnvqd"
+      },
+      "location": "eastus2euap",
+      "properties": {
+        "customerDataStorage": {
+          "blobContainerName": "azurechaosstudioexperiments",
+          "storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+        },
+        "selectors": [
+          {
+            "type": "List",
+            "id": "selector1",
+            "targets": [
+              {
+                "type": "ChaosTarget",
+                "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+              }
+            ]
+          }
+        ],
+        "steps": [
+          {
+            "name": "step1",
+            "branches": [
+              {
+                "name": "branch1",
+                "actions": [
+                  {
+                    "name": "urn:csci:microsoft:virtualMachine:shutdown/1.0",
+                    "type": "continuous",
+                    "duration": "PT10M",
+                    "parameters": [
+                      {
+                        "key": "abruptShutdown",
+                        "value": "false"
+                      }
+                    ],
+                    "selectorId": "selector1"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleExperiment",
+        "type": "Microsoft.Chaos/experiments",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "key7131": "ryohwcoiccwsnewjigfmijz",
+          "key2138": "fjaeecgnvqd"
+        },
+        "location": "eastus2euap",
+        "properties": {
+          "customerDataStorage": {
+            "blobContainerName": "azurechaosstudioexperiments",
+            "storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+          },
+          "provisioningState": "Updating",
+          "selectors": [
+            {
+              "type": "List",
+              "id": "selector1",
+              "targets": [
+                {
+                  "type": "ChaosTarget",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                }
+              ]
+            }
+          ],
+          "steps": [
+            {
+              "name": "step1",
+              "branches": [
+                {
+                  "name": "branch1",
+                  "actions": [
+                    {
+                      "name": "urn:csci:microsoft:virtualMachine:shutdown/1.0",
+                      "type": "continuous",
+                      "duration": "PT10M",
+                      "parameters": [
+                        {
+                          "key": "abruptShutdown",
+                          "value": "false"
+                        }
+                      ],
+                      "selectorId": "selector1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/experiments/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleExperiment",
+        "type": "Microsoft.Chaos/experiments",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "key7131": "ryohwcoiccwsnewjigfmijz",
+          "key2138": "fjaeecgnvqd"
+        },
+        "location": "eastus2euap",
+        "properties": {
+          "customerDataStorage": {
+            "blobContainerName": "azurechaosstudioexperiments",
+            "storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+          },
+          "provisioningState": "Creating",
+          "selectors": [
+            {
+              "type": "List",
+              "id": "selector1",
+              "targets": [
+                {
+                  "type": "ChaosTarget",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                }
+              ]
+            }
+          ],
+          "steps": [
+            {
+              "name": "step1",
+              "branches": [
+                {
+                  "name": "branch1",
+                  "actions": [
+                    {
+                      "name": "urn:csci:microsoft:virtualMachine:shutdown/1.0",
+                      "type": "continuous",
+                      "duration": "PT10M",
+                      "parameters": [
+                        {
+                          "key": "abruptShutdown",
+                          "value": "false"
+                        }
+                      ],
+                      "selectorId": "selector1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/experiments/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Experiments_CreateOrUpdate",
+  "title": "Create/update a Experiment in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Experiments_Delete",
+  "title": "Delete a Experiment in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_ExecutionDetails.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_ExecutionDetails.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "executionId": "f24500ad-744e-4a26-864b-b76199eac333",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "f24500ad-744e-4a26-864b-b76199eac333",
+        "type": "Microsoft.Chaos/experiments/executions/getExecutionDetails",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment/executions/f24500ad-744e-4a26-864b-b76199eac333/getExecutionDetails",
+        "properties": {
+          "failureReason": "Dependency failure",
+          "lastActionAt": "2020-12-14T21:52:52.2552574Z",
+          "runInformation": {
+            "steps": [
+              {
+                "branches": [
+                  {
+                    "actions": [
+                      {
+                        "actionId": "59499d33-6751-4b6e-a1f6-58f4d56a040a",
+                        "actionName": "urn:provider:agent-v2:Microsoft.Azure.Chaos.Fault.CPUPressureAllProcessors",
+                        "endTime": "2020-12-14T13:56:13.6270153-08:00",
+                        "startTime": "2020-12-14T13:56:13.6270153-08:00",
+                        "status": "failed",
+                        "targets": [
+                          {
+                            "status": "succeeded",
+                            "target": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/VM1",
+                            "targetCompletedTime": "2021-04-02T17:30:55+00:00",
+                            "targetFailedTime": "2021-04-02T16:30:55+00:00"
+                          },
+                          {
+                            "status": "failed",
+                            "target": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/VM1",
+                            "targetCompletedTime": "2021-04-02T17:30:55+00:00",
+                            "targetFailedTime": "2021-04-02T16:30:55+00:00"
+                          }
+                        ]
+                      }
+                    ],
+                    "branchId": "FirstBranch",
+                    "branchName": "FirstBranch",
+                    "status": "failed"
+                  }
+                ],
+                "status": "failed",
+                "stepId": "FirstStep",
+                "stepName": "FirstStep"
+              }
+            ]
+          },
+          "startedAt": "2020-12-14T21:52:52.2552574Z",
+          "status": "failed",
+          "stoppedAt": "2020-12-14T21:56:18.9281956Z"
+        }
+      }
+    }
+  },
+  "operationId": "Experiments_ExecutionDetails",
+  "title": "Get experiment execution details."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_Get.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleExperiment",
+        "type": "Microsoft.Chaos/experiments",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "location": "centraluseuap",
+        "properties": {
+          "customerDataStorage": {
+            "blobContainerName": "azurechaosstudioexperiments",
+            "storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+          },
+          "selectors": [
+            {
+              "type": "List",
+              "id": "selector1",
+              "targets": [
+                {
+                  "type": "ChaosTarget",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                }
+              ]
+            }
+          ],
+          "steps": [
+            {
+              "name": "step1",
+              "branches": [
+                {
+                  "name": "branch1",
+                  "actions": [
+                    {
+                      "name": "urn:csci:provider:providername:Shutdown/1.0",
+                      "type": "continuous",
+                      "duration": "PT10M",
+                      "parameters": [
+                        {
+                          "key": "abruptShutdown",
+                          "value": "false"
+                        }
+                      ],
+                      "selectorId": "selector1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Experiments_Get",
+  "title": "Get a Experiment in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_GetExecution.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_GetExecution.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "executionId": "f24500ad-744e-4a26-864b-b76199eac333",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "f24500ad-744e-4a26-864b-b76199eac333",
+        "type": "Microsoft.Chaos/experiments/executions",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment/executions/f24500ad-744e-4a26-864b-b76199eac333",
+        "properties": {
+          "startedAt": "2020-12-14T21:52:52.2552574Z",
+          "status": "failed",
+          "stoppedAt": "2020-12-14T21:56:18.9281956Z"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Experiments_GetExecution",
+  "title": "Get the execution of a Experiment."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_List.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "exampleExperiment",
+            "type": "Microsoft.Chaos/experiments",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+              "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+            },
+            "location": "centraluseuap",
+            "properties": {
+              "customerDataStorage": {
+                "blobContainerName": "azurechaosstudioexperiments",
+                "storageAccountResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+              },
+              "selectors": [
+                {
+                  "type": "List",
+                  "id": "selector1",
+                  "targets": [
+                    {
+                      "type": "ChaosTarget",
+                      "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                    }
+                  ]
+                }
+              ],
+              "steps": [
+                {
+                  "name": "step1",
+                  "branches": [
+                    {
+                      "name": "branch1",
+                      "actions": [
+                        {
+                          "name": "urn:csci:provider:providername:Shutdown/1.0",
+                          "type": "continuous",
+                          "duration": "PT10M",
+                          "parameters": [
+                            {
+                              "key": "abruptShutdown",
+                              "value": "false"
+                            }
+                          ],
+                          "selectorId": "selector1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "createdBy": "User",
+              "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedBy": "User",
+              "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Experiments_List",
+  "title": "List all Experiments in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_ListAll.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/experiments?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "exampleExperiment",
+            "type": "Microsoft.Chaos/experiments",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+              "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+            },
+            "location": "centraluseuap",
+            "properties": {
+              "customerDataStorage": {
+                "blobContainerName": "azurechaosstudioexperiments",
+                "storageAccountResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+              },
+              "selectors": [
+                {
+                  "type": "List",
+                  "id": "selector1",
+                  "targets": [
+                    {
+                      "type": "ChaosTarget",
+                      "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                    }
+                  ]
+                }
+              ],
+              "steps": [
+                {
+                  "name": "step1",
+                  "branches": [
+                    {
+                      "name": "branch1",
+                      "actions": [
+                        {
+                          "name": "urn:csci:provider:providername:Shutdown/1.0",
+                          "type": "continuous",
+                          "duration": "PT10M",
+                          "parameters": [
+                            {
+                              "key": "abruptShutdown",
+                              "value": "false"
+                            }
+                          ],
+                          "selectorId": "selector1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "createdBy": "User",
+              "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedBy": "User",
+              "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Experiments_ListAll",
+  "title": "List all Experiments in a subscription."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_ListAllExecutions.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_ListAllExecutions.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment/executionDetails?continuationToken=&api-version=2025-01-01",
+        "value": [
+          {
+            "name": "f24500ad-744e-4a26-864b-b76199eac333",
+            "type": "Microsoft.Chaos/experiments/executions",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment/executions/f24500ad-744e-4a26-864b-b76199eac333",
+            "properties": {
+              "startedAt": "2020-12-14T21:52:52.2552574Z",
+              "status": "failed",
+              "stoppedAt": "2020-12-14T21:56:18.9281956Z"
+            }
+          },
+          {
+            "name": "14d98367-52ef-4596-be4f-53fc81bbfc33",
+            "type": "Microsoft.Chaos/experiments/executions",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment/executions/14d98367-52ef-4596-be4f-53fc81bbfc33",
+            "properties": {
+              "startedAt": "2020-12-14T21:52:52.2552574Z",
+              "status": "success",
+              "stoppedAt": "2020-12-14T21:56:18.9281956Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Experiments_ListAllExecutions",
+  "title": "List all executions of an Experiment."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_Start.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_Start.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Experiments_Start",
+  "title": "Start a Experiment."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_Update.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Experiments_Update.json
@@ -1,0 +1,104 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "properties": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ManagedIdentity/userAssignedIdentity/exampleUMI": {}
+        }
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleExperiment",
+        "type": "Microsoft.Chaos/experiments",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+        "identity": {
+          "type": "UserAssigned",
+          "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6",
+          "userAssignedIdentities": {
+            "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ManagedIdentity/userAssignedIdentity/exampleUMI": {}
+          }
+        },
+        "location": "centraluseuap",
+        "properties": {
+          "customerDataStorage": {
+            "blobContainerName": "azurechaosstudioexperiments",
+            "storageAccountResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+          },
+          "selectors": [
+            {
+              "type": "List",
+              "id": "selector1",
+              "targets": [
+                {
+                  "type": "ChaosTarget",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                }
+              ]
+            }
+          ],
+          "steps": [
+            {
+              "name": "step1",
+              "branches": [
+                {
+                  "name": "branch1",
+                  "actions": [
+                    {
+                      "name": "urn:csci:provider:providername:Shutdown/1.0",
+                      "type": "continuous",
+                      "duration": "PT10M",
+                      "parameters": [
+                        {
+                          "key": "abruptShutdown",
+                          "value": "false"
+                        }
+                      ],
+                      "selectorId": "selector1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Experiments_Update",
+  "title": "Update an Experiment in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/OperationStatuses_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/OperationStatuses_Get.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "subscriptionId": "e25c0d12-0335-4fec-8ef8-3b4f9a10649e",
+    "location": "westus2",
+    "operationId": "4bdadd97-207c-4de8-9bba-08339ae099c7"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/e25c0d12-0335-4fec-8ef8-3b4f9a10649e/providers/Microsoft.Chaos/locations/westus2/operationStatuses/4bdadd97-207c-4de8-9bba-08339ae099c7",
+        "name": "4bdadd97-207c-4de8-9bba-08339ae099c7",
+        "startTime": "2024-11-14T21:52:52.2552574Z",
+        "status": "Creating"
+      }
+    }
+  },
+  "operationId": "OperationStatuses_Get",
+  "title": "Gets Chaos Studio async operation status."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Operations_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Operations_List.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/providers/Microsoft.Chaos/operations?continuationToken=myContinuationToken&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "Microsoft.Chaos/experiments/read",
+            "display": {
+              "provider": "Microsoft Chaos",
+              "resource": "Chaos Experiment",
+              "operation": "Gets all Chaos Experiments.",
+              "description": "Gets all Chaos Experiments in a resource group."
+            },
+            "isDataAction": false,
+            "origin": "user,system"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_ListAll",
+  "title": "Lists all Chaos Studio operations."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_CreateOrUpdate_Create_Or_Update_A_Private_Access_Resource.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_CreateOrUpdate_Create_Or_Update_A_Private_Access_Resource.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "resource": {
+      "location": "centraluseuap",
+      "properties": {}
+    },
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "provisioningState": "Updating"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_CreateOrUpdate",
+  "title": "Create or Update a private access resource"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_CreateOrUpdate_Create_Or_Update_A_Private_Access_Resource_With_Public_Network_Access.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_CreateOrUpdate_Create_Or_Update_A_Private_Access_Resource_With_Public_Network_Access.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "resource": {
+      "location": "centraluseuap",
+      "properties": {
+        "publicNetworkAccess": "Enabled"
+      }
+    },
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "provisioningState": "Updating",
+          "publicNetworkAccess": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "header": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "provisioningState": "Creating",
+          "publicNetworkAccess": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "header": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_CreateOrUpdate",
+  "title": "Create or Update a private access resource with publicNetworkAccess"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PrivateAccesses_Delete",
+  "title": "Delete a private access resource"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_DeleteAPrivateEndpointConnection.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_DeleteAPrivateEndpointConnection.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PrivateAccesses_DeleteAPrivateEndpointConnection",
+  "title": "Delete a private endpoint connection under a private access resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_GetAPrivateEndpointConnection.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_GetAPrivateEndpointConnection.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Chaos/privateAccesses/PrivateEndpointConnections",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateEndpoinConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_GetAPrivateEndpointConnection",
+  "title": "Get information about a private endpoint connection under a private access resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_GetPrivateLinkResources.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_GetPrivateLinkResources.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "agents",
+            "type": "Microsoft.Chaos/privateAccesses/privateLinkResources",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateLinkResources/agents",
+            "location": "centraluseuap",
+            "properties": {
+              "groupId": "agents",
+              "requiredMembers": [
+                "privateAccess_1"
+              ],
+              "requiredZoneNames": [
+                "privatelink.agents.core.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_GetPrivateLinkResources",
+  "title": "List all possible private link resources under private access resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_Get_Get_A_Private_Access_Resource.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_Get_Get_A_Private_Access_Resource.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccess": {
+      "location": "centraluseuap"
+    },
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {},
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_Get",
+  "title": "Get a private access resource"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_Get_Get_A_Private_Access_Resource_With_Private_Endpoint.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_Get_Get_A_Private_Access_Resource_With_Private_Endpoint.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccess": {
+      "location": "centraluseuap"
+    },
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myprivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "privateEndpointConnections": [
+            {
+              "name": "myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+              "type": "Microsoft.Chaos/privateAccesses/PrivateEndpointConnections",
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateEndpoinConnections/myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+              "properties": {
+                "privateEndpoint": {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                },
+                "privateLinkServiceConnectionState": {
+                  "description": "Auto-Approved",
+                  "actionsRequired": "None",
+                  "status": "Approved"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "publicNetworkAccess": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_Get",
+  "title": "Get a private access resource with private endpoint"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_List.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "myPrivateAccess2",
+            "type": "Microsoft.Chaos/privateAccesses",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess2",
+            "location": "centraluseuap",
+            "properties": {},
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+            }
+          },
+          {
+            "name": "myPrivateAccess",
+            "type": "Microsoft.Chaos/privateAccesses",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+            "location": "centraluseuap",
+            "properties": {
+              "privateEndpointConnections": [
+                {
+                  "name": "myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+                  "type": "Microsoft.Chaos/privateAccesses/PrivateEndpointConnections",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateEndpoinConnections/myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+                  "properties": {
+                    "privateEndpoint": {
+                      "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                    },
+                    "privateLinkServiceConnectionState": {
+                      "description": "Auto-Approved",
+                      "actionsRequired": "None",
+                      "status": "Approved"
+                    }
+                  }
+                }
+              ],
+              "publicNetworkAccess": "Enabled"
+            },
+            "systemData": {
+              "createdAt": "2021-08-01T00:00:00.0Z",
+              "lastModifiedAt": "2021-08-01T00:00:00.0Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "PrivateAccesses_List",
+  "title": "List all private access in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_ListAll.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/privateAccesses?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "myPrivateAccess2",
+            "type": "Microsoft.Chaos/privateAccesses",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess2",
+            "location": "centraluseuap",
+            "properties": {},
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+            }
+          },
+          {
+            "name": "myPrivateAccess",
+            "type": "Microsoft.Chaos/privateAccesses",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup2/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+            "location": "centraluseuap",
+            "properties": {
+              "privateEndpointConnections": [
+                {
+                  "name": "myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+                  "type": "Microsoft.Chaos/privateAccesses/PrivateEndpointConnections",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup2/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateEndpoinConnections/myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+                  "properties": {
+                    "privateEndpoint": {
+                      "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup2/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                    },
+                    "privateLinkServiceConnectionState": {
+                      "description": "Auto-Approved",
+                      "actionsRequired": "None",
+                      "status": "Approved"
+                    }
+                  }
+                }
+              ],
+              "publicNetworkAccess": "Disabled"
+            },
+            "systemData": {
+              "createdAt": "2021-08-01T00:00:00.0Z",
+              "lastModifiedAt": "2021-08-01T00:00:00.0Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "PrivateAccesses_ListAll",
+  "title": "List all private accesses in a subscription."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_ListPrivateEndpointConnections.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_ListPrivateEndpointConnections.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myPrivateEndpointConnection",
+            "type": "Microsoft.Chaos/privateAccesses/PrivateEndpointConnections",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateEndpointConnections/myPrivateEndpointConnection",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_ListPrivateEndpointConnections",
+  "title": "List all private endpoint connections under a private access resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_Update.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/PrivateAccesses_Update.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_Update",
+  "title": "Update a private access resource's tags"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_CreateOrUpdate.json
@@ -1,0 +1,161 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "resource": {
+      "properties": {
+        "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+        "parameters": [
+          {
+            "key": "duration",
+            "value": "PT10M"
+          },
+          {
+            "key": "targetResourceIds",
+            "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm1\",\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm2\"]"
+          }
+        ],
+        "resourceTargeting": {
+          "include": {
+            "locations": [
+              "eastus"
+            ],
+            "zones": [
+              "1"
+            ]
+          },
+          "exclude": {
+            "resources": [
+              "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+            ],
+            "tags": [
+              {
+                "key": "environment",
+                "value": "production"
+              }
+            ],
+            "types": [
+              "Microsoft.Compute/virtualMachineScaleSets"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678",
+        "name": "config-5678-9012-3456-789012345678",
+        "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+        "properties": {
+          "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+          "parameters": [
+            {
+              "key": "duration",
+              "value": "PT10M"
+            },
+            {
+              "key": "targetResourceIds",
+              "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm1\",\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm2\"]"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "resourceTargeting": {
+            "include": {
+              "locations": [
+                "eastus"
+              ],
+              "zones": [
+                "1"
+              ]
+            },
+            "exclude": {
+              "resources": [
+                "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+              ],
+              "tags": [
+                {
+                  "key": "environment",
+                  "value": "production"
+                }
+              ],
+              "types": [
+                "Microsoft.Compute/virtualMachineScaleSets"
+              ]
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T12:00:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678",
+        "name": "config-5678-9012-3456-789012345678",
+        "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+        "properties": {
+          "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+          "parameters": [
+            {
+              "key": "duration",
+              "value": "PT10M"
+            },
+            {
+              "key": "targetResourceIds",
+              "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm1\",\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm2\"]"
+            }
+          ],
+          "provisioningState": "Creating",
+          "resourceTargeting": {
+            "include": {
+              "locations": [
+                "eastus"
+              ],
+              "zones": [
+                "1"
+              ]
+            },
+            "exclude": {
+              "resources": [
+                "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+              ],
+              "tags": [
+                {
+                  "key": "environment",
+                  "value": "production"
+                }
+              ],
+              "types": [
+                "Microsoft.Compute/virtualMachineScaleSets"
+              ]
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioConfigurations_CreateOrUpdate",
+  "title": "Create or update a scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_CreateOrUpdate_With_Physical_Zones.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_CreateOrUpdate_With_Physical_Zones.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-physical-zone",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "resource": {
+      "properties": {
+        "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+        "parameters": [
+          {
+            "key": "duration",
+            "value": "PT10M"
+          }
+        ],
+        "resourceTargeting": {
+          "include": {
+            "physicalZones": [
+              "westus2-az1"
+            ]
+          },
+          "exclude": {
+            "resources": [
+              "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-physical-zone",
+        "name": "config-physical-zone",
+        "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+        "properties": {
+          "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+          "parameters": [
+            {
+              "key": "duration",
+              "value": "PT10M"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "resourceTargeting": {
+            "include": {
+              "physicalZones": [
+                "westus2-az1"
+              ]
+            },
+            "exclude": {
+              "resources": [
+                "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+              ]
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T12:00:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-physical-zone",
+        "name": "config-physical-zone",
+        "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+        "properties": {
+          "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+          "parameters": [
+            {
+              "key": "duration",
+              "value": "PT10M"
+            }
+          ],
+          "provisioningState": "Creating",
+          "resourceTargeting": {
+            "include": {
+              "physicalZones": [
+                "westus2-az1"
+              ]
+            },
+            "exclude": {
+              "resources": [
+                "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+              ]
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioConfigurations_CreateOrUpdate",
+  "title": "Create or update a scenario configuration with physical zone targeting."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_Delete.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/centraluseuap/operationResults/exampleOperationId",
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/centraluseuap/operationStatuses/exampleOperationId"
+      }
+    },
+    "204": {
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioConfigurations_Delete",
+  "title": "Delete a scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_Execute.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_Execute.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678/runs/abcd1234-5678-90ab-cdef-1234567890ab?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "ScenarioConfigurations_Execute",
+  "title": "Execute the scenario execution with the given scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_FixResourcePermissions.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_FixResourcePermissions.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678/permissionsFix/latest?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "ScenarioConfigurations_FixResourcePermissions",
+  "title": "Fixes resource permissions for the given scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_Get.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678",
+        "name": "config-5678-9012-3456-789012345678",
+        "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+        "properties": {
+          "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+          "parameters": [
+            {
+              "key": "duration",
+              "value": "PT10M"
+            },
+            {
+              "key": "targetResourceIds",
+              "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm1\",\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm2\"]"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "resourceTargeting": {
+            "include": {
+              "physicalZones": [
+                "westus2-az1"
+              ]
+            },
+            "exclude": {
+              "resources": [
+                "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+              ],
+              "tags": [
+                {
+                  "key": "environment",
+                  "value": "production"
+                }
+              ],
+              "types": [
+                "Microsoft.Compute/virtualMachineScaleSets"
+              ]
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T12:00:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioConfigurations_Get",
+  "title": "Get a scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_ListAll.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678",
+            "name": "config-5678-9012-3456-789012345678",
+            "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+            "properties": {
+              "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+              "parameters": [
+                {
+                  "key": "duration",
+                  "value": "PT10M"
+                },
+                {
+                  "key": "targetResourceIds",
+                  "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm1\",\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm2\"]"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "resourceTargeting": {
+                "exclude": {
+                  "resources": [
+                    "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+                  ],
+                  "tags": [
+                    {
+                      "key": "environment",
+                      "value": "production"
+                    }
+                  ],
+                  "types": [
+                    "Microsoft.Compute/virtualMachineScaleSets"
+                  ]
+                }
+              }
+            },
+            "systemData": {
+              "createdAt": "2025-01-15T10:30:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-15T12:00:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-abcd-1234-5678-901234567890",
+            "name": "config-abcd-1234-5678-901234567890",
+            "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+            "properties": {
+              "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+              "parameters": [
+                {
+                  "key": "duration",
+                  "value": "PT5M"
+                },
+                {
+                  "key": "targetResourceIds",
+                  "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm3\"]"
+                }
+              ],
+              "provisioningState": "Creating"
+            },
+            "systemData": {
+              "createdAt": "2025-01-20T09:00:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-20T09:00:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ],
+        "nextLink": null
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioConfigurations_ListAll",
+  "title": "Get a list of scenario configurations."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_Validate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioConfigurations_Validate.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678/validations/latest?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "ScenarioConfigurations_Validate",
+  "title": "Validate the given scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioRuns_Cancel.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioRuns_Cancel.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "runId": "abcd1234-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/runs/abcd1234-5678-9012-3456-789012345678?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "ScenarioRuns_Cancel",
+  "title": "Cancel a running scenario run."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioRuns_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioRuns_Get.json
@@ -1,0 +1,127 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "runId": "abcd1234-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/exampleScenario/runs/abcd1234-5678-9012-3456-789012345678",
+        "name": "abcd1234-5678-9012-3456-789012345678",
+        "type": "Microsoft.Chaos/workspaces/scenarios/runs",
+        "properties": {
+          "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+          "scenarioName": "12345678-1234-1234-1234-123456789012",
+          "workspaceName": "exampleWorkspace",
+          "managedIdentityPrincipalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "status": "Succeeded",
+          "resources": [
+            {
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM1"
+            },
+            {
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM2"
+            }
+          ],
+          "excludedResources": [
+            {
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM3"
+            }
+          ],
+          "scenarioRunJson": "{\"experiment\":{\"steps\":[{\"name\":\"step1\",\"branches\":[{\"name\":\"branch1\",\"actions\":[{\"name\":\"urn:csci:provider:microsoft:VirtualMachine_Shutdown/1.0\",\"type\":\"continuous\",\"duration\":\"PT10M\",\"selectorId\":\"selector1\"}]}]}]}}",
+          "scenarioRunSummary": [
+            {
+              "actionUrn": "urn:csci:provider:microsoft:VirtualMachine_Shutdown/1.0",
+              "state": "Succeeded",
+              "startedAt": "2025-01-20T14:30:00.000Z",
+              "completedAt": "2025-01-20T14:40:00.000Z",
+              "resources": [
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM1"
+                },
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM2"
+                }
+              ]
+            }
+          ],
+          "startTime": "2025-01-20T14:30:00.000Z",
+          "endTime": "2025-01-20T14:40:00.000Z",
+          "resourceSnapshotId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "zoneResolution": {
+            "mode": "physical",
+            "requestedPhysicalZones": [
+              "westus2-az1"
+            ],
+            "subscriptionZoneMappings": [
+              {
+                "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+                "zoneMappings": [
+                  {
+                    "physicalZone": "westus2-az1",
+                    "logicalZone": "1"
+                  }
+                ]
+              },
+              {
+                "subscriptionId": "a1b2c3d4-5678-9012-3456-abcdef012345",
+                "zoneMappings": [
+                  {
+                    "physicalZone": "westus2-az1",
+                    "logicalZone": "3"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-20T14:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-20T14:40:00.000Z",
+          "lastModifiedBy": "system",
+          "lastModifiedByType": "Application"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/exampleScenario/runs/abcd1234-5678-9012-3456-789012345678",
+        "name": "abcd1234-5678-9012-3456-789012345678",
+        "type": "Microsoft.Chaos/workspaces/scenarios/runs",
+        "properties": {
+          "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+          "scenarioName": "12345678-1234-1234-1234-123456789012",
+          "workspaceName": "exampleWorkspace",
+          "managedIdentityPrincipalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "status": "Running",
+          "resources": [
+            {
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM1"
+            }
+          ],
+          "startTime": "2025-01-20T14:30:00.000Z",
+          "resourceSnapshotId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        },
+        "systemData": {
+          "createdAt": "2025-01-20T14:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-20T14:30:00.000Z",
+          "lastModifiedBy": "system",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/runs/abcd1234-5678-9012-3456-789012345678?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "ScenarioRuns_Get",
+  "title": "Get a scenario run."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioRuns_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/ScenarioRuns_ListAll.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/runs/abcd1234-5678-9012-3456-789012345678",
+            "name": "abcd1234-5678-9012-3456-789012345678",
+            "type": "Microsoft.Chaos/workspaces/scenarios/runs",
+            "properties": {
+              "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+              "scenarioName": "12345678-1234-1234-1234-123456789012",
+              "workspaceName": "exampleWorkspace",
+              "managedIdentityPrincipalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+              "status": "Succeeded",
+              "resources": [
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM1"
+                }
+              ],
+              "excludedResources": [
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM3"
+                }
+              ],
+              "startTime": "2025-01-20T14:30:00.000Z",
+              "endTime": "2025-01-20T14:40:00.000Z"
+            },
+            "systemData": {
+              "createdAt": "2025-01-20T14:30:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-20T14:40:00.000Z",
+              "lastModifiedBy": "system",
+              "lastModifiedByType": "Application"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/exampleScenario/runs/efgh5678-9012-3456-7890-123456789012",
+            "name": "efgh5678-9012-3456-7890-123456789012",
+            "type": "Microsoft.Chaos/workspaces/scenarios/runs",
+            "properties": {
+              "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+              "scenarioName": "12345678-1234-1234-1234-123456789012",
+              "workspaceName": "exampleWorkspace",
+              "managedIdentityPrincipalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+              "status": "Failed",
+              "resources": [
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM2"
+                }
+              ],
+              "executionErrors": {
+                "permission": [
+                  {
+                    "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM2",
+                    "missingPermissions": [
+                      "Microsoft.Compute/virtualMachines/restart/action"
+                    ],
+                    "requiredPermissions": [
+                      "Microsoft.Compute/virtualMachines/restart/action",
+                      "Microsoft.Compute/virtualMachines/read"
+                    ],
+                    "recommendedRoles": [
+                      "Virtual Machine Contributor"
+                    ],
+                    "identity": {
+                      "objectId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+                      "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+                    },
+                    "errorMessage": "The workspace managed identity is missing the required permissions to run this action on the target resource."
+                  }
+                ],
+                "resource": []
+              },
+              "startTime": "2025-01-19T10:15:00.000Z",
+              "endTime": "2025-01-19T10:18:00.000Z"
+            },
+            "systemData": {
+              "createdAt": "2025-01-19T10:15:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-19T10:18:00.000Z",
+              "lastModifiedBy": "system",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ],
+        "nextLink": null
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioRuns_ListAll",
+  "title": "Get a list of scenario runs."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Scenarios_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Scenarios_CreateOrUpdate.json
@@ -1,0 +1,285 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "zoneDownScenario",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "resource": {
+      "properties": {
+        "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
+        "parameters": [
+          {
+            "name": "duration",
+            "type": "string",
+            "default": "PT15M",
+            "required": false,
+            "description": "The duration of the outage scenario."
+          },
+          {
+            "name": "customRunbook1ResourceId",
+            "type": "string",
+            "required": false,
+            "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+          },
+          {
+            "name": "customRunbook1ParametersJson",
+            "type": "string",
+            "required": false,
+            "default": "{}",
+            "description": "Optional custom runbook 1 parameters in JSON format."
+          }
+        ],
+        "actions": [
+          {
+            "name": "vmssZoneDown",
+            "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+            "description": "Force shutdown VMSS instances in target zone",
+            "duration": "%%{parameters.duration}%%",
+            "parameters": [
+              {
+                "key": "zones",
+                "value": "%%{filters.zones}%%"
+              }
+            ]
+          },
+          {
+            "name": "vmZoneDown",
+            "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+            "description": "Force shutdown VM instances in target zone",
+            "duration": "%%{parameters.duration}%%",
+            "parameters": [
+              {
+                "key": "zones",
+                "value": "%%{filters.zones}%%"
+              }
+            ]
+          },
+          {
+            "name": "redisFailover",
+            "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+            "description": "Force failover of Redis instances to simulate backend zonal outage",
+            "duration": "PT5M",
+            "parameters": [
+              {
+                "key": "RebootType",
+                "value": "PrimaryNode"
+              }
+            ]
+          },
+          {
+            "name": "custom-runbook-1",
+            "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+            "description": "Custom Runbook 1",
+            "duration": "PT30M",
+            "parameters": [
+              {
+                "key": "RunbookParameters",
+                "value": "%%{parameters.customRunbook1ParametersJson}%%"
+              }
+            ],
+            "externalResource": {
+              "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Automation/automationAccounts/exampleAutomationAccount/runbooks/exampleRunbook"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
+        "type": "Microsoft.Chaos/workspaces/scenarios",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
+          "parameters": [
+            {
+              "name": "duration",
+              "type": "string",
+              "default": "PT15M",
+              "required": false,
+              "description": "The duration of the outage scenario."
+            },
+            {
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
+            }
+          ],
+          "actions": [
+            {
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
+              "duration": "PT5M",
+              "parameters": [
+                {
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
+                }
+              ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Automation/automationAccounts/exampleAutomationAccount/runbooks/exampleRunbook"
+              }
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
+        "type": "Microsoft.Chaos/workspaces/scenarios",
+        "properties": {
+          "provisioningState": "Creating",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
+          "parameters": [
+            {
+              "name": "duration",
+              "type": "string",
+              "default": "PT15M",
+              "required": false,
+              "description": "The duration of the outage scenario."
+            },
+            {
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
+            }
+          ],
+          "actions": [
+            {
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
+              "duration": "PT5M",
+              "parameters": [
+                {
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
+                }
+              ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Automation/automationAccounts/exampleAutomationAccount/runbooks/exampleRunbook"
+              }
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Scenarios_CreateOrUpdate",
+  "title": "Create or update a scenario."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Scenarios_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Scenarios_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "myVMShutdownScenario",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Scenarios_Delete",
+  "title": "Delete a Scenario in a workspace."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Scenarios_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Scenarios_Get.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "zoneDownScenario",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
+        "type": "Microsoft.Chaos/workspaces/scenarios",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
+          "parameters": [
+            {
+              "name": "duration",
+              "type": "string",
+              "default": "PT15M",
+              "required": false,
+              "description": "The duration of the outage scenario."
+            },
+            {
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
+            }
+          ],
+          "actions": [
+            {
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
+              "duration": "PT5M",
+              "parameters": [
+                {
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
+                }
+              ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Automation/automationAccounts/exampleAutomationAccount/runbooks/exampleRunbook"
+              }
+            }
+          ],
+          "recommendation": {
+            "recommendationStatus": "Recommended",
+            "evaluationRunAt": "2025-01-15T10:30:00.000Z"
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Scenarios_Get",
+  "title": "Get a scenario."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Scenarios_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Scenarios_ListAll.json
@@ -1,0 +1,168 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+            "name": "zoneDownScenario",
+            "type": "Microsoft.Chaos/workspaces/scenarios",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "version": "1.0",
+              "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
+              "parameters": [
+                {
+                  "name": "duration",
+                  "type": "string",
+                  "default": "PT15M",
+                  "required": false,
+                  "description": "The duration of the outage scenario."
+                },
+                {
+                  "name": "customRunbook1ResourceId",
+                  "type": "string",
+                  "required": false,
+                  "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+                },
+                {
+                  "name": "customRunbook1ParametersJson",
+                  "type": "string",
+                  "required": false,
+                  "default": "{}",
+                  "description": "Optional custom runbook 1 parameters in JSON format."
+                }
+              ],
+              "actions": [
+                {
+                  "name": "vmssZoneDown",
+                  "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+                  "description": "Force shutdown VMSS instances in target zone",
+                  "duration": "%%{parameters.duration}%%",
+                  "parameters": [
+                    {
+                      "key": "zones",
+                      "value": "%%{filters.zones}%%"
+                    }
+                  ]
+                },
+                {
+                  "name": "vmZoneDown",
+                  "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+                  "description": "Force shutdown VM instances in target zone",
+                  "duration": "%%{parameters.duration}%%",
+                  "parameters": [
+                    {
+                      "key": "zones",
+                      "value": "%%{filters.zones}%%"
+                    }
+                  ]
+                },
+                {
+                  "name": "redisFailover",
+                  "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+                  "description": "Force failover of Redis instances to simulate backend zonal outage",
+                  "duration": "PT5M",
+                  "parameters": [
+                    {
+                      "key": "RebootType",
+                      "value": "PrimaryNode"
+                    }
+                  ]
+                },
+                {
+                  "name": "custom-runbook-1",
+                  "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+                  "description": "Custom Runbook 1",
+                  "duration": "PT30M",
+                  "parameters": [
+                    {
+                      "key": "RunbookParameters",
+                      "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                    }
+                  ],
+                  "externalResource": {
+                    "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Automation/automationAccounts/exampleAutomationAccount/runbooks/exampleRunbook"
+                  }
+                }
+              ],
+              "recommendation": {
+                "recommendationStatus": "Recommended",
+                "evaluationRunAt": "2025-01-15T10:30:00.000Z"
+              }
+            },
+            "systemData": {
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/networkLatencyScenario",
+            "name": "networkLatencyScenario",
+            "type": "Microsoft.Chaos/workspaces/scenarios",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "version": "1.1.0",
+              "description": "Introduces network latency to simulate poor network conditions and test application performance under network stress.",
+              "parameters": [
+                {
+                  "name": "duration",
+                  "type": "string",
+                  "default": "PT10M",
+                  "required": false,
+                  "description": "The duration of the network latency injection."
+                },
+                {
+                  "name": "latencyMs",
+                  "type": "number",
+                  "default": "100",
+                  "required": false,
+                  "description": "Latency to inject in milliseconds."
+                }
+              ],
+              "actions": [
+                {
+                  "name": "injectLatency",
+                  "actionId": "urn:csci:microsoft:network:injectLatency/1.0.0",
+                  "description": "Inject network latency to test performance",
+                  "duration": "%%{parameters.duration}%%",
+                  "parameters": [
+                    {
+                      "key": "latencyMs",
+                      "value": "%%{parameters.latencyMs}%%"
+                    }
+                  ]
+                }
+              ],
+              "recommendation": {
+                "recommendationStatus": "NotApplicable"
+              }
+            },
+            "systemData": {
+              "createdAt": "2024-12-15T00:00:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-10T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ],
+        "nextLink": null
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Scenarios_ListAll",
+  "title": "Get a list of scenarios."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/TargetTypes_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/TargetTypes_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetTypeName": "Microsoft-Agent"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Microsoft-Agent",
+        "type": "Microsoft.Chaos/locations/targetTypes",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes/Microsoft-Agent",
+        "properties": {
+          "description": "A target represents Chaos Agent.",
+          "displayName": "Chaos Agent",
+          "propertiesSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine.json",
+          "resourceTypes": [
+            "Microsoft.Compute/virtualMachines",
+            "Microsoft.Compute/virtualMachineScaleSets"
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "TargetTypes_Get",
+  "title": "Get a Target Type for westus2 location"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/TargetTypes_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/TargetTypes_List.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "Microsoft-Agent",
+            "type": "Microsoft.Chaos/locations/targetTypes",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes/Microsoft-Agent",
+            "properties": {
+              "description": "A target represents Chaos Agent.",
+              "displayName": "Chaos Agent",
+              "propertiesSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine.json",
+              "resourceTypes": [
+                "Microsoft.Compute/virtualMachines",
+                "Microsoft.Compute/virtualMachineScaleSets"
+              ]
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "TargetTypes_List",
+  "title": "List all Target Types for westus2 location."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Targets_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Targets_CreateOrUpdate.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "resource": {
+      "properties": {}
+    },
+    "targetName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Microsoft-VirtualMachine",
+        "type": "Microsoft.Chaos/targets",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine",
+        "properties": {},
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "Microsoft-VirtualMachine",
+        "type": "Microsoft.Chaos/targets",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine",
+        "properties": {},
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Targets_CreateOrUpdate",
+  "title": "Create/update a Target that extends a virtual machine resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Targets_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Targets_Delete.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-Agent"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Targets_Delete",
+  "title": "Delete a Target that extends a virtual machine resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Targets_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Targets_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-Agent"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Microsoft-Agent",
+        "type": "Microsoft.Chaos/targets",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-Agent",
+        "location": "centraluseuap",
+        "properties": {
+          "agentProfileId": "ac4e8251-fdc9-4277-8e87-dc57fe5794cf",
+          "identities": [
+            {
+              "type": "CertificateSubjectIssuer",
+              "subject": "CN=example.subject"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Targets_Get",
+  "title": "Get a Target that extends a virtual machine resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Targets_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Targets_List.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "Microsoft-Agent",
+            "type": "Microsoft.Chaos/targets",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-Agent",
+            "location": "centraluseuap",
+            "properties": {
+              "agentProfileId": "ac4e8251-fdc9-4277-8e87-dc57fe5794cf",
+              "identities": [
+                {
+                  "type": "CertificateSubjectIssuer",
+                  "subject": "CN=example.subject"
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Targets_List",
+  "title": "List all Targets that extend a virtual machine resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_CreateOrUpdate.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "resource": {
+      "properties": {
+        "scopes": [
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+        ]
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+        }
+      },
+      "location": "westus2",
+      "tags": {
+        "environment": "production",
+        "department": "engineering",
+        "project": "chaos-testing"
+      }
+    },
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleWorkspace",
+        "type": "Microsoft.Chaos/workspaces",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+          },
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "environment": "production",
+          "department": "engineering",
+          "project": "chaos-testing"
+        },
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "scopes": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationState/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace?api-version=2026-11-01"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleWorkspace",
+        "type": "Microsoft.Chaos/workspaces",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+          },
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "environment": "production",
+          "department": "engineering",
+          "project": "chaos-testing"
+        },
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Creating",
+          "scopes": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup",
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.Compute/virtualMachines/exampleVM"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationState/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Workspaces_CreateOrUpdate",
+  "title": "Create/update a workspace in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Workspaces_Delete",
+  "title": "Delete a Workspace in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_Discover.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_Discover.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/discoveries/latest?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Workspaces_Discover",
+  "title": "Trigger resource discovery for the workspace."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_Evaluate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_Evaluate.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/evaluations/latest?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Workspaces_Evaluate",
+  "title": "Trigger scenario evaluation for the workspace."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_Get.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleWorkspace",
+        "type": "Microsoft.Chaos/workspaces",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+          },
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "environment": "production",
+          "department": "engineering",
+          "project": "chaos-testing"
+        },
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "scopes": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Workspaces_Get",
+  "title": "Get a Workspace in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_List.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "exampleWorkspace",
+            "type": "Microsoft.Chaos/workspaces",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+              },
+              "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+            },
+            "tags": {
+              "environment": "production",
+              "department": "engineering",
+              "project": "chaos-testing"
+            },
+            "location": "westus2",
+            "properties": {
+              "provisioningState": "Updating",
+              "scopes": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+              ]
+            },
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "createdBy": "User",
+              "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedBy": "User",
+              "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Workspaces_List",
+  "title": "List all Workspaces in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_ListAll.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/workspaces?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "exampleWorkspace",
+            "type": "Microsoft.Chaos/workspaces",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+              },
+              "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+            },
+            "tags": {
+              "environment": "production",
+              "department": "engineering",
+              "project": "chaos-testing"
+            },
+            "location": "westus2",
+            "properties": {
+              "provisioningState": "Updating",
+              "scopes": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+              ]
+            },
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "createdBy": "User",
+              "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedBy": "User",
+              "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Workspaces_ListAll",
+  "title": "List all Workspaces in a subscription."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_Update.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Workspaces_Update.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "properties": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+        }
+      },
+      "tags": {
+        "environment": "production",
+        "department": "engineering",
+        "project": "chaos-testing"
+      }
+    },
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleWorkspace",
+        "type": "Microsoft.Chaos/workspaces",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+          },
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "environment": "production",
+          "department": "engineering",
+          "project": "chaos-testing"
+        },
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "scopes": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Workspaces_Update",
+  "title": "Update a Workspace in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/main.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/main.tsp
@@ -59,6 +59,10 @@ enum Versions {
   /**
    * The 2026-08-01-preview API version.
    */
-  @Azure.Core.previewVersion
   v2026_08_01_preview: "2026-08-01-preview",
+
+  /**
+   * The 2026-11-01 API version.
+   */
+  v2026_11_01: "2026-11-01",
 }

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/readme.md
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/readme.md
@@ -31,6 +31,15 @@ openapi-type: arm
 tag: package-2025-01
 ```
 
+### Tag: package-2026-11
+
+These settings apply only when `--tag=package-2026-11` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-11'
+input-file:
+  - stable/2026-11-01/openapi.json
+```
+
 ### Tag: package-2026-08-01-preview
 
 These settings apply only when `--tag=package-2026-08-01-preview` is specified on the command line.

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ActionVersions_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ActionVersions_Get.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "actionName": "microsoft-compute-shutdown",
+    "versionName": "1.0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "1.0",
+        "type": "Microsoft.Chaos/locations/actions/versions",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions/microsoft-compute-shutdown/versions/1.0",
+        "properties": {
+          "displayName": "Shutdown Virtual Machine",
+          "description": "Shuts down a virtual machine to test application resilience to infrastructure failures.",
+          "canonicalId": "microsoft-compute-shutdown/1.0",
+          "actionName": "Shutdown",
+          "version": "1.0.0",
+          "actionType": "Discrete",
+          "supportedTargetTypes": [
+            {
+              "targetType": "Microsoft.Compute/virtualMachines",
+              "requiredPermissions": [
+                "Microsoft.Compute/virtualMachines/powerOff/action",
+                "Microsoft.Compute/virtualMachines/start/action"
+              ]
+            }
+          ],
+          "parametersSchema": {
+            "type": "object",
+            "properties": {
+              "abruptShutdown": {
+                "type": "boolean",
+                "description": "Whether to perform an abrupt shutdown."
+              }
+            },
+            "required": []
+          },
+          "recommendedRoles": [
+            "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.000Z",
+          "lastModifiedAt": "2025-01-01T00:00:00.000Z"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionVersions_Get",
+  "title": "Get an Action Version for westus2 location"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ActionVersions_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ActionVersions_List.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "actionName": "microsoft-compute-shutdown"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions/microsoft-compute-shutdown/versions?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "1.0",
+            "type": "Microsoft.Chaos/locations/actions/versions",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions/microsoft-compute-shutdown/versions/1.0",
+            "properties": {
+              "displayName": "Shutdown Virtual Machine",
+              "description": "Shuts down a virtual machine to test application resilience to infrastructure failures.",
+              "canonicalId": "microsoft-compute-shutdown/1.0",
+              "actionName": "Shutdown",
+              "version": "1.0.0",
+              "actionType": "Discrete",
+              "supportedTargetTypes": [
+                {
+                  "targetType": "Microsoft.Compute/virtualMachines",
+                  "requiredPermissions": [
+                    "Microsoft.Compute/virtualMachines/powerOff/action",
+                    "Microsoft.Compute/virtualMachines/start/action"
+                  ]
+                }
+              ],
+              "parametersSchema": {
+                "type": "object",
+                "properties": {
+                  "abruptShutdown": {
+                    "type": "boolean",
+                    "description": "Whether to perform an abrupt shutdown."
+                  }
+                },
+                "required": []
+              },
+              "recommendedRoles": [
+                "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+              ]
+            },
+            "systemData": {
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "lastModifiedAt": "2025-01-01T00:00:00.000Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ActionVersions_List",
+  "title": "List all Action Versions for a given action."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Actions_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Actions_Get.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "actionName": "microsoft-compute-shutdown"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "microsoft-compute-shutdown",
+        "type": "Microsoft.Chaos/locations/actions",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions/microsoft-compute-shutdown",
+        "properties": {
+          "displayName": "Shutdown Virtual Machine",
+          "description": "Shuts down a virtual machine to test application resilience to infrastructure failures.",
+          "canonicalId": "microsoft-compute-shutdown/1.0",
+          "actionName": "Shutdown",
+          "version": "1.0.0",
+          "actionType": "Discrete",
+          "supportedTargetTypes": [
+            {
+              "targetType": "Microsoft.Compute/virtualMachines",
+              "requiredPermissions": [
+                "Microsoft.Compute/virtualMachines/powerOff/action",
+                "Microsoft.Compute/virtualMachines/start/action"
+              ]
+            }
+          ],
+          "parametersSchema": {
+            "type": "object",
+            "properties": {
+              "abruptShutdown": {
+                "type": "boolean",
+                "description": "Whether to perform an abrupt shutdown."
+              }
+            },
+            "required": []
+          },
+          "recommendedRoles": [
+            "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.000Z",
+          "lastModifiedAt": "2025-01-01T00:00:00.000Z"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Actions_Get",
+  "title": "Get an Action for westus2 location"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Actions_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Actions_List.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "microsoft-compute-shutdown",
+            "type": "Microsoft.Chaos/locations/actions",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/actions/microsoft-compute-shutdown",
+            "properties": {
+              "displayName": "Shutdown Virtual Machine",
+              "description": "Shuts down a virtual machine to test application resilience to infrastructure failures.",
+              "canonicalId": "microsoft-compute-shutdown/1.0",
+              "actionName": "Shutdown",
+              "version": "1.0.0",
+              "actionType": "Discrete",
+              "supportedTargetTypes": [
+                {
+                  "targetType": "Microsoft.Compute/virtualMachines",
+                  "requiredPermissions": [
+                    "Microsoft.Compute/virtualMachines/powerOff/action",
+                    "Microsoft.Compute/virtualMachines/start/action"
+                  ]
+                }
+              ],
+              "parametersSchema": {
+                "type": "object",
+                "properties": {
+                  "abruptShutdown": {
+                    "type": "boolean",
+                    "description": "Whether to perform an abrupt shutdown."
+                  }
+                },
+                "required": []
+              },
+              "recommendedRoles": [
+                "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+              ]
+            },
+            "systemData": {
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "lastModifiedAt": "2025-01-01T00:00:00.000Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Actions_List",
+  "title": "List all Actions for westus2 location."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Capabilities_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Capabilities_CreateOrUpdate.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "resource": {
+      "properties": {}
+    },
+    "capabilityName": "Shutdown-1.0",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Shutdown-1.0",
+        "type": "Microsoft.Chaos/targets/capabilities",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0",
+        "properties": {
+          "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+          "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+          "publisher": "Microsoft",
+          "targetType": "VirtualMachine",
+          "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+        },
+        "systemData": {
+          "createdAt": "2020-05-14T05:08:38.4662189Z",
+          "lastModifiedAt": "2020-05-14T05:08:38.4662189Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "Shutdown-1.0",
+        "type": "Microsoft.Chaos/targets/capabilities",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0",
+        "properties": {
+          "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+          "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+          "publisher": "Microsoft",
+          "targetType": "VirtualMachine",
+          "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+        },
+        "systemData": {
+          "createdAt": "2020-05-14T05:08:38.4662189Z",
+          "lastModifiedAt": "2020-05-14T05:08:38.4662189Z"
+        }
+      }
+    }
+  },
+  "operationId": "Capabilities_CreateOrUpdate",
+  "title": "Create/update a Capability that extends a virtual machine Target resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Capabilities_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Capabilities_Delete.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "capabilityName": "Shutdown-1.0",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Capabilities_Delete",
+  "title": "Delete a Capability that extends a virtual machine Target resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Capabilities_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Capabilities_Get.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "capabilityName": "Shutdown-1.0",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Shutdown-1.0",
+        "type": "Microsoft.Chaos/targets/capabilities",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0",
+        "properties": {
+          "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+          "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+          "publisher": "Microsoft",
+          "targetType": "VirtualMachine",
+          "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+        },
+        "systemData": {
+          "createdAt": "2020-05-14T05:08:38.4662189Z",
+          "lastModifiedAt": "2020-05-14T05:08:38.4662189Z"
+        }
+      }
+    }
+  },
+  "operationId": "Capabilities_Get",
+  "title": "Get a Capability that extends a virtual machine Target resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Capabilities_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Capabilities_List.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine/capabilities?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "Shutdown-1.0",
+            "type": "Microsoft.Chaos/targets/capabilities",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0",
+            "properties": {
+              "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+              "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+              "publisher": "Microsoft",
+              "targetType": "VirtualMachine",
+              "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+            },
+            "systemData": {
+              "createdAt": "2020-05-14T05:08:38.4662189Z",
+              "lastModifiedAt": "2020-05-14T05:08:38.4662189Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Capabilities_List",
+  "title": "List all Capabilities that extend a virtual machine Target resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/CapabilityTypes_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/CapabilityTypes_Get.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "capabilityTypeName": "Shutdown-1.0",
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetTypeName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Shutdown-1.0",
+        "type": "Microsoft.Chaos/locations/targetTypes/capabilityTypes",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes/Microsoft-VirtualMachine/capabilityTypes/Shutdown-1.0",
+        "properties": {
+          "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+          "displayName": "Shutdown VM",
+          "kind": "fault",
+          "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+          "publisher": "Microsoft",
+          "azureRbacActions": [
+            "Microsoft.Compute/virtualMachines/powerOff/action",
+            "Microsoft.Compute/virtualMachines/read"
+          ],
+          "azureRbacDataActions": [],
+          "requiredAzureRoleDefinitionIds": [
+            "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+          ],
+          "runtimeProperties": {
+            "kind": "continuous"
+          },
+          "targetType": "VirtualMachine",
+          "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+        }
+      }
+    }
+  },
+  "operationId": "CapabilityTypes_Get",
+  "title": "Get a Capability Type for a virtual machine Target resource on westus2 location."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/CapabilityTypes_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/CapabilityTypes_List.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetTypeName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes/Microsoft-VirtualMachine/capabilityTypes?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "Shutdown-1.0",
+            "type": "Microsoft.Chaos/locations/targetTypes/capabilityTypes",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes/Microsoft-VirtualMachine/capabilityTypes/Shutdown-1.0",
+            "properties": {
+              "description": "Shutdown an Azure Virtual Machine for a defined period of time.",
+              "displayName": "Shutdown VM",
+              "kind": "fault",
+              "parametersSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine/capabilities/Shutdown-1.0.json",
+              "publisher": "Microsoft",
+              "azureRbacActions": [
+                "Microsoft.Compute/virtualMachines/powerOff/action",
+                "Microsoft.Compute/virtualMachines/read"
+              ],
+              "azureRbacDataActions": [],
+              "requiredAzureRoleDefinitionIds": [
+                "9980e02c-c2be-4d73-94e8-173b1dc7cf3c"
+              ],
+              "runtimeProperties": {
+                "kind": "continuous"
+              },
+              "targetType": "VirtualMachine",
+              "urn": "urn:csci:microsoft:virtualMachine:shutdown/1.0"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "CapabilityTypes_List",
+  "title": "List all Capability Types for a virtual machine Target resource on westus2 location."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_CreateOrUpdate.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "connectionName": "aksClusterConnection",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "resource": {
+      "properties": {
+        "kind": "AksExtension",
+        "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+        "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+        "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/connections/aksClusterConnection",
+        "name": "aksClusterConnection",
+        "type": "Microsoft.Chaos/workspaces/connections",
+        "properties": {
+          "kind": "AksExtension",
+          "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "status": "Connected",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/connections/aksClusterConnection",
+        "name": "aksClusterConnection",
+        "type": "Microsoft.Chaos/workspaces/connections",
+        "properties": {
+          "kind": "AksExtension",
+          "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+          "status": "Pending",
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Connections_CreateOrUpdate",
+  "title": "Create or update a connection."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "connectionName": "aksClusterConnection",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Connections_Delete",
+  "title": "Delete a connection in a workspace."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_Get.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "connectionName": "aksClusterConnection",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/connections/aksClusterConnection",
+        "name": "aksClusterConnection",
+        "type": "Microsoft.Chaos/workspaces/connections",
+        "properties": {
+          "kind": "AksExtension",
+          "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+          "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+          "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+          "status": "Connected",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Connections_Get",
+  "title": "Get a connection."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Connections_ListAll.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/connections/aksClusterConnection",
+            "name": "aksClusterConnection",
+            "type": "Microsoft.Chaos/workspaces/connections",
+            "properties": {
+              "kind": "AksExtension",
+              "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ContainerService/managedClusters/exampleCluster",
+              "principalId": "1a2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+              "dataPlaneEndpoint": "https://eastus.dp.chaos.azure.com",
+              "status": "Connected",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2025-01-15T10:30:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/connections/csfiConnection",
+            "name": "csfiConnection",
+            "type": "Microsoft.Chaos/workspaces/connections",
+            "properties": {
+              "kind": "Csfi",
+              "targetResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVm",
+              "principalId": "9f8e7d6c-5b4a-3c2d-1e0f-9a8b7c6d5e4f",
+              "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+              "certificateSubjectName": "CN=chaos-csfi.dsts.core.windows.net",
+              "certificateIssuer": "CN=Microsoft Azure TLS Issuing CA",
+              "dstsPrincipal": "chaos-csfi.dsts.core.windows.net",
+              "status": "Pending",
+              "provisioningState": "Creating"
+            },
+            "systemData": {
+              "createdAt": "2025-01-16T09:00:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-16T09:00:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ],
+        "nextLink": null
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Connections_ListAll",
+  "title": "Get a list of connections."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/DiscoveredResources_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/DiscoveredResources_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "discoveredResourceName": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/discoveredResources/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "name": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "type": "Microsoft.Chaos/workspaces/discoveredResources",
+        "properties": {
+          "namespace": "Microsoft.Compute",
+          "resourceName": "myVirtualMachine",
+          "resourceType": "virtualMachines",
+          "fullyQualifiedIdentifier": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/myVirtualMachine",
+          "discoveredAt": "2025-01-15T10:30:00.000Z",
+          "scope": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG"
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "system",
+          "createdByType": "Application",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "system",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DiscoveredResources_Get",
+  "title": "Get a discovered resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/DiscoveredResources_ListByWorkspace.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/DiscoveredResources_ListByWorkspace.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/discoveredResources/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "name": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "type": "Microsoft.Chaos/workspaces/discoveredResources",
+            "properties": {
+              "namespace": "Microsoft.Compute",
+              "resourceName": "myVirtualMachine",
+              "resourceType": "virtualMachines",
+              "fullyQualifiedIdentifier": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/myVirtualMachine",
+              "discoveredAt": "2025-01-15T10:30:00.000Z",
+              "scope": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG"
+            },
+            "systemData": {
+              "createdAt": "2025-01-15T10:30:00.000Z",
+              "createdBy": "system",
+              "createdByType": "Application",
+              "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+              "lastModifiedBy": "system",
+              "lastModifiedByType": "Application"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/discoveredResources/b2c3d4e5-f6a7-8901-bcde-f12345678901",
+            "name": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+            "type": "Microsoft.Chaos/workspaces/discoveredResources",
+            "properties": {
+              "namespace": "Microsoft.Storage",
+              "resourceName": "mystorageaccount",
+              "resourceType": "storageAccounts",
+              "fullyQualifiedIdentifier": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/mystorageaccount",
+              "discoveredAt": "2025-01-15T11:00:00.000Z",
+              "scope": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG"
+            },
+            "systemData": {
+              "createdAt": "2025-01-15T11:00:00.000Z",
+              "createdBy": "system",
+              "createdByType": "Application",
+              "lastModifiedAt": "2025-01-15T11:00:00.000Z",
+              "lastModifiedBy": "system",
+              "lastModifiedByType": "Application"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/discoveredResources/c3d4e5f6-a7b8-9012-cdef-123456789012",
+            "name": "c3d4e5f6-a7b8-9012-cdef-123456789012",
+            "type": "Microsoft.Chaos/workspaces/discoveredResources",
+            "properties": {
+              "namespace": "Microsoft.Network",
+              "resourceName": "myVirtualNetwork",
+              "resourceType": "virtualNetworks",
+              "fullyQualifiedIdentifier": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork",
+              "discoveredAt": "2025-01-15T11:15:00.000Z",
+              "scope": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG"
+            },
+            "systemData": {
+              "createdAt": "2025-01-15T11:15:00.000Z",
+              "createdBy": "system",
+              "createdByType": "Application",
+              "lastModifiedAt": "2025-01-15T11:15:00.000Z",
+              "lastModifiedBy": "system",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ],
+        "nextLink": null
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DiscoveredResources_ListByWorkspace",
+  "title": "Get a list of discovered resources for a workspace."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_Cancel.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_Cancel.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Experiments_Cancel",
+  "title": "Cancel a running Experiment."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_CreateOrUpdate.json
@@ -1,0 +1,208 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "resource": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "tags": {
+        "key7131": "ryohwcoiccwsnewjigfmijz",
+        "key2138": "fjaeecgnvqd"
+      },
+      "location": "eastus2euap",
+      "properties": {
+        "customerDataStorage": {
+          "blobContainerName": "azurechaosstudioexperiments",
+          "storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+        },
+        "selectors": [
+          {
+            "type": "List",
+            "id": "selector1",
+            "targets": [
+              {
+                "type": "ChaosTarget",
+                "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+              }
+            ]
+          }
+        ],
+        "steps": [
+          {
+            "name": "step1",
+            "branches": [
+              {
+                "name": "branch1",
+                "actions": [
+                  {
+                    "name": "urn:csci:microsoft:virtualMachine:shutdown/1.0",
+                    "type": "continuous",
+                    "duration": "PT10M",
+                    "parameters": [
+                      {
+                        "key": "abruptShutdown",
+                        "value": "false"
+                      }
+                    ],
+                    "selectorId": "selector1"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleExperiment",
+        "type": "Microsoft.Chaos/experiments",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "key7131": "ryohwcoiccwsnewjigfmijz",
+          "key2138": "fjaeecgnvqd"
+        },
+        "location": "eastus2euap",
+        "properties": {
+          "customerDataStorage": {
+            "blobContainerName": "azurechaosstudioexperiments",
+            "storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+          },
+          "provisioningState": "Updating",
+          "selectors": [
+            {
+              "type": "List",
+              "id": "selector1",
+              "targets": [
+                {
+                  "type": "ChaosTarget",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                }
+              ]
+            }
+          ],
+          "steps": [
+            {
+              "name": "step1",
+              "branches": [
+                {
+                  "name": "branch1",
+                  "actions": [
+                    {
+                      "name": "urn:csci:microsoft:virtualMachine:shutdown/1.0",
+                      "type": "continuous",
+                      "duration": "PT10M",
+                      "parameters": [
+                        {
+                          "key": "abruptShutdown",
+                          "value": "false"
+                        }
+                      ],
+                      "selectorId": "selector1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/experiments/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleExperiment",
+        "type": "Microsoft.Chaos/experiments",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "key7131": "ryohwcoiccwsnewjigfmijz",
+          "key2138": "fjaeecgnvqd"
+        },
+        "location": "eastus2euap",
+        "properties": {
+          "customerDataStorage": {
+            "blobContainerName": "azurechaosstudioexperiments",
+            "storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+          },
+          "provisioningState": "Creating",
+          "selectors": [
+            {
+              "type": "List",
+              "id": "selector1",
+              "targets": [
+                {
+                  "type": "ChaosTarget",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                }
+              ]
+            }
+          ],
+          "steps": [
+            {
+              "name": "step1",
+              "branches": [
+                {
+                  "name": "branch1",
+                  "actions": [
+                    {
+                      "name": "urn:csci:microsoft:virtualMachine:shutdown/1.0",
+                      "type": "continuous",
+                      "duration": "PT10M",
+                      "parameters": [
+                        {
+                          "key": "abruptShutdown",
+                          "value": "false"
+                        }
+                      ],
+                      "selectorId": "selector1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/experiments/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Experiments_CreateOrUpdate",
+  "title": "Create/update a Experiment in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Experiments_Delete",
+  "title": "Delete a Experiment in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_ExecutionDetails.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_ExecutionDetails.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "executionId": "f24500ad-744e-4a26-864b-b76199eac333",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "f24500ad-744e-4a26-864b-b76199eac333",
+        "type": "Microsoft.Chaos/experiments/executions/getExecutionDetails",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment/executions/f24500ad-744e-4a26-864b-b76199eac333/getExecutionDetails",
+        "properties": {
+          "failureReason": "Dependency failure",
+          "lastActionAt": "2020-12-14T21:52:52.2552574Z",
+          "runInformation": {
+            "steps": [
+              {
+                "branches": [
+                  {
+                    "actions": [
+                      {
+                        "actionId": "59499d33-6751-4b6e-a1f6-58f4d56a040a",
+                        "actionName": "urn:provider:agent-v2:Microsoft.Azure.Chaos.Fault.CPUPressureAllProcessors",
+                        "endTime": "2020-12-14T13:56:13.6270153-08:00",
+                        "startTime": "2020-12-14T13:56:13.6270153-08:00",
+                        "status": "failed",
+                        "targets": [
+                          {
+                            "status": "succeeded",
+                            "target": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/VM1",
+                            "targetCompletedTime": "2021-04-02T17:30:55+00:00",
+                            "targetFailedTime": "2021-04-02T16:30:55+00:00"
+                          },
+                          {
+                            "status": "failed",
+                            "target": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/VM1",
+                            "targetCompletedTime": "2021-04-02T17:30:55+00:00",
+                            "targetFailedTime": "2021-04-02T16:30:55+00:00"
+                          }
+                        ]
+                      }
+                    ],
+                    "branchId": "FirstBranch",
+                    "branchName": "FirstBranch",
+                    "status": "failed"
+                  }
+                ],
+                "status": "failed",
+                "stepId": "FirstStep",
+                "stepName": "FirstStep"
+              }
+            ]
+          },
+          "startedAt": "2020-12-14T21:52:52.2552574Z",
+          "status": "failed",
+          "stoppedAt": "2020-12-14T21:56:18.9281956Z"
+        }
+      }
+    }
+  },
+  "operationId": "Experiments_ExecutionDetails",
+  "title": "Get experiment execution details."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_Get.json
@@ -1,0 +1,76 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleExperiment",
+        "type": "Microsoft.Chaos/experiments",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "location": "centraluseuap",
+        "properties": {
+          "customerDataStorage": {
+            "blobContainerName": "azurechaosstudioexperiments",
+            "storageAccountResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+          },
+          "selectors": [
+            {
+              "type": "List",
+              "id": "selector1",
+              "targets": [
+                {
+                  "type": "ChaosTarget",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                }
+              ]
+            }
+          ],
+          "steps": [
+            {
+              "name": "step1",
+              "branches": [
+                {
+                  "name": "branch1",
+                  "actions": [
+                    {
+                      "name": "urn:csci:provider:providername:Shutdown/1.0",
+                      "type": "continuous",
+                      "duration": "PT10M",
+                      "parameters": [
+                        {
+                          "key": "abruptShutdown",
+                          "value": "false"
+                        }
+                      ],
+                      "selectorId": "selector1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Experiments_Get",
+  "title": "Get a Experiment in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_GetExecution.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_GetExecution.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "executionId": "f24500ad-744e-4a26-864b-b76199eac333",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "f24500ad-744e-4a26-864b-b76199eac333",
+        "type": "Microsoft.Chaos/experiments/executions",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment/executions/f24500ad-744e-4a26-864b-b76199eac333",
+        "properties": {
+          "startedAt": "2020-12-14T21:52:52.2552574Z",
+          "status": "failed",
+          "stoppedAt": "2020-12-14T21:56:18.9281956Z"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Experiments_GetExecution",
+  "title": "Get the execution of a Experiment."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_List.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "exampleExperiment",
+            "type": "Microsoft.Chaos/experiments",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+              "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+            },
+            "location": "centraluseuap",
+            "properties": {
+              "customerDataStorage": {
+                "blobContainerName": "azurechaosstudioexperiments",
+                "storageAccountResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+              },
+              "selectors": [
+                {
+                  "type": "List",
+                  "id": "selector1",
+                  "targets": [
+                    {
+                      "type": "ChaosTarget",
+                      "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                    }
+                  ]
+                }
+              ],
+              "steps": [
+                {
+                  "name": "step1",
+                  "branches": [
+                    {
+                      "name": "branch1",
+                      "actions": [
+                        {
+                          "name": "urn:csci:provider:providername:Shutdown/1.0",
+                          "type": "continuous",
+                          "duration": "PT10M",
+                          "parameters": [
+                            {
+                              "key": "abruptShutdown",
+                              "value": "false"
+                            }
+                          ],
+                          "selectorId": "selector1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "createdBy": "User",
+              "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedBy": "User",
+              "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Experiments_List",
+  "title": "List all Experiments in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_ListAll.json
@@ -1,0 +1,80 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/experiments?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "exampleExperiment",
+            "type": "Microsoft.Chaos/experiments",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+              "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+            },
+            "location": "centraluseuap",
+            "properties": {
+              "customerDataStorage": {
+                "blobContainerName": "azurechaosstudioexperiments",
+                "storageAccountResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+              },
+              "selectors": [
+                {
+                  "type": "List",
+                  "id": "selector1",
+                  "targets": [
+                    {
+                      "type": "ChaosTarget",
+                      "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                    }
+                  ]
+                }
+              ],
+              "steps": [
+                {
+                  "name": "step1",
+                  "branches": [
+                    {
+                      "name": "branch1",
+                      "actions": [
+                        {
+                          "name": "urn:csci:provider:providername:Shutdown/1.0",
+                          "type": "continuous",
+                          "duration": "PT10M",
+                          "parameters": [
+                            {
+                              "key": "abruptShutdown",
+                              "value": "false"
+                            }
+                          ],
+                          "selectorId": "selector1"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "createdBy": "User",
+              "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedBy": "User",
+              "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Experiments_ListAll",
+  "title": "List all Experiments in a subscription."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_ListAllExecutions.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_ListAllExecutions.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment/executionDetails?continuationToken=&api-version=2025-01-01",
+        "value": [
+          {
+            "name": "f24500ad-744e-4a26-864b-b76199eac333",
+            "type": "Microsoft.Chaos/experiments/executions",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment/executions/f24500ad-744e-4a26-864b-b76199eac333",
+            "properties": {
+              "startedAt": "2020-12-14T21:52:52.2552574Z",
+              "status": "failed",
+              "stoppedAt": "2020-12-14T21:56:18.9281956Z"
+            }
+          },
+          {
+            "name": "14d98367-52ef-4596-be4f-53fc81bbfc33",
+            "type": "Microsoft.Chaos/experiments/executions",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment/executions/14d98367-52ef-4596-be4f-53fc81bbfc33",
+            "properties": {
+              "startedAt": "2020-12-14T21:52:52.2552574Z",
+              "status": "success",
+              "stoppedAt": "2020-12-14T21:56:18.9281956Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Experiments_ListAllExecutions",
+  "title": "List all executions of an Experiment."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_Start.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_Start.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Experiments_Start",
+  "title": "Start a Experiment."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_Update.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Experiments_Update.json
@@ -1,0 +1,104 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "properties": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ManagedIdentity/userAssignedIdentity/exampleUMI": {}
+        }
+      },
+      "tags": {
+        "key1": "value1",
+        "key2": "value2"
+      }
+    },
+    "experimentName": "exampleExperiment",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleExperiment",
+        "type": "Microsoft.Chaos/experiments",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/experiments/exampleExperiment",
+        "identity": {
+          "type": "UserAssigned",
+          "principalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6",
+          "userAssignedIdentities": {
+            "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.ManagedIdentity/userAssignedIdentity/exampleUMI": {}
+          }
+        },
+        "location": "centraluseuap",
+        "properties": {
+          "customerDataStorage": {
+            "blobContainerName": "azurechaosstudioexperiments",
+            "storageAccountResourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Storage/storageAccounts/exampleStorage"
+          },
+          "selectors": [
+            {
+              "type": "List",
+              "id": "selector1",
+              "targets": [
+                {
+                  "type": "ChaosTarget",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine"
+                }
+              ]
+            }
+          ],
+          "steps": [
+            {
+              "name": "step1",
+              "branches": [
+                {
+                  "name": "branch1",
+                  "actions": [
+                    {
+                      "name": "urn:csci:provider:providername:Shutdown/1.0",
+                      "type": "continuous",
+                      "duration": "PT10M",
+                      "parameters": [
+                        {
+                          "key": "abruptShutdown",
+                          "value": "false"
+                        }
+                      ],
+                      "selectorId": "selector1"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        },
+        "tags": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Experiments_Update",
+  "title": "Update an Experiment in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/OperationStatuses_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/OperationStatuses_Get.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "subscriptionId": "e25c0d12-0335-4fec-8ef8-3b4f9a10649e",
+    "location": "westus2",
+    "operationId": "4bdadd97-207c-4de8-9bba-08339ae099c7"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/e25c0d12-0335-4fec-8ef8-3b4f9a10649e/providers/Microsoft.Chaos/locations/westus2/operationStatuses/4bdadd97-207c-4de8-9bba-08339ae099c7",
+        "name": "4bdadd97-207c-4de8-9bba-08339ae099c7",
+        "startTime": "2024-11-14T21:52:52.2552574Z",
+        "status": "Creating"
+      }
+    }
+  },
+  "operationId": "OperationStatuses_Get",
+  "title": "Gets Chaos Studio async operation status."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Operations_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Operations_List.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/providers/Microsoft.Chaos/operations?continuationToken=myContinuationToken&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "Microsoft.Chaos/experiments/read",
+            "display": {
+              "provider": "Microsoft Chaos",
+              "resource": "Chaos Experiment",
+              "operation": "Gets all Chaos Experiments.",
+              "description": "Gets all Chaos Experiments in a resource group."
+            },
+            "isDataAction": false,
+            "origin": "user,system"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Operations_ListAll",
+  "title": "Lists all Chaos Studio operations."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_CreateOrUpdate_Create_Or_Update_A_Private_Access_Resource.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_CreateOrUpdate_Create_Or_Update_A_Private_Access_Resource.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "resource": {
+      "location": "centraluseuap",
+      "properties": {}
+    },
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "provisioningState": "Updating"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_CreateOrUpdate",
+  "title": "Create or Update a private access resource"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_CreateOrUpdate_Create_Or_Update_A_Private_Access_Resource_With_Public_Network_Access.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_CreateOrUpdate_Create_Or_Update_A_Private_Access_Resource_With_Public_Network_Access.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "resource": {
+      "location": "centraluseuap",
+      "properties": {
+        "publicNetworkAccess": "Enabled"
+      }
+    },
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "provisioningState": "Updating",
+          "publicNetworkAccess": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "header": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "provisioningState": "Creating",
+          "publicNetworkAccess": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "header": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_CreateOrUpdate",
+  "title": "Create or Update a private access resource with publicNetworkAccess"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PrivateAccesses_Delete",
+  "title": "Delete a private access resource"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_DeleteAPrivateEndpointConnection.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_DeleteAPrivateEndpointConnection.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "PrivateAccesses_DeleteAPrivateEndpointConnection",
+  "title": "Delete a private endpoint connection under a private access resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_GetAPrivateEndpointConnection.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_GetAPrivateEndpointConnection.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "privateEndpointConnectionName": "myPrivateEndpointConnection",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateEndpointConnection",
+        "type": "Microsoft.Chaos/privateAccesses/PrivateEndpointConnections",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateEndpoinConnections/myPrivateEndpointConnection",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_GetAPrivateEndpointConnection",
+  "title": "Get information about a private endpoint connection under a private access resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_GetPrivateLinkResources.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_GetPrivateLinkResources.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "agents",
+            "type": "Microsoft.Chaos/privateAccesses/privateLinkResources",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateLinkResources/agents",
+            "location": "centraluseuap",
+            "properties": {
+              "groupId": "agents",
+              "requiredMembers": [
+                "privateAccess_1"
+              ],
+              "requiredZoneNames": [
+                "privatelink.agents.core.windows.net"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_GetPrivateLinkResources",
+  "title": "List all possible private link resources under private access resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_Get_Get_A_Private_Access_Resource.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_Get_Get_A_Private_Access_Resource.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccess": {
+      "location": "centraluseuap"
+    },
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {},
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_Get",
+  "title": "Get a private access resource"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_Get_Get_A_Private_Access_Resource_With_Private_Endpoint.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_Get_Get_A_Private_Access_Resource_With_Private_Endpoint.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccess": {
+      "location": "centraluseuap"
+    },
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myprivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "privateEndpointConnections": [
+            {
+              "name": "myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+              "type": "Microsoft.Chaos/privateAccesses/PrivateEndpointConnections",
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateEndpoinConnections/myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+              "properties": {
+                "privateEndpoint": {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                },
+                "privateLinkServiceConnectionState": {
+                  "description": "Auto-Approved",
+                  "actionsRequired": "None",
+                  "status": "Approved"
+                },
+                "provisioningState": "Succeeded"
+              }
+            }
+          ],
+          "publicNetworkAccess": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_Get",
+  "title": "Get a private access resource with private endpoint"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_List.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "myPrivateAccess2",
+            "type": "Microsoft.Chaos/privateAccesses",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess2",
+            "location": "centraluseuap",
+            "properties": {},
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+            }
+          },
+          {
+            "name": "myPrivateAccess",
+            "type": "Microsoft.Chaos/privateAccesses",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+            "location": "centraluseuap",
+            "properties": {
+              "privateEndpointConnections": [
+                {
+                  "name": "myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+                  "type": "Microsoft.Chaos/privateAccesses/PrivateEndpointConnections",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateEndpoinConnections/myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+                  "properties": {
+                    "privateEndpoint": {
+                      "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                    },
+                    "privateLinkServiceConnectionState": {
+                      "description": "Auto-Approved",
+                      "actionsRequired": "None",
+                      "status": "Approved"
+                    }
+                  }
+                }
+              ],
+              "publicNetworkAccess": "Enabled"
+            },
+            "systemData": {
+              "createdAt": "2021-08-01T00:00:00.0Z",
+              "lastModifiedAt": "2021-08-01T00:00:00.0Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "PrivateAccesses_List",
+  "title": "List all private access in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_ListAll.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/privateAccesses?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "myPrivateAccess2",
+            "type": "Microsoft.Chaos/privateAccesses",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess2",
+            "location": "centraluseuap",
+            "properties": {},
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+            }
+          },
+          {
+            "name": "myPrivateAccess",
+            "type": "Microsoft.Chaos/privateAccesses",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup2/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+            "location": "centraluseuap",
+            "properties": {
+              "privateEndpointConnections": [
+                {
+                  "name": "myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+                  "type": "Microsoft.Chaos/privateAccesses/PrivateEndpointConnections",
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup2/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateEndpoinConnections/myPrivateAccess.d4914cfa-6bc2-4049-a57c-3d1f622d8eef",
+                  "properties": {
+                    "privateEndpoint": {
+                      "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup2/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+                    },
+                    "privateLinkServiceConnectionState": {
+                      "description": "Auto-Approved",
+                      "actionsRequired": "None",
+                      "status": "Approved"
+                    }
+                  }
+                }
+              ],
+              "publicNetworkAccess": "Disabled"
+            },
+            "systemData": {
+              "createdAt": "2021-08-01T00:00:00.0Z",
+              "lastModifiedAt": "2021-08-01T00:00:00.0Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "PrivateAccesses_ListAll",
+  "title": "List all private accesses in a subscription."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_ListPrivateEndpointConnections.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_ListPrivateEndpointConnections.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myPrivateEndpointConnection",
+            "type": "Microsoft.Chaos/privateAccesses/PrivateEndpointConnections",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess/privateEndpointConnections/myPrivateEndpointConnection",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_ListPrivateEndpointConnections",
+  "title": "List all private endpoint connections under a private access resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_Update.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/PrivateAccesses_Update.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "privateAccessName": "myPrivateAccess",
+    "properties": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myPrivateAccess",
+        "type": "Microsoft.Chaos/privateAccesses",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourcegroup/providers/Microsoft.Chaos/privateAccesses/myPrivateAccess",
+        "location": "centraluseuap",
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "PrivateAccesses_Update",
+  "title": "Update a private access resource's tags"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_CreateOrUpdate.json
@@ -1,0 +1,161 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "resource": {
+      "properties": {
+        "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+        "parameters": [
+          {
+            "key": "duration",
+            "value": "PT10M"
+          },
+          {
+            "key": "targetResourceIds",
+            "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm1\",\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm2\"]"
+          }
+        ],
+        "resourceTargeting": {
+          "include": {
+            "locations": [
+              "eastus"
+            ],
+            "zones": [
+              "1"
+            ]
+          },
+          "exclude": {
+            "resources": [
+              "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+            ],
+            "tags": [
+              {
+                "key": "environment",
+                "value": "production"
+              }
+            ],
+            "types": [
+              "Microsoft.Compute/virtualMachineScaleSets"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678",
+        "name": "config-5678-9012-3456-789012345678",
+        "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+        "properties": {
+          "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+          "parameters": [
+            {
+              "key": "duration",
+              "value": "PT10M"
+            },
+            {
+              "key": "targetResourceIds",
+              "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm1\",\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm2\"]"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "resourceTargeting": {
+            "include": {
+              "locations": [
+                "eastus"
+              ],
+              "zones": [
+                "1"
+              ]
+            },
+            "exclude": {
+              "resources": [
+                "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+              ],
+              "tags": [
+                {
+                  "key": "environment",
+                  "value": "production"
+                }
+              ],
+              "types": [
+                "Microsoft.Compute/virtualMachineScaleSets"
+              ]
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T12:00:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678",
+        "name": "config-5678-9012-3456-789012345678",
+        "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+        "properties": {
+          "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+          "parameters": [
+            {
+              "key": "duration",
+              "value": "PT10M"
+            },
+            {
+              "key": "targetResourceIds",
+              "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm1\",\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm2\"]"
+            }
+          ],
+          "provisioningState": "Creating",
+          "resourceTargeting": {
+            "include": {
+              "locations": [
+                "eastus"
+              ],
+              "zones": [
+                "1"
+              ]
+            },
+            "exclude": {
+              "resources": [
+                "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+              ],
+              "tags": [
+                {
+                  "key": "environment",
+                  "value": "production"
+                }
+              ],
+              "types": [
+                "Microsoft.Compute/virtualMachineScaleSets"
+              ]
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioConfigurations_CreateOrUpdate",
+  "title": "Create or update a scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_CreateOrUpdate_With_Physical_Zones.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_CreateOrUpdate_With_Physical_Zones.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-physical-zone",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "resource": {
+      "properties": {
+        "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+        "parameters": [
+          {
+            "key": "duration",
+            "value": "PT10M"
+          }
+        ],
+        "resourceTargeting": {
+          "include": {
+            "physicalZones": [
+              "westus2-az1"
+            ]
+          },
+          "exclude": {
+            "resources": [
+              "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-physical-zone",
+        "name": "config-physical-zone",
+        "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+        "properties": {
+          "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+          "parameters": [
+            {
+              "key": "duration",
+              "value": "PT10M"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "resourceTargeting": {
+            "include": {
+              "physicalZones": [
+                "westus2-az1"
+              ]
+            },
+            "exclude": {
+              "resources": [
+                "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+              ]
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T12:00:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-physical-zone",
+        "name": "config-physical-zone",
+        "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+        "properties": {
+          "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+          "parameters": [
+            {
+              "key": "duration",
+              "value": "PT10M"
+            }
+          ],
+          "provisioningState": "Creating",
+          "resourceTargeting": {
+            "include": {
+              "physicalZones": [
+                "westus2-az1"
+              ]
+            },
+            "exclude": {
+              "resources": [
+                "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+              ]
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioConfigurations_CreateOrUpdate",
+  "title": "Create or update a scenario configuration with physical zone targeting."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_Delete.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/centraluseuap/operationResults/exampleOperationId",
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/centraluseuap/operationStatuses/exampleOperationId"
+      }
+    },
+    "204": {
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioConfigurations_Delete",
+  "title": "Delete a scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_Execute.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_Execute.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678/runs/abcd1234-5678-90ab-cdef-1234567890ab?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "ScenarioConfigurations_Execute",
+  "title": "Execute the scenario execution with the given scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_FixResourcePermissions.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_FixResourcePermissions.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678/permissionsFix/latest?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "ScenarioConfigurations_FixResourcePermissions",
+  "title": "Fixes resource permissions for the given scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_Get.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678",
+        "name": "config-5678-9012-3456-789012345678",
+        "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+        "properties": {
+          "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+          "parameters": [
+            {
+              "key": "duration",
+              "value": "PT10M"
+            },
+            {
+              "key": "targetResourceIds",
+              "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm1\",\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm2\"]"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "resourceTargeting": {
+            "include": {
+              "physicalZones": [
+                "westus2-az1"
+              ]
+            },
+            "exclude": {
+              "resources": [
+                "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+              ],
+              "tags": [
+                {
+                  "key": "environment",
+                  "value": "production"
+                }
+              ],
+              "types": [
+                "Microsoft.Compute/virtualMachineScaleSets"
+              ]
+            }
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T12:00:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioConfigurations_Get",
+  "title": "Get a scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_ListAll.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678",
+            "name": "config-5678-9012-3456-789012345678",
+            "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+            "properties": {
+              "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+              "parameters": [
+                {
+                  "key": "duration",
+                  "value": "PT10M"
+                },
+                {
+                  "key": "targetResourceIds",
+                  "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm1\",\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm2\"]"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "resourceTargeting": {
+                "exclude": {
+                  "resources": [
+                    "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/protectedVM"
+                  ],
+                  "tags": [
+                    {
+                      "key": "environment",
+                      "value": "production"
+                    }
+                  ],
+                  "types": [
+                    "Microsoft.Compute/virtualMachineScaleSets"
+                  ]
+                }
+              }
+            },
+            "systemData": {
+              "createdAt": "2025-01-15T10:30:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-15T12:00:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-abcd-1234-5678-901234567890",
+            "name": "config-abcd-1234-5678-901234567890",
+            "type": "Microsoft.Chaos/workspaces/scenarios/configurations",
+            "properties": {
+              "scenarioId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012",
+              "parameters": [
+                {
+                  "key": "duration",
+                  "value": "PT5M"
+                },
+                {
+                  "key": "targetResourceIds",
+                  "value": "[\"/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/vm3\"]"
+                }
+              ],
+              "provisioningState": "Creating"
+            },
+            "systemData": {
+              "createdAt": "2025-01-20T09:00:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-20T09:00:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ],
+        "nextLink": null
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioConfigurations_ListAll",
+  "title": "Get a list of scenario configurations."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_Validate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioConfigurations_Validate.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/configurations/config-5678-9012-3456-789012345678/validations/latest?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "ScenarioConfigurations_Validate",
+  "title": "Validate the given scenario configuration."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioRuns_Cancel.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioRuns_Cancel.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "runId": "abcd1234-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/runs/abcd1234-5678-9012-3456-789012345678?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "ScenarioRuns_Cancel",
+  "title": "Cancel a running scenario run."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioRuns_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioRuns_Get.json
@@ -1,0 +1,127 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "runId": "abcd1234-5678-9012-3456-789012345678",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/exampleScenario/runs/abcd1234-5678-9012-3456-789012345678",
+        "name": "abcd1234-5678-9012-3456-789012345678",
+        "type": "Microsoft.Chaos/workspaces/scenarios/runs",
+        "properties": {
+          "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+          "scenarioName": "12345678-1234-1234-1234-123456789012",
+          "workspaceName": "exampleWorkspace",
+          "managedIdentityPrincipalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "status": "Succeeded",
+          "resources": [
+            {
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM1"
+            },
+            {
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM2"
+            }
+          ],
+          "excludedResources": [
+            {
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM3"
+            }
+          ],
+          "scenarioRunJson": "{\"experiment\":{\"steps\":[{\"name\":\"step1\",\"branches\":[{\"name\":\"branch1\",\"actions\":[{\"name\":\"urn:csci:provider:microsoft:VirtualMachine_Shutdown/1.0\",\"type\":\"continuous\",\"duration\":\"PT10M\",\"selectorId\":\"selector1\"}]}]}]}}",
+          "scenarioRunSummary": [
+            {
+              "actionUrn": "urn:csci:provider:microsoft:VirtualMachine_Shutdown/1.0",
+              "state": "Succeeded",
+              "startedAt": "2025-01-20T14:30:00.000Z",
+              "completedAt": "2025-01-20T14:40:00.000Z",
+              "resources": [
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM1"
+                },
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM2"
+                }
+              ]
+            }
+          ],
+          "startTime": "2025-01-20T14:30:00.000Z",
+          "endTime": "2025-01-20T14:40:00.000Z",
+          "resourceSnapshotId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+          "zoneResolution": {
+            "mode": "physical",
+            "requestedPhysicalZones": [
+              "westus2-az1"
+            ],
+            "subscriptionZoneMappings": [
+              {
+                "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+                "zoneMappings": [
+                  {
+                    "physicalZone": "westus2-az1",
+                    "logicalZone": "1"
+                  }
+                ]
+              },
+              {
+                "subscriptionId": "a1b2c3d4-5678-9012-3456-abcdef012345",
+                "zoneMappings": [
+                  {
+                    "physicalZone": "westus2-az1",
+                    "logicalZone": "3"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-20T14:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-20T14:40:00.000Z",
+          "lastModifiedBy": "system",
+          "lastModifiedByType": "Application"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/exampleScenario/runs/abcd1234-5678-9012-3456-789012345678",
+        "name": "abcd1234-5678-9012-3456-789012345678",
+        "type": "Microsoft.Chaos/workspaces/scenarios/runs",
+        "properties": {
+          "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+          "scenarioName": "12345678-1234-1234-1234-123456789012",
+          "workspaceName": "exampleWorkspace",
+          "managedIdentityPrincipalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+          "status": "Running",
+          "resources": [
+            {
+              "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM1"
+            }
+          ],
+          "startTime": "2025-01-20T14:30:00.000Z",
+          "resourceSnapshotId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        },
+        "systemData": {
+          "createdAt": "2025-01-20T14:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-20T14:30:00.000Z",
+          "lastModifiedBy": "system",
+          "lastModifiedByType": "Application"
+        }
+      },
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/runs/abcd1234-5678-9012-3456-789012345678?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "ScenarioRuns_Get",
+  "title": "Get a scenario run."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioRuns_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/ScenarioRuns_ListAll.json
@@ -1,0 +1,103 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "12345678-1234-1234-1234-123456789012",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/12345678-1234-1234-1234-123456789012/runs/abcd1234-5678-9012-3456-789012345678",
+            "name": "abcd1234-5678-9012-3456-789012345678",
+            "type": "Microsoft.Chaos/workspaces/scenarios/runs",
+            "properties": {
+              "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+              "scenarioName": "12345678-1234-1234-1234-123456789012",
+              "workspaceName": "exampleWorkspace",
+              "managedIdentityPrincipalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+              "status": "Succeeded",
+              "resources": [
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM1"
+                }
+              ],
+              "excludedResources": [
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM3"
+                }
+              ],
+              "startTime": "2025-01-20T14:30:00.000Z",
+              "endTime": "2025-01-20T14:40:00.000Z"
+            },
+            "systemData": {
+              "createdAt": "2025-01-20T14:30:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-20T14:40:00.000Z",
+              "lastModifiedBy": "system",
+              "lastModifiedByType": "Application"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/exampleScenario/runs/efgh5678-9012-3456-7890-123456789012",
+            "name": "efgh5678-9012-3456-7890-123456789012",
+            "type": "Microsoft.Chaos/workspaces/scenarios/runs",
+            "properties": {
+              "scenarioConfigurationName": "config-5678-9012-3456-789012345678",
+              "scenarioName": "12345678-1234-1234-1234-123456789012",
+              "workspaceName": "exampleWorkspace",
+              "managedIdentityPrincipalId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+              "status": "Failed",
+              "resources": [
+                {
+                  "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM2"
+                }
+              ],
+              "executionErrors": {
+                "permission": [
+                  {
+                    "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM2",
+                    "missingPermissions": [
+                      "Microsoft.Compute/virtualMachines/restart/action"
+                    ],
+                    "requiredPermissions": [
+                      "Microsoft.Compute/virtualMachines/restart/action",
+                      "Microsoft.Compute/virtualMachines/read"
+                    ],
+                    "recommendedRoles": [
+                      "Virtual Machine Contributor"
+                    ],
+                    "identity": {
+                      "objectId": "d04ab567-2c07-43ef-a7f4-4527626b7f56",
+                      "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+                    },
+                    "errorMessage": "The workspace managed identity is missing the required permissions to run this action on the target resource."
+                  }
+                ],
+                "resource": []
+              },
+              "startTime": "2025-01-19T10:15:00.000Z",
+              "endTime": "2025-01-19T10:18:00.000Z"
+            },
+            "systemData": {
+              "createdAt": "2025-01-19T10:15:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-19T10:18:00.000Z",
+              "lastModifiedBy": "system",
+              "lastModifiedByType": "Application"
+            }
+          }
+        ],
+        "nextLink": null
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ScenarioRuns_ListAll",
+  "title": "Get a list of scenario runs."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Scenarios_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Scenarios_CreateOrUpdate.json
@@ -1,0 +1,285 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "zoneDownScenario",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "resource": {
+      "properties": {
+        "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
+        "parameters": [
+          {
+            "name": "duration",
+            "type": "string",
+            "default": "PT15M",
+            "required": false,
+            "description": "The duration of the outage scenario."
+          },
+          {
+            "name": "customRunbook1ResourceId",
+            "type": "string",
+            "required": false,
+            "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+          },
+          {
+            "name": "customRunbook1ParametersJson",
+            "type": "string",
+            "required": false,
+            "default": "{}",
+            "description": "Optional custom runbook 1 parameters in JSON format."
+          }
+        ],
+        "actions": [
+          {
+            "name": "vmssZoneDown",
+            "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+            "description": "Force shutdown VMSS instances in target zone",
+            "duration": "%%{parameters.duration}%%",
+            "parameters": [
+              {
+                "key": "zones",
+                "value": "%%{filters.zones}%%"
+              }
+            ]
+          },
+          {
+            "name": "vmZoneDown",
+            "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+            "description": "Force shutdown VM instances in target zone",
+            "duration": "%%{parameters.duration}%%",
+            "parameters": [
+              {
+                "key": "zones",
+                "value": "%%{filters.zones}%%"
+              }
+            ]
+          },
+          {
+            "name": "redisFailover",
+            "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+            "description": "Force failover of Redis instances to simulate backend zonal outage",
+            "duration": "PT5M",
+            "parameters": [
+              {
+                "key": "RebootType",
+                "value": "PrimaryNode"
+              }
+            ]
+          },
+          {
+            "name": "custom-runbook-1",
+            "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+            "description": "Custom Runbook 1",
+            "duration": "PT30M",
+            "parameters": [
+              {
+                "key": "RunbookParameters",
+                "value": "%%{parameters.customRunbook1ParametersJson}%%"
+              }
+            ],
+            "externalResource": {
+              "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Automation/automationAccounts/exampleAutomationAccount/runbooks/exampleRunbook"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
+        "type": "Microsoft.Chaos/workspaces/scenarios",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
+          "parameters": [
+            {
+              "name": "duration",
+              "type": "string",
+              "default": "PT15M",
+              "required": false,
+              "description": "The duration of the outage scenario."
+            },
+            {
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
+            }
+          ],
+          "actions": [
+            {
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
+              "duration": "PT5M",
+              "parameters": [
+                {
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
+                }
+              ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Automation/automationAccounts/exampleAutomationAccount/runbooks/exampleRunbook"
+              }
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
+        "type": "Microsoft.Chaos/workspaces/scenarios",
+        "properties": {
+          "provisioningState": "Creating",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
+          "parameters": [
+            {
+              "name": "duration",
+              "type": "string",
+              "default": "PT15M",
+              "required": false,
+              "description": "The duration of the outage scenario."
+            },
+            {
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
+            }
+          ],
+          "actions": [
+            {
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
+              "duration": "PT5M",
+              "parameters": [
+                {
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
+                }
+              ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Automation/automationAccounts/exampleAutomationAccount/runbooks/exampleRunbook"
+              }
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2025-01-15T10:30:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Scenarios_CreateOrUpdate",
+  "title": "Create or update a scenario."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Scenarios_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Scenarios_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "myVMShutdownScenario",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Scenarios_Delete",
+  "title": "Delete a Scenario in a workspace."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Scenarios_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Scenarios_Get.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "scenarioName": "zoneDownScenario",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+        "name": "zoneDownScenario",
+        "type": "Microsoft.Chaos/workspaces/scenarios",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "version": "1.0",
+          "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
+          "parameters": [
+            {
+              "name": "duration",
+              "type": "string",
+              "default": "PT15M",
+              "required": false,
+              "description": "The duration of the outage scenario."
+            },
+            {
+              "name": "customRunbook1ResourceId",
+              "type": "string",
+              "required": false,
+              "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+            },
+            {
+              "name": "customRunbook1ParametersJson",
+              "type": "string",
+              "required": false,
+              "default": "{}",
+              "description": "Optional custom runbook 1 parameters in JSON format."
+            }
+          ],
+          "actions": [
+            {
+              "name": "vmssZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VMSS instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "vmZoneDown",
+              "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+              "description": "Force shutdown VM instances in target zone",
+              "duration": "%%{parameters.duration}%%",
+              "parameters": [
+                {
+                  "key": "zones",
+                  "value": "%%{filters.zones}%%"
+                }
+              ]
+            },
+            {
+              "name": "redisFailover",
+              "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+              "description": "Force failover of Redis instances to simulate backend zonal outage",
+              "duration": "PT5M",
+              "parameters": [
+                {
+                  "key": "RebootType",
+                  "value": "PrimaryNode"
+                }
+              ]
+            },
+            {
+              "name": "custom-runbook-1",
+              "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+              "description": "Custom Runbook 1",
+              "duration": "PT30M",
+              "parameters": [
+                {
+                  "key": "RunbookParameters",
+                  "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                }
+              ],
+              "externalResource": {
+                "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Automation/automationAccounts/exampleAutomationAccount/runbooks/exampleRunbook"
+              }
+            }
+          ],
+          "recommendation": {
+            "recommendationStatus": "Recommended",
+            "evaluationRunAt": "2025-01-15T10:30:00.000Z"
+          }
+        },
+        "systemData": {
+          "createdAt": "2025-01-01T00:00:00.000Z",
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Scenarios_Get",
+  "title": "Get a scenario."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Scenarios_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Scenarios_ListAll.json
@@ -1,0 +1,168 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/zoneDownScenario",
+            "name": "zoneDownScenario",
+            "type": "Microsoft.Chaos/workspaces/scenarios",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "version": "1.0",
+              "description": "Induces an outage of all discovered VM and VMSS instances in the target zone with an option to invoke custom scripted actions using Automation Runbooks. Additionally, it forces failover of discovered Redis instances to simulate backend zonal outage.",
+              "parameters": [
+                {
+                  "name": "duration",
+                  "type": "string",
+                  "default": "PT15M",
+                  "required": false,
+                  "description": "The duration of the outage scenario."
+                },
+                {
+                  "name": "customRunbook1ResourceId",
+                  "type": "string",
+                  "required": false,
+                  "description": "Optional custom runbook 1 resource ID. If not provided, this action will be skipped."
+                },
+                {
+                  "name": "customRunbook1ParametersJson",
+                  "type": "string",
+                  "required": false,
+                  "default": "{}",
+                  "description": "Optional custom runbook 1 parameters in JSON format."
+                }
+              ],
+              "actions": [
+                {
+                  "name": "vmssZoneDown",
+                  "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+                  "description": "Force shutdown VMSS instances in target zone",
+                  "duration": "%%{parameters.duration}%%",
+                  "parameters": [
+                    {
+                      "key": "zones",
+                      "value": "%%{filters.zones}%%"
+                    }
+                  ]
+                },
+                {
+                  "name": "vmZoneDown",
+                  "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
+                  "description": "Force shutdown VM instances in target zone",
+                  "duration": "%%{parameters.duration}%%",
+                  "parameters": [
+                    {
+                      "key": "zones",
+                      "value": "%%{filters.zones}%%"
+                    }
+                  ]
+                },
+                {
+                  "name": "redisFailover",
+                  "actionId": "urn:csci:microsoft:azureClusteredCacheForRedis:Reboot/1.0.0",
+                  "description": "Force failover of Redis instances to simulate backend zonal outage",
+                  "duration": "PT5M",
+                  "parameters": [
+                    {
+                      "key": "RebootType",
+                      "value": "PrimaryNode"
+                    }
+                  ]
+                },
+                {
+                  "name": "custom-runbook-1",
+                  "actionId": "urn:csci:microsoft:Automation:StartRunbook/1.0.0",
+                  "description": "Custom Runbook 1",
+                  "duration": "PT30M",
+                  "parameters": [
+                    {
+                      "key": "RunbookParameters",
+                      "value": "%%{parameters.customRunbook1ParametersJson}%%"
+                    }
+                  ],
+                  "externalResource": {
+                    "resourceId": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Automation/automationAccounts/exampleAutomationAccount/runbooks/exampleRunbook"
+                  }
+                }
+              ],
+              "recommendation": {
+                "recommendationStatus": "Recommended",
+                "evaluationRunAt": "2025-01-15T10:30:00.000Z"
+              }
+            },
+            "systemData": {
+              "createdAt": "2025-01-01T00:00:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-15T10:30:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/scenarios/networkLatencyScenario",
+            "name": "networkLatencyScenario",
+            "type": "Microsoft.Chaos/workspaces/scenarios",
+            "properties": {
+              "provisioningState": "Succeeded",
+              "version": "1.1.0",
+              "description": "Introduces network latency to simulate poor network conditions and test application performance under network stress.",
+              "parameters": [
+                {
+                  "name": "duration",
+                  "type": "string",
+                  "default": "PT10M",
+                  "required": false,
+                  "description": "The duration of the network latency injection."
+                },
+                {
+                  "name": "latencyMs",
+                  "type": "number",
+                  "default": "100",
+                  "required": false,
+                  "description": "Latency to inject in milliseconds."
+                }
+              ],
+              "actions": [
+                {
+                  "name": "injectLatency",
+                  "actionId": "urn:csci:microsoft:network:injectLatency/1.0.0",
+                  "description": "Inject network latency to test performance",
+                  "duration": "%%{parameters.duration}%%",
+                  "parameters": [
+                    {
+                      "key": "latencyMs",
+                      "value": "%%{parameters.latencyMs}%%"
+                    }
+                  ]
+                }
+              ],
+              "recommendation": {
+                "recommendationStatus": "NotApplicable"
+              }
+            },
+            "systemData": {
+              "createdAt": "2024-12-15T00:00:00.000Z",
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2025-01-10T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ],
+        "nextLink": null
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Scenarios_ListAll",
+  "title": "Get a list of scenarios."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/TargetTypes_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/TargetTypes_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetTypeName": "Microsoft-Agent"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Microsoft-Agent",
+        "type": "Microsoft.Chaos/locations/targetTypes",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes/Microsoft-Agent",
+        "properties": {
+          "description": "A target represents Chaos Agent.",
+          "displayName": "Chaos Agent",
+          "propertiesSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine.json",
+          "resourceTypes": [
+            "Microsoft.Compute/virtualMachines",
+            "Microsoft.Compute/virtualMachineScaleSets"
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "TargetTypes_Get",
+  "title": "Get a Target Type for westus2 location"
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/TargetTypes_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/TargetTypes_List.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "location": "westus2",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "Microsoft-Agent",
+            "type": "Microsoft.Chaos/locations/targetTypes",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/locations/westus2/targetTypes/Microsoft-Agent",
+            "properties": {
+              "description": "A target represents Chaos Agent.",
+              "displayName": "Chaos Agent",
+              "propertiesSchema": "https://schema.centralus.chaos-prod.azure.com/targets/Microsoft-VirtualMachine.json",
+              "resourceTypes": [
+                "Microsoft.Compute/virtualMachines",
+                "Microsoft.Compute/virtualMachineScaleSets"
+              ]
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "TargetTypes_List",
+  "title": "List all Target Types for westus2 location."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Targets_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Targets_CreateOrUpdate.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "resource": {
+      "properties": {}
+    },
+    "targetName": "Microsoft-VirtualMachine"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Microsoft-VirtualMachine",
+        "type": "Microsoft.Chaos/targets",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine",
+        "properties": {},
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "Microsoft-VirtualMachine",
+        "type": "Microsoft.Chaos/targets",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-VirtualMachine",
+        "properties": {},
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Targets_CreateOrUpdate",
+  "title": "Create/update a Target that extends a virtual machine resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Targets_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Targets_Delete.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-Agent"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Targets_Delete",
+  "title": "Delete a Target that extends a virtual machine resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Targets_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Targets_Get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291",
+    "targetName": "Microsoft-Agent"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Microsoft-Agent",
+        "type": "Microsoft.Chaos/targets",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-Agent",
+        "location": "centraluseuap",
+        "properties": {
+          "agentProfileId": "ac4e8251-fdc9-4277-8e87-dc57fe5794cf",
+          "identities": [
+            {
+              "type": "CertificateSubjectIssuer",
+              "subject": "CN=example.subject"
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Targets_Get",
+  "title": "Get a Target that extends a virtual machine resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Targets_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Targets_List.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "parentProviderNamespace": "Microsoft.Compute",
+    "parentResourceName": "exampleVM",
+    "parentResourceType": "virtualMachines",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "Microsoft-Agent",
+            "type": "Microsoft.Chaos/targets",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Compute/virtualMachines/exampleVM/providers/Microsoft.Chaos/targets/Microsoft-Agent",
+            "location": "centraluseuap",
+            "properties": {
+              "agentProfileId": "ac4e8251-fdc9-4277-8e87-dc57fe5794cf",
+              "identities": [
+                {
+                  "type": "CertificateSubjectIssuer",
+                  "subject": "CN=example.subject"
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Targets_List",
+  "title": "List all Targets that extend a virtual machine resource."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_CreateOrUpdate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_CreateOrUpdate.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "resource": {
+      "properties": {
+        "scopes": [
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+        ]
+      },
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+        }
+      },
+      "location": "westus2",
+      "tags": {
+        "environment": "production",
+        "department": "engineering",
+        "project": "chaos-testing"
+      }
+    },
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleWorkspace",
+        "type": "Microsoft.Chaos/workspaces",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+          },
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "environment": "production",
+          "department": "engineering",
+          "project": "chaos-testing"
+        },
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "scopes": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationState/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace?api-version=2026-11-01"
+      }
+    },
+    "201": {
+      "body": {
+        "name": "exampleWorkspace",
+        "type": "Microsoft.Chaos/workspaces",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+          },
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "environment": "production",
+          "department": "engineering",
+          "project": "chaos-testing"
+        },
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Creating",
+          "scopes": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup",
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.Compute/virtualMachines/exampleVM"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationState/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Workspaces_CreateOrUpdate",
+  "title": "Create/update a workspace in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_Delete.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/eastus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Workspaces_Delete",
+  "title": "Delete a Workspace in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_Discover.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_Discover.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/discoveries/latest?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Workspaces_Discover",
+  "title": "Trigger resource discovery for the workspace."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_Evaluate.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_Evaluate.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace/evaluations/latest?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Workspaces_Evaluate",
+  "title": "Trigger scenario evaluation for the workspace."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_Get.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_Get.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleWorkspace",
+        "type": "Microsoft.Chaos/workspaces",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+          },
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "environment": "production",
+          "department": "engineering",
+          "project": "chaos-testing"
+        },
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "scopes": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Workspaces_Get",
+  "title": "Get a Workspace in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_List.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_List.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "exampleWorkspace",
+            "type": "Microsoft.Chaos/workspaces",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+              },
+              "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+            },
+            "tags": {
+              "environment": "production",
+              "department": "engineering",
+              "project": "chaos-testing"
+            },
+            "location": "westus2",
+            "properties": {
+              "provisioningState": "Updating",
+              "scopes": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+              ]
+            },
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "createdBy": "User",
+              "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedBy": "User",
+              "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Workspaces_List",
+  "title": "List all Workspaces in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_ListAll.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_ListAll.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "continuationToken": null,
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/providers/Microsoft.Chaos/workspaces?continuationToken=&api-version=2026-11-01",
+        "value": [
+          {
+            "name": "exampleWorkspace",
+            "type": "Microsoft.Chaos/workspaces",
+            "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+              },
+              "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+            },
+            "tags": {
+              "environment": "production",
+              "department": "engineering",
+              "project": "chaos-testing"
+            },
+            "location": "westus2",
+            "properties": {
+              "provisioningState": "Updating",
+              "scopes": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+              ]
+            },
+            "systemData": {
+              "createdAt": "2021-07-01T00:00:00.0Z",
+              "createdBy": "User",
+              "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+              "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+              "lastModifiedBy": "User",
+              "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Workspaces_ListAll",
+  "title": "List all Workspaces in a subscription."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_Update.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Workspaces_Update.json
@@ -1,0 +1,69 @@
+{
+  "parameters": {
+    "api-version": "2026-11-01",
+    "properties": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+        }
+      },
+      "tags": {
+        "environment": "production",
+        "department": "engineering",
+        "project": "chaos-testing"
+      }
+    },
+    "workspaceName": "exampleWorkspace",
+    "resourceGroupName": "exampleRG",
+    "subscriptionId": "6b052e15-03d3-4f17-b2e1-be7f07588291"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "exampleWorkspace",
+        "type": "Microsoft.Chaos/workspaces",
+        "id": "/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/exampleRG/providers/Microsoft.Chaos/workspaces/exampleWorkspace",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleIdentity": {}
+          },
+          "tenantId": "8c3e2fb2-fe7a-4bf1-b779-d73990782fe6"
+        },
+        "tags": {
+          "environment": "production",
+          "department": "engineering",
+          "project": "chaos-testing"
+        },
+        "location": "westus2",
+        "properties": {
+          "provisioningState": "Updating",
+          "scopes": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/exampleResourceGroup"
+          ]
+        },
+        "systemData": {
+          "createdAt": "2021-07-01T00:00:00.0Z",
+          "createdBy": "User",
+          "createdByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976",
+          "lastModifiedAt": "2021-07-01T00:00:00.0Z",
+          "lastModifiedBy": "User",
+          "lastModifiedByType": "b3a41dba-4415-4d36-9ee8-e5eaa86db976"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationStatus/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationStatuses/00000000-0000-0000-0000-000000000000?api-version=2026-11-01",
+        "location": "https://management.azure.com/subscriptions/6b052e15-03d3-4f17-b2e1-be7f07588291/resourceGroups/myResourceGroup/providers/Microsoft.Chaos/locations/westus2/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-11-01"
+      }
+    }
+  },
+  "operationId": "Workspaces_Update",
+  "title": "Update a Workspace in a resource group."
+}

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/openapi.json
@@ -1,0 +1,8232 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ChaosManagementClient",
+    "version": "2026-11-01",
+    "description": "Chaos Management Client",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Capabilities"
+    },
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "Targets"
+    },
+    {
+      "name": "CapabilityTypes"
+    },
+    {
+      "name": "Experiments"
+    },
+    {
+      "name": "ExperimentExecutions"
+    },
+    {
+      "name": "PrivateAccesses"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "Actions"
+    },
+    {
+      "name": "ActionVersions"
+    },
+    {
+      "name": "TargetTypes"
+    },
+    {
+      "name": "OperationStatuses"
+    },
+    {
+      "name": "Workspaces"
+    },
+    {
+      "name": "DiscoveredResources"
+    },
+    {
+      "name": "Scenarios"
+    },
+    {
+      "name": "ScenarioConfigurations"
+    },
+    {
+      "name": "ScenarioRuns"
+    },
+    {
+      "name": "Connections"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Chaos/operations": {
+      "get": {
+        "operationId": "Operations_ListAll",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Lists all Chaos Studio operations.": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/experiments": {
+      "get": {
+        "operationId": "Experiments_ListAll",
+        "tags": [
+          "Experiments"
+        ],
+        "description": "Get a list of Experiment resources in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "running",
+            "in": "query",
+            "description": "Optional value that indicates whether to filter results based on if the Experiment is currently running. If null, then the results will not be filtered.",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExperimentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Experiments in a subscription.": {
+            "$ref": "./examples/Experiments_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/locations/{location}/actions": {
+      "get": {
+        "operationId": "Actions_List",
+        "tags": [
+          "Actions"
+        ],
+        "description": "Get a list of Action resources for a given location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ActionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Actions for westus2 location.": {
+            "$ref": "./examples/Actions_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/locations/{location}/actions/{actionName}": {
+      "get": {
+        "operationId": "Actions_Get",
+        "tags": [
+          "Actions"
+        ],
+        "description": "Get an Action resource for a given location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "actionName",
+            "in": "path",
+            "description": "String that represents an Action resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9\\-]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Action"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get an Action for westus2 location": {
+            "$ref": "./examples/Actions_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/locations/{location}/actions/{actionName}/versions": {
+      "get": {
+        "operationId": "ActionVersions_List",
+        "tags": [
+          "ActionVersions"
+        ],
+        "description": "Get a list of Action Version resources for a given location and action.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "actionName",
+            "in": "path",
+            "description": "String that represents an Action resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9\\-]+$"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ActionVersionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Action Versions for a given action.": {
+            "$ref": "./examples/ActionVersions_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/locations/{location}/actions/{actionName}/versions/{versionName}": {
+      "get": {
+        "operationId": "ActionVersions_Get",
+        "tags": [
+          "ActionVersions"
+        ],
+        "description": "Get an Action Version resource for a given location and action.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "actionName",
+            "in": "path",
+            "description": "String that represents an Action resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9\\-]+$"
+          },
+          {
+            "name": "versionName",
+            "in": "path",
+            "description": "String that represents an Action Version resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9\\.]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ActionVersion"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get an Action Version for westus2 location": {
+            "$ref": "./examples/ActionVersions_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/locations/{location}/operationStatuses/{operationId}": {
+      "get": {
+        "operationId": "OperationStatuses_Get",
+        "tags": [
+          "OperationStatuses"
+        ],
+        "description": "Returns the current status of an async operation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/OperationIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/OperationStatusResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Gets Chaos Studio async operation status.": {
+            "$ref": "./examples/OperationStatuses_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/locations/{location}/targetTypes": {
+      "get": {
+        "operationId": "TargetTypes_List",
+        "tags": [
+          "TargetTypes"
+        ],
+        "description": "Get a list of Target Type resources for given location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/TargetTypeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Target Types for westus2 location.": {
+            "$ref": "./examples/TargetTypes_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/locations/{location}/targetTypes/{targetTypeName}": {
+      "get": {
+        "operationId": "TargetTypes_Get",
+        "tags": [
+          "TargetTypes"
+        ],
+        "description": "Get a Target Type resources for given location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "targetTypeName",
+            "in": "path",
+            "description": "String that represents a Target Type resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TargetType"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Target Type for westus2 location": {
+            "$ref": "./examples/TargetTypes_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/locations/{location}/targetTypes/{targetTypeName}/capabilityTypes": {
+      "get": {
+        "operationId": "CapabilityTypes_List",
+        "tags": [
+          "CapabilityTypes"
+        ],
+        "description": "Get a list of Capability Type resources for given Target Type and location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "targetTypeName",
+            "in": "path",
+            "description": "String that represents a Target Type resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CapabilityTypeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Capability Types for a virtual machine Target resource on westus2 location.": {
+            "$ref": "./examples/CapabilityTypes_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/locations/{location}/targetTypes/{targetTypeName}/capabilityTypes/{capabilityTypeName}": {
+      "get": {
+        "operationId": "CapabilityTypes_Get",
+        "tags": [
+          "CapabilityTypes"
+        ],
+        "description": "Get a Capability Type resource for given Target Type and location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "targetTypeName",
+            "in": "path",
+            "description": "String that represents a Target Type resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+          },
+          {
+            "name": "capabilityTypeName",
+            "in": "path",
+            "description": "String that represents a Capability Type resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9\\-\\.]+-\\d\\.\\d$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CapabilityType"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Capability Type for a virtual machine Target resource on westus2 location.": {
+            "$ref": "./examples/CapabilityTypes_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/privateAccesses": {
+      "get": {
+        "operationId": "PrivateAccesses_ListAll",
+        "tags": [
+          "PrivateAccesses"
+        ],
+        "description": "Get a list of private access resources in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PrivateAccessListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all private accesses in a subscription.": {
+            "$ref": "./examples/PrivateAccesses_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Chaos/workspaces": {
+      "get": {
+        "operationId": "Workspaces_ListAll",
+        "tags": [
+          "Workspaces"
+        ],
+        "description": "Get a list of all Workspace resources in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/WorkspaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Workspaces in a subscription.": {
+            "$ref": "./examples/Workspaces_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{parentProviderNamespace}/{parentResourceType}/{parentResourceName}/providers/Microsoft.Chaos/targets": {
+      "get": {
+        "operationId": "Targets_List",
+        "tags": [
+          "Targets"
+        ],
+        "description": "Get a list of Target resources that extend a tracked regional resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentProviderNamespace",
+            "in": "path",
+            "description": "The parent resource provider namespace.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The parent resource type.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The parent resource name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/TargetListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Targets that extend a virtual machine resource.": {
+            "$ref": "./examples/Targets_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{parentProviderNamespace}/{parentResourceType}/{parentResourceName}/providers/Microsoft.Chaos/targets/{targetName}": {
+      "get": {
+        "operationId": "Targets_Get",
+        "tags": [
+          "Targets"
+        ],
+        "description": "Get a Target resource that extends a tracked regional resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentProviderNamespace",
+            "in": "path",
+            "description": "The parent resource provider namespace.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The parent resource type.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The parent resource name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "targetName",
+            "in": "path",
+            "description": "String that represents a Target resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Target"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Target that extends a virtual machine resource.": {
+            "$ref": "./examples/Targets_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Targets_CreateOrUpdate",
+        "tags": [
+          "Targets"
+        ],
+        "description": "Create or update a Target resource that extends a tracked regional resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentProviderNamespace",
+            "in": "path",
+            "description": "The parent resource provider namespace.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The parent resource type.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The parent resource name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "targetName",
+            "in": "path",
+            "description": "String that represents a Target resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Target resource to be created or updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Target"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Target' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Target"
+            }
+          },
+          "201": {
+            "description": "Resource 'Target' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Target"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create/update a Target that extends a virtual machine resource.": {
+            "$ref": "./examples/Targets_CreateOrUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Targets_Delete",
+        "tags": [
+          "Targets"
+        ],
+        "description": "Delete a Target resource that extends a tracked regional resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentProviderNamespace",
+            "in": "path",
+            "description": "The parent resource provider namespace.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The parent resource type.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The parent resource name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "targetName",
+            "in": "path",
+            "description": "String that represents a Target resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a Target that extends a virtual machine resource.": {
+            "$ref": "./examples/Targets_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{parentProviderNamespace}/{parentResourceType}/{parentResourceName}/providers/Microsoft.Chaos/targets/{targetName}/capabilities": {
+      "get": {
+        "operationId": "Capabilities_List",
+        "tags": [
+          "Capabilities"
+        ],
+        "description": "Get a list of Capability resources that extend a Target resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentProviderNamespace",
+            "in": "path",
+            "description": "The parent resource provider namespace.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The parent resource type.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The parent resource name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "targetName",
+            "in": "path",
+            "description": "String that represents a Target resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CapabilityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Capabilities that extend a virtual machine Target resource.": {
+            "$ref": "./examples/Capabilities_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{parentProviderNamespace}/{parentResourceType}/{parentResourceName}/providers/Microsoft.Chaos/targets/{targetName}/capabilities/{capabilityName}": {
+      "get": {
+        "operationId": "Capabilities_Get",
+        "tags": [
+          "Capabilities"
+        ],
+        "description": "Get a Capability resource that extends a Target resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentProviderNamespace",
+            "in": "path",
+            "description": "The parent resource provider namespace.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The parent resource type.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The parent resource name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "targetName",
+            "in": "path",
+            "description": "String that represents a Target resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+          },
+          {
+            "name": "capabilityName",
+            "in": "path",
+            "description": "String that represents a Capability resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9\\-\\.]+-\\d\\.\\d$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Capability"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Capability that extends a virtual machine Target resource.": {
+            "$ref": "./examples/Capabilities_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Capabilities_CreateOrUpdate",
+        "tags": [
+          "Capabilities"
+        ],
+        "description": "Create or update a Capability resource that extends a Target resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentProviderNamespace",
+            "in": "path",
+            "description": "The parent resource provider namespace.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The parent resource type.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The parent resource name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "targetName",
+            "in": "path",
+            "description": "String that represents a Target resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+          },
+          {
+            "name": "capabilityName",
+            "in": "path",
+            "description": "String that represents a Capability resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9\\-\\.]+-\\d\\.\\d$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Capability resource to be created or updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Capability"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Capability' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Capability"
+            }
+          },
+          "201": {
+            "description": "Resource 'Capability' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Capability"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create/update a Capability that extends a virtual machine Target resource.": {
+            "$ref": "./examples/Capabilities_CreateOrUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Capabilities_Delete",
+        "tags": [
+          "Capabilities"
+        ],
+        "description": "Delete a Capability that extends a Target resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "parentProviderNamespace",
+            "in": "path",
+            "description": "The parent resource provider namespace.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceType",
+            "in": "path",
+            "description": "The parent resource type.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "parentResourceName",
+            "in": "path",
+            "description": "The parent resource name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-_.]{2,62}$"
+          },
+          {
+            "name": "targetName",
+            "in": "path",
+            "description": "String that represents a Target resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\-\\.]+$"
+          },
+          {
+            "name": "capabilityName",
+            "in": "path",
+            "description": "String that represents a Capability resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9\\-\\.]+-\\d\\.\\d$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a Capability that extends a virtual machine Target resource.": {
+            "$ref": "./examples/Capabilities_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments": {
+      "get": {
+        "operationId": "Experiments_List",
+        "tags": [
+          "Experiments"
+        ],
+        "description": "Get a list of Experiment resources in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "running",
+            "in": "query",
+            "description": "Optional value that indicates whether to filter results based on if the Experiment is currently running. If null, then the results will not be filtered.",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExperimentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Experiments in a resource group.": {
+            "$ref": "./examples/Experiments_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}": {
+      "get": {
+        "operationId": "Experiments_Get",
+        "tags": [
+          "Experiments"
+        ],
+        "description": "Get a Experiment resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "experimentName",
+            "in": "path",
+            "description": "String that represents a Experiment resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Experiment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Experiment in a resource group.": {
+            "$ref": "./examples/Experiments_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Experiments_CreateOrUpdate",
+        "tags": [
+          "Experiments"
+        ],
+        "description": "Create or update a Experiment resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "experimentName",
+            "in": "path",
+            "description": "String that represents a Experiment resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Experiment resource to be created or updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Experiment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Experiment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Experiment"
+            }
+          },
+          "201": {
+            "description": "Resource 'Experiment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Experiment"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create/update a Experiment in a resource group.": {
+            "$ref": "./examples/Experiments_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Experiments_Update",
+        "tags": [
+          "Experiments"
+        ],
+        "description": "Update an experiment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "experimentName",
+            "in": "path",
+            "description": "String that represents a Experiment resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "Parameters supplied to the Update experiment operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExperimentUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Experiment"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update an Experiment in a resource group.": {
+            "$ref": "./examples/Experiments_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Experiments_Delete",
+        "tags": [
+          "Experiments"
+        ],
+        "description": "Delete a Experiment resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "experimentName",
+            "in": "path",
+            "description": "String that represents a Experiment resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a Experiment in a resource group.": {
+            "$ref": "./examples/Experiments_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}/cancel": {
+      "post": {
+        "operationId": "Experiments_Cancel",
+        "tags": [
+          "Experiments"
+        ],
+        "description": "Cancel a running Experiment resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "experimentName",
+            "in": "path",
+            "description": "String that represents a Experiment resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Cancel a running Experiment.": {
+            "$ref": "./examples/Experiments_Cancel.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}/executions": {
+      "get": {
+        "operationId": "Experiments_ListAllExecutions",
+        "tags": [
+          "ExperimentExecutions"
+        ],
+        "description": "Get a list of executions of an Experiment resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "experimentName",
+            "in": "path",
+            "description": "String that represents a Experiment resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExperimentExecutionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all executions of an Experiment.": {
+            "$ref": "./examples/Experiments_ListAllExecutions.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}/executions/{executionId}": {
+      "get": {
+        "operationId": "Experiments_GetExecution",
+        "tags": [
+          "ExperimentExecutions"
+        ],
+        "description": "Get an execution of an Experiment resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "experimentName",
+            "in": "path",
+            "description": "String that represents a Experiment resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "executionId",
+            "in": "path",
+            "description": "GUID that represents a Experiment execution detail.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExperimentExecution"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get the execution of a Experiment.": {
+            "$ref": "./examples/Experiments_GetExecution.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}/executions/{executionId}/getExecutionDetails": {
+      "post": {
+        "operationId": "Experiments_ExecutionDetails",
+        "tags": [
+          "ExperimentExecutions"
+        ],
+        "description": "Execution details of an experiment resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "experimentName",
+            "in": "path",
+            "description": "String that represents a Experiment resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "executionId",
+            "in": "path",
+            "description": "GUID that represents a Experiment execution detail.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExperimentExecutionDetails"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get experiment execution details.": {
+            "$ref": "./examples/Experiments_ExecutionDetails.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/experiments/{experimentName}/start": {
+      "post": {
+        "operationId": "Experiments_Start",
+        "tags": [
+          "Experiments"
+        ],
+        "description": "Start a Experiment resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "experimentName",
+            "in": "path",
+            "description": "String that represents a Experiment resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Start a Experiment.": {
+            "$ref": "./examples/Experiments_Start.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/privateAccesses": {
+      "get": {
+        "operationId": "PrivateAccesses_List",
+        "tags": [
+          "PrivateAccesses"
+        ],
+        "description": "Get a list of private access resources in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PrivateAccessListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all private access in a resource group.": {
+            "$ref": "./examples/PrivateAccesses_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/privateAccesses/{privateAccessName}": {
+      "get": {
+        "operationId": "PrivateAccesses_Get",
+        "tags": [
+          "PrivateAccesses"
+        ],
+        "description": "Get a private access resource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateAccessName",
+            "in": "path",
+            "description": "The name of the private access resource that is being created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateAccess"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a private access resource": {
+            "$ref": "./examples/PrivateAccesses_Get_Get_A_Private_Access_Resource.json"
+          },
+          "Get a private access resource with private endpoint": {
+            "$ref": "./examples/PrivateAccesses_Get_Get_A_Private_Access_Resource_With_Private_Endpoint.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateAccesses_CreateOrUpdate",
+        "tags": [
+          "PrivateAccesses"
+        ],
+        "description": "Create or update a private access",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateAccessName",
+            "in": "path",
+            "description": "The name of the private access resource that is being created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "private access resource to be created or updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateAccess"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateAccess' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateAccess"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateAccess' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateAccess"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update a private access resource": {
+            "$ref": "./examples/PrivateAccesses_CreateOrUpdate_Create_Or_Update_A_Private_Access_Resource.json"
+          },
+          "Create or Update a private access resource with publicNetworkAccess": {
+            "$ref": "./examples/PrivateAccesses_CreateOrUpdate_Create_Or_Update_A_Private_Access_Resource_With_Public_Network_Access.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PrivateAccesses_Update",
+        "tags": [
+          "PrivateAccesses"
+        ],
+        "description": "Patch a private access tags",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateAccessName",
+            "in": "path",
+            "description": "The name of the private access resource that is being created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "private access resource's tags to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateAccessPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateAccess"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update a private access resource's tags": {
+            "$ref": "./examples/PrivateAccesses_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PrivateAccesses_Delete",
+        "tags": [
+          "PrivateAccesses"
+        ],
+        "description": "Delete a private access",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateAccessName",
+            "in": "path",
+            "description": "The name of the private access resource that is being created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a private access resource": {
+            "$ref": "./examples/PrivateAccesses_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/privateAccesses/{privateAccessName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateAccesses_ListPrivateEndpointConnections",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "List information about private endpoint connections under a private access resource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateAccessName",
+            "in": "path",
+            "description": "The name of the private access resource that is being created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all private endpoint connections under a private access resource.": {
+            "$ref": "./examples/PrivateAccesses_ListPrivateEndpointConnections.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/privateAccesses/{privateAccessName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateAccesses_GetAPrivateEndpointConnection",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets information about a private endpoint connection under a private access resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateAccessName",
+            "in": "path",
+            "description": "The name of the private access resource that is being created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get information about a private endpoint connection under a private access resource.": {
+            "$ref": "./examples/PrivateAccesses_GetAPrivateEndpointConnection.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PrivateAccesses_DeleteAPrivateEndpointConnection",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Deletes a private endpoint connection under a private access resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateAccessName",
+            "in": "path",
+            "description": "The name of the private access resource that is being created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a private endpoint connection under a private access resource.": {
+            "$ref": "./examples/PrivateAccesses_DeleteAPrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/privateAccesses/{privateAccessName}/privateLinkResources": {
+      "get": {
+        "operationId": "PrivateAccesses_GetPrivateLinkResources",
+        "tags": [
+          "PrivateAccesses"
+        ],
+        "description": "Gets the private link resources possible under private access resource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateAccessName",
+            "in": "path",
+            "description": "The name of the private access resource that is being created. Supported characters for the name are a-z, A-Z, 0-9, _ and -. The maximum name length is 80 characters.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all possible private link resources under private access resource.": {
+            "$ref": "./examples/PrivateAccesses_GetPrivateLinkResources.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces": {
+      "get": {
+        "operationId": "Workspaces_List",
+        "tags": [
+          "Workspaces"
+        ],
+        "description": "Get a list of Workspace resources in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "continuationToken",
+            "in": "query",
+            "description": "String that sets the continuation token.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/WorkspaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all Workspaces in a resource group.": {
+            "$ref": "./examples/Workspaces_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}": {
+      "get": {
+        "operationId": "Workspaces_Get",
+        "tags": [
+          "Workspaces"
+        ],
+        "description": "Get a Workspace resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Workspace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Workspace in a resource group.": {
+            "$ref": "./examples/Workspaces_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Workspaces_CreateOrUpdate",
+        "tags": [
+          "Workspaces"
+        ],
+        "description": "Create or update a Workspace resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Workspace resource to be created or updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Workspace"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Workspace' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Workspace"
+            }
+          },
+          "201": {
+            "description": "Resource 'Workspace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Workspace"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create/update a workspace in a resource group.": {
+            "$ref": "./examples/Workspaces_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Workspaces_Update",
+        "tags": [
+          "Workspaces"
+        ],
+        "description": "Update a Workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "Parameters supplied to the Update Workspace operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WorkspaceUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Workspace"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update a Workspace in a resource group.": {
+            "$ref": "./examples/Workspaces_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Workspaces_Delete",
+        "tags": [
+          "Workspaces"
+        ],
+        "description": "Delete a Workspace resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a Workspace in a resource group.": {
+            "$ref": "./examples/Workspaces_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/connections": {
+      "get": {
+        "operationId": "Connections_ListAll",
+        "tags": [
+          "Connections"
+        ],
+        "description": "Get a list of connections.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a list of connections.": {
+            "$ref": "./examples/Connections_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/connections/{connectionName}": {
+      "get": {
+        "operationId": "Connections_Get",
+        "tags": [
+          "Connections"
+        ],
+        "description": "Get a connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Name of the connection.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Connection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a connection.": {
+            "$ref": "./examples/Connections_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Connections_CreateOrUpdate",
+        "tags": [
+          "Connections"
+        ],
+        "description": "Create or update a connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Name of the connection.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Connection resource to be created or updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Connection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Connection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Connection"
+            }
+          },
+          "201": {
+            "description": "Resource 'Connection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Connection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update a connection.": {
+            "$ref": "./examples/Connections_CreateOrUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Connections_Delete",
+        "tags": [
+          "Connections"
+        ],
+        "description": "Delete a connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Name of the connection.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a connection in a workspace.": {
+            "$ref": "./examples/Connections_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/discover": {
+      "post": {
+        "operationId": "Workspaces_Discover",
+        "tags": [
+          "Workspaces"
+        ],
+        "description": "Triggers resource discovery for the workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Trigger resource discovery for the workspace.": {
+            "$ref": "./examples/Workspaces_Discover.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/discoveredResources": {
+      "get": {
+        "operationId": "DiscoveredResources_ListByWorkspace",
+        "tags": [
+          "DiscoveredResources"
+        ],
+        "description": "Get a list of discovered resources for a workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DiscoveredResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a list of discovered resources for a workspace.": {
+            "$ref": "./examples/DiscoveredResources_ListByWorkspace.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/discoveredResources/{discoveredResourceName}": {
+      "get": {
+        "operationId": "DiscoveredResources_Get",
+        "tags": [
+          "DiscoveredResources"
+        ],
+        "description": "Get a discovered resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "discoveredResourceName",
+            "in": "path",
+            "description": "Name of the discovered resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9-]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DiscoveredResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a discovered resource.": {
+            "$ref": "./examples/DiscoveredResources_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/evaluate": {
+      "post": {
+        "operationId": "Workspaces_Evaluate",
+        "tags": [
+          "Workspaces"
+        ],
+        "description": "Triggers scenario evaluation for the workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Trigger scenario evaluation for the workspace.": {
+            "$ref": "./examples/Workspaces_Evaluate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/scenarios": {
+      "get": {
+        "operationId": "Scenarios_ListAll",
+        "tags": [
+          "Scenarios"
+        ],
+        "description": "Get a list of scenarios.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ScenarioListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a list of scenarios.": {
+            "$ref": "./examples/Scenarios_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/scenarios/{scenarioName}": {
+      "get": {
+        "operationId": "Scenarios_Get",
+        "tags": [
+          "Scenarios"
+        ],
+        "description": "Get a scenario.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Scenario"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a scenario.": {
+            "$ref": "./examples/Scenarios_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Scenarios_CreateOrUpdate",
+        "tags": [
+          "Scenarios"
+        ],
+        "description": "Create or update a scenario.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Scenario"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Scenario' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Scenario"
+            }
+          },
+          "201": {
+            "description": "Resource 'Scenario' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Scenario"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update a scenario.": {
+            "$ref": "./examples/Scenarios_CreateOrUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Scenarios_Delete",
+        "tags": [
+          "Scenarios"
+        ],
+        "description": "Delete a scenario.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a Scenario in a workspace.": {
+            "$ref": "./examples/Scenarios_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/scenarios/{scenarioName}/configurations": {
+      "get": {
+        "operationId": "ScenarioConfigurations_ListAll",
+        "tags": [
+          "ScenarioConfigurations"
+        ],
+        "description": "Get a list of scenario definitions.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ScenarioConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a list of scenario configurations.": {
+            "$ref": "./examples/ScenarioConfigurations_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/scenarios/{scenarioName}/configurations/{scenarioConfigurationName}": {
+      "get": {
+        "operationId": "ScenarioConfigurations_Get",
+        "tags": [
+          "ScenarioConfigurations"
+        ],
+        "description": "Get a scenario definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioConfigurationName",
+            "in": "path",
+            "description": "Name of the scenario definition.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ScenarioConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a scenario configuration.": {
+            "$ref": "./examples/ScenarioConfigurations_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ScenarioConfigurations_CreateOrUpdate",
+        "tags": [
+          "ScenarioConfigurations"
+        ],
+        "description": "Create or update a scenario definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioConfigurationName",
+            "in": "path",
+            "description": "Name of the scenario definition.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ScenarioConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ScenarioConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ScenarioConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'ScenarioConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ScenarioConfiguration"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update a scenario configuration with physical zone targeting.": {
+            "$ref": "./examples/ScenarioConfigurations_CreateOrUpdate_With_Physical_Zones.json"
+          },
+          "Create or update a scenario configuration.": {
+            "$ref": "./examples/ScenarioConfigurations_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ScenarioConfigurations_Delete",
+        "tags": [
+          "ScenarioConfigurations"
+        ],
+        "description": "Delete a scenario definition.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioConfigurationName",
+            "in": "path",
+            "description": "Name of the scenario definition.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a scenario configuration.": {
+            "$ref": "./examples/ScenarioConfigurations_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/scenarios/{scenarioName}/configurations/{scenarioConfigurationName}/execute": {
+      "post": {
+        "operationId": "ScenarioConfigurations_Execute",
+        "tags": [
+          "ScenarioConfigurations"
+        ],
+        "description": "Execute the scenario execution with the given scenario configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioConfigurationName",
+            "in": "path",
+            "description": "Name of the scenario definition.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Execute the scenario execution with the given scenario configuration.": {
+            "$ref": "./examples/ScenarioConfigurations_Execute.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/scenarios/{scenarioName}/configurations/{scenarioConfigurationName}/fixResourcePermissions": {
+      "post": {
+        "operationId": "ScenarioConfigurations_FixResourcePermissions",
+        "tags": [
+          "ScenarioConfigurations"
+        ],
+        "description": "Fixes resource permissions for the given scenario configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioConfigurationName",
+            "in": "path",
+            "description": "Name of the scenario definition.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/FixResourcePermissionsRequest"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Fixes resource permissions for the given scenario configuration.": {
+            "$ref": "./examples/ScenarioConfigurations_FixResourcePermissions.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/scenarios/{scenarioName}/configurations/{scenarioConfigurationName}/validate": {
+      "post": {
+        "operationId": "ScenarioConfigurations_Validate",
+        "tags": [
+          "ScenarioConfigurations"
+        ],
+        "description": "Validate the given scenario configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioConfigurationName",
+            "in": "path",
+            "description": "Name of the scenario definition.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Validate the given scenario configuration.": {
+            "$ref": "./examples/ScenarioConfigurations_Validate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/scenarios/{scenarioName}/runs": {
+      "get": {
+        "operationId": "ScenarioRuns_ListAll",
+        "tags": [
+          "ScenarioRuns"
+        ],
+        "description": "Get a list of scenario runs.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ScenarioRunListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a list of scenario runs.": {
+            "$ref": "./examples/ScenarioRuns_ListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/scenarios/{scenarioName}/runs/{runId}": {
+      "get": {
+        "operationId": "ScenarioRuns_Get",
+        "tags": [
+          "ScenarioRuns"
+        ],
+        "description": "Get a scenario run.\n\nThis endpoint is also the polling target for ScenarioConfigurations.execute\nand ScenarioRuns.cancel (final-state-via: location). While the run is in\nprogress the service returns 202 with a Location header pointing back to\nthis URL; clients must keep polling until they receive 200, which carries\nthe final ScenarioRun body.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "description": "The name of the ScenarioRun",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ScenarioRun"
+            }
+          },
+          "202": {
+            "description": "Indicates the scenario run is still in progress. Clients polling via the\nLocation header should continue polling until a 200 response is returned.\nThe body reflects the current run state at the time of the poll.",
+            "schema": {
+              "$ref": "#/definitions/ScenarioRun"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "format": "uri",
+                "description": "The URL where the status of the long-running operation can be polled."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The number of seconds the client should wait before polling again.",
+                "minimum": 0,
+                "maximum": 2147483647
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a scenario run.": {
+            "$ref": "./examples/ScenarioRuns_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Chaos/workspaces/{workspaceName}/scenarios/{scenarioName}/runs/{runId}/cancel": {
+      "post": {
+        "operationId": "ScenarioRuns_Cancel",
+        "tags": [
+          "ScenarioRuns"
+        ],
+        "description": "Cancel the currently running scenario execution.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "String that represents a Workspace resource name.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "scenarioName",
+            "in": "path",
+            "description": "Name of the scenario.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^<>%&:?#/\\\\]+$"
+          },
+          {
+            "name": "runId",
+            "in": "path",
+            "description": "The name of the ScenarioRun",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Cancel a running scenario run.": {
+            "$ref": "./examples/ScenarioRuns_Cancel.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "Action": {
+      "type": "object",
+      "description": "Model that represents an Action resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ActionProperties",
+          "description": "The properties of the action resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ActionDependency": {
+      "type": "object",
+      "description": "Model that represents an action dependency.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ActionDependencyType",
+          "description": "The type of dependency."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the action this depends on."
+        },
+        "onActionLifecycle": {
+          "$ref": "#/definitions/ActionLifecycle",
+          "description": "The lifecycle state of the dependency action that triggers this action to start."
+        }
+      },
+      "required": [
+        "type",
+        "name"
+      ]
+    },
+    "ActionDependencyType": {
+      "type": "string",
+      "description": "Enum for action dependency type.",
+      "enum": [
+        "Action"
+      ],
+      "x-ms-enum": {
+        "name": "ActionDependencyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Action",
+            "value": "Action",
+            "description": "Action dependency type."
+          }
+        ]
+      }
+    },
+    "ActionKind": {
+      "type": "string",
+      "description": "Union of action types.",
+      "enum": [
+        "Discrete",
+        "Continuous",
+        "Cancelable"
+      ],
+      "x-ms-enum": {
+        "name": "ActionKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Discrete",
+            "value": "Discrete",
+            "description": "Discrete action type."
+          },
+          {
+            "name": "Continuous",
+            "value": "Continuous",
+            "description": "Continuous action type."
+          },
+          {
+            "name": "Cancelable",
+            "value": "Cancelable",
+            "description": "Cancelable action type."
+          }
+        ]
+      }
+    },
+    "ActionLifecycle": {
+      "type": "string",
+      "description": "Enum for action lifecycle states.",
+      "enum": [
+        "AnyTerminal",
+        "Start",
+        "Running",
+        "Success",
+        "Failure",
+        "Skipped"
+      ],
+      "x-ms-enum": {
+        "name": "ActionLifecycle",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AnyTerminal",
+            "value": "AnyTerminal",
+            "description": "Trigger when action reaches any terminal state."
+          },
+          {
+            "name": "Start",
+            "value": "Start",
+            "description": "Trigger when action starts."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Trigger when action is running."
+          },
+          {
+            "name": "Success",
+            "value": "Success",
+            "description": "Trigger on success."
+          },
+          {
+            "name": "Failure",
+            "value": "Failure",
+            "description": "Trigger on failure."
+          },
+          {
+            "name": "Skipped",
+            "value": "Skipped",
+            "description": "Trigger when action is skipped."
+          }
+        ]
+      }
+    },
+    "ActionListResult": {
+      "type": "object",
+      "description": "Model that represents a list of Action resources and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Action items on this page",
+          "items": {
+            "$ref": "#/definitions/Action"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ActionProperties": {
+      "type": "object",
+      "description": "Model that represents the properties of an Action resource.",
+      "properties": {
+        "canonicalId": {
+          "type": "string",
+          "description": "Canonical identifier of the action (e.g., \"microsoft-compute-shutdown/1.0\").",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Human-readable display name of the action.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what this action does.",
+          "readOnly": true
+        },
+        "actionName": {
+          "type": "string",
+          "description": "The short name of the action (e.g., \"Shutdown\").",
+          "readOnly": true
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the action (e.g., \"1.0.0\").",
+          "readOnly": true
+        },
+        "actionType": {
+          "$ref": "#/definitions/ActionKind",
+          "description": "The type of the action.",
+          "readOnly": true
+        },
+        "supportedTargetTypes": {
+          "type": "array",
+          "description": "List of target types supported by this action.",
+          "items": {
+            "$ref": "#/definitions/ActionSupportedTargetType"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "targetType"
+          ]
+        },
+        "parametersSchema": {
+          "type": "object",
+          "description": "JSON Schema describing the parameters for this action.",
+          "readOnly": true
+        },
+        "recommendedRoles": {
+          "type": "array",
+          "description": "Recommended Azure RBAC role definition GUIDs for this action.",
+          "items": {
+            "$ref": "#/definitions/Azure.Core.uuid"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ActionStatus": {
+      "type": "object",
+      "description": "Model that represents the an action and its status.",
+      "properties": {
+        "actionName": {
+          "type": "string",
+          "description": "The name of the action status.",
+          "readOnly": true
+        },
+        "actionId": {
+          "type": "string",
+          "description": "The id of the action status.",
+          "readOnly": true
+        },
+        "status": {
+          "type": "string",
+          "description": "The status of the action.",
+          "readOnly": true
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "String that represents the start time of the action.",
+          "readOnly": true
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "String that represents the end time of the action.",
+          "readOnly": true
+        },
+        "targets": {
+          "type": "array",
+          "description": "The array of targets.",
+          "items": {
+            "$ref": "#/definitions/ExperimentExecutionActionTargetDetailsProperties"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ActionSupportedTargetType": {
+      "type": "object",
+      "description": "Model that represents a target type supported by an action.",
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "description": "The Azure resource type (e.g., \"Microsoft.Compute/virtualMachines\")."
+        },
+        "requiredPermissions": {
+          "type": "array",
+          "description": "List of Azure permissions required for this target type.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ActionVersion": {
+      "type": "object",
+      "description": "Model that represents an Action Version resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ActionProperties",
+          "description": "The properties of the action version resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ActionVersionListResult": {
+      "type": "object",
+      "description": "Model that represents a list of Action Version resources and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ActionVersion items on this page",
+          "items": {
+            "$ref": "#/definitions/ActionVersion"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Azure.Core.azureLocation": {
+      "type": "string",
+      "description": "Represents an Azure geography region where supported resource providers live."
+    },
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "BranchStatus": {
+      "type": "object",
+      "description": "Model that represents the a list of actions and action statuses.",
+      "properties": {
+        "branchName": {
+          "type": "string",
+          "description": "The name of the branch status.",
+          "readOnly": true
+        },
+        "branchId": {
+          "type": "string",
+          "description": "The id of the branch status.",
+          "readOnly": true
+        },
+        "status": {
+          "type": "string",
+          "description": "The status of the branch.",
+          "readOnly": true
+        },
+        "actions": {
+          "type": "array",
+          "description": "The array of actions.",
+          "items": {
+            "$ref": "#/definitions/ActionStatus"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "actionId"
+          ]
+        }
+      }
+    },
+    "Capability": {
+      "type": "object",
+      "description": "Model that represents a Capability resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CapabilityProperties",
+          "description": "The properties of a capability resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CapabilityListResult": {
+      "type": "object",
+      "description": "Model that represents a list of Capability resources and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Capability items on this page",
+          "items": {
+            "$ref": "#/definitions/Capability"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "CapabilityProperties": {
+      "type": "object",
+      "description": "Model that represents the Capability properties model.",
+      "properties": {
+        "publisher": {
+          "type": "string",
+          "description": "String of the Publisher that this Capability extends.",
+          "readOnly": true
+        },
+        "targetType": {
+          "type": "string",
+          "description": "String of the Target Type that this Capability extends.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Localized string of the description.",
+          "readOnly": true
+        },
+        "parametersSchema": {
+          "type": "string",
+          "description": "URL to retrieve JSON schema of the Capability parameters.",
+          "maxLength": 2048,
+          "readOnly": true
+        },
+        "urn": {
+          "type": "string",
+          "description": "String of the URN for this Capability Type.",
+          "maxLength": 2048,
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state. Not currently in use because resource is created synchronously.",
+          "readOnly": true
+        }
+      }
+    },
+    "CapabilityType": {
+      "type": "object",
+      "description": "Model that represents a Capability Type resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CapabilityTypeProperties",
+          "description": "The properties of the capability type resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CapabilityTypeListResult": {
+      "type": "object",
+      "description": "Model that represents a list of Capability Type resources and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The CapabilityType items on this page",
+          "items": {
+            "$ref": "#/definitions/CapabilityType"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "CapabilityTypeProperties": {
+      "type": "object",
+      "description": "Model that represents the Capability Type properties model.",
+      "properties": {
+        "publisher": {
+          "type": "string",
+          "description": "String of the Publisher that this Capability Type extends.",
+          "readOnly": true
+        },
+        "targetType": {
+          "type": "string",
+          "description": "String of the Target Type that this Capability Type extends.",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Localized string of the display name.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Localized string of the description.",
+          "readOnly": true
+        },
+        "parametersSchema": {
+          "type": "string",
+          "description": "URL to retrieve JSON schema of the Capability Type parameters.",
+          "maxLength": 2048,
+          "readOnly": true
+        },
+        "urn": {
+          "type": "string",
+          "description": "String of the URN for this Capability Type.",
+          "maxLength": 2048,
+          "readOnly": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "String of the kind of this Capability Type.",
+          "readOnly": true
+        },
+        "azureRbacActions": {
+          "type": "array",
+          "description": "Control plane actions necessary to execute capability type.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "azureRbacDataActions": {
+          "type": "array",
+          "description": "Data plane actions necessary to execute capability type.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "requiredAzureRoleDefinitionIds": {
+          "type": "array",
+          "description": "Required Azure Role Definition Ids to execute capability type.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "runtimeProperties": {
+          "$ref": "#/definitions/CapabilityTypePropertiesRuntimeProperties",
+          "description": "Runtime properties of this Capability Type.",
+          "readOnly": true
+        }
+      }
+    },
+    "CapabilityTypePropertiesRuntimeProperties": {
+      "type": "object",
+      "description": "Runtime properties of this Capability Type.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "String of the kind of the resource's action type (continuous or discrete).",
+          "readOnly": true
+        }
+      }
+    },
+    "ChaosExperimentAction": {
+      "type": "object",
+      "description": "Model that represents the base action model. 9 total per experiment.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "String that represents a Capability URN.",
+          "maxLength": 2048
+        },
+        "type": {
+          "$ref": "#/definitions/ExperimentActionType",
+          "description": "Chaos experiment action discriminator type"
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "ChaosExperimentBranch": {
+      "type": "object",
+      "description": "Model that represents a branch in the step. 9 total per experiment.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "String of the branch name.",
+          "minLength": 1
+        },
+        "actions": {
+          "type": "array",
+          "description": "List of actions.",
+          "items": {
+            "$ref": "#/definitions/ChaosExperimentAction"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "actions"
+      ]
+    },
+    "ChaosExperimentStep": {
+      "type": "object",
+      "description": "Model that represents a step in the Experiment resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "String of the step name.",
+          "minLength": 1
+        },
+        "branches": {
+          "type": "array",
+          "description": "List of branches.",
+          "items": {
+            "$ref": "#/definitions/ChaosExperimentBranch"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "branches"
+      ]
+    },
+    "ChaosTargetFilter": {
+      "type": "object",
+      "description": "Model that represents available filter types that can be applied to a targets list.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/FilterType",
+          "description": "Chaos target filter discriminator type"
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "ChaosTargetListSelector": {
+      "type": "object",
+      "description": "Model that represents a list selector.",
+      "properties": {
+        "targets": {
+          "type": "array",
+          "description": "List of Target references.",
+          "items": {
+            "$ref": "#/definitions/TargetReference"
+          }
+        }
+      },
+      "required": [
+        "targets"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChaosTargetSelector"
+        }
+      ],
+      "x-ms-discriminator-value": "List"
+    },
+    "ChaosTargetQuerySelector": {
+      "type": "object",
+      "description": "Model that represents a query selector.",
+      "properties": {
+        "queryString": {
+          "type": "string",
+          "description": "Azure Resource Graph (ARG) Query Language query for target resources."
+        },
+        "subscriptionIds": {
+          "type": "array",
+          "description": "Subscription id list to scope resource query.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "queryString",
+        "subscriptionIds"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChaosTargetSelector"
+        }
+      ],
+      "x-ms-discriminator-value": "Query"
+    },
+    "ChaosTargetSelector": {
+      "type": "object",
+      "description": "Model that represents a selector in the Experiment resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "String of the selector ID.",
+          "minLength": 1
+        },
+        "type": {
+          "$ref": "#/definitions/SelectorType",
+          "description": "Chaos target selector discriminator type"
+        },
+        "filter": {
+          "$ref": "#/definitions/ChaosTargetFilter",
+          "description": "Model that represents available filter types that can be applied to a targets list."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "id",
+        "type"
+      ]
+    },
+    "ChaosTargetSimpleFilter": {
+      "type": "object",
+      "description": "Model that represents a simple target filter.",
+      "properties": {
+        "parameters": {
+          "$ref": "#/definitions/ChaosTargetSimpleFilterParameters",
+          "description": "Model that represents the Simple filter parameters."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChaosTargetFilter"
+        }
+      ],
+      "x-ms-discriminator-value": "Simple"
+    },
+    "ChaosTargetSimpleFilterParameters": {
+      "type": "object",
+      "description": "Model that represents the Simple filter parameters.",
+      "properties": {
+        "zones": {
+          "type": "array",
+          "description": "List of Azure availability zones to filter targets by.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Connection": {
+      "type": "object",
+      "description": "Model that represents a connection between a workspace and a target resource.\nA connection provisions and tracks the trust relationship that authorizes the\nactor to reach the Chaos Studio data plane for the workspace and target during\nfault injection.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectionProperties",
+          "description": "The properties of the connection."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ConnectionKind": {
+      "type": "string",
+      "description": "The kind of connection, indicating the actor type authorized to reach the Chaos Studio data plane for the workspace and target.",
+      "enum": [
+        "AksExtension",
+        "ChaosAgent",
+        "Csfi"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AksExtension",
+            "value": "AksExtension",
+            "description": "A connection backed by the Chaos AKS cluster extension."
+          },
+          {
+            "name": "ChaosAgent",
+            "value": "ChaosAgent",
+            "description": "A connection backed by the Chaos agent installed on the target resource."
+          },
+          {
+            "name": "Csfi",
+            "value": "Csfi",
+            "description": "A connection backed by Cloud Service Fault Injection (CSFI)."
+          }
+        ]
+      }
+    },
+    "ConnectionListResult": {
+      "type": "object",
+      "description": "Model that represents a list of connections and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Connection items on this page",
+          "items": {
+            "$ref": "#/definitions/Connection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ConnectionProperties": {
+      "type": "object",
+      "description": "Model that represents the properties of a connection.\n\nThe schema is flat and discriminated by `kind`. Optional fields form the\nsuperset across all connection kinds; which fields are required is\nvalidated by the service per kind.",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ConnectionKind",
+          "description": "The kind of connection, indicating the actor type authorized to reach the Chaos Studio data plane for the workspace and target."
+        },
+        "targetResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The fully qualified Azure resource ID of the target resource this connection is established with."
+        },
+        "principalId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The Microsoft Entra principal (object) ID of the identity used by the connection."
+        },
+        "tenantId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "The Microsoft Entra tenant ID that the connection identity belongs to."
+        },
+        "certificateSubjectName": {
+          "type": "string",
+          "description": "The subject name of the certificate used to authenticate the connection."
+        },
+        "certificateIssuer": {
+          "type": "string",
+          "description": "The issuer of the certificate used to authenticate the connection."
+        },
+        "dstsPrincipal": {
+          "type": "string",
+          "description": "The dSTS principal name used to authenticate the connection."
+        },
+        "dataPlaneEndpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "The regional Chaos Studio data-plane endpoint assigned to this connection.\nClients and agents use this endpoint to reach the Chaos Studio data plane\nfor the connection.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/ConnectionStatus",
+          "description": "The current status of the connection.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The most recent provisioning state for the connection resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "kind",
+        "targetResourceId"
+      ]
+    },
+    "ConnectionStatus": {
+      "type": "string",
+      "description": "The status of a connection.",
+      "enum": [
+        "Pending",
+        "Connected",
+        "Disconnected",
+        "Revoked"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "The connection has been created but is not yet sending heartbeats; the trust relationship is not yet established."
+          },
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "The connection is established and actively heartbeating."
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "The connection's heartbeat has gone stale; heartbeats are no longer being received."
+          },
+          {
+            "name": "Revoked",
+            "value": "Revoked",
+            "description": "The connection's credentials have been revoked."
+          }
+        ]
+      }
+    },
+    "ContinuousAction": {
+      "type": "object",
+      "description": "Model that represents a continuous action.",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO8601 formatted string that represents a duration."
+        },
+        "parameters": {
+          "type": "array",
+          "description": "List of key value pairs.",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        },
+        "selectorId": {
+          "type": "string",
+          "description": "String that represents a selector.",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "duration",
+        "parameters",
+        "selectorId"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChaosExperimentAction"
+        }
+      ],
+      "x-ms-discriminator-value": "continuous"
+    },
+    "CustomerDataStorageProperties": {
+      "type": "object",
+      "description": "Model that represents the Customer Managed Storage for an Experiment.",
+      "properties": {
+        "storageAccountResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure Resource ID of the Storage account to use for Customer Data storage.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          }
+        },
+        "blobContainerName": {
+          "type": "string",
+          "description": "Name of the Azure Blob Storage container to use or create.",
+          "minLength": 3,
+          "maxLength": 63,
+          "pattern": "^[a-z0-9]([a-z0-9]|(-(?!-))){1,61}[a-z0-9]$"
+        }
+      }
+    },
+    "DelayAction": {
+      "type": "object",
+      "description": "Model that represents a delay action.",
+      "properties": {
+        "duration": {
+          "type": "string",
+          "format": "duration",
+          "description": "ISO8601 formatted string that represents a duration."
+        }
+      },
+      "required": [
+        "duration"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChaosExperimentAction"
+        }
+      ],
+      "x-ms-discriminator-value": "delay"
+    },
+    "DiscoveredResource": {
+      "type": "object",
+      "description": "Model that represents a discovered resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DiscoveredResourceProperties",
+          "description": "The properties of the discovered resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DiscoveredResourceListResult": {
+      "type": "object",
+      "description": "Model that represents a list of discovered resources and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DiscoveredResource items on this page",
+          "items": {
+            "$ref": "#/definitions/DiscoveredResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DiscoveredResourceProperties": {
+      "type": "object",
+      "description": "Model that represents the properties of a discovered resource.",
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "The namespace of the discovered resource.",
+          "readOnly": true,
+          "x-ms-client-name": "resourceNamespace"
+        },
+        "resourceName": {
+          "type": "string",
+          "description": "The name of the discovered resource.",
+          "readOnly": true
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "The resource type of the discovered resource.",
+          "readOnly": true
+        },
+        "fullyQualifiedIdentifier": {
+          "type": "string",
+          "description": "The fully qualified identifier of the discovered resource.",
+          "readOnly": true
+        },
+        "discoveredAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time when the resource was discovered.",
+          "readOnly": true
+        },
+        "scope": {
+          "type": "string",
+          "description": "The scope of the discovered resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "namespace",
+        "resourceName",
+        "resourceType",
+        "fullyQualifiedIdentifier",
+        "discoveredAt",
+        "scope"
+      ]
+    },
+    "DiscreteAction": {
+      "type": "object",
+      "description": "Model that represents a discrete action.",
+      "properties": {
+        "parameters": {
+          "type": "array",
+          "description": "List of key value pairs.",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        },
+        "selectorId": {
+          "type": "string",
+          "description": "String that represents a selector.",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "parameters",
+        "selectorId"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ChaosExperimentAction"
+        }
+      ],
+      "x-ms-discriminator-value": "discrete"
+    },
+    "EntraIdentity": {
+      "type": "object",
+      "description": "Model that represents the Azure Entra identity.",
+      "properties": {
+        "objectId": {
+          "type": "string",
+          "description": "The identity object id.",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The identity tenant id.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "objectId",
+        "tenantId"
+      ]
+    },
+    "Experiment": {
+      "type": "object",
+      "description": "Model that represents a Experiment resource.",
+      "properties": {
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        },
+        "properties": {
+          "$ref": "#/definitions/ExperimentProperties",
+          "description": "The properties of the experiment resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ExperimentActionType": {
+      "type": "string",
+      "description": "Enum union of Chaos experiment action types.",
+      "enum": [
+        "delay",
+        "discrete",
+        "continuous"
+      ],
+      "x-ms-enum": {
+        "name": "ExperimentActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "delay",
+            "value": "delay"
+          },
+          {
+            "name": "discrete",
+            "value": "discrete"
+          },
+          {
+            "name": "continuous",
+            "value": "continuous"
+          }
+        ]
+      }
+    },
+    "ExperimentExecution": {
+      "type": "object",
+      "description": "Model that represents the execution of a Experiment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExperimentExecutionProperties",
+          "description": "The properties of experiment execution status.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ExperimentExecutionActionTargetDetailsError": {
+      "type": "object",
+      "description": "Model that represents the Experiment action target details error model.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message",
+          "readOnly": true
+        }
+      }
+    },
+    "ExperimentExecutionActionTargetDetailsProperties": {
+      "type": "object",
+      "description": "Model that represents the Experiment action target details properties model.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "The status of the execution.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The target for the action.",
+          "readOnly": true
+        },
+        "targetFailedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "String that represents the failed date time.",
+          "readOnly": true
+        },
+        "targetCompletedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "String that represents the completed date time.",
+          "readOnly": true
+        },
+        "error": {
+          "$ref": "#/definitions/ExperimentExecutionActionTargetDetailsError",
+          "description": "The error of the action.",
+          "readOnly": true
+        }
+      }
+    },
+    "ExperimentExecutionDetails": {
+      "type": "object",
+      "description": "Model that represents the execution details of an Experiment.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "String of the resource type.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "description": "String of the fully qualified resource ID.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "String of the resource name.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/ExperimentExecutionDetailsProperties",
+          "description": "The properties of the experiment execution details.",
+          "readOnly": true,
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "ExperimentExecutionDetailsProperties": {
+      "type": "object",
+      "description": "Model that represents the extended properties of an experiment execution.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "The status of the execution.",
+          "readOnly": true
+        },
+        "startedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "String that represents the start date time.",
+          "readOnly": true
+        },
+        "stoppedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "String that represents the stop date time.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state. Not currently in use for executions.",
+          "readOnly": true
+        },
+        "failureReason": {
+          "type": "string",
+          "description": "The reason why the execution failed.",
+          "readOnly": true
+        },
+        "lastActionAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "String that represents the last action date time.",
+          "readOnly": true
+        },
+        "runInformation": {
+          "$ref": "#/definitions/ExperimentExecutionDetailsPropertiesRunInformation",
+          "description": "The information of the experiment run.",
+          "readOnly": true
+        }
+      }
+    },
+    "ExperimentExecutionDetailsPropertiesRunInformation": {
+      "type": "object",
+      "description": "The information of the experiment run.",
+      "properties": {
+        "steps": {
+          "type": "array",
+          "description": "The steps of the experiment run.",
+          "items": {
+            "$ref": "#/definitions/StepStatus"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "stepName"
+          ]
+        }
+      }
+    },
+    "ExperimentExecutionListResult": {
+      "type": "object",
+      "description": "Model that represents a list of Experiment executions and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExperimentExecution items on this page",
+          "items": {
+            "$ref": "#/definitions/ExperimentExecution"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExperimentExecutionProperties": {
+      "type": "object",
+      "description": "Model that represents the execution properties of an Experiment.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "The status of the execution.",
+          "readOnly": true
+        },
+        "startedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "String that represents the start date time.",
+          "readOnly": true
+        },
+        "stoppedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "String that represents the stop date time.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state. Not currently in use for executions.",
+          "readOnly": true
+        }
+      }
+    },
+    "ExperimentListResult": {
+      "type": "object",
+      "description": "Model that represents a list of Experiment resources and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Experiment items on this page",
+          "items": {
+            "$ref": "#/definitions/Experiment"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExperimentProperties": {
+      "type": "object",
+      "description": "Model that represents the Experiment properties model.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Most recent provisioning state for the given experiment resource.",
+          "readOnly": true
+        },
+        "steps": {
+          "type": "array",
+          "description": "List of steps.",
+          "items": {
+            "$ref": "#/definitions/ChaosExperimentStep"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "selectors": {
+          "type": "array",
+          "description": "List of selectors.",
+          "items": {
+            "$ref": "#/definitions/ChaosTargetSelector"
+          }
+        },
+        "customerDataStorage": {
+          "$ref": "#/definitions/CustomerDataStorageProperties",
+          "description": "Optional customer-managed Storage account where Experiment schema will be stored."
+        }
+      },
+      "required": [
+        "steps",
+        "selectors"
+      ]
+    },
+    "ExperimentUpdate": {
+      "type": "object",
+      "description": "Describes an experiment update.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      }
+    },
+    "ExternalResource": {
+      "type": "object",
+      "description": "Model that represents an external resource reference.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the external resource."
+        }
+      }
+    },
+    "FilterType": {
+      "type": "string",
+      "description": "Enum that discriminates between filter types. Currently only `Simple` type is supported.",
+      "enum": [
+        "Simple"
+      ],
+      "x-ms-enum": {
+        "name": "FilterType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Simple",
+            "value": "Simple",
+            "description": "Simple filter type."
+          }
+        ]
+      }
+    },
+    "FixResourcePermissionsRequest": {
+      "type": "object",
+      "description": "Request body for fixing resource permissions.",
+      "properties": {
+        "whatIf": {
+          "type": "boolean",
+          "description": "Optional value that indicates whether to run a \"dry run\" of fixing resource permissions."
+        }
+      }
+    },
+    "KeyValuePair": {
+      "type": "object",
+      "description": "A key-value pair used to describe parameters for actions or configurations.",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The name of the setting for the action.",
+          "minLength": 1
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the setting for the action.",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "key",
+        "value"
+      ]
+    },
+    "OperationError": {
+      "type": "object",
+      "description": "Represents a system or infrastructure error encountered during an async operation.",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "The error code identifying the type of system error."
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "A human-readable description of the system error."
+        }
+      },
+      "required": [
+        "errorCode",
+        "errorMessage"
+      ]
+    },
+    "ParameterType": {
+      "type": "string",
+      "description": "Enum for parameter types.",
+      "enum": [
+        "string",
+        "number",
+        "boolean",
+        "object",
+        "array"
+      ],
+      "x-ms-enum": {
+        "name": "ParameterType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "String",
+            "value": "string",
+            "description": "String parameter type."
+          },
+          {
+            "name": "Number",
+            "value": "number",
+            "description": "Number parameter type."
+          },
+          {
+            "name": "Boolean",
+            "value": "boolean",
+            "description": "Boolean parameter type."
+          },
+          {
+            "name": "Object",
+            "value": "object",
+            "description": "Object parameter type."
+          },
+          {
+            "name": "Array",
+            "value": "array",
+            "description": "Array parameter type."
+          }
+        ]
+      }
+    },
+    "PermissionError": {
+      "type": "object",
+      "description": "Model that represents the permission error.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource id for the affected resource.",
+          "readOnly": true
+        },
+        "missingPermissions": {
+          "type": "array",
+          "description": "The missing permissions.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "requiredPermissions": {
+          "type": "array",
+          "description": "The required permissions.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "recommendedRoles": {
+          "type": "array",
+          "description": "The recommended roles.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "identity": {
+          "$ref": "#/definitions/EntraIdentity",
+          "description": "The identity.",
+          "readOnly": true
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "The error message describing the permission validation failure, when the\nfailure carries a distinct message (for example, when the target could not\nbe read to evaluate access).",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "resourceId",
+        "missingPermissions",
+        "requiredPermissions",
+        "recommendedRoles"
+      ]
+    },
+    "PermissionsFix": {
+      "type": "object",
+      "description": "Model that represents the fix resource permissions result.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PermissionsFixProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PermissionsFixProperties": {
+      "type": "object",
+      "description": "Model that represents the properties of the permission fix operation.",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/PermissionsFixState",
+          "description": "The permission fix state.",
+          "readOnly": true
+        },
+        "startedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The permission fix UTC start time.",
+          "readOnly": true
+        },
+        "completedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The permission fix UTC end time.",
+          "readOnly": true
+        },
+        "whatIfMode": {
+          "type": "boolean",
+          "description": "Whether this was a what-if (dry run) operation.",
+          "readOnly": true
+        },
+        "roleAssignments": {
+          "type": "array",
+          "description": "The list of role assignment results.",
+          "items": {
+            "$ref": "#/definitions/RoleAssignmentResult"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "summary": {
+          "$ref": "#/definitions/PermissionsFixSummary",
+          "description": "Summary of the permission fix operation.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "state",
+        "startedAt",
+        "whatIfMode",
+        "roleAssignments",
+        "summary"
+      ]
+    },
+    "PermissionsFixState": {
+      "type": "string",
+      "description": "Enum of the permission fix state.",
+      "enum": [
+        "NotStarted",
+        "InProgress",
+        "Succeeded",
+        "Failed",
+        "PartiallySucceeded",
+        "WhatIfCompleted"
+      ],
+      "x-ms-enum": {
+        "name": "PermissionsFixState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "The permission fix has not started."
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "The permission fix is in progress."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "All role assignments succeeded."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "All role assignments failed."
+          },
+          {
+            "name": "PartiallySucceeded",
+            "value": "PartiallySucceeded",
+            "description": "Some role assignments succeeded and some failed."
+          },
+          {
+            "name": "WhatIfCompleted",
+            "value": "WhatIfCompleted",
+            "description": "What-if analysis completed (no changes made)."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "PermissionsFixSummary": {
+      "type": "object",
+      "description": "Summary of the permission fix operation.",
+      "properties": {
+        "totalRequired": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of role assignments required.",
+          "readOnly": true
+        },
+        "succeeded": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of successful role assignments.",
+          "readOnly": true
+        },
+        "failed": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of failed role assignments.",
+          "readOnly": true
+        },
+        "skipped": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of skipped role assignments (already existed).",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "totalRequired",
+        "succeeded",
+        "failed",
+        "skipped"
+      ]
+    },
+    "PhysicalToLogicalZoneMapping": {
+      "type": "object",
+      "description": "Maps a physical zone to the resolved logical zone for a given subscription.",
+      "properties": {
+        "physicalZone": {
+          "type": "string",
+          "description": "The physical availability zone (e.g., `\"westus2-az1\"`).",
+          "readOnly": true
+        },
+        "logicalZone": {
+          "type": "string",
+          "description": "The logical availability zone resolved for this subscription\n(e.g., `\"1\"`, `\"2\"`, `\"3\"`).",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "physicalZone",
+        "logicalZone"
+      ]
+    },
+    "PrivateAccess": {
+      "type": "object",
+      "description": "PrivateAccesses tracked resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateAccessProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "PrivateAccessListResult": {
+      "type": "object",
+      "description": "Model that represents a list of private access resources and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateAccess items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateAccess"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateAccessPatch": {
+      "type": "object",
+      "description": "Describes a private access update.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PrivateAccessProperties": {
+      "type": "object",
+      "description": "The properties of a private access resource",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Most recent provisioning state for the given privateAccess resource.",
+          "readOnly": true
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "A readonly collection of private endpoint connection. Currently only one endpoint connection is supported.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccessOption",
+          "description": "Public Network Access Control for PrivateAccess resource."
+        }
+      }
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "The private endpoint resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The Azure identifier for private endpoint.",
+          "readOnly": true
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "The private endpoint connection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Resource properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "A list of private link resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateEndpointConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the private endpoint connection.",
+      "properties": {
+        "groupIds": {
+          "type": "array",
+          "description": "The group ids for the private endpoint resource.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The private endpoint resource."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "A collection of information about the state of the connection between service consumer and provider."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private endpoint connection resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ]
+    },
+    "PrivateEndpointServiceConnectionStatus": {
+      "type": "string",
+      "description": "The private endpoint connection status.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointServiceConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Pending status."
+          },
+          {
+            "name": "Approved",
+            "value": "Approved",
+            "description": "Approved status."
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected",
+            "description": "Rejected status."
+          }
+        ]
+      }
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "A private link resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "PrivateLinkResourceListResult": {
+      "type": "object",
+      "description": "A list of private link resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateLinkResource items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateLinkResourceProperties": {
+      "type": "object",
+      "description": "Properties of a private link resource.",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The private link resource group id.",
+          "readOnly": true
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "The private link resource required member names.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "The private link resource private link DNS zone name.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Resource provisioning state. Not currently in use.",
+          "readOnly": true
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionState": {
+      "type": "object",
+      "description": "A collection of information about the state of the connection between service consumer and provider.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PrivateEndpointServiceConnectionStatus",
+          "description": "Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service."
+        },
+        "description": {
+          "type": "string",
+          "description": "The reason for approval/rejection of the connection."
+        },
+        "actionsRequired": {
+          "type": "string",
+          "description": "A message indicating if changes on the service provider require any updates on the consumer."
+        }
+      }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "Current provisioning state for a given Azure Chaos resource.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Running"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Initial creation in progress."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Update in progress."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deletion in progress."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Action is running."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "PublicNetworkAccessOption": {
+      "type": "string",
+      "description": "Public Network Access Control for PrivateAccess resource.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccessOption",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled access."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled access."
+          }
+        ]
+      }
+    },
+    "Recommendation": {
+      "type": "object",
+      "description": "Model that represents a scenario recommendation.",
+      "properties": {
+        "recommendationStatus": {
+          "$ref": "#/definitions/RecommendationStatus",
+          "description": "The recommendation status.",
+          "readOnly": true
+        },
+        "evaluationRunAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The UTC time when the recommendation was evaluated.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "recommendationStatus"
+      ]
+    },
+    "RecommendationStatus": {
+      "type": "string",
+      "description": "Enum of the scenario validation state.",
+      "enum": [
+        "NotEvaluated",
+        "Recommended",
+        "NotApplicable",
+        "Evaluating",
+        "EvaluationFailed",
+        "EvaluationCancelled"
+      ],
+      "x-ms-enum": {
+        "name": "RecommendationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotEvaluated",
+            "value": "NotEvaluated",
+            "description": "The scenario recommendation status has not been evaluated."
+          },
+          {
+            "name": "Recommended",
+            "value": "Recommended",
+            "description": "The scenario recommendation status is recommended."
+          },
+          {
+            "name": "NotApplicable",
+            "value": "NotApplicable",
+            "description": "The scenario recommendation status is not applicable."
+          },
+          {
+            "name": "Evaluating",
+            "value": "Evaluating",
+            "description": "The scenario recommendation status is currently being evaluated."
+          },
+          {
+            "name": "EvaluationFailed",
+            "value": "EvaluationFailed",
+            "description": "The scenario recommendation evaluation has failed."
+          },
+          {
+            "name": "EvaluationCancelled",
+            "value": "EvaluationCancelled",
+            "description": "The scenario recommendation evaluation was cancelled."
+          }
+        ]
+      }
+    },
+    "ResourceStateError": {
+      "type": "object",
+      "description": "Model that represents the resource state error.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource id for the affected resource.",
+          "readOnly": true
+        },
+        "errorCode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The error code.",
+          "readOnly": true
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "The error message.",
+          "readOnly": true
+        },
+        "remediationUri": {
+          "type": "string",
+          "description": "The remediation uri.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "resourceId",
+        "errorCode",
+        "errorMessage",
+        "remediationUri"
+      ]
+    },
+    "ResourceTargeting": {
+      "type": "object",
+      "description": "Model that represents unified resource targeting with symmetric include/exclude criteria.\nBoth sides support the same set of dimensions.",
+      "properties": {
+        "include": {
+          "$ref": "#/definitions/ResourceTargetingCriteria",
+          "description": "Inclusion criteria. Resources must match ALL active dimensions to be candidates.\nNull or omitted means no inclusion filtering (all resources are candidates)."
+        },
+        "exclude": {
+          "$ref": "#/definitions/ResourceTargetingCriteria",
+          "description": "Exclusion criteria. Resources matching ANY active dimension are removed.\nNull or omitted means no exclusions applied."
+        }
+      }
+    },
+    "ResourceTargetingCriteria": {
+      "type": "object",
+      "description": "Model that represents a set of targeting criteria for resource selection.\nUsed on both the include and exclude sides of ResourceTargeting.\n\nAll dimensions use unified null/empty semantics:\n- Null or omitted means \"no constraint\" (this dimension is inactive).\n- Empty array is treated the same as null (no constraint).\n- Non-empty array means the dimension is active.",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "description": "Array of Azure location strings (e.g., \"eastus\", \"westeurope\", \"global\").\nCase-insensitive, normalized form only (e.g., \"eastus\" not \"East US\").",
+          "items": {
+            "type": "string"
+          }
+        },
+        "zones": {
+          "type": "array",
+          "description": "Array of logical availability zone identifiers (e.g., \"1\", \"2\", \"3\", \"zone-redundant\").\n\nMutually exclusive with `physicalZones` — set one or the other, not both.\nWhen set, `locations` must also be set on the same side (zone IDs are only meaningful within a region).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "physicalZones": {
+          "type": "array",
+          "description": "Array of physical datacenter zone identifiers in `{region}-az{N}` format\n(e.g., \"westus2-az1\"). Resolved to logical zones per-subscription at execution time.\n\nMutually exclusive with `zones` — set one or the other, not both.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "types": {
+          "type": "array",
+          "description": "Array of Azure resource type strings (e.g., \"Microsoft.Compute/virtualMachines\").\nCase-insensitive equality. Supports trailing wildcard (e.g., \"Microsoft.Compute/*\").",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "description": "Array of tag key-value pairs for filtering by Azure resource tags.\nKey and value are matched case-insensitively. Use \"*\" as value to match any value for a key.",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        },
+        "resources": {
+          "type": "array",
+          "description": "Array of fully qualified Azure resource IDs. Case-insensitive equality.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource."
+          }
+        }
+      }
+    },
+    "RoleAssignmentError": {
+      "type": "object",
+      "description": "Error details for a failed role assignment.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Azure error code.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Error message.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ]
+    },
+    "RoleAssignmentResult": {
+      "type": "object",
+      "description": "Result of a single role assignment operation.",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The target Azure resource ID.",
+          "readOnly": true
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The managed identity principal ID.",
+          "readOnly": true
+        },
+        "roleDefinitionId": {
+          "type": "string",
+          "description": "The Azure RBAC role definition ID.",
+          "readOnly": true
+        },
+        "roleDefinitionName": {
+          "type": "string",
+          "description": "Human-readable role name.",
+          "readOnly": true
+        },
+        "scope": {
+          "type": "string",
+          "description": "The scope at which the role was/will be assigned.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/RoleAssignmentStatus",
+          "description": "The status of the role assignment operation.",
+          "readOnly": true
+        },
+        "roleAssignmentId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The created role assignment resource ID (null if failed or what-if mode).",
+          "readOnly": true
+        },
+        "error": {
+          "$ref": "#/definitions/RoleAssignmentError",
+          "description": "Error details if the assignment failed.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "targetResourceId",
+        "principalId",
+        "roleDefinitionId",
+        "roleDefinitionName",
+        "scope",
+        "status"
+      ]
+    },
+    "RoleAssignmentStatus": {
+      "type": "string",
+      "description": "Enum of the role assignment status.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Skipped",
+        "Pending"
+      ],
+      "x-ms-enum": {
+        "name": "RoleAssignmentStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The role assignment succeeded."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The role assignment failed."
+          },
+          {
+            "name": "Skipped",
+            "value": "Skipped",
+            "description": "The role assignment was skipped (already exists)."
+          },
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "The role assignment is pending (what-if mode)."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "RunAfter": {
+      "type": "object",
+      "description": "Model that represents action dependencies.",
+      "properties": {
+        "behavior": {
+          "type": "string",
+          "description": "Defines how multiple dependencies are evaluated.",
+          "default": "Any",
+          "enum": [
+            "Any",
+            "All",
+            "AtLeastOne"
+          ],
+          "x-ms-enum": {
+            "name": "RunAfterBehavior",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Any",
+                "value": "Any",
+                "description": "Always continues after all dependencies (like a finally block)."
+              },
+              {
+                "name": "All",
+                "value": "All",
+                "description": "All dependencies must be satisfied to continue."
+              },
+              {
+                "name": "AtLeastOne",
+                "value": "AtLeastOne",
+                "description": "At least one dependency must be satisfied to continue."
+              }
+            ]
+          }
+        },
+        "items": {
+          "type": "array",
+          "description": "Array of action dependencies.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/ActionDependency"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "items"
+      ]
+    },
+    "Scenario": {
+      "type": "object",
+      "description": "Model that represents the scenario.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ScenarioProperties",
+          "description": "The properties of scenario."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ScenarioAction": {
+      "type": "object",
+      "description": "Model that represents a scenario action.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique name for the action.",
+          "pattern": "^[a-zA-Z0-9-_]+$"
+        },
+        "actionId": {
+          "type": "string",
+          "description": "Identifier of the action and version (e.g., \"microsoft-compute-shutdown/1.0\")."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this action does."
+        },
+        "duration": {
+          "type": "string",
+          "description": "ISO 8601 duration for how long the action runs (e.g., PT30M for 30 minutes). Supports template macro syntax (%%\\{parameters.\\<name\\>\\}%%)."
+        },
+        "parameters": {
+          "type": "array",
+          "description": "Action-specific parameter values.",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        },
+        "runAfter": {
+          "$ref": "#/definitions/RunAfter",
+          "description": "Action dependencies that control when this action starts."
+        },
+        "waitBefore": {
+          "type": "string",
+          "description": "ISO 8601 duration to wait before action starts (e.g., PT30S for 30 seconds). Supports template macro syntax."
+        },
+        "timeout": {
+          "type": "string",
+          "description": "ISO 8601 duration for maximum action execution time. Supports template macro syntax."
+        },
+        "externalResource": {
+          "$ref": "#/definitions/ExternalResource",
+          "description": "External resource reference for the action."
+        }
+      },
+      "required": [
+        "name",
+        "actionId",
+        "duration"
+      ]
+    },
+    "ScenarioConfiguration": {
+      "type": "object",
+      "description": "Model that represents the scenario.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ScenarioConfigurationProperties",
+          "description": "The properties of scenario definition."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ScenarioConfigurationListResult": {
+      "type": "object",
+      "description": "Model that represents a list of scenario configurations and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ScenarioConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/ScenarioConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ScenarioConfigurationProperties": {
+      "type": "object",
+      "description": "Model that represents the properties of the scenario configuration.",
+      "properties": {
+        "scenarioId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the scenario this configuration applies to."
+        },
+        "parameters": {
+          "type": "array",
+          "description": "Runtime parameter values for the scenario. Keys must match parameter names defined in the scenario.",
+          "items": {
+            "$ref": "#/definitions/KeyValuePair"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Most recent provisioning state for the given scenario resource.",
+          "readOnly": true
+        },
+        "resourceTargeting": {
+          "$ref": "#/definitions/ResourceTargeting",
+          "description": "Unified resource targeting policy that controls which discovered resources participate\nin fault injection. Replaces the separate `exclusions` and `filters` properties with\nsymmetric include/exclude criteria.\n\nInclude uses AND logic — a resource must match ALL active include dimensions.\nExclude uses OR logic — a resource is removed if it matches ANY exclude dimension.\nWhen include and exclude conflict on the same resource, exclude wins.\n\nNull or omitted means all discovered resources participate (no targeting constraints)."
+        }
+      },
+      "required": [
+        "scenarioId"
+      ]
+    },
+    "ScenarioErrors": {
+      "type": "object",
+      "description": "Model that represents the scenario run errors.",
+      "properties": {
+        "errorCode": {
+          "type": "string",
+          "description": "Error code for internal server errors."
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Error message for internal server errors."
+        },
+        "permission": {
+          "type": "array",
+          "description": "Any permission errors associated with the scenario run.",
+          "items": {
+            "$ref": "#/definitions/PermissionError"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "resourceId"
+          ]
+        },
+        "resource": {
+          "type": "array",
+          "description": "Any resource state errors associated with the scenario run.",
+          "items": {
+            "$ref": "#/definitions/ResourceStateError"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "resourceId"
+          ]
+        }
+      },
+      "required": [
+        "permission",
+        "resource"
+      ]
+    },
+    "ScenarioListResult": {
+      "type": "object",
+      "description": "Model that represents a list of scenarios and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Scenario items on this page",
+          "items": {
+            "$ref": "#/definitions/Scenario"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ScenarioParameter": {
+      "type": "object",
+      "description": "Model that represents a single scenario parameter definition.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the parameter.",
+          "minLength": 1
+        },
+        "type": {
+          "$ref": "#/definitions/ParameterType",
+          "description": "Parameter data type."
+        },
+        "default": {
+          "type": "string",
+          "description": "Default value for the parameter."
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this parameter is required."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the parameter."
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "ScenarioProperties": {
+      "type": "object",
+      "description": "Model that represents the properties of the scenario.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Most recent provisioning state for the given scenario resource.",
+          "readOnly": true
+        },
+        "createdFrom": {
+          "type": "string",
+          "description": "Resource ID of the template version this scenario was created from (optional).",
+          "readOnly": true
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the scenario.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what this scenario does (optional)."
+        },
+        "parameters": {
+          "type": "array",
+          "description": "Parameter definitions for the scenario.",
+          "items": {
+            "$ref": "#/definitions/ScenarioParameter"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "description": "Array of actions that define the scenario's orchestration.",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/definitions/ScenarioAction"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "recommendation": {
+          "$ref": "#/definitions/Recommendation",
+          "description": "The recommendation information for this scenario.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "parameters",
+        "actions"
+      ]
+    },
+    "ScenarioRun": {
+      "type": "object",
+      "description": "Model that represents the scenario run.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ScenarioRunProperties",
+          "description": "The properties of scenario run."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ScenarioRunListResult": {
+      "type": "object",
+      "description": "Model that represents a list of scenario runs and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ScenarioRun items on this page",
+          "items": {
+            "$ref": "#/definitions/ScenarioRun"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ScenarioRunProperties": {
+      "type": "object",
+      "description": "Model that represents the properties of the scenario run.",
+      "properties": {
+        "workspaceName": {
+          "type": "string",
+          "description": "The workspace name.",
+          "readOnly": true
+        },
+        "scenarioName": {
+          "type": "string",
+          "description": "The scenario name.",
+          "readOnly": true
+        },
+        "scenarioConfigurationName": {
+          "type": "string",
+          "description": "The scenario configuration name.",
+          "readOnly": true
+        },
+        "managedIdentityPrincipalId": {
+          "type": "string",
+          "description": "The principal id for the managed identity used for the run.",
+          "readOnly": true
+        },
+        "resourceSnapshotId": {
+          "type": "string",
+          "description": "The resource snapshot ID this run is pinned to. Resolved from the scenario's\npinned evaluation snapshot (template scenarios) or the latest discovery\nsnapshot (custom scenarios) at run creation, ensuring the run executes against\nthe same set of discovered resources that produced the recommendation.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/ScenarioRunState",
+          "description": "The scenario run status.",
+          "readOnly": true
+        },
+        "resources": {
+          "type": "array",
+          "description": "All resources discovered for the scenario run.",
+          "items": {
+            "$ref": "#/definitions/ScenarioRunResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        },
+        "excludedResources": {
+          "type": "array",
+          "description": "Resources that matched the scenario's target resource types but were excluded\nfrom fault injection by the configuration's resource-targeting filters\n(for example zone, location, or explicit exclusions). These resources will not be impacted by the run.",
+          "items": {
+            "$ref": "#/definitions/ScenarioRunResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        },
+        "errors": {
+          "type": "array",
+          "description": "System or infrastructure errors encountered during the scenario run.",
+          "items": {
+            "$ref": "#/definitions/OperationError"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "executionErrors": {
+          "$ref": "#/definitions/ScenarioErrors",
+          "description": "Business errors from fault injection — permission and resource state issues.",
+          "readOnly": true
+        },
+        "scenarioRunJson": {
+          "type": "string",
+          "description": "The scenario run json.",
+          "readOnly": true
+        },
+        "scenarioRunSummary": {
+          "type": "array",
+          "description": "The scenario run summary.",
+          "items": {
+            "$ref": "#/definitions/ScenarioRunSummaryAction"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "actionUrn"
+          ]
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the scenario run was started.",
+          "readOnly": true
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the scenario run was completed.",
+          "readOnly": true
+        },
+        "zoneResolution": {
+          "$ref": "#/definitions/ZoneResolutionInfo",
+          "description": "Zone resolution information. Present when the scenario configuration\nused physical zone targeting (`physicalZones`). Contains the mode,\nrequested physical zones, and per-subscription logical zone mappings.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "workspaceName",
+        "scenarioName",
+        "scenarioConfigurationName",
+        "managedIdentityPrincipalId",
+        "status",
+        "resources",
+        "startTime"
+      ]
+    },
+    "ScenarioRunResource": {
+      "type": "object",
+      "description": "Model that represents the scenario run resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The resource id.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "ScenarioRunState": {
+      "type": "string",
+      "description": "Enum of the scenario run state.",
+      "enum": [
+        "Queued",
+        "Resolving",
+        "Generating",
+        "Validating",
+        "ValidationSucceeded",
+        "Starting",
+        "Preparing",
+        "Running",
+        "CleaningUp",
+        "Canceling",
+        "Canceled",
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "ScenarioRunState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Queued",
+            "value": "Queued",
+            "description": "The scenario run has been queued and is waiting to start."
+          },
+          {
+            "name": "Resolving",
+            "value": "Resolving",
+            "description": "The scenario run is in the process of being resolved."
+          },
+          {
+            "name": "Generating",
+            "value": "Generating",
+            "description": "The scenario run is in the process of being generated."
+          },
+          {
+            "name": "Validating",
+            "value": "Validating",
+            "description": "The scenario run is in the process of being validated."
+          },
+          {
+            "name": "ValidationSucceeded",
+            "value": "ValidationSucceeded",
+            "description": "The scenario run validation has completed successfully."
+          },
+          {
+            "name": "Starting",
+            "value": "Starting",
+            "description": "The scenario run is in the process of being started."
+          },
+          {
+            "name": "Preparing",
+            "value": "Preparing",
+            "description": "The scenario run is in the process of being prepared."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The scenario run is in the process of running."
+          },
+          {
+            "name": "CleaningUp",
+            "value": "CleaningUp",
+            "description": "The scenario run is in the process of being cleaned up."
+          },
+          {
+            "name": "Canceling",
+            "value": "Canceling",
+            "description": "The scenario run is in the process of being canceled."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The scenario run has been canceled."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The scenario run has completed successfully."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The scenario run has failed."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ScenarioRunSummaryAction": {
+      "type": "object",
+      "description": "Model that represents the scenario run action.",
+      "properties": {
+        "resources": {
+          "type": "array",
+          "description": "The resources associated with the specified action.",
+          "items": {
+            "$ref": "#/definitions/ScenarioRunResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        },
+        "actionUrn": {
+          "type": "string",
+          "description": "The urn for the given chaos action.",
+          "readOnly": true
+        },
+        "state": {
+          "$ref": "#/definitions/ScenarioSummaryState",
+          "description": "The state of the action.",
+          "readOnly": true
+        },
+        "startedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the action was started.",
+          "readOnly": true
+        },
+        "completedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the action was completed.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "resources",
+        "actionUrn",
+        "state"
+      ]
+    },
+    "ScenarioSummaryState": {
+      "type": "string",
+      "description": "Enum of the scenario run summary action state.",
+      "enum": [
+        "Pending",
+        "Starting",
+        "Running",
+        "Stopping",
+        "Succeeded",
+        "Canceling",
+        "Canceled",
+        "FailingOnError",
+        "Failed",
+        "Skipped"
+      ],
+      "x-ms-enum": {
+        "name": "ScenarioSummaryState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "The action is pending and has not started."
+          },
+          {
+            "name": "Starting",
+            "value": "Starting",
+            "description": "The action is in the process of starting."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The action is in the process of running."
+          },
+          {
+            "name": "Stopping",
+            "value": "Stopping",
+            "description": "The action is in the process of stopping."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The action has completed successfully."
+          },
+          {
+            "name": "Canceling",
+            "value": "Canceling",
+            "description": "The action is in the process of being canceled."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The action has been canceled."
+          },
+          {
+            "name": "FailingOnError",
+            "value": "FailingOnError",
+            "description": "The action is failing due to an error."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The action has failed."
+          },
+          {
+            "name": "Skipped",
+            "value": "Skipped",
+            "description": "The action was skipped."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ScenarioValidationState": {
+      "type": "string",
+      "description": "Enum of the scenario validation state.",
+      "enum": [
+        "Resolving",
+        "Generating",
+        "Validating",
+        "Accepted",
+        "NotStarted",
+        "RequiresAttention",
+        "NoResolvedResources",
+        "Succeeded"
+      ],
+      "x-ms-enum": {
+        "name": "ScenarioValidationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Resolving",
+            "value": "Resolving",
+            "description": "The scenario validation is in a resolving state."
+          },
+          {
+            "name": "Generating",
+            "value": "Generating",
+            "description": "The scenario validation is in a generating state."
+          },
+          {
+            "name": "Validating",
+            "value": "Validating",
+            "description": "The scenario validation is in a validating state."
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The scenario validation has been accepted."
+          },
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "The scenario validation has not yet started."
+          },
+          {
+            "name": "RequiresAttention",
+            "value": "RequiresAttention",
+            "description": "The scenario validation reflects a state that requires attention.\nThis is a terminal failure state indicating validation issues were found."
+          },
+          {
+            "name": "NoResolvedResources",
+            "value": "NoResolvedResources",
+            "description": "The scenario validation found no valid resources to perform fault behaviors against.\nThis is a terminal failure state."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The scenario validation completed successfully and the scenario is ready to execute."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "SelectorType": {
+      "type": "string",
+      "description": "Enum of the selector type.",
+      "enum": [
+        "List",
+        "Query"
+      ],
+      "x-ms-enum": {
+        "name": "SelectorType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "List",
+            "value": "List",
+            "description": "List selector type."
+          },
+          {
+            "name": "Query",
+            "value": "Query",
+            "description": "Query selector type."
+          }
+        ]
+      }
+    },
+    "StepStatus": {
+      "type": "object",
+      "description": "Model that represents the a list of branches and branch statuses.",
+      "properties": {
+        "stepName": {
+          "type": "string",
+          "description": "The name of the step.",
+          "readOnly": true
+        },
+        "stepId": {
+          "type": "string",
+          "description": "The id of the step.",
+          "readOnly": true
+        },
+        "status": {
+          "type": "string",
+          "description": "The value of the status of the step.",
+          "readOnly": true
+        },
+        "branches": {
+          "type": "array",
+          "description": "The array of branches.",
+          "items": {
+            "$ref": "#/definitions/BranchStatus"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "branchName"
+          ]
+        }
+      }
+    },
+    "Target": {
+      "type": "object",
+      "description": "Model that represents a Target resource.",
+      "properties": {
+        "properties": {
+          "type": "object",
+          "description": "The properties of the target resource.",
+          "additionalProperties": {},
+          "x-ms-client-flatten": true
+        },
+        "location": {
+          "$ref": "#/definitions/Azure.Core.azureLocation",
+          "description": "Azure resource location.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TargetListResult": {
+      "type": "object",
+      "description": "Model that represents a list of Target resources and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Target items on this page",
+          "items": {
+            "$ref": "#/definitions/Target"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "TargetReference": {
+      "type": "object",
+      "description": "Model that represents a reference to a Target in the selector.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/TargetReferenceType",
+          "description": "Enum of the Target reference type."
+        },
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "String of the resource ID of a Target resource."
+        }
+      },
+      "required": [
+        "type",
+        "id"
+      ]
+    },
+    "TargetReferenceType": {
+      "type": "string",
+      "description": "Enum of the Target reference type.",
+      "enum": [
+        "ChaosTarget"
+      ],
+      "x-ms-enum": {
+        "name": "TargetReferenceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ChaosTarget",
+            "value": "ChaosTarget",
+            "description": "Chaos target reference type."
+          }
+        ]
+      }
+    },
+    "TargetType": {
+      "type": "object",
+      "description": "Model that represents a Target Type resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/TargetTypeProperties",
+          "description": "The properties of the target type resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "TargetTypeListResult": {
+      "type": "object",
+      "description": "Model that represents a list of Target Type resources and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The TargetType items on this page",
+          "items": {
+            "$ref": "#/definitions/TargetType"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "TargetTypeProperties": {
+      "type": "object",
+      "description": "Model that represents the base Target Type properties model.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "Localized string of the display name.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Localized string of the description.",
+          "readOnly": true
+        },
+        "propertiesSchema": {
+          "type": "string",
+          "description": "URL to retrieve JSON schema of the Target Type properties.",
+          "maxLength": 2048,
+          "readOnly": true
+        },
+        "resourceTypes": {
+          "type": "array",
+          "description": "List of resource types this Target Type can extend.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "TemplateEvaluationResultItem": {
+      "type": "object",
+      "description": "Model that represents a single template evaluation result.",
+      "properties": {
+        "templateId": {
+          "type": "string",
+          "description": "The template ID that was evaluated. Optional because the underlying BE field may\nbe null for legacy evaluations created before template-centric persistence landed;\nthe GW falls back to `scenarioName` in that case (`scenario.Id == templateId` by BE\nconvention), so ARM responses are typically populated in practice."
+        },
+        "templateName": {
+          "type": "string",
+          "description": "The template name that was evaluated. Optional for the same reason as `templateId`."
+        },
+        "evaluationResult": {
+          "$ref": "#/definitions/RecommendationStatus",
+          "description": "The evaluation result for this template."
+        }
+      },
+      "required": [
+        "evaluationResult"
+      ]
+    },
+    "Validation": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ValidationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ValidationProperties": {
+      "type": "object",
+      "description": "Model that represents the properties of the scenario validation.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ScenarioValidationState",
+          "description": "The scenario validation status.",
+          "readOnly": true
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The scenario validation UTC start time.",
+          "readOnly": true
+        },
+        "executionPlanJson": {
+          "type": "string",
+          "description": "Execution plan created from validation. This plan will be executed as-is on next scenario execution."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The scenario validation UTC end time.",
+          "readOnly": true
+        },
+        "resources": {
+          "type": "array",
+          "description": "Resources that matched the scenario's target resource types and will be impacted\nby the run, resolved after applying the configuration's resource-targeting filters.",
+          "items": {
+            "$ref": "#/definitions/ScenarioRunResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        },
+        "excludedResources": {
+          "type": "array",
+          "description": "Resources that matched the scenario's target resource types but were excluded\nfrom fault injection by the configuration's resource-targeting filters\n(for example zone, location, or explicit exclusions). These resources will not be impacted.",
+          "items": {
+            "$ref": "#/definitions/ScenarioRunResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        },
+        "errors": {
+          "type": "array",
+          "description": "System or infrastructure errors encountered during validation.",
+          "items": {
+            "$ref": "#/definitions/OperationError"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "validationErrors": {
+          "$ref": "#/definitions/ScenarioErrors",
+          "description": "Business errors from validation — permission and resource state issues."
+        }
+      },
+      "required": [
+        "status",
+        "startTime"
+      ]
+    },
+    "Workspace": {
+      "type": "object",
+      "description": "Model that represents a Workspace resource.",
+      "properties": {
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        },
+        "properties": {
+          "$ref": "#/definitions/WorkspaceProperties",
+          "description": "The properties of the Workspace resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "WorkspaceDiscovery": {
+      "type": "object",
+      "description": "Model that represents the latest workspace discovery result.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WorkspaceDiscoveryProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "WorkspaceDiscoveryProperties": {
+      "type": "object",
+      "description": "Model that represents the properties of the workspace discovery.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/WorkspaceDiscoveryStatus",
+          "description": "The discovery status.",
+          "readOnly": true
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The discovery UTC start time.",
+          "readOnly": true
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The discovery UTC end time.",
+          "readOnly": true
+        },
+        "errors": {
+          "type": "array",
+          "description": "System or infrastructure errors encountered during discovery.",
+          "items": {
+            "$ref": "#/definitions/OperationError"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "workspaceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The workspace ID this discovery belongs to.",
+          "readOnly": true
+        },
+        "resourceSnapshotId": {
+          "type": "string",
+          "description": "The resource snapshot ID produced by this discovery.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "status",
+        "workspaceId"
+      ]
+    },
+    "WorkspaceDiscoveryStatus": {
+      "type": "string",
+      "description": "Enum of the workspace discovery status.",
+      "enum": [
+        "Pending",
+        "Queued",
+        "InProgress",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "WorkspaceDiscoveryStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "The discovery is pending and has not started."
+          },
+          {
+            "name": "Queued",
+            "value": "Queued",
+            "description": "The discovery has been accepted and is queued for execution."
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "The discovery is in progress."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The discovery completed successfully."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The discovery failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The discovery was canceled."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "WorkspaceEvaluation": {
+      "type": "object",
+      "description": "Model that represents the latest workspace evaluation result.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WorkspaceEvaluationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "WorkspaceEvaluationProperties": {
+      "type": "object",
+      "description": "Model that represents the properties of the workspace evaluation.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/WorkspaceEvaluationStatus",
+          "description": "The evaluation status.",
+          "readOnly": true
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The evaluation UTC start time.",
+          "readOnly": true
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The evaluation UTC end time.",
+          "readOnly": true
+        },
+        "errors": {
+          "type": "array",
+          "description": "System or infrastructure errors encountered during evaluation.",
+          "items": {
+            "$ref": "#/definitions/OperationError"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "workspaceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The workspace ID this evaluation belongs to.",
+          "readOnly": true
+        },
+        "resourceSnapshotId": {
+          "type": "string",
+          "description": "The resource snapshot ID used for this evaluation.",
+          "readOnly": true
+        },
+        "numTemplatesToEvaluate": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of templates to evaluate.",
+          "readOnly": true
+        },
+        "numTemplatesEvaluatedSucceeded": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of templates that evaluated successfully.",
+          "readOnly": true
+        },
+        "numTemplatesEvaluatedFailed": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of templates that failed evaluation.",
+          "readOnly": true
+        },
+        "numTemplatesEvaluatedCancelled": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of templates that were cancelled during evaluation.",
+          "readOnly": true
+        },
+        "evaluationResult": {
+          "$ref": "#/definitions/RecommendationStatus",
+          "description": "The overall evaluation result.",
+          "readOnly": true
+        },
+        "results": {
+          "type": "array",
+          "description": "Per-template evaluation results.",
+          "items": {
+            "$ref": "#/definitions/TemplateEvaluationResultItem"
+          },
+          "readOnly": true,
+          "x-ms-client-name": "Results",
+          "x-ms-identifiers": [
+            "templateId"
+          ]
+        }
+      },
+      "required": [
+        "status",
+        "workspaceId"
+      ]
+    },
+    "WorkspaceEvaluationStatus": {
+      "type": "string",
+      "description": "Enum of the workspace evaluation status.",
+      "enum": [
+        "Pending",
+        "Queued",
+        "InProgress",
+        "Succeeded",
+        "PartiallySucceeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "WorkspaceEvaluationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "The evaluation is pending and has not started."
+          },
+          {
+            "name": "Queued",
+            "value": "Queued",
+            "description": "The evaluation has been accepted and is queued for execution."
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "The evaluation is in progress."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The evaluation completed successfully."
+          },
+          {
+            "name": "PartiallySucceeded",
+            "value": "PartiallySucceeded",
+            "description": "The evaluation partially succeeded — some scenarios succeeded while others failed."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The evaluation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The evaluation was canceled."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "WorkspaceListResult": {
+      "type": "object",
+      "description": "Model that represents a list of Workspace resources and a link for pagination.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Workspace items on this page",
+          "items": {
+            "$ref": "#/definitions/Workspace"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "WorkspaceProperties": {
+      "type": "object",
+      "description": "Model that represents the Workspace properties model.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Most recent provisioning state for the given Workspace resource.",
+          "readOnly": true
+        },
+        "communicationEndpoint": {
+          "type": "string",
+          "description": "The communication endpoint used to connect and communicate with the workspace for fault-injection orchestration.",
+          "readOnly": true
+        },
+        "scopes": {
+          "type": "array",
+          "description": "The intended workspace-level resource scope to be used by child scenarios.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource."
+          }
+        }
+      },
+      "required": [
+        "scopes"
+      ]
+    },
+    "WorkspaceUpdate": {
+      "type": "object",
+      "description": "Describes a workspace update.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      }
+    },
+    "ZoneResolutionInfo": {
+      "type": "object",
+      "description": "Information about how physical zones were resolved to logical zones\nfor each subscription during scenario execution.",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/ZoneResolutionMode",
+          "description": "The zone targeting mode used for this run.\n`logical` — customer specified logical zone identifiers directly.\n`physical` — customer specified physical zone identifiers; the system\nresolved them to per-subscription logical zones at execution time.",
+          "readOnly": true
+        },
+        "requestedPhysicalZones": {
+          "type": "array",
+          "description": "The physical zone identifiers requested by the customer in the\nscenario configuration (e.g., `[\"westus2-az1\"]`).\nEmpty array when `mode` is `logical`.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "subscriptionZoneMappings": {
+          "type": "array",
+          "description": "Per-subscription zone resolution results. Each entry maps a subscription\nto the logical zone resolved from the requested physical zone.\nEmpty when `mode` is `logical`.",
+          "items": {
+            "$ref": "#/definitions/ZoneResolutionMapping"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "subscriptionId"
+          ]
+        }
+      },
+      "required": [
+        "mode",
+        "requestedPhysicalZones",
+        "subscriptionZoneMappings"
+      ]
+    },
+    "ZoneResolutionMapping": {
+      "type": "object",
+      "description": "Maps a single subscription to its physical-to-logical zone resolutions.",
+      "properties": {
+        "subscriptionId": {
+          "type": "string",
+          "description": "The subscription ID (e.g., `\"6b052e15-03d3-4f17-b2e1-be7f07588291\"`).",
+          "readOnly": true
+        },
+        "zoneMappings": {
+          "type": "array",
+          "description": "The physical-to-logical zone mappings for this subscription.",
+          "items": {
+            "$ref": "#/definitions/PhysicalToLogicalZoneMapping"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "physicalZone"
+          ]
+        }
+      },
+      "required": [
+        "subscriptionId",
+        "zoneMappings"
+      ]
+    },
+    "ZoneResolutionMode": {
+      "type": "string",
+      "description": "The zone resolution mode for a scenario run.",
+      "enum": [
+        "logical",
+        "physical"
+      ],
+      "x-ms-enum": {
+        "name": "ZoneResolutionMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Logical",
+            "value": "logical",
+            "description": "Logical zone mode — customer specified logical zone identifiers directly."
+          },
+          {
+            "name": "Physical",
+            "value": "physical",
+            "description": "Physical zone mode — system resolved physical zones to per-subscription\nlogical zones at execution time."
+          }
+        ]
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
## Summary

- add the `2026-11-01` stable API version for Microsoft.Chaos
- promote the complete current `2026-08-01-preview` API surface
- add versioned source examples and generated OpenAPI output
- add the `package-2026-11` AutoRest tag

## Notes

This draft establishes the GA baseline while `2026-08-01-preview` finishes publishing. It should be updated from `main` after that preview lands so the GA surface and examples reflect the final published preview.