### PR TITLE
Add lifecycle policy progress system event

### DIFF
--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/LifecyclePolicyProgressExample.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/LifecyclePolicyProgressExample.tsp
@@ -1,0 +1,9 @@
+import "./Storage.tsp";
+
+namespace Microsoft.EventGrid.SystemEvents;
+
+const MicrosoftStorageLifecyclePolicyProgressExample: StorageLifecyclePolicyProgressEventData = #{
+  scheduleTime: "2026/05/30 02:18:35.9024958",
+  jobStatus: "InProgress",
+  objectProcessed: 7054966,
+};

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/Storage.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/Storage.tsp
@@ -1,3 +1,4 @@
+import "./LifecyclePolicyProgressExample.tsp";
 import "@typespec/versioning";
 using TypeSpec.Versioning;
 /** Describes the schema of the Azure Storage events published to Azure Event Grid. This corresponds to the Data property of an EventGridEvent. */
@@ -203,6 +204,22 @@ namespace Microsoft.EventGrid.SystemEvents {
     tierToColdSummary: StorageLifecyclePolicyActionSummaryDetail;
   }
 
+  /** Schema of the Data property of an EventGridEvent for a Microsoft.Storage.LifecyclePolicyProgress event. */
+  @example(MicrosoftStorageLifecyclePolicyProgressExample)
+  model StorageLifecyclePolicyProgressEventData {
+    /** The earliest scan start time reported by the lifecycle policy tasks, formatted as a service-defined timestamp string. */
+    scheduleTime: string;
+
+    /** The current status of the lifecycle policy job. */
+    jobStatus: StorageLifecyclePolicyProgressStatus;
+
+    /** The reason why the lifecycle policy job was interrupted. */
+    interruptedCause?: StorageLifecyclePolicyProgressInterruptedCause;
+
+    /** The cumulative number of successful lifecycle policy action operations. */
+    objectProcessed?: int64;
+  }
+
   /** Execution statistics of a specific policy action in a Blob Management cycle. */
   model StorageLifecyclePolicyActionSummaryDetail {
     /** Total number of objects to be acted on by this action. */
@@ -383,6 +400,34 @@ namespace Microsoft.EventGrid.SystemEvents {
 
     /** Incomplete */
     "Incomplete",
+
+    string,
+  }
+
+  /** The status of a lifecycle policy progress event. */
+  union StorageLifecyclePolicyProgressStatus {
+    /** The lifecycle policy job started. */
+    "Started",
+
+    /** The lifecycle policy job is in progress. */
+    "InProgress",
+
+    /** The lifecycle policy job was interrupted. */
+    "Interrupted",
+
+    /** The lifecycle policy job completed. */
+    "Completed",
+
+    string,
+  }
+
+  /** The reason why a lifecycle policy job was interrupted. */
+  union StorageLifecyclePolicyProgressInterruptedCause {
+    /** The job grace period expired. */
+    "Grace time expired",
+
+    /** The lifecycle policy rule was updated. */
+    "Rule Updated",
 
     string,
   }

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/client.tsp
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/client.tsp
@@ -59,6 +59,14 @@ using Azure.ClientGenerator.Core;
   Access.public
 );
 @@usage(
+  Microsoft.EventGrid.SystemEvents.StorageLifecyclePolicyProgressEventData,
+  Usage.output | Usage.json
+);
+@@access(
+  Microsoft.EventGrid.SystemEvents.StorageLifecyclePolicyProgressEventData,
+  Access.public
+);
+@@usage(
   Microsoft.EventGrid.SystemEvents.StorageLifecyclePolicyActionSummaryDetail,
   Usage.output | Usage.json
 );
@@ -129,6 +137,22 @@ using Azure.ClientGenerator.Core;
 );
 //Enums
 @@usage(
+  Microsoft.EventGrid.SystemEvents.StorageLifecyclePolicyProgressStatus,
+  Usage.output | Usage.json
+);
+@@access(
+  Microsoft.EventGrid.SystemEvents.StorageLifecyclePolicyProgressStatus,
+  Access.public
+);
+@@usage(
+  Microsoft.EventGrid.SystemEvents.StorageLifecyclePolicyProgressInterruptedCause,
+  Usage.output | Usage.json
+);
+@@access(
+  Microsoft.EventGrid.SystemEvents.StorageLifecyclePolicyProgressInterruptedCause,
+  Access.public
+);
+@@usage(
   Microsoft.EventGrid.SystemEvents.StorageTaskAssignmentCompletedStatus,
   Usage.output | Usage.json
 );
