### PR TITLE
Add listBlobsRaw with accept header for Rust

### DIFF
--- a/specification/storage/data-plane/BlobStorage/Common/routes.tsp
+++ b/specification/storage/data-plane/BlobStorage/Common/routes.tsp
@@ -635,6 +635,34 @@ interface Container {
     }
   >;
 
+  /** Returns a list of the blobs as raw data to be deserialized in the client. */
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API"
+  #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Existing API"
+  #suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "Fixed set of content types returned by the service"
+  @get
+  @sharedRoute
+  @route("?restype=container&comp=list")
+  @scope("rust")
+  listBlobsRaw is StorageOperationResponseBody<
+    {
+      /** The Accept header indicating the requested response media type. */
+      #suppress "@typespec/http/content-type-ignored" "Raw response deserialized in the client"
+      @header("accept")
+      accept: string;
+
+      ...PrefixParameter;
+      ...MarkerParameter;
+      ...MaxResultsParameter;
+      ...ListBlobsIncludeParameter;
+      ...TimeoutParameter;
+      ...ListBlobsStartFrom;
+    },
+    {
+      @body body: bytes;
+    },
+    "application/vnd.apache.arrow.stream" | "application/xml"
+  >;
+
   /** Returns a list of the blobs in Apache Arrow format as raw data, to be deserialized by the client. */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Keeping operation shape inline with existing service patterns"
   #suppress "@azure-tools/typespec-azure-core/use-standard-names" "Keeping operation shape inline with existing service patterns"

--- a/specification/storage/data-plane/BlobStorage/client.tsp
+++ b/specification/storage/data-plane/BlobStorage/client.tsp
@@ -1266,6 +1266,14 @@ op uploadPagesNoStructuredMessage is StorageOperationRequestBody<
 
 @@override(PageBlob.uploadPages, uploadPagesNoStructuredMessage, "rust");
 
+/** Hide listBlobs for Rust but we still need it to generate ListBlobsResponse as a Page. */
+@@access(Storage.Blob.Container.listBlobs, Access.internal, "rust");
+@@access(ListBlobsResponse, Access.public, "rust");
+
+/** Hide other Arrow functions from Rust since listBlobsRaw does everything we need. */
+@@scope(Storage.Blob.Container.listBlobFlatSegmentApacheArrow, "!rust");
+@@scope(Storage.Blob.Container.listBlobHierarchySegmentApacheArrow, "!rust");
+
 /** An HTTP byte range, e.g. "bytes=0-1023". */
 @alternateType(
   {

--- a/specification/storage/data-plane/BlobStorage/client.tsp
+++ b/specification/storage/data-plane/BlobStorage/client.tsp
@@ -1266,9 +1266,11 @@ op uploadPagesNoStructuredMessage is StorageOperationRequestBody<
 
 @@override(PageBlob.uploadPages, uploadPagesNoStructuredMessage, "rust");
 
-/** Hide listBlobs for Rust but we still need it to generate ListBlobsResponse as a Page. */
+/** Hide and rename listBlobs for Rust but we still need it to generate ListBlobsResponse as a Page. */
 @@access(Storage.Blob.Container.listBlobs, Access.internal, "rust");
+@@clientName(Storage.Blob.Container.listBlobs, "listBlobsXml", "rust");
 @@access(ListBlobsResponse, Access.public, "rust");
+@@access(Storage.Blob.Container.listBlobsRaw, Access.internal, "rust");
 
 /** Hide other Arrow functions from Rust since listBlobsRaw does everything we need. */
 @@scope(Storage.Blob.Container.listBlobFlatSegmentApacheArrow, "!rust");

--- a/specification/storage/data-plane/BlobStorage/tspconfig.yaml
+++ b/specification/storage/data-plane/BlobStorage/tspconfig.yaml
@@ -41,7 +41,6 @@ options:
     crate-version: "0.1.0"
     flavor: azure
     temp-omit-doc-links: true
-    api-version: "2026-10-06"
   "@azure-tools/typespec-go":
     containing-module: "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
     service-dir: "sdk/storage"


### PR DESCRIPTION
To get the right signature so we can return a `Pager<ListBlobsResponse, AutoFormat>` we need to return an `AsyncResponse` that will contain the first page of results.
