### PR TITLE
[Storage] `azure_storage_blob` Prep for `v1.1.0-beta.2` release TypeSpec

### DIFF
--- a/specification/storage/data-plane/BlobStorage/client.tsp
+++ b/specification/storage/data-plane/BlobStorage/client.tsp
@@ -209,18 +209,6 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 @@access(Storage.Blob.Blob.download, Access.internal, "rust");
 @@clientName(Storage.Blob.Service.findBlobsByTags, "findBlobsByTags", "rust");
 @@clientName(Storage.Blob.Container.findBlobsByTags, "findBlobsByTags", "rust");
-@@clientName(
-  Storage.Blob.Container.listBlobHierarchySegment,
-  "ListBlobsHierarchical",
-  "rust"
-);
-#suppress "@azure-tools/typespec-client-generator-core/client-option" ""
-@@clientOption(
-  Storage.Blob.Container.listBlobHierarchySegment,
-  "forcePageIterator",
-  true,
-  "rust"
-);
 #suppress "@azure-tools/typespec-client-generator-core/client-option" ""
 @@clientOption(
   Storage.Blob.PageBlob.getPageRanges,
@@ -837,11 +825,10 @@ model SignedIdentifiersGo is Array<SignedIdentifier>;
 
 @@scope(Storage.Blob.Container.rename, "!rust");
 @@scope(Storage.Blob.Container.restore, "!rust");
-@@scope(Storage.Blob.Blob.abortCopyFromUrl, "!rust");
 @@scope(Storage.Blob.Blob.copyFromUrl, "!rust");
 @@scope(Storage.Blob.Blob.setExpiry, "!rust");
-@@scope(Storage.Blob.Blob.startCopyFromUrl, "!rust");
 @@scope(Storage.Blob.BlockBlob.query, "!rust");
+@@scope(Storage.Blob.Container.listBlobHierarchySegment, "!rust");
 @@scope(Storage.Blob.PageBlob.copyIncremental, "!rust");
 @@scope(Storage.Blob.PageBlob.getPageRangesDiff, "!rust");
 

--- a/specification/storage/data-plane/BlobStorage/client.tsp
+++ b/specification/storage/data-plane/BlobStorage/client.tsp
@@ -207,6 +207,7 @@ interface PageBlobClient extends Storage.Blob.PageBlob {}
 @@access(Storage.Blob.BlockBlob.upload, Access.internal, "rust");
 @@clientName(Storage.Blob.Blob.download, "download_internal", "rust");
 @@access(Storage.Blob.Blob.download, Access.internal, "rust");
+@@clientName(Storage.Blob.Blob.abortCopyFromUrl, "abortCopy", "rust");
 @@clientName(Storage.Blob.Service.findBlobsByTags, "findBlobsByTags", "rust");
 @@clientName(Storage.Blob.Container.findBlobsByTags, "findBlobsByTags", "rust");
 #suppress "@azure-tools/typespec-client-generator-core/client-option" ""

--- a/specification/storage/data-plane/BlobStorage/tspconfig.yaml
+++ b/specification/storage/data-plane/BlobStorage/tspconfig.yaml
@@ -41,7 +41,7 @@ options:
     crate-version: "0.1.0"
     flavor: azure
     temp-omit-doc-links: true
-    api-version: "2026-10-06"
+    api-version: "2026-04-06"
   "@azure-tools/typespec-go":
     containing-module: "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
     service-dir: "sdk/storage"


### PR DESCRIPTION
- Adds `start_copy_from_url` and `abort_copy` support in Rust
- Removes `list_blob_hierarchical` support (punting to a later release)