@@ -184,6 +208,10 @@ using Azure.ClientGenerator.Core;
 );
 @@useSystemTextJsonConverter(
   Microsoft.EventGrid.SystemEvents.StorageLifecyclePolicyCompletedEventData,
+  "csharp"
+);
+@@useSystemTextJsonConverter(
+  Microsoft.EventGrid.SystemEvents.StorageLifecyclePolicyProgressEventData,
   "csharp"
 );
 @@useSystemTextJsonConverter(

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2018-01-01/GeneratedSystemEvents.json
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2018-01-01/GeneratedSystemEvents.json
@@ -9003,6 +9003,93 @@
         "tierToColdSummary"
       ]
     },
+    "StorageLifecyclePolicyProgressEventData": {
+      "type": "object",
+      "description": "Schema of the Data property of an EventGridEvent for a Microsoft.Storage.LifecyclePolicyProgress event.",
+      "properties": {
+        "scheduleTime": {
+          "type": "string",
+          "description": "The earliest scan start time reported by the lifecycle policy tasks, formatted as a service-defined timestamp string."
+        },
+        "jobStatus": {
+          "$ref": "#/definitions/StorageLifecyclePolicyProgressStatus",
+          "description": "The current status of the lifecycle policy job."
+        },
+        "interruptedCause": {
+          "$ref": "#/definitions/StorageLifecyclePolicyProgressInterruptedCause",
+          "description": "The reason why the lifecycle policy job was interrupted."
+        },
+        "objectProcessed": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The cumulative number of successful lifecycle policy action operations."
+        }
+      },
+      "required": [
+        "scheduleTime",
+        "jobStatus"
+      ]
+    },
+    "StorageLifecyclePolicyProgressInterruptedCause": {
+      "type": "string",
+      "description": "The reason why a lifecycle policy job was interrupted.",
+      "enum": [
+        "Grace time expired",
+        "Rule Updated"
+      ],
+      "x-ms-enum": {
+        "name": "StorageLifecyclePolicyProgressInterruptedCause",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Grace time expired",
+            "value": "Grace time expired",
+            "description": "The job grace period expired."
+          },
+          {
+            "name": "Rule Updated",
+            "value": "Rule Updated",
+            "description": "The lifecycle policy rule was updated."
+          }
+        ]
+      }
+    },
+    "StorageLifecyclePolicyProgressStatus": {
+      "type": "string",
+      "description": "The status of a lifecycle policy progress event.",
+      "enum": [
+        "Started",
+        "InProgress",
+        "Interrupted",
+        "Completed"
+      ],
+      "x-ms-enum": {
+        "name": "StorageLifecyclePolicyProgressStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Started",
+            "value": "Started",
+            "description": "The lifecycle policy job started."
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "The lifecycle policy job is in progress."
+          },
+          {
+            "name": "Interrupted",
+            "value": "Interrupted",
+            "description": "The lifecycle policy job was interrupted."
+          },
+          {
+            "name": "Completed",
+            "value": "Completed",
+            "description": "The lifecycle policy job completed."
+          }
+        ]
+      }
+    },
     "StorageLifecyclePolicyRunSummary": {
       "type": "object",
       "description": "Policy run status of an account in a Blob Management cycle.",

--- a/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2024-01-01/GeneratedSystemEvents.json
+++ b/specification/eventgrid/data-plane/EventGridSystemEvents/stable/2024-01-01/GeneratedSystemEvents.json
@@ -9149,6 +9149,93 @@
         "tierToColdSummary"
       ]
     },
