### PR TITLE
[Discovery] Move C# type renames to client.tsp

### DIFF
--- a/specification/discovery/Discovery.Management/client.tsp
+++ b/specification/discovery/Discovery.Management/client.tsp
@@ -13,6 +13,77 @@ using Microsoft.Discovery.Shared;
 using Azure.ClientGenerator.Core;
 using TypeSpec.Versioning;
 
+// C# names use the service prefix to avoid collisions with other management libraries.
+@@clientName(Bookshelf, "DiscoveryBookshelf", "csharp");
+@@clientName(ChatModelDeployment, "DiscoveryChatModelDeployment", "csharp");
+@@clientName(NodePool, "DiscoveryNodePool", "csharp");
+@@clientName(Project, "DiscoveryProject", "csharp");
+@@clientName(StorageAsset, "DiscoveryStorageAsset", "csharp");
+@@clientName(StorageContainer, "DiscoveryStorageContainer", "csharp");
+@@clientName(Supercomputer, "DiscoverySupercomputer", "csharp");
+@@clientName(Tool, "DiscoveryTool", "csharp");
+@@clientName(Workspace, "DiscoveryWorkspace", "csharp");
+
+@@clientName(
+  ChatModelDeploymentProperties,
+  "DiscoveryChatModelDeploymentProperties",
+  "csharp"
+);
+@@clientName(CustomerManagedKeys, "DiscoveryCustomerManagedKeys", "csharp");
+@@clientName(KeyVaultProperties, "DiscoveryKeyVaultProperties", "csharp");
+@@clientName(Identity, "DiscoveryManagedIdentityReference", "csharp");
+@@clientName(
+  Azure.ResourceManager.CommonTypes.MoboBrokerResource,
+  "DiscoveryMoboBrokerResource",
+  "csharp"
+);
+@@clientName(NetworkEgressType, "DiscoveryNetworkEgressType", "csharp");
+@@clientName(NodePoolProperties, "DiscoveryNodePoolProperties", "csharp");
+@@clientName(
+  Azure.ResourceManager.CommonTypes.PrivateEndpointConnectionProperties,
+  "DiscoveryPrivateEndpointConnectionProperties",
+  "csharp"
+);
+@@clientName(ProjectProperties, "DiscoveryProjectProperties", "csharp");
+@@clientName(ProvisioningState, "DiscoveryProvisioningState", "csharp");
+@@clientName(PublicNetworkAccess, "DiscoveryPublicNetworkAccess", "csharp");
+@@clientName(ScaleSetPriority, "DiscoveryScaleSetPriority", "csharp");
+@@clientName(
+  StorageAssetProperties,
+  "DiscoveryStorageAssetProperties",
+  "csharp"
+);
+@@clientName(
+  StorageContainerProperties,
+  "DiscoveryStorageContainerProperties",
+  "csharp"
+);
+@@clientName(StorageStore, "DiscoveryStorageStore", "csharp");
+@@clientName(
+  SupercomputerIdentities,
+  "DiscoverySupercomputerIdentities",
+  "csharp"
+);
+@@clientName(
+  SupercomputerProperties,
+  "DiscoverySupercomputerProperties",
+  "csharp"
+);
+@@clientName(
+  Azure.ResourceManager.CommonTypes.SystemAssignedServiceIdentity,
+  "DiscoverySystemAssignedServiceIdentity",
+  "csharp"
+);
+@@clientName(
+  Azure.ResourceManager.CommonTypes.SystemAssignedServiceIdentityType,
+  "DiscoverySystemAssignedServiceIdentityType",
+  "csharp"
+);
+@@clientName(SystemSku, "DiscoverySystemSku", "csharp");
+@@clientName(ToolProperties, "DiscoveryToolProperties", "csharp");
+@@clientName(VmSize, "DiscoveryVmSize", "csharp");
+@@clientName(WorkspaceProperties, "DiscoveryWorkspaceProperties", "csharp");
+
 // Rename DiscoveryStorage to ManagedStorage for Go SDK to avoid collision with Storage type
 // after the Go emitter removes the "Discovery" prefix
 @@clientName(

--- a/specification/discovery/Discovery.Management/client.tsp
+++ b/specification/discovery/Discovery.Management/client.tsp
@@ -83,6 +83,8 @@ using TypeSpec.Versioning;
 @@clientName(ToolProperties, "DiscoveryToolProperties", "csharp");
 @@clientName(VmSize, "DiscoveryVmSize", "csharp");
 @@clientName(WorkspaceProperties, "DiscoveryWorkspaceProperties", "csharp");
+@@clientName(BlobStorageMountProtocol.NFS, "Nfs", "csharp");
+@@clientName(NetAppMountProtocol.NFS, "Nfs", "csharp");
 
 // Rename DiscoveryStorage to ManagedStorage for Go SDK to avoid collision with Storage type
 // after the Go emitter removes the "Discovery" prefix


### PR DESCRIPTION
Moves the Discovery management SDK C# type renames from SDK-side CodeGenType customizations to @@clientName decorators in client.tsp. This lets regeneration produce the intended names directly from TypeSpec, including ARM resource wrappers and common-type references.\n\nRelated SDK PR: Azure/azure-sdk-for-net#61207