### PR TITLE
Centurion WAF: add WAF policy tier + Basic_WAF_v2/Standard_WAF_v2 SKUs (2025-09-01)

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/WafPolicyCreateOrUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/WafPolicyCreateOrUpdate.json
@@ -4,6 +4,7 @@
     "parameters": {
       "location": "WestUs",
       "properties": {
+        "tier": "Standard",
         "customRules": [
           {
             "name": "Rule1",

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/WafPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/WafPolicyGet.json
@@ -397,7 +397,8 @@
             "state": "Enabled"
           },
           "provisioningState": "Succeeded",
-          "resourceState": "Enabled"
+          "resourceState": "Enabled",
+          "tier": "Standard"
         },
         "tags": {
           "key1": "value1",

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -64,13 +64,13 @@ union ApplicationGatewaySkuName {
   Basic: "Basic",
 
   /**
-   * Basic_WAF_v2
+   * Basic tier Application Gateway with WAF enabled.
    */
   @added(Versions.v2025_09_01)
   Basic_WAF_v2: "Basic_WAF_v2",
 
   /**
-   * Standard_WAF_v2
+   * Standard tier Application Gateway with WAF enabled.
    */
   @added(Versions.v2025_09_01)
   Standard_WAF_v2: "Standard_WAF_v2",
@@ -25569,12 +25569,12 @@ union WebApplicationFirewallPolicyTier {
   string,
 
   /**
-   * Basic
+   * Basic tier web application firewall policy.
    */
   Basic: "Basic",
 
   /**
-   * Standard
+   * Standard tier web application firewall policy.
    */
   Standard: "Standard",
 }

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -62,6 +62,18 @@ union ApplicationGatewaySkuName {
    * Basic
    */
   Basic: "Basic",
+
+  /**
+   * Basic_WAF_v2
+   */
+  @added(Versions.v2025_09_01)
+  Basic_WAF_v2: "Basic_WAF_v2",
+
+  /**
+   * Standard_WAF_v2
+   */
+  @added(Versions.v2025_09_01)
+  Standard_WAF_v2: "Standard_WAF_v2",
 }
 
 /**
@@ -25548,6 +25560,26 @@ model ConnectionPolicyProperties {
 model ListConnectionPoliciesResult is Azure.Core.Page<ConnectionPolicy>;
 
 /**
+ * Tier of a web application firewall policy.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@Azure.ResourceManager.Legacy.feature(Features.applicationGateway)
+@added(Versions.v2025_09_01)
+union WebApplicationFirewallPolicyTier {
+  string,
+
+  /**
+   * Basic
+   */
+  Basic: "Basic",
+
+  /**
+   * Standard
+   */
+  Standard: "Standard",
+}
+
+/**
  * Defines web application firewall policy properties.
  */
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
@@ -25604,6 +25636,12 @@ model WebApplicationFirewallPolicyPropertiesFormat {
    */
   @visibility(Lifecycle.Read)
   applicationGatewayForContainers?: ApplicationGatewayForContainersReferenceDefinition[];
+
+  /**
+   * Tier of a web application firewall policy.
+   */
+  @added(Versions.v2025_09_01)
+  tier?: WebApplicationFirewallPolicyTier;
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -6399,6 +6399,12 @@ model ApplicationGatewayPropertiesFormat {
   autoscaleConfiguration?: ApplicationGatewayAutoscaleConfiguration;
 
   /**
+   * The reserved capacity of the application gateway resource. Applicable to the Basic_v2 and Basic_WAF_v2 SKU tiers.
+   */
+  @added(Versions.v2025_09_01)
+  reservedCapacity?: int32;
+
+  /**
    * PrivateLink configurations on application gateway.
    */
   privateLinkConfigurations?: ApplicationGatewayPrivateLinkConfiguration[];

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/applicationGateway.json
@@ -3528,6 +3528,11 @@
           "$ref": "#/definitions/ApplicationGatewayAutoscaleConfiguration",
           "description": "Autoscale Configuration."
         },
+        "reservedCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The reserved capacity of the application gateway resource. Applicable to the Basic_v2 and Basic_WAF_v2 SKU tiers."
+        },
         "privateLinkConfigurations": {
           "type": "array",
           "description": "PrivateLink configurations on application gateway.",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/applicationGateway.json
@@ -5090,6 +5090,10 @@
             "$ref": "#/definitions/ApplicationGatewayForContainersReferenceDefinition"
           },
           "readOnly": true
+        },
+        "tier": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallPolicyTier",
+          "description": "Tier of a web application firewall policy."
         }
       },
       "required": [

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
@@ -913,12 +913,12 @@
           {
             "name": "Basic_WAF_v2",
             "value": "Basic_WAF_v2",
-            "description": "Basic_WAF_v2"
+            "description": "Basic tier Application Gateway with WAF enabled."
           },
           {
             "name": "Standard_WAF_v2",
             "value": "Standard_WAF_v2",
-            "description": "Standard_WAF_v2"
+            "description": "Standard tier Application Gateway with WAF enabled."
           }
         ]
       }
