### PR TITLE
Preserve Confidential Ledger protocol-only API surface

### DIFF
--- a/specification/confidentialledger/data-plane/ConfidentialLedger/tspconfig.yaml
+++ b/specification/confidentialledger/data-plane/ConfidentialLedger/tspconfig.yaml
@@ -37,3 +37,4 @@ options:
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
     namespace: Azure.Security.ConfidentialLedger
     model-namespace: true
+    generate-convenience-methods: false


### PR DESCRIPTION
## Summary
- disable convenience method generation for Azure.Security.ConfidentialLedger
- preserve the protocol-only API surface used by the legacy emitter
- avoid adding unintended CancellationToken and typed-model overloads during generator migration

Follow-up for Azure/azure-rest-api-specs#45346 and Azure/azure-sdk-for-net#61836.

--generated by Copilot