### PR TITLE
Regenerate Network/service.yaml to include 2025-09-01 version

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/service.yaml
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/service.yaml
@@ -2666,3 +2666,24 @@ versions:
       - ../stable/2025-07-01/virtualNetworkAppliance.json
       - ../stable/2025-07-01/interconnectGroup.json
       - ../stable/2025-07-01/common.json
+  - version: 2025-09-01
+    source: typespec
+    swagger-files:
+      - ../stable/2025-09-01/applicationGateway.json
+      - ../stable/2025-09-01/expressRoute.json
+      - ../stable/2025-09-01/firewall.json
+      - ../stable/2025-09-01/loadBalancer.json
+      - ../stable/2025-09-01/networkGateway.json
+      - ../stable/2025-09-01/networkManager.json
+      - ../stable/2025-09-01/networkSecurityPerimeter.json
+      - ../stable/2025-09-01/networkWatcher.json
+      - ../stable/2025-09-01/networkingOperations.json
+      - ../stable/2025-09-01/virtualNetwork.json
+      - ../stable/2025-09-01/virtualWan.json
+      - ../stable/2025-09-01/firewallPolicy.json
+      - ../stable/2025-09-01/azureWebCategory.json
+      - ../stable/2025-09-01/serviceGateway.json
+      - ../stable/2025-09-01/virtualNetworkAppliance.json
+      - ../stable/2025-09-01/interconnectGroup.json
+      - ../stable/2025-09-01/firstPartyServiceTag.json
+      - ../stable/2025-09-01/common.json


### PR DESCRIPTION
## What
Adds the `2025-09-01` stable version block to `Microsoft.Network/Network/Network/service.yaml`.

## Why
PR #44805 (merged into main on 2026-08-06) migrated `service.yaml` to be a `tsp compile`-generated artifact and populated it with the versions present on main at that time. When main was subsequently merged back into this release branch, the fresh `service.yaml` came in **without** the `2025-09-01` entry, because that version only exists on this release branch.

Result: the `TypeSpec Validation` check on the release PR (#44988) fails with:

`
Files have been changed after `tsp compile`. Run `tsp compile` and ensure all files are included in your change.
`
…because CI regenerates `service.yaml` at validation time and finds an unstaged 21-line append for the 2025-09-01 block.

## How
Ran locally:
`
cd specification/network/resource-manager/Microsoft.Network/Network
npm exec --no -- tsp compile Network
`
with `@azure-tools/typespec-autorest 0.70.1` and `@typespec/compiler 1.14.0` (matching the versions declared in this repo's `package.json`). Only `service.yaml` changes — a clean 21-line append matching the diff CI produced. No spec/TypeSpec source changes.

## Target
Base: `Vslokar/release-microsoft-network-2025-09-01` (the release branch, not `main`).

Once this merges, re-running the `TypeSpec Validation` check on #44988 will pass.