### PR TITLE
Add azure-lint-rule-evaluation skill

### DIFF
--- a/.github/skills/azure-lint-rule-evaluation/SKILL.md
+++ b/.github/skills/azure-lint-rule-evaluation/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: azure-lint-rule-evaluation
+license: MIT
+metadata:
+  version: "1.0.0"
+description: 'Evaluate the violations produced by a new or changed TypeSpec/OpenAPI linter rule (typically from a typespec-azure or tooling PR) when it is run against Azure/azure-rest-api-specs, and decide for each violation whether it is a real author error, a false positive (rule bug), or indeterminate. USE FOR: "validate the failures from this lint rule PR", "is this new linter rule catching real bugs or false positives", "triage lro-response-mismatch / <rule-id> violations across these specs", "evaluate External Integration / typespec-next check failures for a candidate rule". Produces a markdown report with source links + evidence, suppresses confirmed author errors with a fixme justification, and validates with tsv. DO NOT USE FOR: authoring/changing spec content to add features (use azure-typespec-author), API design review (use azure-api-review), SDK generation, or fixing the rule implementation itself.'
+compatibility: "Node.js >= 20, npm; a local clone of Azure/azure-rest-api-specs; the candidate rule packages installable via pkg.pr.new (or a local build); npx tsv (@azure-tools/typespec-validation)."
+---
+
+# Azure Lint Rule Evaluation
+
+Given a PR that introduces or changes a linter rule (e.g. an
+`@azure-tools/typespec-azure-*` rule) and a set of specs that now fail, decide
+**per violation** whether the rule caught a genuine authoring error, produced a
+false positive, or is indeterminate — then suppress the real errors, leave the
+false positives visible, and report the analysis with evidence.
+
+## Rules
+
+- **Classify against author intent, not against the rule.** A violation is a
+  _user-error_ only when the flagged encoding genuinely differs from what the
+  author intended on the wire; it is a _false-positive_ when the encoding matches
+  intent but the rule's expectation is wrong; otherwise _indeterminate_.
+- **Get ground truth first.** Never guess what the rule computed. Capture the
+  rule's own inputs/outputs (see [ground-truth instrumentation](references/ground-truth-and-diagnostics.md))
+  so every determination cites the actual computed values, not an assumption.
+- **Gather intent evidence** from the PR (rule description, message text, test
+  cases), the spec source, the generated Swagger, and repo conventions before
+  deciding. When intent cannot be established, mark **indeterminate** — do not
+  force a call.
+- **Only suppress confirmed user-errors**, in-place, with the justification
+  string the requester specified (e.g. `"fixme-invalid-lro-result"`). Never
+  suppress false positives — they must remain visible so the rule can be fixed.
+- **Validate**: after suppressing, the user-error diagnostics must disappear
+  under `tsv`; the false positives should remain. Confirm before reporting.
+- **Commit** suppressions (and the report) — `tsv` compares generated Swagger and
+  the working tree against the base branch, so uncommitted `.tsp` edits make it
+  fail on git differences.
+
+## Workflow
+
+1. **Read the rule.** Fetch the PR. Extract the rule id, `severity`, `messages`
+   (each message = one violation variant), the `url`, and the decision logic
+   (what it computes and what it compares against). Read the rule's own test
+   cases — they encode the author's intended pass/fail examples.
+
+2. **Set up the environment.** Check out the target branch (usually
+   `typespec-next`). Install the candidate rule packages from pkg.pr.new and pin
+   the matching dev-versions. See
+   [environment setup](references/environment-setup.md).
+
+3. **Reproduce.** Run `npx tsv <spec-dir>` in each failing spec directory. `tsv`
+   recurses into every sub-directory containing a `tspconfig.yaml`, so one
+   invocation covers all sub-projects of a service — no manual enumeration.
+   Record which specs from the requested list produce **zero** violations too;
+   they belong in the report.
+
+4. **Collect ground truth.** Enumerate every violation and, for each, the exact
+   values the rule computed (the encoded/actual value vs the expected value) and
+   a stable source location. Prefer lightweight instrumentation of the rule over
+   inference. See [ground-truth & diagnostics](references/ground-truth-and-diagnostics.md).
+
+5. **Classify** each violation as `user-error`, `false-positive`, or
+   `indeterminate`, recording the evidence. See
+   [classification](references/classification.md) for the general procedure and
+   the worked LRO (`lro-response-mismatch`) heuristics.
+
+6. **Suppress** confirmed user-errors and **let the formatter place them.** Insert
+   `#suppress "<rule-id>" "<justification>"` above each flagged operation, then run
+   `tsp format` on the edited files so the directive lands in canonical position.
+   See [suppress & validate](references/suppress-and-validate.md).
+
+7. **Validate.** Re-run `tsv` on the affected specs; confirm every suppressed
+   user-error is gone and the false positives remain. The working tree must be
+   clean (changes committed) or `tsv`'s git checks fail.
+
+8. **Report.** Write a markdown report grouping violations by determination, each
+   with a base-branch source link, the encoded vs expected values, the evidence,
+   and — for user-errors — **how to fix it at the source instead of suppressing**.
+   Include the no-violation specs. See [reporting](references/reporting.md).
+
+> The steps above are rule-agnostic: they apply to any new or changed
+> TypeSpec/OpenAPI linter rule, not just `lro-response-mismatch`. Everywhere this
+> skill uses that rule, treat it as a worked example — substitute the rule under
+> evaluation's own contract, computed values, and conventions.
+
+## Examples
+
+- "Validate the failures from typespec-azure PR #4145's new `lro-response-mismatch`
+  rule against these 24 specs and tell me which are real bugs vs false positives."
+- "The External Integration check on typespec-next is red for this candidate rule —
+  triage each violation, suppress the real ones with `fixme-invalid-lro-result`,
+  and give me a report."
+
+## Troubleshooting
+
+- **`npx tsv` finds nothing / wrong packages** — confirm the pkg.pr.new install and
+  dev-version pins actually landed (`npm ls <rule-package>`); use
+  `--registry https://registry.npmjs.org` for the `next` dev-version pins.
+- **`tsv` fails on "Files have been changed after `tsp format`"** — your suppress
+  directive isn't in canonical position; run `tsp format` on the file and re-check.
+- **`tsv` fails on git differences** — commit the suppressions (and report); the
+  Swagger/format/diff checks compare against the base branch.
+- **Editors add a BOM** — writing `.tsp` with a BOM-adding encoding corrupts line 1;
+  write UTF-8 **without** BOM and preserve the file's original line endings.

