### PR TITLE
Add csharp customizations for HybridContainerService migration

### DIFF
--- a/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/back-compatible.tsp
+++ b/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/back-compatible.tsp
@@ -1,8 +1,42 @@
 import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
+using Azure.ClientGenerator.Core.Legacy;
 using Microsoft.HybridContainerService;
 
 @@clientName(VmSkuProfiles.getVMSkus, "getVmSkus", "autorest");
 @@clientName(VmSkuProfiles.createVMSkus, "createVmSkus", "autorest");
 @@clientName(VmSkuProfiles.deleteVMSkus, "deleteVmSkus", "autorest");
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(AgentPool.properties, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(HybridIdentityMetadata.properties, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(ProvisionedClusterUpgradeProfile.properties, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(VmSkuProfile.properties, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(ProvisionedClusterProperties.linuxProfile, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(LinuxProfileProperties.ssh, "csharp");
+@@clientName(LinuxProfilePropertiesSsh.publicKeys, "SshPublicKeys", "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(
+  ProvisionedClusterProperties.clusterVMAccessProfile,
+  "csharp"
+);
+@@clientName(
+  ClusterVMAccessProfile.authorizedIPRanges,
+  "ClusterVmAccessAuthorizedIPRanges",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(ProvisionedClusterProperties.cloudProviderProfile, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(CloudProviderProfile.infraNetworkProfile, "csharp");
+@@clientName(
+  CloudProviderProfileInfraNetworkProfile.vnetSubnetIds,
+  "InfraNetworkVnetSubnetIds",
+  "csharp"
+);

--- a/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/client.tsp
+++ b/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/client.tsp
@@ -243,5 +243,5 @@ union VirtualNetworkProvisioningState {
   Access.internal,
   "csharp"
 );
-@@usage(OsType, Usage.input, "csharp");
-@@usage(OSSKU, Usage.input, "csharp");
+
+@@usage(AgentPoolProfile, Usage.input, "csharp");

--- a/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/client.tsp
+++ b/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/client.tsp
@@ -2,9 +2,276 @@ import "./main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 
 using Microsoft.HybridContainerService;
+using Azure.ClientGenerator.Core;
+using Azure.ClientGenerator.Core.Legacy;
 
 @@Azure.ClientGenerator.Core.clientName(
   HybridIdentityMetadataOperationGroup,
   "HybridIdentityMetadata",
   "!autorest"
+);
+
+@@clientName(AgentPool, "HybridContainerServiceAgentPool", "csharp");
+@@clientName(VirtualNetwork, "HybridContainerServiceVirtualNetwork", "csharp");
+@@clientName(VmSkuProfile, "HybridContainerServiceVmSku", "csharp");
+
+@@clientName(AddonPhase, "ProvisionedClusterAddonPhase", "csharp");
+@@clientName(
+  AddonStatusProfile,
+  "ProvisionedClusterAddonStatusProfile",
+  "csharp"
+);
+@@clientName(
+  AgentPoolProfile,
+  "HybridContainerServiceAgentPoolProfile",
+  "csharp"
+);
+@@clientName(AgentPoolProfile.osType, "OSType", "csharp");
+@@clientName(AgentPoolProfile.osSKU, "OSSku", "csharp");
+@@clientName(
+  AgentPoolProvisioningStatus,
+  "AgentPoolProvisioningStatusProperties",
+  "csharp"
+);
+@@clientName(
+  AgentPoolProvisioningStatusStatus,
+  "AgentPoolProvisioningStatus",
+  "csharp"
+);
+@@clientName(
+  AzureHybridBenefit,
+  "ProvisionedClusterAzureHybridBenefit",
+  "csharp"
+);
+@@clientName(
+  CloudProviderProfile,
+  "ProvisionedClusterCloudProviderProfile",
+  "csharp"
+);
+@@clientName(
+  CloudProviderProfileInfraNetworkProfile,
+  "ProvisionedClusterInfraNetworkProfile",
+  "csharp"
+);
+@@clientName(
+  ControlPlaneProfileControlPlaneEndpoint,
+  "ProvisionedClusterControlPlaneEndpoint",
+  "csharp"
+);
+@@clientName(
+  ControlPlaneProfile,
+  "ProvisionedClusterControlPlaneProfile",
+  "csharp"
+);
+@@clientName(CredentialResult, "HybridContainerServiceCredential", "csharp");
+@@clientName(Expander, "HybridContainerServiceExpander", "csharp");
+@@clientName(
+  ExtendedLocation,
+  "HybridContainerServiceExtendedLocation",
+  "csharp"
+);
+@@clientName(ExtendedLocation.type, "ExtendedLocationType", "csharp");
+@@clientName(
+  ExtendedLocationTypes,
+  "HybridContainerServiceExtendedLocationType",
+  "csharp"
+);
+@@clientName(LinuxProfilePropertiesSsh, "LinuxSshConfiguration", "csharp");
+@@clientName(
+  LinuxProfilePropertiesSshPublicKeysItem,
+  "LinuxSshPublicKey",
+  "csharp"
+);
+@@clientName(
+  ListCredentialResponse,
+  "HybridContainerServiceCredentialListResult",
+  "csharp"
+);
+@@clientName(
+  ListCredentialResponseError,
+  "HybridContainerServiceCredentialListError",
+  "csharp"
+);
+@@clientName(
+  NamedAgentPoolProfile,
+  "HybridContainerServiceNamedAgentPoolProfile",
+  "csharp"
+);
+@@clientName(NetworkPolicy, "ProvisionedClusterNetworkPolicy", "csharp");
+@@clientName(NetworkProfile, "ProvisionedClusterNetworkProfile", "csharp");
+@@clientName(
+  NetworkProfileLoadBalancerProfile,
+  "ProvisionedClusterLoadBalancerProfile",
+  "csharp"
+);
+@@clientName(OSSKU, "HybridContainerServiceOSSku", "csharp");
+@@clientName(OsType, "HybridContainerServiceOSType", "csharp");
+@@clientName(
+  ProvisioningState,
+  "HybridContainerServiceResourceProvisioningState",
+  "csharp"
+);
+@@clientName(ProvisionedClusterPoolUpgradeProfile.osType, "OSType", "csharp");
+@@clientName(
+  ProvisionedClusterPropertiesStatus,
+  "ProvisionedClusterStatus",
+  "csharp"
+);
+@@clientName(SecurityProfile, "ProvisionedClusterSecurityProfile", "csharp");
+@@clientName(SecurityProfileFipsImage.enabled, "IsFipsImageEnabled", "csharp");
+@@clientName(
+  VirtualNetworkProperties,
+  "HybridContainerServiceVirtualNetworkProperties",
+  "csharp"
+);
+@@clientName(
+  VirtualNetworkProperties.ipAddressPrefix,
+  "IPAddressPrefix",
+  "csharp"
+);
+@@clientName(VirtualNetworkProperties.vlanID, "VlanId", "csharp");
+@@clientName(
+  VirtualNetworkPropertiesInfraVnetProfile,
+  "InfraVnetProfile",
+  "csharp"
+);
+@@clientName(
+  VirtualNetworkPropertiesInfraVnetProfileHci,
+  "HciInfraVnetProfile",
+  "csharp"
+);
+@@clientName(
+  VirtualNetworkPropertiesStatus,
+  "HybridContainerServiceNetworkStatus",
+  "csharp"
+);
+@@clientName(
+  VirtualNetworkPropertiesStatusOperationStatusError,
+  "HybridContainerServiceNetworkOperationError",
+  "csharp"
+);
+@@clientName(
+  VirtualNetworkPropertiesVipPoolItem,
+  "KubernetesVirtualIPItem",
+  "csharp"
+);
+@@clientName(
+  VirtualNetworkPropertiesVmipPoolItem,
+  "VirtualMachineIPItem",
+  "csharp"
+);
+@@clientName(
+  VmSkuProperties,
+  "HybridContainerServiceVmSkuProperties",
+  "csharp"
+);
+@@clientName(
+  VmSkuCapabilities,
+  "HybridContainerServiceVmSkuCapabilities",
+  "csharp"
+);
+@@clientName(
+  StorageProfileSmbCSIDriver.enabled,
+  "IsSmbCsiDriverEnabled",
+  "csharp"
+);
+@@clientName(
+  StorageProfileNfsCSIDriver.enabled,
+  "IsNfsCsiDriverEnabled",
+  "csharp"
+);
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(AgentPool.properties, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(HybridIdentityMetadata.properties, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(ProvisionedClusterUpgradeProfile.properties, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(VmSkuProfile.properties, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(ProvisionedClusterProperties.linuxProfile, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(LinuxProfileProperties.ssh, "csharp");
+@@clientName(LinuxProfilePropertiesSsh.publicKeys, "SshPublicKeys", "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(
+  ProvisionedClusterProperties.clusterVMAccessProfile,
+  "csharp"
+);
+@@clientName(
+  ClusterVMAccessProfile.authorizedIPRanges,
+  "ClusterVmAccessAuthorizedIPRanges",
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(ProvisionedClusterProperties.cloudProviderProfile, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
+@@flattenProperty(CloudProviderProfile.infraNetworkProfile, "csharp");
+@@clientName(
+  CloudProviderProfileInfraNetworkProfile.vnetSubnetIds,
+  "InfraNetworkVnetSubnetIds",
+  "csharp"
+);
+@@alternateType(VirtualNetwork.extendedLocation, ExtendedLocation, "csharp");
+
+@@clientName(KubernetesVersionReadiness.osType, "OSType", "csharp");
+@@clientName(KubernetesVersionReadiness.osSku, "OSSku", "csharp");
+
+@@usage(AgentPoolProfile, Usage.input, "csharp");
+@@usage(AgentPoolProfile, Usage.output, "csharp");
+@@usage(ProvisionedClusterPoolUpgradeProfile, Usage.input, "csharp");
+@@usage(ProvisionedClusterPoolUpgradeProfileProperties, Usage.input, "csharp");
+
+/**
+ * Provisioning state used by the shipped C# virtual network model.
+ */
+union VirtualNetworkProvisioningState {
+  string,
+
+  /** The request was accepted. */
+  Accepted: "Accepted",
+
+  /** The operation was canceled. */
+  Canceled: "Canceled",
+
+  /** The resource is being created. */
+  Creating: "Creating",
+
+  /** The resource is being deleted. */
+  Deleting: "Deleting",
+
+  /** The operation failed. */
+  Failed: "Failed",
+
+  /** The operation is pending. */
+  Pending: "Pending",
+
+  /** The operation succeeded. */
+  Succeeded: "Succeeded",
+
+  /** The resource is being updated. */
+  Updating: "Updating",
+}
+
+@@clientName(
+  VirtualNetworkProvisioningState,
+  "HybridContainerServiceProvisioningState",
+  "csharp"
+);
+@@alternateType(
+  VirtualNetworkProperties.provisioningState,
+  VirtualNetworkProvisioningState,
+  "csharp"
+);
+
+@@clientName(
+  ProvisionedClusterUpgradeProfiles.listUpgradeProfile,
+  "ListUpgradeProfiles",
+  "csharp"
+);
+@@access(
+  ProvisionedClusterUpgradeProfiles.listUpgradeProfile,
+  Access.internal,
+  "csharp"
 );

--- a/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/client.tsp
+++ b/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/client.tsp
@@ -246,3 +246,4 @@ union VirtualNetworkProvisioningState {
 
 @@usage(AgentPoolProfile, Usage.input, "csharp");
 @@usage(ProvisionedClusterUpgradeProfileProperties, Usage.input, "csharp");
+@@usage(ProvisionedClusterUpgradeProfile, Usage.input, "csharp");

--- a/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/client.tsp
+++ b/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/client.tsp
@@ -245,3 +245,4 @@ union VirtualNetworkProvisioningState {
 );
 
 @@usage(AgentPoolProfile, Usage.input, "csharp");
+@@usage(ProvisionedClusterUpgradeProfileProperties, Usage.input, "csharp");

--- a/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/client.tsp
+++ b/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/client.tsp
@@ -181,38 +181,6 @@ using Azure.ClientGenerator.Core.Legacy;
   "csharp"
 );
 
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
-@@flattenProperty(AgentPool.properties, "csharp");
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
-@@flattenProperty(HybridIdentityMetadata.properties, "csharp");
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
-@@flattenProperty(ProvisionedClusterUpgradeProfile.properties, "csharp");
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
-@@flattenProperty(VmSkuProfile.properties, "csharp");
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
-@@flattenProperty(ProvisionedClusterProperties.linuxProfile, "csharp");
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
-@@flattenProperty(LinuxProfileProperties.ssh, "csharp");
-@@clientName(LinuxProfilePropertiesSsh.publicKeys, "SshPublicKeys", "csharp");
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
-@@flattenProperty(
-  ProvisionedClusterProperties.clusterVMAccessProfile,
-  "csharp"
-);
-@@clientName(
-  ClusterVMAccessProfile.authorizedIPRanges,
-  "ClusterVmAccessAuthorizedIPRanges",
-  "csharp"
-);
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
-@@flattenProperty(ProvisionedClusterProperties.cloudProviderProfile, "csharp");
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Preserves the flattened data shape of the shipped C# SDK."
-@@flattenProperty(CloudProviderProfile.infraNetworkProfile, "csharp");
-@@clientName(
-  CloudProviderProfileInfraNetworkProfile.vnetSubnetIds,
-  "InfraNetworkVnetSubnetIds",
-  "csharp"
-);
 @@alternateType(VirtualNetwork.extendedLocation, ExtendedLocation, "csharp");
 
 @@clientName(KubernetesVersionReadiness.osType, "OSType", "csharp");
@@ -275,3 +243,5 @@ union VirtualNetworkProvisioningState {
   Access.internal,
   "csharp"
 );
+@@usage(OsType, Usage.input, "csharp");
+@@usage(OSSKU, Usage.input, "csharp");

--- a/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/tspconfig.yaml
+++ b/specification/hybridaks/resource-manager/Microsoft.HybridContainerService/HybridContainerService/tspconfig.yaml
@@ -13,7 +13,7 @@ options:
     examples-dir: "{project-root}/examples"
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.HybridContainerService"
-    emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
+    emitter-output-dir: "{output-dir}/sdk/hybridaks/{namespace}"
   "@azure-tools/typespec-python":
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-hybridcontainerservice"
     namespace: "azure.mgmt.hybridcontainerservice"


### PR DESCRIPTION
## Summary
- preserve the shipped .NET management SDK names and flattened model shapes
- retain resource hierarchy and API compatibility during the TypeSpec migration
- keep the generated OpenAPI unchanged

## Validation
- TypeSpec compilation succeeds with no diagnostics
- generated OpenAPI has no diff