### PR TITLE
IoT Operations: map ResourceHealthStatus timestamps to DateTimeOffset in C# SDK (client.tsp)

### DIFF
--- a/specification/iotoperations/resource-manager/Microsoft.IoTOperations/IoTOperations/client.tsp
+++ b/specification/iotoperations/resource-manager/Microsoft.IoTOperations/IoTOperations/client.tsp
@@ -162,6 +162,11 @@ using Microsoft.IoTOperations;
   "csharp"
 );
 
+// Surface the RFC3339 timestamp properties as DateTimeOffset in the C# SDK
+// without changing the wire contract (service still emits/accepts strings).
+@@alternateType(ResourceHealthStatus.lastTransitionTime, utcDateTime, "csharp");
+@@alternateType(ResourceHealthStatus.lastUpdateTime, utcDateTime, "csharp");
+
 @@clientName(
   Versions.`2024-11-01`,
   "$DO_NOT_NORMALIZE$V2024-11-01",


### PR DESCRIPTION
## Summary

Surfaces the IoT Operations `ResourceHealthStatus` RFC3339 timestamp properties as `DateTimeOffset` (instead of `string`) in the **C# SDK only**, via client-side type projection. There is **no change to the service wire contract** — the properties remain strings on the REST API for every language.

## Change

In `client.tsp`:

```tsp
@@alternateType(ResourceHealthStatus.lastTransitionTime, utcDateTime, "csharp");
@@alternateType(ResourceHealthStatus.lastUpdateTime, utcDateTime, "csharp");
```

`ResourceHealthStatus.lastTransitionTime` and `ResourceHealthStatus.lastUpdateTime` are documented as RFC3339 timestamps but declared as `string` in `models/base.tsp`. Because the underlying API is already released, changing the model type in `main.tsp` would be a breaking change; `@@alternateType(..., "csharp")` applies the improved `DateTimeOffset` projection to the .NET SDK without affecting service behavior or other languages.

## Context

Addresses code owner feedback on **Azure/azure-sdk-for-net#61456**, where @ArthurMa1978 recommended:

> Please use the `@@alternateType` decorator to change the type of these properties in client.tsp, no impact to service behavior.

Client-only change (`client.tsp`); no `main.tsp` / API surface modification.

cc @byronjinmsft