--- a/.github/skills/azure-lint-rule-evaluation/references/classification.md
+++ b/.github/skills/azure-lint-rule-evaluation/references/classification.md
@@ -1,0 +1,84 @@
+# Classification
+
+For each violation decide one of three labels, and always record the **evidence**.
+
+| Label            | Meaning                                                                                                                                           | Action                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `user-error`     | The flagged encoding genuinely differs from what the author intended on the wire. The rule caught a real modeling bug.                            | Suppress in-place with the requester's justification. |
+| `false-positive` | The encoding matches the author's intent; the rule's expectation is wrong (too strict, wrong comparison target, legacy pattern it doesn't model). | Do **not** suppress. Report so the rule can be fixed. |
+| `indeterminate`  | Intent cannot be established from available evidence.                                                                                             | Do **not** suppress. Report as indeterminate.         |
+
+## General procedure
+
+1. Start from the **ground-truth** row (actual vs expected the rule computed).
+2. Determine **author intent** — what the operation is supposed to return / do on
+   the wire — from, in order of strength:
+   - the generated **Swagger** (what clients actually see);
+   - the **spec source** (declared responses, `LroHeaders`, template used, doc
+     comments, existing suppressions/comments explaining intent);
+   - the **rule's PR** (description, message text, and especially its test cases,
+     which encode intended pass/fail examples);
+   - **repo conventions** and the requester's stated policy.
+3. Compare intent to the encoding:
+   - encoding ≠ intent → **user-error**;
+   - encoding = intent but rule flagged it → **false-positive**;
+   - intent unclear / conflicting → **indeterminate**.
+4. When the requester states a policy directive ("actions must return their
+   intended response type", "delete must be void"), treat it as ground truth for
+   intent and apply it uniformly — don't re-litigate each instance.
+
+## Worked example: `lro-response-mismatch`
+
+The procedure above is rule-agnostic. This section applies it to one concrete
+rule as an illustration — the same steps (ground truth → intent → compare →
+classify → fix/suppress) transfer to any rule; only the rule's contract and the
+"expected" convention change.
+
+This rule compares an ARM LRO's **encoded `finalResult`** (from `getLroMetadata`)
+against the expected result for the operation shape. Establish the encoded
+`finalResult` from `getLroMetadata` (instrument the rule if needed) — **do not
+guess it** from the source. Policy used to classify:
+
+- **PUT / PATCH must resolve `finalResult` to the resource type.**
+  - `finalResult = void` (custom `LroHeaders`/response dropped
+    `FinalResult=<resource>`) → **user-error**: the LRO yields no resource.
+  - `finalResult` = a _different_ named type than the resource (e.g. a sub-resource
+    `PrivateEndpointConnection` on an interface whose resource is the parent) →
+    **user-error**: the operation should resolve to the resource it is modeled on;
+    fix by modeling the create on the correct resource or setting `FinalResult`.
+  - `finalResult` = the resource type → pass. A **false-positive** would require the
+    rule to flag a PUT/PATCH whose `finalResult` _actually equals_ the resource type.
+- **DELETE must be void on the wire.**
+  - `finalResult` is anything non-void — `OperationStatusResult`, a named result
+    model, a resource type, or `unknown` (e.g. a body-returning delete kept for
+    backward compatibility) → **user-error**: delete LROs must resolve to `void`;
+    suppress the deliberate deviation, or drop the body (a breaking change).
+  - A **false-positive** would require the rule to flag a delete whose `finalResult`
+    is _actually_ `void`.
+- **POST actions must return their intended response.** Intent comes from **either**
+  the operation template's `Response` parameter **or** the declared 200 response
+  body (a 204 / no-body action → `void`). POST is the only shape with genuine
+  wiggle room, so check both signals.
+  - `finalResult = void` while a non-void `Response`/200 body is declared (often a
+    custom `LroHeaders`/`final-state-via` that drops the body) → **user-error**: the
+    action delivers nothing. Fix by using the standard template or setting
+    `FinalResult=<Response>` on the intended terminal header.
+  - `finalResult` = an `ArmResponse<T>` **envelope** (including a named alias like
+    `ArmXResponse is ArmResponse<T>`) passed as `Response`, while the intended
+    payload is the bare `T` → **user-error**: the envelope carries HTTP
+    status/headers; the intended `finalResult` is `T`. Fix by passing `Response = T`
+    (`ArmResourceActionAsync` already wraps it in the 200 envelope). This is the rule
+    acting as intended, **not** a false positive, even though the envelope's wire
+    body is `T`.
+  - POST declares both a 200-with-body and a 204 → **user-error** (`conflicting
+responses`): keep one terminal shape.
+  - A **false-positive** would require the rule to flag a POST whose `finalResult`
+    _actually equals_ its intended response (template `Response` param or 200 body).
+
+The transferable lesson: a **false-positive means the encoding already matches the
+convention but the rule fired anyway** (a computation bug) — e.g. it would have to
+flag an actually-void delete or an actually-resource PUT. An author _intending_ to
+encode a non-idiomatic value (body-returning delete, envelope-as-`Response`,
+sub-resource PUT) is a **user-error**, not a false positive. Decide from **what the
+wire response is meant to be** (Swagger + source + `getLroMetadata` + the
+requester's policy), not from the rule alone.

--- a/.github/skills/azure-lint-rule-evaluation/references/environment-setup.md
+++ b/.github/skills/azure-lint-rule-evaluation/references/environment-setup.md
@@ -1,0 +1,68 @@
+# Environment setup
+
+Goal: run the **candidate** rule (from the PR under evaluation) against the target
+branch of `azure-rest-api-specs`, exactly as the CI "External Integration" /
+typespec-next check does.
+
+## 1. Target branch
+
+Most candidate rules are validated against the `typespec-next` branch (it tracks
+the pre-release TypeSpec toolchain). Check out that branch (or the branch the
+requester names) in your local `azure-rest-api-specs` clone. Do the work on a
+throwaway branch off it, e.g. `eval-typespec-next`.
+
+## 2. Install the candidate packages
+
+The PR author usually publishes per-PR builds via **pkg.pr.new**. The PR (or a
+pkg.pr.new template link) lists install specifiers such as:
+
+```
+@azure-tools/typespec-azure-resource-manager@https://pkg.pr.new/.../@<sha>
+```
+
+Update the repo root `package.json` dependencies to point at those specifiers,
+**and** pin the matching pre-release dev-versions of the rest of the TypeSpec
+toolchain (`@typespec/*`, `@azure-tools/*`) so the compiler and the candidate
+rule package resolve against a consistent `next` snapshot. Then:
+
+```powershell
+npm install --registry https://registry.npmjs.org
+```
+
+The `--registry` flag matters: the `next`/dev-version pins resolve from the
+public npm registry, while the pkg.pr.new URLs are absolute and fetch directly.
+
+## 3. Confirm the rule is actually loaded
+
+```powershell
+npm ls @azure-tools/typespec-azure-resource-manager   # or the rule's package
+```
+
+Verify the installed version/URL is the candidate build, and that the rule source
+under `node_modules/.../dist/src/rules/<rule>.js` is the PR version (this is also
+the file you instrument for ground truth — see
+`ground-truth-and-diagnostics.md`).
+
+## 4. Run validation
+
+From the repo, run per failing spec directory:
+
+```powershell
+npx tsv specification/<service>/<path>
+```
+
+`tsv` (`@azure-tools/typespec-validation`) recurses into every sub-directory that
+contains a `tspconfig.yaml`, compiling each sub-project with
+`tsp compile --warn-as-error`. So a single `tsv <service-dir>` covers all of a
+service's projects — you do **not** need to enumerate sub-projects yourself.
+
+Note: `--warn-as-error` means even a `severity: "warning"` rule fails the build,
+which is why warning-level rules show up as check failures.
+
+## Gotchas
+
+- Keep the modified `package.json` / `package-lock.json` out of the final
+  suppression commit unless the requester wants them — they are evaluation-only
+  environment setup, not a spec change.
+- If a spec fails to compile for reasons unrelated to the candidate rule
+  (toolchain drift on `next`), note it and exclude it from rule classification.

--- a/.github/skills/azure-lint-rule-evaluation/references/ground-truth-and-diagnostics.md
+++ b/.github/skills/azure-lint-rule-evaluation/references/ground-truth-and-diagnostics.md
@@ -1,0 +1,75 @@
+# Ground truth & diagnostics
+
+You cannot classify a violation correctly unless you know **exactly what the rule
+computed**. Two levels of data are needed for every violation:
+
+1. A **stable source location** (file + line) that maps to the flagged operation.
+2. The rule's **actual vs expected** values — the two things it compared.
+
+## Parsing raw diagnostics
+
+`tsp compile` / `tsv` print diagnostics as `path:line:col - warning <rule-id>: <message>`.
+Capture stdout+stderr, strip ANSI color codes, and keep only lines matching the
+rule id. This gives you the count and locations, but usually **not** the computed
+values — the message is a generic template. That is why instrumentation matters.
+
+## Instrumenting the rule for ground truth (recommended)
+
+The rule is plain JS under
+`node_modules/@azure-tools/<pkg>/dist/src/rules/<rule>.js`. Add a tiny logging
+helper that runs at each point the rule decides to report, emitting a single
+machine-readable line to stderr. Do **not** change any decision logic — only add
+logging.
+
+Pattern:
+
+```js
+import { getSourceLocation } from "@typespec/compiler";
+// ...inside create(context), next to the existing report call:
+function dbg(op, kind, actual, expected) {
+  try {
+    const sl = getSourceLocation(op.operation.node);
+    const line = sl?.file ? sl.file.getLineAndCharacterOfPosition(sl.pos).line + 1 : "?";
+    console.error(
+      "RULEDBG " +
+        JSON.stringify({
+          file: sl?.file?.path,
+          line,
+          op: op.name,
+          kind,
+          actual: describe(actual),
+          expected: describe(expected),
+        }),
+    );
+  } catch {}
+}
+```
+
+Call `dbg(...)` immediately before each `context.reportDiagnostic(...)`, passing
+the variant (`kind`) and the two compared types. Then:
+
+```powershell
+npx tsp compile <dir> --no-emit 2>&1 | Select-String 'RULEDBG '
+```
+
+Collect every `RULEDBG` line across all specs into a table
+(`file, line, op, kind, actual, expected`). This is the authoritative dataset for
+classification and for the report's "encoded vs expected" columns.
+
+**Remove the instrumentation before final validation** so `tsv` runs the pristine
+rule. Reinstall the package or revert the added lines; the diagnostic set is
+unchanged by the logging, but validate with the clean rule to be safe.
+
+### Line semantics
+
+`getSourceLocation(op.operation.node).pos` typically points at the operation's
+**leading trivia** — i.e. the first line of its doc-comment / decorator block, not
+the `op` keyword line. This is exactly where a `#suppress` should be inserted
+(above the doc + decorators), so use this line directly for suppression placement.
+
+## Storing the dataset
+
+Keep the violations in a queryable form (a small SQLite table or CSV) with columns
+for `file, line, op, kind, actual, expected, determination, evidence`. You will
+sort by `(file, line)` to drive suppression insertion and group by `determination`
+for the report.

--- a/.github/skills/azure-lint-rule-evaluation/references/reporting.md
+++ b/.github/skills/azure-lint-rule-evaluation/references/reporting.md
@@ -1,0 +1,71 @@
+# Reporting
+
+Produce a single markdown report (name it as the requester asks, e.g.
+`lro-rule-eval.md`). Structure:
+
+## 1. Header / context
+
+- The rule id and a link to the PR that introduces/changes it.
+- The branch and repo it was evaluated against (e.g. `typespec-next` of
+  `Azure/azure-rest-api-specs`).
+
+## 2. What the rule checks
+
+A short, plain-language statement of the rule's contract — what it computes and
+what it compares against — so a reader can judge each determination.
+
+## 3. Method
+
+Bullet the reproduction steps: candidate packages installed, `tsv` per spec,
+ground-truth capture of actual vs expected, classification against intent.
+
+## 4. Determination summary
+
+A count table:
+
+| Determination  | Count     |
+| -------------- | --------- |
+| user-error     | N         |
+| false-positive | M         |
+| indeterminate  | K         |
+| **Total**      | **N+M+K** |
+
+## 5. One section per determination
+
+For **user-error** and **false-positive** (and **indeterminate** if any), a table
+with one row per violation:
+
+| Source | Operation | Variant | Encoded (actual) | Expected | Evidence | How to fix instead of suppress |
+| ------ | --------- | ------- | ---------------- | -------- | -------- | ------------------------------ |
+
+- **Source** is a clickable link to the exact line on the evaluated branch:
+  `https://github.com/Azure/azure-rest-api-specs/blob/<branch>/<path>#L<line>`.
+- **Encoded** and **Expected** are the ground-truth values the rule computed.
+- **Evidence** is one sentence explaining _why_ this determination holds — cite
+  the wire/Swagger, the source construct, the rule's comparison, and/or the
+  requester's policy. This is the most important column; make it specific to the
+  instance, not boilerplate.
+- **How to fix instead of suppress** — for each user-error, the concrete source
+  change that makes the encoding match intent (the correct template, parameter,
+  header, or response shape), so suppression is a last resort rather than the only
+  option. Suppression records that a deviation is known; it does not fix the model.
+  Group the recurring fixes into a short "correction playbook" above the table.
+
+Precede each section with a short paragraph describing the dominant patterns for
+the rule under evaluation (for `lro-response-mismatch`, e.g. "body-returning
+DELETEs kept for backward compat", "envelope passed as an action `Response`",
+"`void` final result from custom `LroHeaders`"). Adapt the patterns to whatever
+rule you are evaluating.
+
+## 6. Specs with no violations
+
+List every spec from the requested set that produced **zero** violations, with a
+link. Absence of findings is a result worth recording — it tells the rule author
+where the rule is already clean.
+
+## Tips
+
+- Generate the tables programmatically from the stored dataset so the report and
+  the applied suppressions can never drift apart.
+- Keep determinations and evidence in the dataset (not just prose) so re-runs are
+  reproducible.

--- a/.github/skills/azure-lint-rule-evaluation/references/suppress-and-validate.md
+++ b/.github/skills/azure-lint-rule-evaluation/references/suppress-and-validate.md
@@ -1,0 +1,59 @@
+# Suppress & validate
+
+## Inserting suppressions
+
+For each **user-error** violation, add a suppression directly above the flagged
+operation:
+
+```tsp
+#suppress "<rule-id>" "<justification>"
+```
+
+Use the exact justification string the requester specified (e.g.
+`fixme-invalid-lro-result`). The rule id is the fully-qualified name, e.g.
+`@azure-tools/typespec-azure-resource-manager/lro-response-mismatch`.
+
+### Placement
+
+TypeSpec applies a `#suppress` to the statement whose **leading trivia** it sits
+in, so it can go anywhere above the operation's doc-comment + decorators. Two
+robust options:
+
+- Insert the directive on its own line immediately **before** the line reported by
+  the ground-truth source location (which points at the doc/decorator block
+  start), matching that line's indentation; **then run `tsp format`** — the
+  formatter moves it into the canonical position (grouped with any other
+  `#suppress` directives, directly above the operation). Letting the formatter
+  place it is the reliable approach and is required to pass `tsv`'s format check.
+
+### Scripting the edits safely
+
+- Drive insertions from the stored dataset, one file at a time, inserting from the
+  **bottom of the file upward** (descending line order) so earlier inserts don't
+  shift later line numbers.
+- Write files as **UTF-8 without BOM** and preserve the file's original line
+  endings. A BOM-adding writer corrupts line 1 and shows up as a spurious diff; if
+  a file originally had a BOM, keep it. Verify with `git diff --numstat` that each
+  file's only change is the added suppression line(s) (`N insertions, 0 deletions`).
+- Run `tsp format <files...>` on every edited file afterward and re-check the diff
+  contains only suppression-line changes.
+
+## Validate
+
+1. Remove any rule instrumentation so the pristine rule runs.
+2. Commit the suppressions (see below) — required before `tsv`'s git checks.
+3. Re-run `npx tsv <spec-dir>` on each affected spec. Confirm:
+   - **Compilation completed successfully** (no user-error diagnostics remain);
+   - the **false-positive** violations still appear (they were not suppressed);
+   - no "Files have been changed after `tsp format`" and no git-difference
+     failures.
+
+Validate at least one spec per violation variant (e.g. a POST-heavy service, a
+DELETE-heavy service, and a mixed PUT/PATCH service).
+
+## Commit
+
+`tsv` compares generated Swagger and the working tree against the base branch, so
+uncommitted `.tsp` edits fail its git checks. Stage the suppressed `.tsp` files
+and the report and commit (keep evaluation-only `package.json`/lockfile changes
+out unless requested). Include any repository-required commit trailers.


### PR DESCRIPTION
## Summary

Adds the **`azure-lint-rule-evaluation`** skill: a reusable playbook that guides an LLM through evaluating a new/candidate TypeSpec linter rule (e.g. from a `pkg.pr.new` build) against the specs repo and deciding, per violation, whether it is a genuine user error, a false positive, or indeterminate.

## Contents

- `SKILL.md` — entry point and workflow.
- `references/environment-setup.md` — installing candidate rule packages and running `tsv`.
- `references/classification.md` — user-error vs false-positive vs indeterminate criteria.
- `references/ground-truth-and-diagnostics.md` — confirming intent via `getLroMetadata` and diagnostics.
- `references/reporting.md` — producing a per-violation evaluation report with source links.
- `references/suppress-and-validate.md` — applying justified suppressions and re-validating.

Documentation only; no spec or tooling changes.