@@ -9912,12 +9912,12 @@
           {
             "name": "Basic",
             "value": "Basic",
-            "description": "Basic"
+            "description": "Basic tier web application firewall policy."
           },
           {
             "name": "Standard",
             "value": "Standard",
-            "description": "Standard"
+            "description": "Standard tier web application firewall policy."
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
@@ -862,7 +862,9 @@
         "WAF_Large",
         "Standard_v2",
         "WAF_v2",
-        "Basic"
+        "Basic",
+        "Basic_WAF_v2",
+        "Standard_WAF_v2"
       ],
       "x-ms-enum": {
         "name": "ApplicationGatewaySkuName",
@@ -907,6 +909,16 @@
             "name": "Basic",
             "value": "Basic",
             "description": "Basic"
+          },
+          {
+            "name": "Basic_WAF_v2",
+            "value": "Basic_WAF_v2",
+            "description": "Basic_WAF_v2"
+          },
+          {
+            "name": "Standard_WAF_v2",
+            "value": "Standard_WAF_v2",
+            "description": "Standard_WAF_v2"
           }
         ]
       }
@@ -9882,6 +9894,30 @@
             "name": "Deleting",
             "value": "Deleting",
             "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallPolicyTier": {
+      "type": "string",
+      "description": "Tier of a web application firewall policy.",
+      "enum": [
+        "Basic",
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallPolicyTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
           }
         ]
       }

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/WafPolicyCreateOrUpdate.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/WafPolicyCreateOrUpdate.json
@@ -4,6 +4,7 @@
     "parameters": {
       "location": "WestUs",
       "properties": {
+        "tier": "Standard",
         "customRules": [
           {
             "name": "Rule1",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/WafPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/WafPolicyGet.json
@@ -397,7 +397,8 @@
             "state": "Enabled"
           },
           "provisioningState": "Succeeded",
-          "resourceState": "Enabled"
+          "resourceState": "Enabled",
+          "tier": "Standard"
         },
         "tags": {
           "key1": "value1",


### PR DESCRIPTION
## Summary
Adds Centurion WAF (Basic WAF v2) API contract changes to api-version 2025-09-01:

1. **Application Gateway SKU names** - added Basic_WAF_v2 and Standard_WAF_v2 to ApplicationGatewaySkuName.
2. **WAF Policy tier** - new WebApplicationFirewallPolicyTier enum (Basic / Standard) and optional 	ier property on WebApplicationFirewallPolicyPropertiesFormat.

All changes authored in TypeSpec (Network/Network/models.tsp) and gated with @added(Versions.v2025_09_01); swagger regenerated via 	sp compile. Examples (WafPolicyGet / WafPolicyCreateOrUpdate) updated to demonstrate 	ier.

Source: signed-off *Application Gateway WAF Tier API Specification*.

Local validation: tsp compile clean, oav validate-spec + validate-example pass, tsp format unchanged.