### PR TITLE
[Microsoft.Sql] Remove Java API version pin

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/tspconfig.yaml
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/tspconfig.yaml
@@ -17,7 +17,6 @@ options:
     emitter-output-dir: "{output-dir}/sdk/sqlmanagement/{namespace}"
     enable-wire-path-attribute: true
   "@azure-tools/typespec-java":
-    api-version: "2025-01-01"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-sql"
     namespace: "com.azure.resourcemanager.sql"
     flavor: "azure"


### PR DESCRIPTION
Removes the Java `api-version` pin from the Microsoft.Sql TypeSpec configuration so Java generation uses the latest API version.

This should unblock regeneration of [Azure/azure-sdk-for-java#50038](https://github.com/Azure/azure-sdk-for-java/pull/50038), which currently regenerates the already-released `2025-01-01` API without Java code changes.