+    "StorageLifecyclePolicyProgressEventData": {
+      "type": "object",
+      "description": "Schema of the Data property of an EventGridEvent for a Microsoft.Storage.LifecyclePolicyProgress event.",
+      "properties": {
+        "scheduleTime": {
+          "type": "string",
+          "description": "The earliest scan start time reported by the lifecycle policy tasks, formatted as a service-defined timestamp string."
+        },
+        "jobStatus": {
+          "$ref": "#/definitions/StorageLifecyclePolicyProgressStatus",
+          "description": "The current status of the lifecycle policy job."
+        },
+        "interruptedCause": {
+          "$ref": "#/definitions/StorageLifecyclePolicyProgressInterruptedCause",
+          "description": "The reason why the lifecycle policy job was interrupted."
+        },
+        "objectProcessed": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The cumulative number of successful lifecycle policy action operations."
+        }
+      },
+      "required": [
+        "scheduleTime",
+        "jobStatus"
+      ]
+    },
+    "StorageLifecyclePolicyProgressInterruptedCause": {
+      "type": "string",
+      "description": "The reason why a lifecycle policy job was interrupted.",
+      "enum": [
+        "Grace time expired",
+        "Rule Updated"
+      ],
+      "x-ms-enum": {
+        "name": "StorageLifecyclePolicyProgressInterruptedCause",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Grace time expired",
+            "value": "Grace time expired",
+            "description": "The job grace period expired."
+          },
+          {
+            "name": "Rule Updated",
+            "value": "Rule Updated",
+            "description": "The lifecycle policy rule was updated."
+          }
+        ]
+      }
+    },
+    "StorageLifecyclePolicyProgressStatus": {
+      "type": "string",
+      "description": "The status of a lifecycle policy progress event.",
+      "enum": [
+        "Started",
+        "InProgress",
+        "Interrupted",
+        "Completed"
+      ],
+      "x-ms-enum": {
+        "name": "StorageLifecyclePolicyProgressStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Started",
+            "value": "Started",
+            "description": "The lifecycle policy job started."
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "The lifecycle policy job is in progress."
+          },
+          {
+            "name": "Interrupted",
+            "value": "Interrupted",
+            "description": "The lifecycle policy job was interrupted."
+          },
+          {
+            "name": "Completed",
+            "value": "Completed",
+            "description": "The lifecycle policy job completed."
+          }
+        ]
+      }
+    },
     "StorageLifecyclePolicyRunSummary": {
       "type": "object",
       "description": "Policy run status of an account in a Blob Management cycle.",


### PR DESCRIPTION
# Data Plane API Specification Update Pull Request

Onboard the `Microsoft.Storage.LifecyclePolicyProgress` Azure Event Grid system event so its public data contract is available in generated Swagger and Event Grid SDK models.

## API Info: The Basics

* Link to API Spec engagement record issue: TBD - Azure SDK Architecture Board / Event Grid system-event review

Is this review for:

- [ ] a private preview
- [ ] a public preview
- [x] GA release

The Event Grid system-events guidance treats a merged event contract as GA. Production delivery must remain disabled until Architecture Board review is complete and this PR is merged.

### Change Scope

* Design Document: Lifecycle Management progress Event Grid schema, validated against the service implementation and a captured event.
* Previous API Spec Doc: N/A - new system event.
* Updated paths:
  * `specification/eventgrid/data-plane/EventGridSystemEvents/Microsoft.Storage/`
  * `specification/eventgrid/data-plane/EventGridSystemEvents/stable/2018-01-01/GeneratedSystemEvents.json`
  * `specification/eventgrid/data-plane/EventGridSystemEvents/stable/2024-01-01/GeneratedSystemEvents.json`

## Event contract

* Event type: `Microsoft.Storage.LifecyclePolicyProgress`
* Model: `StorageLifecyclePolicyProgressEventData`
* `scheduleTime` and `jobStatus` are required.
* `interruptedCause` is emitted only for interrupted jobs.
* `objectProcessed` is omitted for `Started` and emitted as a JSON integer for later statuses.
* `scheduleTime` remains a string because the current wire contract uses the service-defined `yyyy/MM/dd HH:mm:ss.fffffff` format rather than RFC 3339.
* Job status and interruption cause are public extensible unions.
* Includes a typed TypeSpec example based on a captured service event.

## Validation

* Repository-pinned dependencies installed with `npm ci`.
* TypeSpec source formatted with the repository Prettier plugin.
* `npx tsp compile .` completed successfully.
* Both supported generated Swagger versions contain identical required fields, optionality, types, and extensible enums.
* `git diff --check` passed.
