### PR TITLE
Update the typespec for blob-auditing APIs to support parameter for selective fields auditing feature.

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
@@ -4416,6 +4416,15 @@ model ServerBlobAuditingPolicyProperties {
   isManagedIdentityInUse?: boolean;
 
   /**
+   * Specifies the required fields to include in audit events (optional).
+   * Each item must be a valid audit_event field name.
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  requiredFields?: string[];
+
+  /**
    * Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.
    */
   state: BlobAuditingPolicyState;
@@ -4552,6 +4561,15 @@ model DatabaseBlobAuditingPolicyProperties {
    * Specifies whether Managed Identity is used to access blob storage
    */
   isManagedIdentityInUse?: boolean;
+
+  /**
+   * Specifies the required fields to include in audit events (optional).
+   * Each item must be a valid audit_event field name.
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  requiredFields?: string[];
 
   /**
    * Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.
@@ -4695,6 +4713,15 @@ model ExtendedDatabaseBlobAuditingPolicyProperties {
    * Specifies whether Managed Identity is used to access blob storage
    */
   isManagedIdentityInUse?: boolean;
+
+  /**
+   * Specifies the required fields to include in audit events (optional).
+   * Each item must be a valid audit_event field name.
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  requiredFields?: string[];
 
   /**
    * Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.
@@ -4853,6 +4880,15 @@ model ExtendedServerBlobAuditingPolicyProperties {
    * Specifies whether Managed Identity is used to access blob storage
    */
   isManagedIdentityInUse?: boolean;
+
+  /**
+   * Specifies the required fields to include in audit events (optional).
+   * Each item must be a valid audit_event field name.
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  requiredFields?: string[];
 
   /**
    * Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/blobAuditing.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/blobAuditing.json
@@ -991,6 +991,13 @@
           "type": "boolean",
           "description": "Specifies whether Managed Identity is used to access blob storage"
         },
+        "requiredFields": {
+          "type": "array",
+          "description": "Specifies the required fields to include in audit events (optional).\nEach item must be a valid audit_event field name.\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation.",
+          "items": {
+            "type": "string"
+          }
+        },
         "state": {
           "$ref": "./common.json#/definitions/BlobAuditingPolicyState",
           "description": "Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
@@ -1091,6 +1098,13 @@
         "isManagedIdentityInUse": {
           "type": "boolean",
           "description": "Specifies whether Managed Identity is used to access blob storage"
+        },
+        "requiredFields": {
+          "type": "array",
+          "description": "Specifies the required fields to include in audit events (optional).\nEach item must be a valid audit_event field name.\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation.",
+          "items": {
+            "type": "string"
+          }
         },
         "state": {
           "$ref": "./common.json#/definitions/BlobAuditingPolicyState",
@@ -1197,6 +1211,13 @@
           "type": "boolean",
           "description": "Specifies whether Managed Identity is used to access blob storage"
         },
+        "requiredFields": {
+          "type": "array",
+          "description": "Specifies the required fields to include in audit events (optional).\nEach item must be a valid audit_event field name.\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation.",
+          "items": {
+            "type": "string"
+          }
+        },
         "state": {
           "$ref": "./common.json#/definitions/BlobAuditingPolicyState",
           "description": "Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
@@ -1297,6 +1318,13 @@
         "isManagedIdentityInUse": {
           "type": "boolean",
           "description": "Specifies whether Managed Identity is used to access blob storage"
+        },
+        "requiredFields": {
+          "type": "array",
+          "description": "Specifies the required fields to include in audit events (optional).\nEach item must be a valid audit_event field name.\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation.",
+          "items": {
+            "type": "string"
+          }
         },
         "state": {
           "$ref": "./common.json#/definitions/BlobAuditingPolicyState",


### PR DESCRIPTION
This change updates the following blob-auditing APIs with a new parameter "requiredFields" to support the selective fields auditing. ServerBlobAuditingPolicyProperties
DatabaseBlobAuditingPolicyProperties
ExtendedDatabaseBlobAuditingPolicyProperties
ExtendedServerBlobAuditingPolicyProperties

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
