### PR TITLE
[Docs] Update `PathRenameMode` Description

### DIFF
--- a/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
+++ b/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
@@ -814,7 +814,7 @@
           {
             "name": "mode",
             "in": "query",
-            "description": "Optional. Valid only when namespace is enabled. This parameter determines the behavior of the rename operation. The value must be \"legacy\" or \"posix\", and the default value will be \"posix\". ",
+            "description": "Optional. Valid only when namespace is enabled. This parameter determines the behavior of the rename operation. The value must be \"legacy\" or \"posix\", and the default value will be \"posix\". When renaming a directory to a destination directory that already exists, the source directory is moved into the destination directory as a subdirectory.",
             "required": false,
             "type": "string",
             "enum": [

--- a/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
+++ b/specification/storage/data-plane/Microsoft.StorageDataLake/stable/2019-12-12/DataLakeStorage.json
@@ -814,7 +814,7 @@
           {
             "name": "mode",
             "in": "query",
-            "description": "Optional. Valid only when namespace is enabled. This parameter determines the behavior of the rename operation. The value must be \"legacy\" or \"posix\", and the default value will be \"posix\". When renaming a directory to a destination directory that already exists, the source directory is moved into the destination directory as a subdirectory.",
+            "description": "Optional. Valid only when namespace is enabled. This parameter determines the behavior of the rename operation. The value must be \"legacy\" or \"posix\", and the default value will be \"posix\". When renaming a directory to a path that already exists, the source directory is not replaced. Instead, it is moved into the existing destination directory as a subdirectory.\n\nExample\n\nBefore the rename operation:\n\n/source\n  file1.txt\n\n/destination\n  file2.txt\n\nRenaming /source to /destination results in:\n\n/destination\n  file2.txt\n  /source\n    file1.txt\n\nIn this scenario, the existing /destination directory is preserved, and /source is moved under it as a subdirectory rather than replacing it.",
             "required": false,
             "type": "string",
             "enum": [


### PR DESCRIPTION
Updates to include information about the scenario of renaming to an existing name in the destination.
>+++
When renaming a directory to a destination directory that already exists, the source directory is moved into the destination directory as a subdirectory.