### PR TITLE
Add NSP BCDR preview API contract

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
@@ -60,6 +60,11 @@ enum Versions {
    * The 2025-09-01 API version.
    */
   v2025_09_01: "2025-09-01",
+
+  /**
+   * The 2026-08-01-preview API version.
+   */
+  v2026_08_01_preview: "2026-08-01-preview",
 }
 
 #suppress "@azure-tools/typespec-azure-core/no-enum" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterDelete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "testNSP1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NetworkSecurityPerimeterDelete",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/networkSecurityPerimeterOperationStatuses/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeters_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterGet.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NetworkSecurityPerimeterGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "nsp1",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+        "location": "East US 2 EUAP",
+        "properties": {
+          "perimeterGuid": "guid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterList.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "List Network Security Perimeter",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "testNSP1",
+            "type": "Microsoft.Network/networkSecurityPerimeters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/testNSP1",
+            "location": "East US 2 EUAP",
+            "properties": {
+              "perimeterGuid": "guid",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          },
+          {
+            "name": "testNSP2",
+            "type": "Microsoft.Network/networkSecurityPerimeters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/testNSP2",
+            "location": "East US 2 EUAP",
+            "properties": {
+              "perimeterGuid": "guid",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterListAll.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NetworkSecurityPerimetersList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkSecurityPerimeters?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "testNSP1",
+            "type": "Microsoft.Network/networkSecurityPerimeters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/testNSP1",
+            "location": "East US 2 EUAP",
+            "properties": {
+              "perimeterGuid": "guid",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          },
+          {
+            "name": "testNSP2",
+            "type": "Microsoft.Network/networkSecurityPerimeters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/testNSP2",
+            "location": "East US 2 EUAP",
+            "properties": {
+              "perimeterGuid": "guid",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_ListBySubscription"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterPatch.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterPatch.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "tags": {
+        "description": "nsp1"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Patch Network Security Perimeter",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "TestNetworkSecurityPerimeter",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/TestNetworkSecurityPerimeter",
+        "location": "East US 2 EUAP",
+        "properties": {
+          "perimeterGuid": "guid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        },
+        "tags": {
+          "description": "nsp1"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_Patch"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterPut.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "location": "location1",
+      "properties": {}
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Put Network Security Perimeter",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "TestNetworkSecurityPerimeter",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/TestNetworkSecurityPerimeter",
+        "location": "East US 2 EUAP",
+        "properties": {
+          "perimeterGuid": "guid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "TestNetworkSecurityPerimeter",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/TestNetworkSecurityPerimeter",
+        "location": "East US 2 EUAP",
+        "properties": {
+          "perimeterGuid": "guid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterPutGeoLinked.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NetworkSecurityPerimeterPutGeoLinked.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "geoLinkedNsp",
+    "parameters": {
+      "location": "eastus2",
+      "properties": {
+        "createMode": "GeoLinkedPerimeter",
+        "remotePerimeterId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/source-rg/providers/Microsoft.Network/networkSecurityPerimeters/source-nsp"
+      }
+    },
+    "resourceGroupName": "geo-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Create a geo-linked Network Security Perimeter",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "geoLinkedNsp",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/geo-rg/providers/Microsoft.Network/networkSecurityPerimeters/geoLinkedNsp",
+        "location": "eastus2",
+        "properties": {
+          "createMode": "GeoLinkedPerimeter",
+          "remotePerimeterId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/source-rg/providers/Microsoft.Network/networkSecurityPerimeters/source-nsp",
+          "perimeterGuid": "00000000-0000-0000-0000-000000000001",
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "geoLinkedNsp",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/geo-rg/providers/Microsoft.Network/networkSecurityPerimeters/geoLinkedNsp",
+        "location": "eastus2",
+        "properties": {
+          "createMode": "GeoLinkedPerimeter",
+          "remotePerimeterId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/source-rg/providers/Microsoft.Network/networkSecurityPerimeters/source-nsp",
+          "perimeterGuid": "00000000-0000-0000-0000-000000000001",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAccessRuleDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAccessRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accessRuleName": "accessRule1",
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAccessRulesDelete",
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterAccessRules_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAccessRuleGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAccessRuleGet.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "accessRuleName": "accessRule1",
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAccessRuleGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "accessRule1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules/accessRule1",
+        "properties": {
+          "addressPrefixes": [],
+          "direction": "Outbound",
+          "emailAddresses": [],
+          "fullyQualifiedDomainNames": [
+            "paasrp1.contoso.org",
+            "paasrp2.contoso.org"
+          ],
+          "networkSecurityPerimeters": [],
+          "phoneNumbers": [],
+          "provisioningState": "Succeeded",
+          "serviceTags": [],
+          "subscriptions": []
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAccessRules_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAccessRuleList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAccessRuleList.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAccessRulesList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "accessRule1",
+            "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules",
+            "id": "/subscriptions/rg1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules/accessRule1",
+            "properties": {
+              "addressPrefixes": [
+                "10.11.0.0/16",
+                "10.10.1.0/24"
+              ],
+              "direction": "Inbound",
+              "emailAddresses": [],
+              "fullyQualifiedDomainNames": [],
+              "networkSecurityPerimeters": [],
+              "phoneNumbers": [],
+              "provisioningState": "Succeeded",
+              "serviceTags": [],
+              "subscriptions": []
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "accessRule2",
+            "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules/accessRule2",
+            "properties": {
+              "addressPrefixes": [],
+              "direction": "Outbound",
+              "emailAddresses": [],
+              "fullyQualifiedDomainNames": [
+                "paasrp1.contoso.org",
+                "paasrp2.contoso.org"
+              ],
+              "networkSecurityPerimeters": [],
+              "phoneNumbers": [],
+              "provisioningState": "Succeeded",
+              "serviceTags": [],
+              "subscriptions": []
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAccessRules_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAccessRulePut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAccessRulePut.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "accessRuleName": "accessRule1",
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {
+        "addressPrefixes": [
+          "10.11.0.0/16",
+          "10.10.1.0/24"
+        ],
+        "direction": "Inbound"
+      }
+    },
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAccessRulePut",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "accessRule1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules/accessRule1",
+        "properties": {
+          "addressPrefixes": [
+            "10.11.0.0/16",
+            "10.10.1.0/24"
+          ],
+          "direction": "Inbound",
+          "emailAddresses": [],
+          "fullyQualifiedDomainNames": [],
+          "networkSecurityPerimeters": [],
+          "phoneNumbers": [],
+          "provisioningState": "Succeeded",
+          "serviceTags": [],
+          "subscriptions": []
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "accessRule1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules/accessRule1",
+        "properties": {
+          "addressPrefixes": [
+            "10.11.0.0/16",
+            "10.10.1.0/24"
+          ],
+          "direction": "Inbound",
+          "emailAddresses": [],
+          "fullyQualifiedDomainNames": [],
+          "networkSecurityPerimeters": [],
+          "phoneNumbers": [],
+          "provisioningState": "Succeeded",
+          "serviceTags": [],
+          "subscriptions": []
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAccessRules_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAccessRuleReconcile.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAccessRuleReconcile.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "accessRuleName": "accessRuleName1",
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {}
+    },
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAccessRuleReconcile",
+  "responses": {
+    "200": {
+      "body": {}
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAccessRules_Reconcile"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAssociationDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAssociationDelete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "operationId": "operationId1",
+    "api-version": "2026-08-01-preview",
+    "associationName": "association1",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAssociationDelete",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/networkSecurityPerimeterOperationStatuses/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterAssociations_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAssociationGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAssociationGet.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "associationName": "association1",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAssociationGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "association1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association1",
+        "properties": {
+          "accessMode": "Enforced",
+          "hasProvisioningIssues": "no",
+          "privateLinkResource": {
+            "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+          },
+          "profile": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAssociations_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAssociationList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAssociationList.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAssociationList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "association1",
+            "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association1",
+            "properties": {
+              "accessMode": "Enforced",
+              "hasProvisioningIssues": "no",
+              "privateLinkResource": {
+                "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+              },
+              "profile": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "association2",
+            "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association2",
+            "properties": {
+              "accessMode": "Audit",
+              "hasProvisioningIssues": "no",
+              "privateLinkResource": {
+                "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+              },
+              "profile": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "association3",
+            "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association3",
+            "properties": {
+              "accessMode": "Learning",
+              "hasProvisioningIssues": "yes",
+              "privateLinkResource": {
+                "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+              },
+              "profile": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+              },
+              "provisioningState": "Failed"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAssociations_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAssociationPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAssociationPut.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "associationName": "association1",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {
+        "accessMode": "Enforced",
+        "privateLinkResource": {
+          "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+        },
+        "profile": {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAssociationPut",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "association1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association1",
+        "properties": {
+          "accessMode": "Enforced",
+          "hasProvisioningIssues": "no",
+          "privateLinkResource": {
+            "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+          },
+          "profile": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "association1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association1",
+        "properties": {
+          "accessMode": "Enforced",
+          "hasProvisioningIssues": "no",
+          "privateLinkResource": {
+            "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+          },
+          "profile": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "association1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association1",
+        "properties": {
+          "accessMode": "Learning",
+          "hasProvisioningIssues": "no",
+          "privateLinkResource": {
+            "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+          },
+          "profile": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+          },
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/networkSecurityPerimeterOperationStatuses/{operationId}?api-version={api-version}"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAssociations_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAssociationReconcile.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspAssociationReconcile.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "associationName": "association1",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {}
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAssociationReconcile",
+  "responses": {
+    "200": {
+      "body": {}
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAssociations_Reconcile"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkDelete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "linkName": "link1",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinkDelete",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/links/{linkName}/operationResults/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterLinks_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkGet.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "linkName": "link1",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinksGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "link1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/links",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/links/link1",
+        "properties": {
+          "description": "Auto Approved",
+          "autoApprovedRemotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2",
+          "localInboundProfiles": [
+            "*"
+          ],
+          "localOutboundProfiles": [
+            "*"
+          ],
+          "provisioningState": "Succeeded",
+          "remoteInboundProfiles": [
+            "*"
+          ],
+          "remoteOutboundProfiles": [
+            "*"
+          ],
+          "remotePerimeterGuid": "guid",
+          "remotePerimeterLocation": "westus2",
+          "status": "Approved"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLinks_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkList.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinkList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/links?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "link1",
+            "type": "Microsoft.Network/networkSecurityPerimeters/links",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/links/link1",
+            "properties": {
+              "description": "Auto Approved",
+              "autoApprovedRemotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2",
+              "localInboundProfiles": [
+                "*"
+              ],
+              "localOutboundProfiles": [
+                "*"
+              ],
+              "provisioningState": "Succeeded",
+              "remoteInboundProfiles": [
+                "*"
+              ],
+              "remoteOutboundProfiles": [
+                "*"
+              ],
+              "remotePerimeterGuid": "guid",
+              "remotePerimeterLocation": "westus2",
+              "status": "Approved"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLinks_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkPut.json
@@ -1,0 +1,94 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "linkName": "link1",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {
+        "autoApprovedRemotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2",
+        "localInboundProfiles": [
+          "*"
+        ],
+        "remoteInboundProfiles": [
+          "*"
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinksPut",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "link1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/links",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/links/link1",
+        "properties": {
+          "description": "Auto Approved",
+          "autoApprovedRemotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2",
+          "localInboundProfiles": [
+            "*"
+          ],
+          "localOutboundProfiles": [
+            "*"
+          ],
+          "provisioningState": "Succeeded",
+          "remoteInboundProfiles": [
+            "*"
+          ],
+          "remoteOutboundProfiles": [
+            "*"
+          ],
+          "remotePerimeterGuid": "guid",
+          "remotePerimeterLocation": "westus2",
+          "status": "Approved"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "link1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/links",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/links/link1",
+        "properties": {
+          "description": "Auto Approved",
+          "autoApprovedRemotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2",
+          "localInboundProfiles": [
+            "*"
+          ],
+          "localOutboundProfiles": [
+            "*"
+          ],
+          "provisioningState": "Succeeded",
+          "remoteInboundProfiles": [
+            "*"
+          ],
+          "remoteOutboundProfiles": [
+            "*"
+          ],
+          "remotePerimeterGuid": "guid",
+          "remotePerimeterLocation": "westus2",
+          "status": "Approved"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLinks_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkReferenceDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkReferenceDelete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "linkReferenceName": "link1-guid",
+    "networkSecurityPerimeterName": "nsp2",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinkReferenceDelete",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/linkreferences/{linkReferenceName}/operationResults/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterLinkReferences_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkReferenceGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkReferenceGet.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "linkReferenceName": "link1-guid",
+    "networkSecurityPerimeterName": "nsp2",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinkReferencesGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "link1-guid",
+        "type": "Microsoft.Network/networkSecurityPerimeters/linkreferences",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2/linkreferences/link1-guid",
+        "properties": {
+          "description": "Auto Approved",
+          "localInboundProfiles": [
+            "*"
+          ],
+          "localOutboundProfiles": [
+            "*"
+          ],
+          "provisioningState": "Succeeded",
+          "remoteInboundProfiles": [
+            "*"
+          ],
+          "remoteOutboundProfiles": [
+            "*"
+          ],
+          "remotePerimeterGuid": "guid",
+          "remotePerimeterLocation": "westus2",
+          "remotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+          "status": "Approved"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLinkReferences_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkReferenceList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLinkReferenceList.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp2",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinkReferenceList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2/linkreferences?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "link1-guid",
+            "type": "Microsoft.Network/networkSecurityPerimeters/linkreferences",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2/linkreferences/link1-guid",
+            "properties": {
+              "description": "Auto Approved",
+              "localInboundProfiles": [
+                "*"
+              ],
+              "localOutboundProfiles": [
+                "*"
+              ],
+              "provisioningState": "Succeeded",
+              "remoteInboundProfiles": [
+                "*"
+              ],
+              "remoteOutboundProfiles": [
+                "*"
+              ],
+              "remotePerimeterGuid": "guid",
+              "remotePerimeterLocation": "westus2",
+              "remotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+              "status": "Approved"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLinkReferences_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLoggingConfigurationDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLoggingConfigurationDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "loggingConfigurationName": "instance",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLoggingConfigurationDelete",
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterLoggingConfigurations_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLoggingConfigurationGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLoggingConfigurationGet.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "loggingConfigurationName": "instance",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLoggingConfigurationGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "instance",
+        "type": "Microsoft.Network/networkSecurityPerimeters/loggingConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/loggingConfigurations/instance",
+        "properties": {
+          "enabledLogCategories": [
+            "NspPublicInboundPerimeterRulesDenied",
+            "NspPublicOutboundPerimeterRulesDenied"
+          ],
+          "version": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLoggingConfigurations_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLoggingConfigurationList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLoggingConfigurationList.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLoggingConfigurationList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/loggingConfigurations?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "instance",
+            "type": "Microsoft.Network/networkSecurityPerimeters/loggingConfigurations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/loggingConfigurations/instance",
+            "properties": {
+              "enabledLogCategories": [
+                "NspPublicInboundPerimeterRulesDenied",
+                "NspPublicOutboundPerimeterRulesDenied"
+              ],
+              "version": "0"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLoggingConfigurations_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLoggingConfigurationPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspLoggingConfigurationPut.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "loggingConfigurationName": "instance",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {
+        "enabledLogCategories": [
+          "NspPublicInboundPerimeterRulesDenied",
+          "NspPublicOutboundPerimeterRulesDenied"
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLoggingConfigurationPut",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "instance",
+        "type": "Microsoft.Network/networkSecurityPerimeters/loggingConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/loggingConfigurations/instance",
+        "properties": {
+          "enabledLogCategories": [
+            "NspPublicInboundPerimeterRulesDenied",
+            "NspPublicOutboundPerimeterRulesDenied"
+          ],
+          "version": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "instance",
+        "type": "Microsoft.Network/networkSecurityPerimeters/loggingConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/loggingConfigurations/instance",
+        "properties": {
+          "enabledLogCategories": [
+            "NspPublicInboundPerimeterRulesDenied",
+            "NspPublicOutboundPerimeterRulesDenied"
+          ],
+          "version": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLoggingConfigurations_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspOperationStatusGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspOperationStatusGet.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "operationId": "operationId1",
+    "api-version": "2026-08-01-preview",
+    "location": "location1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspOperationStatusGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "operationId1",
+        "endTime": "2025-01-09T10:46:55.0948652Z",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/location1/networkSecurityPerimeterOperationStatuses/operationId1",
+        "startTime": "2025-01-09T10:46:51.0988675Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterOperationStatuses_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspProfileDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspProfileDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspProfilesDelete",
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterProfiles_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspProfileGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspProfileGet.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspProfilesGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "nsp1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1",
+        "properties": {
+          "accessRulesVersion": "0",
+          "diagnosticSettingsVersion": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterProfiles_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspProfileList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspProfileList.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspProfilesList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "profile1",
+            "type": "Microsoft.Network/networkSecurityPerimeters/profiles",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1",
+            "properties": {
+              "accessRulesVersion": "0",
+              "diagnosticSettingsVersion": "0"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "profile2",
+            "type": "Microsoft.Network/networkSecurityPerimeters/profiles",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile2",
+            "properties": {
+              "accessRulesVersion": "0",
+              "diagnosticSettingsVersion": "0"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterProfiles_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspProfilePut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspProfilePut.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {}
+    },
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspProfilesPut",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "profile1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1",
+        "properties": {
+          "accessRulesVersion": "0",
+          "diagnosticSettingsVersion": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "profile1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1",
+        "properties": {
+          "accessRulesVersion": "0",
+          "diagnosticSettingsVersion": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterProfiles_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspServiceTagsList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/NspServiceTagsList.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "location": "westus",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NSPServiceTagsList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/nspServiceTags?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "serviceTags": [
+              "ActionGroup",
+              "AppConfigurationInternal",
+              "AzureCloud",
+              "PRIVATE",
+              "ApiManagement",
+              "MicrosoftPublicIPSpace",
+              "MicrosoftPrivateIPSpace"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterServiceTags_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/PerimeterAssociableResourcesList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-08-01-preview/PerimeterAssociableResourcesList.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "location": "westus",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NetworkSecurityPerimeterAssociableResourceTypes",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/perimeterAssociableResourceTypes?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "Microsoft.Sql.servers",
+            "type": "Microsoft.Network/PerimeterAssociableResourceTypes",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/perimeterAssociableResourceTypes/Microsoft.Sql.servers",
+            "properties": {
+              "displayName": "Microsoft.Sql/servers",
+              "publicDnsZones": [
+                "database.windows.net"
+              ],
+              "resourceType": "Microsoft.Sql/servers",
+              "serviceTags": [
+                "Sql"
+              ],
+              "readinessState": "GA",
+              "outboundSupported": true,
+              "description": ""
+            }
+          },
+          {
+            "name": "Microsoft.Storage.accounts",
+            "type": "Microsoft.Network/PerimeterAssociableResourceTypes",
+            "id": "/subscriptions/{subscriptionId}/providers/Microsoft.Network/perimeterAssociableResourceTypes/Microsoft.Storage.storageAccounts",
+            "properties": {
+              "displayName": "Microsoft.Storage/accounts",
+              "publicDnsZones": [
+                "blob.core.windows.net",
+                "table.core.windows.net",
+                "queue.core.windows.net",
+                "file.core.windows.net"
+              ],
+              "resourceType": "Microsoft.Storage/accounts",
+              "serviceTags": [
+                "Storage"
+              ],
+              "readinessState": "GA",
+              "outboundSupported": true,
+              "description": ""
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAssociableResourceTypes_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/main.tsp
@@ -180,6 +180,12 @@ enum Versions {
    */
   @useDependency(Common.Versions.v2025_09_01)
   v2025_09_01: "2025-09-01",
+
+  /**
+   * The 2026-08-01-preview API version.
+   */
+  @useDependency(Common.Versions.v2026_08_01_preview)
+  v2026_08_01_preview: "2026-08-01-preview",
 }
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -2820,6 +2820,30 @@ union NspLinkStatus {
    * Disconnected
    */
   Disconnected: "Disconnected",
+
+  /**
+   * A service-managed BCDR relationship that is awaiting peer reconciliation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  Dormant: "Dormant",
+}
+
+/**
+ * The creation mode of a network security perimeter.
+ */
+@added(Versions.v2026_08_01_preview)
+union NspCreateMode {
+  string,
+
+  /**
+   * A normal independently created network security perimeter.
+   */
+  Default: "Default",
+
+  /**
+   * A network security perimeter created as a geo-linked peer of another perimeter.
+   */
+  GeoLinkedPerimeter: "GeoLinkedPerimeter",
 }
 
 /**
@@ -15681,6 +15705,24 @@ model NetworkSecurityPerimeterProperties {
    */
   @visibility(Lifecycle.Read)
   perimeterGuid?: string;
+
+  /**
+   * The creation mode of the network security perimeter. This property is immutable after creation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  createMode?: NspCreateMode;
+
+  /**
+   * The resource ID of the source network security perimeter. This property is required when createMode is GeoLinkedPerimeter and is immutable after creation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  remotePerimeterId?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Network/networkSecurityPerimeters";
+    }
+  ]>;
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/service.yaml
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/service.yaml
@@ -2687,3 +2687,24 @@ versions:
       - ../stable/2025-09-01/interconnectGroup.json
       - ../stable/2025-09-01/firstPartyServiceTag.json
       - ../stable/2025-09-01/common.json
+  - version: 2026-08-01-preview
+    source: typespec
+    swagger-files:
+      - ../preview/2026-08-01-preview/applicationGateway.json
+      - ../preview/2026-08-01-preview/expressRoute.json
+      - ../preview/2026-08-01-preview/firewall.json
+      - ../preview/2026-08-01-preview/loadBalancer.json
+      - ../preview/2026-08-01-preview/networkGateway.json
+      - ../preview/2026-08-01-preview/networkManager.json
+      - ../preview/2026-08-01-preview/networkSecurityPerimeter.json
+      - ../preview/2026-08-01-preview/networkWatcher.json
+      - ../preview/2026-08-01-preview/networkingOperations.json
+      - ../preview/2026-08-01-preview/virtualNetwork.json
+      - ../preview/2026-08-01-preview/virtualWan.json
+      - ../preview/2026-08-01-preview/firewallPolicy.json
+      - ../preview/2026-08-01-preview/azureWebCategory.json
+      - ../preview/2026-08-01-preview/serviceGateway.json
+      - ../preview/2026-08-01-preview/virtualNetworkAppliance.json
+      - ../preview/2026-08-01-preview/interconnectGroup.json
+      - ../preview/2026-08-01-preview/firstPartyServiceTag.json
+      - ../preview/2026-08-01-preview/common.json

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/applicationGateway.json
@@ -1,0 +1,4982 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "ApplicationGateways"
+    },
+    {
+      "name": "ApplicationGatewayPrivateLinkResources"
+    },
+    {
+      "name": "ApplicationGatewayPrivateEndpointConnections"
+    },
+    {
+      "name": "WebApplicationFirewallPolicies"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies": {
+      "get": {
+        "operationId": "WebApplicationFirewallPolicies_ListAll",
+        "tags": [
+          "WebApplicationFirewallPolicies"
+        ],
+        "description": "Gets all the WAF policies in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/WebApplicationFirewallPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableRequestHeaders": {
+      "get": {
+        "operationId": "ApplicationGateways_ListAvailableRequestHeaders",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Lists all available request headers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableResponseHeaders": {
+      "get": {
+        "operationId": "ApplicationGateways_ListAvailableResponseHeaders",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Lists all available response headers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableServerVariables": {
+      "get": {
+        "operationId": "ApplicationGateways_ListAvailableServerVariables",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Lists all available server variables.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default": {
+      "get": {
+        "operationId": "ApplicationGateways_ListAvailableSslOptions",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Lists available Ssl options for configuring Ssl policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayAvailableSslOptions"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies": {
+      "get": {
+        "operationId": "ApplicationGateways_ListAvailableSslPredefinedPolicies",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Lists all SSL predefined policies for configuring Ssl policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayAvailableSslPredefinedPolicies"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableSslOptions/default/predefinedPolicies/{predefinedPolicyName}": {
+      "get": {
+        "operationId": "ApplicationGateways_GetSslPredefinedPolicy",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Gets Ssl predefined policy with the specified policy name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "predefinedPolicyName",
+            "in": "path",
+            "description": "The name of the ssl predefined policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewaySslPredefinedPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGatewayAvailableWafRuleSets": {
+      "get": {
+        "operationId": "ApplicationGateways_ListAvailableWafRuleSets",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Lists all available web application firewall rule sets.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayAvailableWafRuleSetsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationGateways": {
+      "get": {
+        "operationId": "ApplicationGateways_ListAll",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Gets all the application gateways in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/applicationGatewayWafDynamicManifests": {
+      "get": {
+        "operationId": "ApplicationGatewayWafDynamicManifests_Get",
+        "description": "Gets the regional application gateway waf manifest.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "The location for which the WAF dynamic manifest is requested.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayWafDynamicManifestResultList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/applicationGatewayWafDynamicManifests/dafault": {
+      "get": {
+        "operationId": "ApplicationGatewayWafDynamicManifestsDefault_Get",
+        "description": "Gets the regional application gateway waf manifest.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "location",
+            "in": "path",
+            "description": "The location for which the WAF dynamic manifest is requested.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayWafDynamicManifestResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies": {
+      "get": {
+        "operationId": "WebApplicationFirewallPolicies_List",
+        "tags": [
+          "WebApplicationFirewallPolicies"
+        ],
+        "description": "Lists all of the protection policies within a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/WebApplicationFirewallPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ApplicationGatewayWebApplicationFirewallPolicies/{policyName}": {
+      "get": {
+        "operationId": "WebApplicationFirewallPolicies_Get",
+        "tags": [
+          "WebApplicationFirewallPolicies"
+        ],
+        "description": "Retrieve protection policy with specified name within a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "The name of the policy.",
+            "required": true,
+            "type": "string",
+            "maxLength": 128
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WebApplicationFirewallPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "WebApplicationFirewallPolicies_CreateOrUpdate",
+        "tags": [
+          "WebApplicationFirewallPolicies"
+        ],
+        "description": "Creates or update policy with specified rule set name within a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "The name of the policy.",
+            "required": true,
+            "type": "string",
+            "maxLength": 128
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Policy to be created.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/WebApplicationFirewallPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'WebApplicationFirewallPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/WebApplicationFirewallPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'WebApplicationFirewallPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/WebApplicationFirewallPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "WebApplicationFirewallPolicies_Delete",
+        "tags": [
+          "WebApplicationFirewallPolicies"
+        ],
+        "description": "Deletes Policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "policyName",
+            "in": "path",
+            "description": "The name of the policy.",
+            "required": true,
+            "type": "string",
+            "maxLength": 128
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways": {
+      "get": {
+        "operationId": "ApplicationGateways_List",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Lists all application gateways in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}": {
+      "get": {
+        "operationId": "ApplicationGateways_Get",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Gets the specified application gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ApplicationGateways_CreateOrUpdate",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Creates or updates the specified application gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update application gateway operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationGateway"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ApplicationGateway' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGateway"
+            }
+          },
+          "201": {
+            "description": "Resource 'ApplicationGateway' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGateway"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ApplicationGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ApplicationGateways_UpdateTags",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Updates the specified application gateway tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update application gateway tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ApplicationGateways_Delete",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Deletes the specified application gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/backendhealth": {
+      "post": {
+        "operationId": "ApplicationGateways_BackendHealth",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Gets the backend health of the specified application gateway in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands BackendAddressPool and BackendHttpSettings referenced in backend health.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayBackendHealth"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ApplicationGatewayBackendHealth"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/getBackendHealthOnDemand": {
+      "post": {
+        "operationId": "ApplicationGateways_BackendHealthOnDemand",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Gets the backend health for given combination of backend pool and http setting of the specified application gateway in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands BackendAddressPool and BackendHttpSettings referenced in backend health.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "probeRequest",
+            "in": "body",
+            "description": "Request body for on-demand test probe operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayOnDemandProbe"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayBackendHealthOnDemand"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ApplicationGatewayBackendHealthOnDemand"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "ApplicationGatewayPrivateEndpointConnections_List",
+        "tags": [
+          "ApplicationGatewayPrivateEndpointConnections"
+        ],
+        "description": "Lists all private endpoint connections on an application gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayPrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/privateEndpointConnections/{connectionName}": {
+      "get": {
+        "operationId": "ApplicationGatewayPrivateEndpointConnections_Get",
+        "tags": [
+          "ApplicationGatewayPrivateEndpointConnections"
+        ],
+        "description": "Gets the specified private endpoint connection on application gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Name of the private endpoint connection on an application gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayPrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ApplicationGatewayPrivateEndpointConnections_Update",
+        "tags": [
+          "ApplicationGatewayPrivateEndpointConnections"
+        ],
+        "description": "Updates the specified private endpoint connection on application gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Name of the private endpoint connection on an application gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update application gateway private endpoint connection operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayPrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ApplicationGatewayPrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayPrivateEndpointConnection"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ApplicationGatewayPrivateEndpointConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ApplicationGatewayPrivateEndpointConnections_Delete",
+        "tags": [
+          "ApplicationGatewayPrivateEndpointConnections"
+        ],
+        "description": "Deletes the specified private endpoint connection on application gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Name of the private endpoint connection on an application gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/privateLinkResources": {
+      "get": {
+        "operationId": "ApplicationGatewayPrivateLinkResources_List",
+        "tags": [
+          "ApplicationGatewayPrivateLinkResources"
+        ],
+        "description": "Lists all private link resources on an application gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationGatewayPrivateLinkResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/start": {
+      "post": {
+        "operationId": "ApplicationGateways_Start",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Starts the specified application gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}/stop": {
+      "post": {
+        "operationId": "ApplicationGateways_Stop",
+        "tags": [
+          "ApplicationGateways"
+        ],
+        "description": "Stops the specified application gateway in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationGatewayName",
+            "in": "path",
+            "description": "The name of the application gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "ApplicationGateway": {
+      "type": "object",
+      "description": "Application gateway resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayPropertiesFormat",
+          "description": "Properties of the application gateway.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "zones": {
+          "type": "array",
+          "description": "A list of availability zones denoting where the resource needs to come from.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identity": {
+          "$ref": "./common.json#/definitions/ManagedServiceIdentity",
+          "description": "The identity of the application gateway, if configured."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ApplicationGatewayAuthenticationCertificate": {
+      "type": "object",
+      "description": "Authentication certificates of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayAuthenticationCertificatePropertiesFormat",
+          "description": "Properties of the application gateway authentication certificate.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the authentication certificate that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayAuthenticationCertificatePropertiesFormat": {
+      "type": "object",
+      "description": "Authentication certificates properties of an application gateway.",
+      "properties": {
+        "data": {
+          "type": "string",
+          "description": "Certificate public data."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the authentication certificate resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayAutoscaleConfiguration": {
+      "type": "object",
+      "description": "Application Gateway autoscale configuration.",
+      "properties": {
+        "minCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Lower bound on number of Application Gateway capacity.",
+          "minimum": 0
+        },
+        "maxCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Upper bound on number of Application Gateway capacity.",
+          "minimum": 2
+        }
+      },
+      "required": [
+        "minCapacity"
+      ]
+    },
+    "ApplicationGatewayAvailableSslOptions": {
+      "type": "object",
+      "description": "Response for ApplicationGatewayAvailableSslOptions API service call.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayAvailableSslOptionsPropertiesFormat",
+          "description": "Properties of the application gateway available SSL options.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ApplicationGatewayAvailableSslOptionsPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of ApplicationGatewayAvailableSslOptions.",
+      "properties": {
+        "predefinedPolicies": {
+          "type": "array",
+          "description": "List of available Ssl predefined policy.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "defaultPolicy": {
+          "$ref": "./common.json#/definitions/ApplicationGatewaySslPolicyName",
+          "description": "Name of the Ssl predefined policy applied by default to application gateway."
+        },
+        "availableCipherSuites": {
+          "type": "array",
+          "description": "List of available Ssl cipher suites.",
+          "items": {
+            "$ref": "./common.json#/definitions/ApplicationGatewaySslCipherSuite"
+          }
+        },
+        "availableProtocols": {
+          "type": "array",
+          "description": "List of available Ssl protocols.",
+          "items": {
+            "$ref": "./common.json#/definitions/ApplicationGatewaySslProtocol"
+          }
+        }
+      }
+    },
+    "ApplicationGatewayAvailableSslPredefinedPolicies": {
+      "type": "object",
+      "description": "Response for ApplicationGatewayAvailableSslOptions API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ApplicationGatewaySslPredefinedPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewaySslPredefinedPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ApplicationGatewayAvailableWafRuleSetsResult": {
+      "type": "object",
+      "description": "Response for ApplicationGatewayAvailableWafRuleSets API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of application gateway rule sets.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallRuleSet"
+          }
+        }
+      }
+    },
+    "ApplicationGatewayBackendAddress": {
+      "type": "object",
+      "description": "Backend address of an application gateway.",
+      "properties": {
+        "fqdn": {
+          "type": "string",
+          "description": "Fully qualified domain name (FQDN)."
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "IP address."
+        }
+      }
+    },
+    "ApplicationGatewayBackendAddressPool": {
+      "type": "object",
+      "description": "Backend Address Pool of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayBackendAddressPoolPropertiesFormat",
+          "description": "Properties of the application gateway backend address pool.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the backend address pool that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayBackendAddressPoolPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of Backend Address Pool of an application gateway.",
+      "properties": {
+        "backendIPConfigurations": {
+          "type": "array",
+          "description": "Collection of references to IPs defined in network interfaces.",
+          "items": {
+            "$ref": "./virtualNetwork.json#/definitions/NetworkInterfaceIPConfiguration"
+          },
+          "readOnly": true
+        },
+        "backendAddresses": {
+          "type": "array",
+          "description": "Backend addresses.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendAddress"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the backend address pool resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayBackendHealth": {
+      "type": "object",
+      "description": "Response for ApplicationGatewayBackendHealth API service call.",
+      "properties": {
+        "backendAddressPools": {
+          "type": "array",
+          "description": "A list of ApplicationGatewayBackendHealthPool resources.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendHealthPool"
+          }
+        }
+      }
+    },
+    "ApplicationGatewayBackendHealthHttpSettings": {
+      "type": "object",
+      "description": "Application gateway BackendHealthHttp settings.",
+      "properties": {
+        "backendHttpSettings": {
+          "$ref": "#/definitions/ApplicationGatewayBackendHttpSettings",
+          "description": "Reference to an ApplicationGatewayBackendHttpSettings resource."
+        },
+        "servers": {
+          "type": "array",
+          "description": "List of ApplicationGatewayBackendHealthServer resources.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendHealthServer"
+          }
+        }
+      }
+    },
+    "ApplicationGatewayBackendHealthOnDemand": {
+      "type": "object",
+      "description": "Result of on demand test probe.",
+      "properties": {
+        "backendAddressPool": {
+          "$ref": "#/definitions/ApplicationGatewayBackendAddressPool",
+          "description": "Reference to an ApplicationGatewayBackendAddressPool resource."
+        },
+        "backendHealthHttpSettings": {
+          "$ref": "#/definitions/ApplicationGatewayBackendHealthHttpSettings",
+          "description": "Application gateway BackendHealthHttp settings."
+        }
+      }
+    },
+    "ApplicationGatewayBackendHealthPool": {
+      "type": "object",
+      "description": "Application gateway BackendHealth pool.",
+      "properties": {
+        "backendAddressPool": {
+          "$ref": "#/definitions/ApplicationGatewayBackendAddressPool",
+          "description": "Reference to an ApplicationGatewayBackendAddressPool resource."
+        },
+        "backendHttpSettingsCollection": {
+          "type": "array",
+          "description": "List of ApplicationGatewayBackendHealthHttpSettings resources.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendHealthHttpSettings"
+          }
+        }
+      }
+    },
+    "ApplicationGatewayBackendHealthServer": {
+      "type": "object",
+      "description": "Application gateway backendhealth http settings.",
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "IP address or FQDN of backend server."
+        },
+        "ipConfiguration": {
+          "$ref": "./virtualNetwork.json#/definitions/NetworkInterfaceIPConfiguration",
+          "description": "Reference to IP configuration of backend server."
+        },
+        "health": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayBackendHealthServerHealth",
+          "description": "Health of backend server."
+        },
+        "healthProbeLog": {
+          "type": "string",
+          "description": "Health Probe Log."
+        }
+      }
+    },
+    "ApplicationGatewayBackendHttpSettings": {
+      "type": "object",
+      "description": "Backend address pool settings of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayBackendHttpSettingsPropertiesFormat",
+          "description": "Properties of the application gateway backend HTTP settings.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the backend http settings that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayBackendHttpSettingsPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of Backend address pool settings of an application gateway.",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The destination port on the backend."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayProtocol",
+          "description": "The protocol used to communicate with the backend."
+        },
+        "cookieBasedAffinity": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayCookieBasedAffinity",
+          "description": "Cookie based affinity."
+        },
+        "requestTimeout": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Request timeout in seconds. Application Gateway will fail the request if response is not received within RequestTimeout. Acceptable values are from 1 second to 86400 seconds."
+        },
+        "probe": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Probe resource of an application gateway."
+        },
+        "authenticationCertificates": {
+          "type": "array",
+          "description": "Array of references to application gateway authentication certificates.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "trustedRootCertificates": {
+          "type": "array",
+          "description": "Array of references to application gateway trusted root certificates.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "connectionDraining": {
+          "$ref": "#/definitions/ApplicationGatewayConnectionDraining",
+          "description": "Connection draining of the backend http settings resource."
+        },
+        "hostName": {
+          "type": "string",
+          "description": "Host header to be sent to the backend servers."
+        },
+        "pickHostNameFromBackendAddress": {
+          "type": "boolean",
+          "description": "Whether to pick host header should be picked from the host name of the backend server. Default value is false."
+        },
+        "affinityCookieName": {
+          "type": "string",
+          "description": "Cookie name to use for the affinity cookie."
+        },
+        "probeEnabled": {
+          "type": "boolean",
+          "description": "Whether the probe is enabled. Default value is false."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path which should be used as a prefix for all HTTP requests. Null means no path will be prefixed. Default value is null."
+        },
+        "dedicatedBackendConnection": {
+          "type": "boolean",
+          "description": "Enable or disable dedicated connection per backend server. Default is set to false."
+        },
+        "validateCertChainAndExpiry": {
+          "type": "boolean",
+          "description": "Verify or skip both chain and expiry validations of the certificate on the backend server. Default is set to true.",
+          "default": true
+        },
+        "validateSNI": {
+          "type": "boolean",
+          "description": "When enabled, verifies if the Common Name of the certificate provided by the backend server matches the Server Name Indication (SNI) value. Default value is true.",
+          "default": true
+        },
+        "sniName": {
+          "type": "string",
+          "description": "Specify an SNI value to match the common name of the certificate on the backend. By default, the application gateway uses the incoming request’s host header as the SNI. Default value is null."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the backend HTTP settings resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayBackendSettings": {
+      "type": "object",
+      "description": "Backend address pool settings of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayBackendSettingsPropertiesFormat",
+          "description": "Properties of the application gateway backend settings.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the backend settings that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayBackendSettingsPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of Backend address pool settings of an application gateway.",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The destination port on the backend."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayProtocol",
+          "description": "The protocol used to communicate with the backend."
+        },
+        "timeout": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Connection timeout in seconds. Application Gateway will fail the request if response is not received within ConnectionTimeout. Acceptable values are from 1 second to 86400 seconds."
+        },
+        "probe": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Probe resource of an application gateway."
+        },
+        "trustedRootCertificates": {
+          "type": "array",
+          "description": "Array of references to application gateway trusted root certificates.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "hostName": {
+          "type": "string",
+          "description": "Server name indication to be sent to the backend servers for Tls protocol."
+        },
+        "pickHostNameFromBackendAddress": {
+          "type": "boolean",
+          "description": "Whether to pick server name indication from the host name of the backend server for Tls protocol. Default value is false."
+        },
+        "enableL4ClientIpPreservation": {
+          "type": "boolean",
+          "description": "Whether to send Proxy Protocol header to backend servers over TCP or TLS protocols. Default value is false."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the backend HTTP settings resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayClientAuthConfiguration": {
+      "type": "object",
+      "description": "Application gateway client authentication configuration.",
+      "properties": {
+        "verifyClientCertIssuerDN": {
+          "type": "boolean",
+          "description": "Verify client certificate issuer name on the application gateway."
+        },
+        "verifyClientRevocation": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayClientRevocationOptions",
+          "description": "Verify client certificate revocation status."
+        },
+        "verifyClientAuthMode": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayClientAuthVerificationModes",
+          "description": "Verify client Authentication mode."
+        }
+      }
+    },
+    "ApplicationGatewayConnectionDraining": {
+      "type": "object",
+      "description": "Connection draining allows open connections to a backend server to be active for a specified time after the backend server got removed from the configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether connection draining is enabled or not."
+        },
+        "drainTimeoutInSec": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of seconds connection draining is active. Acceptable values are from 1 second to 3600 seconds.",
+          "minimum": 1,
+          "maximum": 3600
+        }
+      },
+      "required": [
+        "enabled",
+        "drainTimeoutInSec"
+      ]
+    },
+    "ApplicationGatewayCustomError": {
+      "type": "object",
+      "description": "Custom error of an application gateway.",
+      "properties": {
+        "statusCode": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayCustomErrorStatusCode",
+          "description": "Status code of the application gateway custom error."
+        },
+        "customErrorPageUrl": {
+          "type": "string",
+          "description": "Error page URL of the application gateway custom error."
+        }
+      }
+    },
+    "ApplicationGatewayEntraJWTValidationConfig": {
+      "type": "object",
+      "description": "Entra JWT Validation Configuration of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayEntraJWTValidationConfigPropertiesFormat",
+          "description": "Properties of the application gateway entra jwt validation configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the entra jwt validation configuration that is unique within an application gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayEntraJWTValidationConfigPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of entra jwt validation configuration of the application gateway.",
+      "properties": {
+        "unAuthorizedRequestAction": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayUnAuthorizedRequestAction",
+          "description": "Unauthorized request action."
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The Tenant ID of the Microsoft Entra ID application."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The Client ID of the Microsoft Entra ID application."
+        },
+        "audiences": {
+          "type": "array",
+          "description": "List of acceptable audience claims that can be present in the token (aud claim). A maximum of 5 audiences are permitted.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the entra jwt validation configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayFirewallDisabledRuleGroup": {
+      "type": "object",
+      "description": "Allows to disable rules within a rule group or an entire rule group.",
+      "properties": {
+        "ruleGroupName": {
+          "type": "string",
+          "description": "The name of the rule group that will be disabled."
+        },
+        "rules": {
+          "type": "array",
+          "description": "The list of rules that will be disabled. If null, all rules of the rule group will be disabled.",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "required": [
+        "ruleGroupName"
+      ]
+    },
+    "ApplicationGatewayFirewallExclusion": {
+      "type": "object",
+      "description": "Allow to exclude some variable satisfy the condition for the WAF check.",
+      "properties": {
+        "matchVariable": {
+          "type": "string",
+          "description": "The variable to be excluded."
+        },
+        "selectorMatchOperator": {
+          "type": "string",
+          "description": "When matchVariable is a collection, operate on the selector to specify which elements in the collection this exclusion applies to."
+        },
+        "selector": {
+          "type": "string",
+          "description": "When matchVariable is a collection, operator used to specify which elements in the collection this exclusion applies to."
+        }
+      },
+      "required": [
+        "matchVariable",
+        "selectorMatchOperator",
+        "selector"
+      ]
+    },
+    "ApplicationGatewayFirewallManifestRuleSet": {
+      "type": "object",
+      "description": "Properties of the web application firewall rule set.",
+      "properties": {
+        "ruleSetType": {
+          "type": "string",
+          "description": "The type of the web application firewall rule set."
+        },
+        "ruleSetVersion": {
+          "type": "string",
+          "description": "The version of the web application firewall rule set type."
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayRuleSetStatusOptions",
+          "description": "The rule set status"
+        },
+        "tiers": {
+          "type": "array",
+          "description": "Tier of an application gateway that support the rule set.",
+          "items": {
+            "$ref": "./common.json#/definitions/ApplicationGatewayTierTypes"
+          }
+        },
+        "ruleGroups": {
+          "type": "array",
+          "description": "The rule groups of the web application firewall rule set.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallRuleGroup"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "ruleSetType",
+        "ruleSetVersion",
+        "ruleGroups"
+      ]
+    },
+    "ApplicationGatewayFirewallRule": {
+      "type": "object",
+      "description": "A web application firewall rule.",
+      "properties": {
+        "ruleId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The identifier of the web application firewall rule."
+        },
+        "ruleIdString": {
+          "type": "string",
+          "description": "The string representation of the web application firewall rule identifier."
+        },
+        "state": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayWafRuleStateTypes",
+          "description": "The string representation of the web application firewall rule state."
+        },
+        "action": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayWafRuleActionTypes",
+          "description": "The string representation of the web application firewall rule action."
+        },
+        "sensitivity": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayWafRuleSensitivityTypes",
+          "description": "The string representation of the web application firewall rule sensitivity."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the web application firewall rule."
+        }
+      },
+      "required": [
+        "ruleId"
+      ]
+    },
+    "ApplicationGatewayFirewallRuleGroup": {
+      "type": "object",
+      "description": "A web application firewall rule group.",
+      "properties": {
+        "ruleGroupName": {
+          "type": "string",
+          "description": "The name of the web application firewall rule group."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the web application firewall rule group."
+        },
+        "rules": {
+          "type": "array",
+          "description": "The rules of the web application firewall rule group.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallRule"
+          }
+        }
+      },
+      "required": [
+        "ruleGroupName",
+        "rules"
+      ]
+    },
+    "ApplicationGatewayFirewallRuleSet": {
+      "type": "object",
+      "description": "A web application firewall rule set.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayFirewallRuleSetPropertiesFormat",
+          "description": "Properties of the application gateway firewall rule set.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ApplicationGatewayFirewallRuleSetPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the web application firewall rule set.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the web application firewall rule set.",
+          "readOnly": true
+        },
+        "ruleSetType": {
+          "type": "string",
+          "description": "The type of the web application firewall rule set."
+        },
+        "ruleSetVersion": {
+          "type": "string",
+          "description": "The version of the web application firewall rule set type."
+        },
+        "ruleGroups": {
+          "type": "array",
+          "description": "The rule groups of the web application firewall rule set.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallRuleGroup"
+          }
+        },
+        "tiers": {
+          "type": "array",
+          "description": "Tier of an application gateway that support the rule set.",
+          "items": {
+            "$ref": "./common.json#/definitions/ApplicationGatewayTierTypes"
+          }
+        }
+      },
+      "required": [
+        "ruleSetType",
+        "ruleSetVersion",
+        "ruleGroups"
+      ]
+    },
+    "ApplicationGatewayForContainersReferenceDefinition": {
+      "type": "object",
+      "description": "Defines an application gateway for containers reference.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource Id of the application gateway for containers.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ServiceNetworking/trafficControllers"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "ApplicationGatewayFrontendIPConfiguration": {
+      "type": "object",
+      "description": "Frontend IP configuration of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayFrontendIPConfigurationPropertiesFormat",
+          "description": "Properties of the application gateway frontend IP configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the frontend IP configuration that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayFrontendIPConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of Frontend IP configuration of an application gateway.",
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "description": "PrivateIPAddress of the network interface IP Configuration."
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The private IP address allocation method."
+        },
+        "subnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the subnet resource."
+        },
+        "publicIPAddress": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the PublicIP resource."
+        },
+        "privateLinkConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the application gateway private link configuration."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the frontend IP configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayFrontendPort": {
+      "type": "object",
+      "description": "Frontend port of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayFrontendPortPropertiesFormat",
+          "description": "Properties of the application gateway frontend port.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the frontend port that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayFrontendPortPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of Frontend port of an application gateway.",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Frontend port."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the frontend port resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayGlobalConfiguration": {
+      "type": "object",
+      "description": "Application Gateway global configuration.",
+      "properties": {
+        "enableRequestBuffering": {
+          "type": "boolean",
+          "description": "Enable request buffering."
+        },
+        "enableResponseBuffering": {
+          "type": "boolean",
+          "description": "Enable response buffering."
+        },
+        "disableDefaultServerHeaderInResponse": {
+          "type": "boolean",
+          "description": "Disable default server header in response."
+        }
+      }
+    },
+    "ApplicationGatewayHeaderConfiguration": {
+      "type": "object",
+      "description": "Header configuration of the Actions set in Application Gateway.",
+      "properties": {
+        "headerName": {
+          "type": "string",
+          "description": "Header name of the header configuration."
+        },
+        "headerValueMatcher": {
+          "$ref": "#/definitions/HeaderValueMatcher",
+          "description": "An optional field under \"Rewrite Action\". It lets you capture and modify the value(s) of a specific header when multiple headers with the same name exist. Currently supported for Set-Cookie Response header only. For more details, visit https://aka.ms/appgwheadercrud"
+        },
+        "headerValue": {
+          "type": "string",
+          "description": "Header value of the header configuration."
+        }
+      }
+    },
+    "ApplicationGatewayHttpListener": {
+      "type": "object",
+      "description": "Http listener of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayHttpListenerPropertiesFormat",
+          "description": "Properties of the application gateway HTTP listener.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the HTTP listener that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayHttpListenerPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of HTTP listener of an application gateway.",
+      "properties": {
+        "frontendIPConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Frontend IP configuration resource of an application gateway."
+        },
+        "frontendPort": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Frontend port resource of an application gateway."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayProtocol",
+          "description": "Protocol of the HTTP listener."
+        },
+        "hostName": {
+          "type": "string",
+          "description": "Host name of HTTP listener."
+        },
+        "sslCertificate": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "SSL certificate resource of an application gateway."
+        },
+        "sslProfile": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "SSL profile resource of the application gateway."
+        },
+        "requireServerNameIndication": {
+          "type": "boolean",
+          "description": "Applicable only if protocol is https. Enables SNI for multi-hosting."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the HTTP listener resource.",
+          "readOnly": true
+        },
+        "customErrorConfigurations": {
+          "type": "array",
+          "description": "Custom error configurations of the HTTP listener.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayCustomError"
+          }
+        },
+        "firewallPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the FirewallPolicy resource."
+        },
+        "hostNames": {
+          "type": "array",
+          "description": "List of Host names for HTTP Listener that allows special wildcard characters as well.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ApplicationGatewayIPConfiguration": {
+      "type": "object",
+      "description": "IP configuration of an application gateway. Currently 1 public and 1 private IP configuration is allowed.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayIPConfigurationPropertiesFormat",
+          "description": "Properties of the application gateway IP configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the IP configuration that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayIPConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of IP configuration of an application gateway.",
+      "properties": {
+        "subnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the subnet resource. A subnet from where application gateway gets its private address."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the application gateway IP configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayListResult": {
+      "type": "object",
+      "description": "The response of a ApplicationGateway list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ApplicationGateway items on this page",
+          "items": {
+            "$ref": "#/definitions/ApplicationGateway"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ApplicationGatewayListener": {
+      "type": "object",
+      "description": "Listener of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayListenerPropertiesFormat",
+          "description": "Properties of the application gateway listener.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the listener that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayListenerPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of listener of an application gateway.",
+      "properties": {
+        "frontendIPConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Frontend IP configuration resource of an application gateway."
+        },
+        "frontendPort": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Frontend port resource of an application gateway."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayProtocol",
+          "description": "Protocol of the listener."
+        },
+        "sslCertificate": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "SSL certificate resource of an application gateway."
+        },
+        "sslProfile": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "SSL profile resource of the application gateway."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the listener resource.",
+          "readOnly": true
+        },
+        "hostNames": {
+          "type": "array",
+          "description": "List of Server Name Indications(SNI) for TLS Multi-site Listener that allows special wildcard characters as well.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ApplicationGatewayLoadDistributionPolicy": {
+      "type": "object",
+      "description": "Load Distribution Policy of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayLoadDistributionPolicyPropertiesFormat",
+          "description": "Properties of the application gateway load distribution policy.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the load distribution policy that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayLoadDistributionPolicyPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of Load Distribution Policy of an application gateway.",
+      "properties": {
+        "loadDistributionTargets": {
+          "type": "array",
+          "description": "Load Distribution Targets resource of an application gateway.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayLoadDistributionTarget"
+          }
+        },
+        "loadDistributionAlgorithm": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayLoadDistributionAlgorithm",
+          "description": "Load Distribution Targets resource of an application gateway."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the Load Distribution Policy resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayLoadDistributionTarget": {
+      "type": "object",
+      "description": "Load Distribution Target of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayLoadDistributionTargetPropertiesFormat",
+          "description": "Properties of the application gateway load distribution target.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the load distribution policy that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayLoadDistributionTargetPropertiesFormat": {
+      "type": "object",
+      "properties": {
+        "weightPerServer": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Weight per server. Range between 1 and 100.",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "backendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Backend address pool resource of the application gateway."
+        }
+      }
+    },
+    "ApplicationGatewayManagedHsm": {
+      "type": "object",
+      "description": "Managed HSM properties of an application gateway.",
+      "properties": {
+        "keyId": {
+          "type": "string",
+          "format": "uri",
+          "description": "Key identifier of a key stored in Managed HSM."
+        },
+        "publicCertData": {
+          "type": "string",
+          "description": "Base-64 encoded value of a base-64 public certificate."
+        }
+      }
+    },
+    "ApplicationGatewayOnDemandProbe": {
+      "type": "object",
+      "description": "Details of on demand test probe request.",
+      "properties": {
+        "protocol": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayProtocol",
+          "description": "The protocol used for the probe."
+        },
+        "host": {
+          "type": "string",
+          "description": "Host name to send the probe to."
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path of probe. Valid path starts from '/'. Probe is sent to <Protocol>://<host>:<port><path>."
+        },
+        "timeout": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The probe timeout in seconds. Probe marked as failed if valid response is not received with this timeout period. Acceptable values are from 1 second to 86400 seconds."
+        },
+        "pickHostNameFromBackendHttpSettings": {
+          "type": "boolean",
+          "description": "Whether the host header should be picked from the backend http settings. Default value is false."
+        },
+        "enableProbeProxyProtocolHeader": {
+          "type": "boolean",
+          "description": "Whether to send Proxy Protocol header along with the Health Probe over TCP or TLS protocol. Default value is false."
+        },
+        "match": {
+          "$ref": "#/definitions/ApplicationGatewayProbeHealthResponseMatch",
+          "description": "Criterion for classifying a healthy probe response."
+        },
+        "backendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to backend pool of application gateway to which probe request will be sent."
+        },
+        "backendHttpSettings": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to backend http setting of application gateway to be used for test probe."
+        }
+      }
+    },
+    "ApplicationGatewayPathRule": {
+      "type": "object",
+      "description": "Path rule of URL path map of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayPathRulePropertiesFormat",
+          "description": "Properties of the application gateway path rule.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the path rule that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayPathRulePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of path rule of an application gateway.",
+      "properties": {
+        "paths": {
+          "type": "array",
+          "description": "Path rules of URL path map.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "backendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Backend address pool resource of URL path map path rule."
+        },
+        "backendHttpSettings": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Backend http settings resource of URL path map path rule."
+        },
+        "redirectConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Redirect configuration resource of URL path map path rule."
+        },
+        "rewriteRuleSet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Rewrite rule set resource of URL path map path rule."
+        },
+        "loadDistributionPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Load Distribution Policy resource of URL path map path rule."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the path rule resource.",
+          "readOnly": true
+        },
+        "firewallPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the FirewallPolicy resource."
+        }
+      }
+    },
+    "ApplicationGatewayPrivateEndpointConnection": {
+      "type": "object",
+      "description": "Private Endpoint connection on an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayPrivateEndpointConnectionProperties",
+          "description": "Properties of the application gateway private endpoint connection.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "ApplicationGatewayPrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "The response of a ApplicationGatewayPrivateEndpointConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ApplicationGatewayPrivateEndpointConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayPrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ApplicationGatewayPrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of Private Link Resource of an application gateway.",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "./virtualNetwork.json#/definitions/PrivateEndpoint",
+          "description": "The resource of private end point.",
+          "readOnly": true
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "./virtualNetwork.json#/definitions/PrivateLinkServiceConnectionState",
+          "description": "A collection of information about the state of the connection between service consumer and provider."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the application gateway private endpoint connection resource.",
+          "readOnly": true
+        },
+        "linkIdentifier": {
+          "type": "string",
+          "description": "The consumer link id.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayPrivateLinkConfiguration": {
+      "type": "object",
+      "description": "Private Link Configuration on an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayPrivateLinkConfigurationProperties",
+          "description": "Properties of the application gateway private link configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the private link configuration that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayPrivateLinkConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of private link configuration on an application gateway.",
+      "properties": {
+        "ipConfigurations": {
+          "type": "array",
+          "description": "An array of application gateway private link ip configurations.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayPrivateLinkIpConfiguration"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the application gateway private link configuration.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayPrivateLinkIpConfiguration": {
+      "type": "object",
+      "description": "The application gateway private link ip configuration.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayPrivateLinkIpConfigurationProperties",
+          "description": "Properties of an application gateway private link ip configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of application gateway private link ip configuration."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayPrivateLinkIpConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of an application gateway private link IP configuration.",
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "description": "The private IP address of the IP configuration."
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The private IP address allocation method."
+        },
+        "subnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the subnet resource."
+        },
+        "primary": {
+          "type": "boolean",
+          "description": "Whether the ip configuration is primary or not."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the application gateway private link IP configuration.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayPrivateLinkResource": {
+      "type": "object",
+      "description": "PrivateLink Resource of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayPrivateLinkResourceProperties",
+          "description": "Properties of the application gateway private link resource.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the private link resource that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayPrivateLinkResourceListResult": {
+      "type": "object",
+      "description": "The response of a ApplicationGatewayPrivateLinkResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ApplicationGatewayPrivateLinkResource items on this page",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayPrivateLinkResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ApplicationGatewayPrivateLinkResourceProperties": {
+      "type": "object",
+      "description": "Properties of a private link resource.",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "Group identifier of private link resource.",
+          "readOnly": true
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "Required member names of private link resource.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "Required DNS zone names of the the private link resource.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ApplicationGatewayProbe": {
+      "type": "object",
+      "description": "Probe of the application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayProbePropertiesFormat",
+          "description": "Properties of the application gateway probe.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the probe that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayProbeHealthResponseMatch": {
+      "type": "object",
+      "description": "Application gateway probe health response match.",
+      "properties": {
+        "body": {
+          "type": "string",
+          "description": "Body that must be contained in the health response. Default value is empty."
+        },
+        "statusCodes": {
+          "type": "array",
+          "description": "Allowed ranges of healthy status codes. Default range of healthy status codes is 200-399.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ApplicationGatewayProbePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of probe of an application gateway.",
+      "properties": {
+        "protocol": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayProtocol",
+          "description": "The protocol used for the probe."
+        },
+        "host": {
+          "type": "string",
+          "description": "Host name to send the probe to."
+        },
+        "path": {
+          "type": "string",
+          "description": "Relative path of probe. Valid path starts from '/'. Probe is sent to <Protocol>://<host>:<port><path>."
+        },
+        "interval": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The probing interval in seconds. This is the time interval between two consecutive probes. Acceptable values are from 1 second to 86400 seconds."
+        },
+        "timeout": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The probe timeout in seconds. Probe marked as failed if valid response is not received with this timeout period. Acceptable values are from 1 second to 86400 seconds."
+        },
+        "unhealthyThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The probe retry count. Backend server is marked down after consecutive probe failure count reaches UnhealthyThreshold. Acceptable values are from 1 second to 20."
+        },
+        "pickHostNameFromBackendHttpSettings": {
+          "type": "boolean",
+          "description": "Whether the host header should be picked from the backend http settings. Default value is false."
+        },
+        "pickHostNameFromBackendSettings": {
+          "type": "boolean",
+          "description": "Whether the server name indication should be picked from the backend settings for Tls protocol. Default value is false."
+        },
+        "minServers": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of servers that are always marked healthy. Default value is 0."
+        },
+        "match": {
+          "$ref": "#/definitions/ApplicationGatewayProbeHealthResponseMatch",
+          "description": "Criterion for classifying a healthy probe response."
+        },
+        "enableProbeProxyProtocolHeader": {
+          "type": "boolean",
+          "description": "Whether to send Proxy Protocol header along with the Health Probe over TCP or TLS protocol. Default value is false."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the probe resource.",
+          "readOnly": true
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Custom port which will be used for probing the backend servers. The valid value ranges from 1 to 65535. In case not set, port from http settings will be used. This property is valid for Basic, Standard_v2 and WAF_v2 only.",
+          "minimum": 1,
+          "maximum": 65535
+        }
+      }
+    },
+    "ApplicationGatewayPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the application gateway.",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/ApplicationGatewaySku",
+          "description": "SKU of the application gateway resource."
+        },
+        "sslPolicy": {
+          "$ref": "#/definitions/ApplicationGatewaySslPolicy",
+          "description": "SSL policy of the application gateway resource."
+        },
+        "operationalState": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayOperationalState",
+          "description": "Operational state of the application gateway resource.",
+          "readOnly": true
+        },
+        "gatewayIPConfigurations": {
+          "type": "array",
+          "description": "Subnets of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayIPConfiguration"
+          }
+        },
+        "authenticationCertificates": {
+          "type": "array",
+          "description": "Authentication certificates of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayAuthenticationCertificate"
+          }
+        },
+        "trustedRootCertificates": {
+          "type": "array",
+          "description": "Trusted Root certificates of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayTrustedRootCertificate"
+          }
+        },
+        "trustedClientCertificates": {
+          "type": "array",
+          "description": "Trusted client certificates of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayTrustedClientCertificate"
+          }
+        },
+        "sslCertificates": {
+          "type": "array",
+          "description": "SSL certificates of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewaySslCertificate"
+          }
+        },
+        "frontendIPConfigurations": {
+          "type": "array",
+          "description": "Frontend IP addresses of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFrontendIPConfiguration"
+          }
+        },
+        "frontendPorts": {
+          "type": "array",
+          "description": "Frontend ports of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFrontendPort"
+          }
+        },
+        "probes": {
+          "type": "array",
+          "description": "Probes of the application gateway resource.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayProbe"
+          }
+        },
+        "backendAddressPools": {
+          "type": "array",
+          "description": "Backend address pool of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendAddressPool"
+          }
+        },
+        "backendHttpSettingsCollection": {
+          "type": "array",
+          "description": "Backend http settings of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendHttpSettings"
+          }
+        },
+        "backendSettingsCollection": {
+          "type": "array",
+          "description": "Backend settings of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayBackendSettings"
+          }
+        },
+        "httpListeners": {
+          "type": "array",
+          "description": "Http listeners of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayHttpListener"
+          }
+        },
+        "listeners": {
+          "type": "array",
+          "description": "Listeners of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayListener"
+          }
+        },
+        "sslProfiles": {
+          "type": "array",
+          "description": "SSL profiles of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewaySslProfile"
+          }
+        },
+        "urlPathMaps": {
+          "type": "array",
+          "description": "URL path map of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayUrlPathMap"
+          }
+        },
+        "requestRoutingRules": {
+          "type": "array",
+          "description": "Request routing rules of the application gateway resource.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayRequestRoutingRule"
+          }
+        },
+        "routingRules": {
+          "type": "array",
+          "description": "Routing rules of the application gateway resource.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayRoutingRule"
+          }
+        },
+        "rewriteRuleSets": {
+          "type": "array",
+          "description": "Rewrite rules for the application gateway resource.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayRewriteRuleSet"
+          }
+        },
+        "redirectConfigurations": {
+          "type": "array",
+          "description": "Redirect configurations of the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayRedirectConfiguration"
+          }
+        },
+        "webApplicationFirewallConfiguration": {
+          "$ref": "#/definitions/ApplicationGatewayWebApplicationFirewallConfiguration",
+          "description": "Web application firewall configuration."
+        },
+        "firewallPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the FirewallPolicy resource."
+        },
+        "enableHttp2": {
+          "type": "boolean",
+          "description": "Whether HTTP2 is enabled on the application gateway resource."
+        },
+        "enableFips": {
+          "type": "boolean",
+          "description": "Whether FIPS is enabled on the application gateway resource."
+        },
+        "autoscaleConfiguration": {
+          "$ref": "#/definitions/ApplicationGatewayAutoscaleConfiguration",
+          "description": "Autoscale Configuration."
+        },
+        "privateLinkConfigurations": {
+          "type": "array",
+          "description": "PrivateLink configurations on application gateway.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayPrivateLinkConfiguration"
+          }
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "Private Endpoint connections on application gateway.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayPrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the application gateway resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the application gateway resource.",
+          "readOnly": true
+        },
+        "customErrorConfigurations": {
+          "type": "array",
+          "description": "Custom error configurations of the application gateway resource.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayCustomError"
+          }
+        },
+        "forceFirewallPolicyAssociation": {
+          "type": "boolean",
+          "description": "If true, associates a firewall policy with an application gateway regardless whether the policy differs from the WAF Config."
+        },
+        "loadDistributionPolicies": {
+          "type": "array",
+          "description": "Load distribution policies of the application gateway resource.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayLoadDistributionPolicy"
+          }
+        },
+        "entraJWTValidationConfigs": {
+          "type": "array",
+          "description": "Entra JWT validation configurations for the application gateway resource. For default limits, see [Application Gateway limits](https://docs.microsoft.com/azure/azure-subscription-service-limits#application-gateway-limits).",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayEntraJWTValidationConfig"
+          }
+        },
+        "globalConfiguration": {
+          "$ref": "#/definitions/ApplicationGatewayGlobalConfiguration",
+          "description": "Global Configuration."
+        },
+        "defaultPredefinedSslPolicy": {
+          "$ref": "./common.json#/definitions/ApplicationGatewaySslPolicyName",
+          "description": "The default predefined SSL Policy applied on the application gateway resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayRedirectConfiguration": {
+      "type": "object",
+      "description": "Redirect configuration of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayRedirectConfigurationPropertiesFormat",
+          "description": "Properties of the application gateway redirect configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the redirect configuration that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayRedirectConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of redirect configuration of the application gateway.",
+      "properties": {
+        "redirectType": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayRedirectType",
+          "description": "HTTP redirection type."
+        },
+        "targetListener": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to a listener to redirect the request to."
+        },
+        "targetUrl": {
+          "type": "string",
+          "description": "Url to redirect the request to."
+        },
+        "includePath": {
+          "type": "boolean",
+          "description": "Include path in the redirected url."
+        },
+        "includeQueryString": {
+          "type": "boolean",
+          "description": "Include query string in the redirected url."
+        },
+        "requestRoutingRules": {
+          "type": "array",
+          "description": "Request routing specifying redirect configuration.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "urlPathMaps": {
+          "type": "array",
+          "description": "Url path maps specifying default redirect configuration.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "pathRules": {
+          "type": "array",
+          "description": "Path rules specifying redirect configuration.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        }
+      }
+    },
+    "ApplicationGatewayRequestRoutingRule": {
+      "type": "object",
+      "description": "Request routing rule of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayRequestRoutingRulePropertiesFormat",
+          "description": "Properties of the application gateway request routing rule.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the request routing rule that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayRequestRoutingRulePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of request routing rule of the application gateway.",
+      "properties": {
+        "ruleType": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayRequestRoutingRuleType",
+          "description": "Rule type."
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority of the request routing rule.",
+          "minimum": 1,
+          "maximum": 20000
+        },
+        "backendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Backend address pool resource of the application gateway."
+        },
+        "backendHttpSettings": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Backend http settings resource of the application gateway."
+        },
+        "httpListener": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Http listener resource of the application gateway."
+        },
+        "urlPathMap": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "URL path map resource of the application gateway."
+        },
+        "rewriteRuleSet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Rewrite Rule Set resource in Basic rule of the application gateway."
+        },
+        "redirectConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Redirect configuration resource of the application gateway."
+        },
+        "loadDistributionPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Load Distribution Policy resource of the application gateway."
+        },
+        "entraJWTValidationConfig": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Entra JWT validation configuration resource of the application gateway."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the request routing rule resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayRewriteRule": {
+      "type": "object",
+      "description": "Rewrite rule of an application gateway.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the rewrite rule that is unique within an Application Gateway."
+        },
+        "ruleSequence": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rule Sequence of the rewrite rule that determines the order of execution of a particular rule in a RewriteRuleSet."
+        },
+        "conditions": {
+          "type": "array",
+          "description": "Conditions based on which the action set execution will be evaluated.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayRewriteRuleCondition"
+          }
+        },
+        "actionSet": {
+          "$ref": "#/definitions/ApplicationGatewayRewriteRuleActionSet",
+          "description": "Set of actions to be done as part of the rewrite Rule."
+        }
+      }
+    },
+    "ApplicationGatewayRewriteRuleActionSet": {
+      "type": "object",
+      "description": "Set of actions in the Rewrite Rule in Application Gateway.",
+      "properties": {
+        "requestHeaderConfigurations": {
+          "type": "array",
+          "description": "Request Header Actions in the Action Set.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayHeaderConfiguration"
+          }
+        },
+        "responseHeaderConfigurations": {
+          "type": "array",
+          "description": "Response Header Actions in the Action Set.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayHeaderConfiguration"
+          }
+        },
+        "urlConfiguration": {
+          "$ref": "#/definitions/ApplicationGatewayUrlConfiguration",
+          "description": "Url Configuration Action in the Action Set."
+        }
+      }
+    },
+    "ApplicationGatewayRewriteRuleCondition": {
+      "type": "object",
+      "description": "Set of conditions in the Rewrite Rule in Application Gateway.",
+      "properties": {
+        "variable": {
+          "type": "string",
+          "description": "The condition parameter of the RewriteRuleCondition."
+        },
+        "pattern": {
+          "type": "string",
+          "description": "The pattern, either fixed string or regular expression, that evaluates the truthfulness of the condition."
+        },
+        "ignoreCase": {
+          "type": "boolean",
+          "description": "Setting this parameter to truth value with force the pattern to do a case in-sensitive comparison."
+        },
+        "negate": {
+          "type": "boolean",
+          "description": "Setting this value as truth will force to check the negation of the condition given by the user."
+        }
+      }
+    },
+    "ApplicationGatewayRewriteRuleSet": {
+      "type": "object",
+      "description": "Rewrite rule set of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayRewriteRuleSetPropertiesFormat",
+          "description": "Properties of the application gateway rewrite rule set.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the rewrite rule set that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayRewriteRuleSetPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of rewrite rule set of the application gateway.",
+      "properties": {
+        "rewriteRules": {
+          "type": "array",
+          "description": "Rewrite rules in the rewrite rule set.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayRewriteRule"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the rewrite rule set resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayRoutingRule": {
+      "type": "object",
+      "description": "Routing rule of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayRoutingRulePropertiesFormat",
+          "description": "Properties of the application gateway routing rule.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the routing rule that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayRoutingRulePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of routing rule of the application gateway.",
+      "properties": {
+        "ruleType": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayRequestRoutingRuleType",
+          "description": "Rule type."
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority of the routing rule.",
+          "minimum": 1,
+          "maximum": 20000
+        },
+        "backendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Backend address pool resource of the application gateway."
+        },
+        "backendSettings": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Backend settings resource of the application gateway."
+        },
+        "listener": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Listener resource of the application gateway."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the request routing rule resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "priority"
+      ]
+    },
+    "ApplicationGatewaySku": {
+      "type": "object",
+      "description": "SKU of an application gateway.",
+      "properties": {
+        "name": {
+          "$ref": "./common.json#/definitions/ApplicationGatewaySkuName",
+          "description": "Name of an application gateway SKU."
+        },
+        "tier": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayTier",
+          "description": "Tier of an application gateway."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Capacity (instance count) of an application gateway."
+        },
+        "family": {
+          "$ref": "./common.json#/definitions/ApplicationGatewaySkuFamily",
+          "description": "Family of an application gateway SKU."
+        }
+      }
+    },
+    "ApplicationGatewaySslCertificate": {
+      "type": "object",
+      "description": "SSL certificates of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewaySslCertificatePropertiesFormat",
+          "description": "Properties of the application gateway SSL certificate.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the SSL certificate that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewaySslCertificatePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of SSL certificates of an application gateway.",
+      "properties": {
+        "data": {
+          "type": "string",
+          "description": "Base-64 encoded pfx certificate. Only applicable in PUT Request."
+        },
+        "password": {
+          "type": "string",
+          "description": "Password for the pfx file specified in data. Only applicable in PUT request."
+        },
+        "publicCertData": {
+          "type": "string",
+          "description": "Base-64 encoded Public cert data corresponding to pfx specified in data. Only applicable in GET request.",
+          "readOnly": true
+        },
+        "keyVaultSecretId": {
+          "type": "string",
+          "description": "Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault."
+        },
+        "hsm": {
+          "$ref": "#/definitions/ApplicationGatewayManagedHsm",
+          "description": "Managed HSM properties of the Application Gateway resource."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the SSL certificate resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewaySslPolicy": {
+      "type": "object",
+      "description": "Application Gateway Ssl policy.",
+      "properties": {
+        "disabledSslProtocols": {
+          "type": "array",
+          "description": "Ssl protocols to be disabled on application gateway.",
+          "items": {
+            "$ref": "./common.json#/definitions/ApplicationGatewaySslProtocol"
+          }
+        },
+        "policyType": {
+          "$ref": "./common.json#/definitions/ApplicationGatewaySslPolicyType",
+          "description": "Type of Ssl Policy."
+        },
+        "policyName": {
+          "$ref": "./common.json#/definitions/ApplicationGatewaySslPolicyName",
+          "description": "Name of Ssl predefined policy."
+        },
+        "cipherSuites": {
+          "type": "array",
+          "description": "Ssl cipher suites to be enabled in the specified order to application gateway.",
+          "items": {
+            "$ref": "./common.json#/definitions/ApplicationGatewaySslCipherSuite"
+          }
+        },
+        "minProtocolVersion": {
+          "$ref": "./common.json#/definitions/ApplicationGatewaySslProtocol",
+          "description": "Minimum version of Ssl protocol to be supported on application gateway."
+        }
+      }
+    },
+    "ApplicationGatewaySslPredefinedPolicy": {
+      "type": "object",
+      "description": "An Ssl predefined policy.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the Ssl predefined policy."
+        },
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewaySslPredefinedPolicyPropertiesFormat",
+          "description": "Properties of the application gateway SSL predefined policy.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewaySslPredefinedPolicyPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of ApplicationGatewaySslPredefinedPolicy.",
+      "properties": {
+        "cipherSuites": {
+          "type": "array",
+          "description": "Ssl cipher suites to be enabled in the specified order for application gateway.",
+          "items": {
+            "$ref": "./common.json#/definitions/ApplicationGatewaySslCipherSuite"
+          }
+        },
+        "minProtocolVersion": {
+          "$ref": "./common.json#/definitions/ApplicationGatewaySslProtocol",
+          "description": "Minimum version of Ssl protocol to be supported on application gateway."
+        }
+      }
+    },
+    "ApplicationGatewaySslProfile": {
+      "type": "object",
+      "description": "SSL profile of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewaySslProfilePropertiesFormat",
+          "description": "Properties of the application gateway SSL profile.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the SSL profile that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewaySslProfilePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of SSL profile of an application gateway.",
+      "properties": {
+        "trustedClientCertificates": {
+          "type": "array",
+          "description": "Array of references to application gateway trusted client certificates.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "sslPolicy": {
+          "$ref": "#/definitions/ApplicationGatewaySslPolicy",
+          "description": "SSL policy of the application gateway resource."
+        },
+        "clientAuthConfiguration": {
+          "$ref": "#/definitions/ApplicationGatewayClientAuthConfiguration",
+          "description": "Client authentication configuration of the application gateway resource."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the HTTP listener resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayTrustedClientCertificate": {
+      "type": "object",
+      "description": "Trusted client certificates of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayTrustedClientCertificatePropertiesFormat",
+          "description": "Properties of the application gateway trusted client certificate.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the trusted client certificate that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayTrustedClientCertificatePropertiesFormat": {
+      "type": "object",
+      "description": "Trusted client certificates properties of an application gateway.",
+      "properties": {
+        "data": {
+          "type": "string",
+          "description": "Certificate public data."
+        },
+        "validatedCertData": {
+          "type": "string",
+          "description": "Validated certificate data.",
+          "readOnly": true
+        },
+        "clientCertIssuerDN": {
+          "type": "string",
+          "description": "Distinguished name of client certificate issuer.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the trusted client certificate resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayTrustedRootCertificate": {
+      "type": "object",
+      "description": "Trusted Root certificates of an application gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayTrustedRootCertificatePropertiesFormat",
+          "description": "Properties of the application gateway trusted root certificate.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the trusted root certificate that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayTrustedRootCertificatePropertiesFormat": {
+      "type": "object",
+      "description": "Trusted Root certificates properties of an application gateway.",
+      "properties": {
+        "data": {
+          "type": "string",
+          "description": "Certificate public data."
+        },
+        "keyVaultSecretId": {
+          "type": "string",
+          "description": "Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the trusted root certificate resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayUrlConfiguration": {
+      "type": "object",
+      "description": "Url configuration of the Actions set in Application Gateway.",
+      "properties": {
+        "modifiedPath": {
+          "type": "string",
+          "description": "Url path which user has provided for url rewrite. Null means no path will be updated. Default value is null."
+        },
+        "modifiedQueryString": {
+          "type": "string",
+          "description": "Query string which user has provided for url rewrite. Null means no query string will be updated. Default value is null."
+        },
+        "reroute": {
+          "type": "boolean",
+          "description": "If set as true, it will re-evaluate the url path map provided in path based request routing rules using modified path. Default value is false."
+        }
+      }
+    },
+    "ApplicationGatewayUrlPathMap": {
+      "type": "object",
+      "description": "UrlPathMaps give a url path to the backend mapping information for PathBasedRouting.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayUrlPathMapPropertiesFormat",
+          "description": "Properties of the application gateway URL path map.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the URL path map that is unique within an Application Gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ApplicationGatewayUrlPathMapPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of UrlPathMap of the application gateway.",
+      "properties": {
+        "defaultBackendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Default backend address pool resource of URL path map."
+        },
+        "defaultBackendHttpSettings": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Default backend http settings resource of URL path map."
+        },
+        "defaultRewriteRuleSet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Default Rewrite rule set resource of URL path map."
+        },
+        "defaultRedirectConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Default redirect configuration resource of URL path map."
+        },
+        "defaultLoadDistributionPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Default Load Distribution Policy resource of URL path map."
+        },
+        "pathRules": {
+          "type": "array",
+          "description": "Path rule of URL path map resource.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayPathRule"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the URL path map resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationGatewayWafDynamicManifestPropertiesResult": {
+      "type": "object",
+      "description": "Properties of ApplicationGatewayWafDynamicManifest.",
+      "properties": {
+        "defaultRuleSet": {
+          "$ref": "#/definitions/DefaultRuleSetPropertyFormat",
+          "description": "The default ruleset.",
+          "x-ms-client-flatten": true
+        },
+        "availableRuleSets": {
+          "type": "array",
+          "description": "The available rulesets.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallManifestRuleSet"
+          },
+          "x-ms-client-flatten": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ApplicationGatewayWafDynamicManifestResult": {
+      "type": "object",
+      "description": "Response for ApplicationGatewayWafDynamicManifest API service call.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationGatewayWafDynamicManifestPropertiesResult",
+          "description": "Properties of the ApplicationGatewayWafDynamicManifest .",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ProxyResourceWithSettableId"
+        }
+      ]
+    },
+    "ApplicationGatewayWafDynamicManifestResultList": {
+      "type": "object",
+      "description": "Response for ApplicationGatewayWafDynamicManifests API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ApplicationGatewayWafDynamicManifestResult items on this page",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayWafDynamicManifestResult"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ApplicationGatewayWebApplicationFirewallConfiguration": {
+      "type": "object",
+      "description": "Application gateway web application firewall configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the web application firewall is enabled or not."
+        },
+        "firewallMode": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayFirewallMode",
+          "description": "Web application firewall mode."
+        },
+        "ruleSetType": {
+          "type": "string",
+          "description": "The type of the web application firewall rule set. Possible values are: 'OWASP'."
+        },
+        "ruleSetVersion": {
+          "type": "string",
+          "description": "The version of the rule set type."
+        },
+        "disabledRuleGroups": {
+          "type": "array",
+          "description": "The disabled rule groups.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallDisabledRuleGroup"
+          }
+        },
+        "requestBodyCheck": {
+          "type": "boolean",
+          "description": "Whether allow WAF to check request Body."
+        },
+        "maxRequestBodySize": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum request body size for WAF.",
+          "minimum": 8,
+          "maximum": 128
+        },
+        "maxRequestBodySizeInKb": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum request body size in Kb for WAF.",
+          "minimum": 8,
+          "maximum": 128
+        },
+        "fileUploadLimitInMb": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum file upload size in Mb for WAF.",
+          "minimum": 0
+        },
+        "exclusions": {
+          "type": "array",
+          "description": "The exclusion list.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayFirewallExclusion"
+          }
+        }
+      },
+      "required": [
+        "enabled",
+        "firewallMode",
+        "ruleSetType",
+        "ruleSetVersion"
+      ]
+    },
+    "DefaultRuleSetPropertyFormat": {
+      "type": "object",
+      "description": "the default web application firewall rule set.",
+      "properties": {
+        "ruleSetType": {
+          "type": "string",
+          "description": "The type of the web application firewall rule set."
+        },
+        "ruleSetVersion": {
+          "type": "string",
+          "description": "The version of the web application firewall rule set type."
+        }
+      }
+    },
+    "ExceptionEntry": {
+      "type": "object",
+      "description": "Adds exception to allow a request when the condition is satisfied.",
+      "properties": {
+        "matchVariable": {
+          "$ref": "./common.json#/definitions/ExceptionEntryMatchVariable",
+          "description": "The variable on which we evaluate the exception condition"
+        },
+        "values": {
+          "type": "array",
+          "description": "Allowed values for the matchVariable",
+          "items": {
+            "type": "string"
+          }
+        },
+        "valueMatchOperator": {
+          "$ref": "./common.json#/definitions/ExceptionEntryValueMatchOperator",
+          "description": "Operates on the allowed values for the matchVariable"
+        },
+        "selectorMatchOperator": {
+          "$ref": "./common.json#/definitions/ExceptionEntrySelectorMatchOperator",
+          "description": "When the matchVariable points to a key-value pair (e.g, RequestHeader), this operates on the selector"
+        },
+        "selector": {
+          "type": "string",
+          "description": "When the matchVariable points to a key-value pair (e.g, RequestHeader), this identifies the key."
+        },
+        "exceptionManagedRuleSets": {
+          "type": "array",
+          "description": "The managed rule sets that are associated with the exception.",
+          "items": {
+            "$ref": "#/definitions/ExclusionManagedRuleSet"
+          }
+        }
+      },
+      "required": [
+        "matchVariable",
+        "valueMatchOperator"
+      ]
+    },
+    "ExclusionManagedRule": {
+      "type": "object",
+      "description": "Defines a managed rule to use for exclusion.",
+      "properties": {
+        "ruleId": {
+          "type": "string",
+          "description": "Identifier for the managed rule."
+        }
+      },
+      "required": [
+        "ruleId"
+      ]
+    },
+    "ExclusionManagedRuleGroup": {
+      "type": "object",
+      "description": "Defines a managed rule group to use for exclusion.",
+      "properties": {
+        "ruleGroupName": {
+          "type": "string",
+          "description": "The managed rule group for exclusion."
+        },
+        "rules": {
+          "type": "array",
+          "description": "List of rules that will be excluded. If none specified, all rules in the group will be excluded.",
+          "items": {
+            "$ref": "#/definitions/ExclusionManagedRule"
+          }
+        }
+      },
+      "required": [
+        "ruleGroupName"
+      ]
+    },
+    "ExclusionManagedRuleSet": {
+      "type": "object",
+      "description": "Defines a managed rule set for Exclusions.",
+      "properties": {
+        "ruleSetType": {
+          "type": "string",
+          "description": "Defines the rule set type to use."
+        },
+        "ruleSetVersion": {
+          "type": "string",
+          "description": "Defines the version of the rule set to use."
+        },
+        "ruleGroups": {
+          "type": "array",
+          "description": "Defines the rule groups to apply to the rule set.",
+          "items": {
+            "$ref": "#/definitions/ExclusionManagedRuleGroup"
+          }
+        }
+      },
+      "required": [
+        "ruleSetType",
+        "ruleSetVersion"
+      ]
+    },
+    "GroupByUserSession": {
+      "type": "object",
+      "description": "Define user session identifier group by clauses.",
+      "properties": {
+        "groupByVariables": {
+          "type": "array",
+          "description": "List of group by clause variables.",
+          "items": {
+            "$ref": "#/definitions/GroupByVariable"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "groupByVariables"
+      ]
+    },
+    "GroupByVariable": {
+      "type": "object",
+      "description": "Define user session group by clause variables.",
+      "properties": {
+        "variableName": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayFirewallUserSessionVariable",
+          "description": "User Session clause variable."
+        }
+      },
+      "required": [
+        "variableName"
+      ]
+    },
+    "HeaderValueMatcher": {
+      "type": "object",
+      "description": "An optional field under \"Rewrite Action\". It lets you capture and modify the value(s) of a specific header when multiple headers with the same name exist. Currently supported for Set-Cookie Response header only. For more details, visit https://aka.ms/appgwheadercrud",
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "The pattern, either fixed string or regular expression, that evaluates if a header value should be selected for rewrite."
+        },
+        "ignoreCase": {
+          "type": "boolean",
+          "description": "Setting this parameter to truth value with force the pattern to do a case in-sensitive comparison."
+        },
+        "negate": {
+          "type": "boolean",
+          "description": "Setting this value as truth will force to check the negation of the condition given by the user in the pattern field."
+        }
+      }
+    },
+    "ManagedRuleGroupOverride": {
+      "type": "object",
+      "description": "Defines a managed rule group override setting.",
+      "properties": {
+        "ruleGroupName": {
+          "type": "string",
+          "description": "The managed rule group to override."
+        },
+        "rules": {
+          "type": "array",
+          "description": "List of rules that will be disabled. If none specified, all rules in the group will be disabled.",
+          "items": {
+            "$ref": "#/definitions/ManagedRuleOverride"
+          }
+        }
+      },
+      "required": [
+        "ruleGroupName"
+      ]
+    },
+    "ManagedRuleOverride": {
+      "type": "object",
+      "description": "Defines a managed rule group override setting.",
+      "properties": {
+        "ruleId": {
+          "type": "string",
+          "description": "Identifier for the managed rule."
+        },
+        "state": {
+          "$ref": "./common.json#/definitions/ManagedRuleEnabledState",
+          "description": "The state of the managed rule. Defaults to Disabled if not specified."
+        },
+        "action": {
+          "$ref": "./common.json#/definitions/ActionType",
+          "description": "Describes the override action to be applied when rule matches."
+        },
+        "sensitivity": {
+          "$ref": "./common.json#/definitions/SensitivityType",
+          "description": "Describes the override sensitivity to be applied when rule matches."
+        }
+      },
+      "required": [
+        "ruleId"
+      ]
+    },
+    "ManagedRuleSet": {
+      "type": "object",
+      "description": "Defines a managed rule set.",
+      "properties": {
+        "ruleSetType": {
+          "type": "string",
+          "description": "Defines the rule set type to use."
+        },
+        "ruleSetVersion": {
+          "type": "string",
+          "description": "Defines the version of the rule set to use."
+        },
+        "ruleGroupOverrides": {
+          "type": "array",
+          "description": "Defines the rule group overrides to apply to the rule set.",
+          "items": {
+            "$ref": "#/definitions/ManagedRuleGroupOverride"
+          }
+        },
+        "computedDisabledRules": {
+          "type": "array",
+          "description": "Stores the final list of disabled rule groups",
+          "items": {
+            "$ref": "#/definitions/ManagedRuleSetRuleGroup"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "ruleSetType",
+        "ruleSetVersion"
+      ]
+    },
+    "ManagedRuleSetRuleGroup": {
+      "type": "object",
+      "description": "Defines a managed rule set rule group",
+      "properties": {
+        "ruleGroupName": {
+          "type": "string",
+          "description": "Name of the rule group"
+        },
+        "rules": {
+          "type": "array",
+          "description": "List of rules within the rule group",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "ruleGroupName"
+      ]
+    },
+    "ManagedRulesDefinition": {
+      "type": "object",
+      "description": "Allow to exclude some variable satisfy the condition for the WAF check.",
+      "properties": {
+        "exceptions": {
+          "type": "array",
+          "description": "The exceptions that are applied on the policy.",
+          "items": {
+            "$ref": "#/definitions/ExceptionEntry"
+          }
+        },
+        "exclusions": {
+          "type": "array",
+          "description": "The Exclusions that are applied on the policy.",
+          "items": {
+            "$ref": "#/definitions/OwaspCrsExclusionEntry"
+          }
+        },
+        "managedRuleSets": {
+          "type": "array",
+          "description": "The managed rule sets that are associated with the policy.",
+          "items": {
+            "$ref": "#/definitions/ManagedRuleSet"
+          }
+        }
+      },
+      "required": [
+        "managedRuleSets"
+      ]
+    },
+    "MatchCondition": {
+      "type": "object",
+      "description": "Define match conditions.",
+      "properties": {
+        "matchVariables": {
+          "type": "array",
+          "description": "List of match variables.",
+          "items": {
+            "$ref": "#/definitions/MatchVariable"
+          }
+        },
+        "operator": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallOperator",
+          "description": "The operator to be matched."
+        },
+        "negationConditon": {
+          "type": "boolean",
+          "description": "Whether this is negate condition or not."
+        },
+        "matchValues": {
+          "type": "array",
+          "description": "Match value.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "transforms": {
+          "type": "array",
+          "description": "List of transforms.",
+          "items": {
+            "$ref": "./common.json#/definitions/WebApplicationFirewallTransform"
+          }
+        }
+      },
+      "required": [
+        "matchVariables",
+        "operator",
+        "matchValues"
+      ]
+    },
+    "MatchVariable": {
+      "type": "object",
+      "description": "Define match variables.",
+      "properties": {
+        "variableName": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallMatchVariable",
+          "description": "Match Variable."
+        },
+        "selector": {
+          "type": "string",
+          "description": "The selector of match variable."
+        }
+      },
+      "required": [
+        "variableName"
+      ]
+    },
+    "OwaspCrsExclusionEntry": {
+      "type": "object",
+      "description": "Allow to exclude some variable satisfy the condition for the WAF check.",
+      "properties": {
+        "matchVariable": {
+          "$ref": "./common.json#/definitions/OwaspCrsExclusionEntryMatchVariable",
+          "description": "The variable to be excluded."
+        },
+        "selectorMatchOperator": {
+          "$ref": "./common.json#/definitions/OwaspCrsExclusionEntrySelectorMatchOperator",
+          "description": "When matchVariable is a collection, operate on the selector to specify which elements in the collection this exclusion applies to."
+        },
+        "selector": {
+          "type": "string",
+          "description": "When matchVariable is a collection, operator used to specify which elements in the collection this exclusion applies to."
+        },
+        "exclusionManagedRuleSets": {
+          "type": "array",
+          "description": "The managed rule sets that are associated with the exclusion.",
+          "items": {
+            "$ref": "#/definitions/ExclusionManagedRuleSet"
+          }
+        }
+      },
+      "required": [
+        "matchVariable",
+        "selectorMatchOperator",
+        "selector"
+      ]
+    },
+    "PolicySettings": {
+      "type": "object",
+      "description": "Defines contents of a web application firewall global configuration.",
+      "properties": {
+        "state": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallEnabledState",
+          "description": "The state of the policy."
+        },
+        "mode": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallMode",
+          "description": "The mode of the policy."
+        },
+        "requestBodyCheck": {
+          "type": "boolean",
+          "description": "Whether to allow WAF to check request Body."
+        },
+        "requestBodyInspectLimitInKB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Max inspection limit in KB for request body inspection for WAF."
+        },
+        "requestBodyEnforcement": {
+          "type": "boolean",
+          "description": "Whether allow WAF to enforce request body limits.",
+          "default": true
+        },
+        "maxRequestBodySizeInKb": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum request body size in Kb for WAF.",
+          "minimum": 8
+        },
+        "fileUploadEnforcement": {
+          "type": "boolean",
+          "description": "Whether allow WAF to enforce file upload limits.",
+          "default": true
+        },
+        "fileUploadLimitInMb": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum file upload size in Mb for WAF.",
+          "minimum": 0
+        },
+        "customBlockResponseStatusCode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "If the action type is block, customer can override the response status code.",
+          "minimum": 0
+        },
+        "customBlockResponseBody": {
+          "type": "string",
+          "description": "If the action type is block, customer can override the response body. The body must be specified in base64 encoding.",
+          "maxLength": 32768,
+          "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$"
+        },
+        "logScrubbing": {
+          "$ref": "#/definitions/PolicySettingsLogScrubbing",
+          "description": "To scrub sensitive log fields"
+        },
+        "jsChallengeCookieExpirationInMins": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Web Application Firewall JavaScript Challenge Cookie Expiration time in minutes.",
+          "minimum": 5,
+          "maximum": 1440
+        },
+        "captchaExpirationInMins": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Web Application Firewall CAPTCHA Cookie Expiration time in minutes.",
+          "minimum": 5,
+          "maximum": 1440
+        }
+      }
+    },
+    "PolicySettingsLogScrubbing": {
+      "type": "object",
+      "description": "To scrub sensitive log fields",
+      "properties": {
+        "state": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallScrubbingState",
+          "description": "State of the log scrubbing config. Default value is Enabled."
+        },
+        "scrubbingRules": {
+          "type": "array",
+          "description": "The rules that are applied to the logs for scrubbing.",
+          "items": {
+            "$ref": "#/definitions/WebApplicationFirewallScrubbingRules"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "WebApplicationFirewallCustomRule": {
+      "type": "object",
+      "description": "Defines contents of a web application rule.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a policy. This name can be used to access the resource.",
+          "maxLength": 128
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority of the rule. Rules with a lower value will be evaluated before rules with a higher value."
+        },
+        "state": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallState",
+          "description": "Describes if the custom rule is in enabled or disabled state. Defaults to Enabled if not specified."
+        },
+        "rateLimitDuration": {
+          "$ref": "./common.json#/definitions/ApplicationGatewayFirewallRateLimitDuration",
+          "description": "Duration over which Rate Limit policy will be applied. Applies only when ruleType is RateLimitRule."
+        },
+        "rateLimitThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rate Limit threshold to apply in case ruleType is RateLimitRule. Must be greater than or equal to 1"
+        },
+        "ruleType": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallRuleType",
+          "description": "The rule type."
+        },
+        "matchConditions": {
+          "type": "array",
+          "description": "List of match conditions.",
+          "items": {
+            "$ref": "#/definitions/MatchCondition"
+          }
+        },
+        "groupByUserSession": {
+          "type": "array",
+          "description": "List of user session identifier group by clauses.",
+          "items": {
+            "$ref": "#/definitions/GroupByUserSession"
+          },
+          "x-ms-identifiers": []
+        },
+        "action": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallAction",
+          "description": "Type of Actions."
+        }
+      },
+      "required": [
+        "priority",
+        "ruleType",
+        "matchConditions",
+        "action"
+      ]
+    },
+    "WebApplicationFirewallPolicy": {
+      "type": "object",
+      "description": "Defines web application firewall policy.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WebApplicationFirewallPolicyPropertiesFormat",
+          "description": "Properties of the web application firewall policy.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "WebApplicationFirewallPolicyListResult": {
+      "type": "object",
+      "description": "Paged collection of WebApplicationFirewallPolicy items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The WebApplicationFirewallPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/WebApplicationFirewallPolicy"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "WebApplicationFirewallPolicyPropertiesFormat": {
+      "type": "object",
+      "description": "Defines web application firewall policy properties.",
+      "properties": {
+        "policySettings": {
+          "$ref": "#/definitions/PolicySettings",
+          "description": "The PolicySettings for policy."
+        },
+        "customRules": {
+          "type": "array",
+          "description": "The custom rules inside the policy.",
+          "items": {
+            "$ref": "#/definitions/WebApplicationFirewallCustomRule"
+          }
+        },
+        "applicationGateways": {
+          "type": "array",
+          "description": "A collection of references to application gateways.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGateway"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the web application firewall policy resource.",
+          "readOnly": true
+        },
+        "resourceState": {
+          "$ref": "./common.json#/definitions/WebApplicationFirewallPolicyResourceState",
+          "title": "Resource status of the policy.",
+          "description": "Resource status of the policy.",
+          "readOnly": true
+        },
+        "managedRules": {
+          "$ref": "#/definitions/ManagedRulesDefinition",
+          "description": "Describes the managedRules structure."
+        },
+        "httpListeners": {
+          "type": "array",
+          "description": "A collection of references to application gateway http listeners.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "pathBasedRules": {
+          "type": "array",
+          "description": "A collection of references to application gateway path rules.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "applicationGatewayForContainers": {
+          "type": "array",
+          "description": "A collection of references to application gateway for containers.",
+          "items": {
+            "$ref": "#/definitions/ApplicationGatewayForContainersReferenceDefinition"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "managedRules"
+      ]
+    },
+    "WebApplicationFirewallScrubbingRules": {
+      "type": "object",
+      "description": "Allow certain variables to be scrubbed on WAF logs",
+      "properties": {
+        "matchVariable": {
+          "$ref": "./common.json#/definitions/ScrubbingRuleEntryMatchVariable",
+          "description": "The variable to be scrubbed from the logs."
+        },
+        "selectorMatchOperator": {
+          "$ref": "./common.json#/definitions/scrubbingRuleEntryMatchOperator",
+          "description": "When matchVariable is a collection, operate on the selector to specify which elements in the collection this rule applies to."
+        },
+        "selector": {
+          "type": "string",
+          "description": "When matchVariable is a collection, operator used to specify which elements in the collection this rule applies to."
+        },
+        "state": {
+          "$ref": "./common.json#/definitions/scrubbingRuleEntryState",
+          "description": "Defines the state of log scrubbing rule. Default value is Enabled."
+        }
+      },
+      "required": [
+        "matchVariable",
+        "selectorMatchOperator"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/azureWebCategory.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/azureWebCategory.json
@@ -1,0 +1,178 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "WebCategories"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureWebCategories": {
+      "get": {
+        "operationId": "WebCategories_ListBySubscription",
+        "tags": [
+          "WebCategories"
+        ],
+        "description": "Gets all the Azure Web Categories in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AzureWebCategoryListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureWebCategories/{name}": {
+      "get": {
+        "operationId": "WebCategories_Get",
+        "tags": [
+          "WebCategories"
+        ],
+        "description": "Gets the specified Azure Web Category.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "The name of the azureWebCategory.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands resourceIds back referenced by the azureWebCategory resource.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AzureWebCategory"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AzureWebCategory": {
+      "type": "object",
+      "description": "Azure Web Category Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureWebCategoryPropertiesFormat",
+          "description": "Properties of the Azure Web Category.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AzureWebCategoryListResult": {
+      "type": "object",
+      "description": "List of Azure Web Categories for a given Subscription.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AzureWebCategory items on this page",
+          "items": {
+            "$ref": "#/definitions/AzureWebCategory"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AzureWebCategoryPropertiesFormat": {
+      "type": "object",
+      "description": "Azure Web Category Properties.",
+      "properties": {
+        "group": {
+          "type": "string",
+          "description": "The name of the group that the category belongs to.",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/common.json
@@ -1,0 +1,10123 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [],
+  "paths": {},
+  "definitions": {
+    "Access": {
+      "type": "string",
+      "description": "Access to be allowed or denied.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "Access",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny",
+            "description": "Deny"
+          }
+        ]
+      }
+    },
+    "AccessMode": {
+      "type": "string",
+      "description": "The access mode of the private link service.",
+      "enum": [
+        "Default",
+        "Restricted"
+      ],
+      "x-ms-enum": {
+        "name": "AccessMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Allows unrestricted access to the private link service."
+          },
+          {
+            "name": "Restricted",
+            "value": "Restricted",
+            "description": "Limits access to subscriptions which are inside visibility list only."
+          }
+        ]
+      }
+    },
+    "AccessRuleDirection": {
+      "type": "string",
+      "description": "Direction that specifies whether the access rules is inbound/outbound.",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "AccessRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound",
+            "description": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound",
+            "description": "Outbound"
+          }
+        ]
+      }
+    },
+    "ActionType": {
+      "type": "string",
+      "description": "Defines the action to take on rule match.",
+      "enum": [
+        "AnomalyScoring",
+        "Allow",
+        "Block",
+        "Log",
+        "JSChallenge",
+        "CAPTCHA"
+      ],
+      "x-ms-enum": {
+        "name": "ActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AnomalyScoring",
+            "value": "AnomalyScoring",
+            "description": "AnomalyScoring"
+          },
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          },
+          {
+            "name": "Block",
+            "value": "Block",
+            "description": "Block"
+          },
+          {
+            "name": "Log",
+            "value": "Log",
+            "description": "Log"
+          },
+          {
+            "name": "JSChallenge",
+            "value": "JSChallenge",
+            "description": "JSChallenge"
+          },
+          {
+            "name": "CAPTCHA",
+            "value": "CAPTCHA",
+            "description": "CAPTCHA"
+          }
+        ]
+      }
+    },
+    "AddressPrefixType": {
+      "type": "string",
+      "description": "Address prefix type.",
+      "enum": [
+        "IPPrefix",
+        "ServiceTag",
+        "NetworkGroup"
+      ],
+      "x-ms-enum": {
+        "name": "AddressPrefixType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPPrefix",
+            "value": "IPPrefix",
+            "description": "IPPrefix"
+          },
+          {
+            "name": "ServiceTag",
+            "value": "ServiceTag",
+            "description": "ServiceTag"
+          },
+          {
+            "name": "NetworkGroup",
+            "value": "NetworkGroup",
+            "description": "NetworkGroup"
+          }
+        ]
+      }
+    },
+    "AddressSpaceAggregationOption": {
+      "type": "string",
+      "description": "Option indicating the update behavior of a resource's address prefixes referenced within a network manager configuration.",
+      "enum": [
+        "None",
+        "Manual"
+      ],
+      "x-ms-enum": {
+        "name": "AddressSpaceAggregationOption",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "Manual",
+            "value": "Manual",
+            "description": "Manual"
+          }
+        ]
+      }
+    },
+    "AddressUpdateAction": {
+      "type": "string",
+      "description": "Specifies the type of update operation to perform on addresses within the address location of service gateway.\n\n- FullUpdate: Replaces all existing address data with the new list provided in the request. Any previously defined addresses not included will be removed.\n- PartialUpdate: Updates only the specified addresses.",
+      "enum": [
+        "FullUpdate",
+        "PartialUpdate"
+      ],
+      "x-ms-enum": {
+        "name": "AddressUpdateAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FullUpdate",
+            "value": "FullUpdate",
+            "description": "FullUpdate"
+          },
+          {
+            "name": "PartialUpdate",
+            "value": "PartialUpdate",
+            "description": "PartialUpdate"
+          }
+        ]
+      }
+    },
+    "AdminRuleKind": {
+      "type": "string",
+      "description": "Whether the rule is custom or default.",
+      "enum": [
+        "Custom",
+        "Default"
+      ],
+      "x-ms-enum": {
+        "name": "AdminRuleKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "Custom"
+          },
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default"
+          }
+        ]
+      }
+    },
+    "AdminState": {
+      "type": "string",
+      "description": "Property to indicate if the Express Route Gateway serves traffic when there are multiple Express Route Gateways in the vnet",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "AdminState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "AdvertisedPublicPrefixPropertiesValidationState": {
+      "type": "string",
+      "description": "Advertised Public Prefix State that denotes if the prefix is validated or not.",
+      "enum": [
+        "NotConfigured",
+        "Configuring",
+        "Configured",
+        "ValidationNeeded",
+        "ValidationFailed",
+        "ManualValidationNeeded",
+        "AsnValidationFailed",
+        "CertificateMissingInRoutingRegistry",
+        "InvalidSignatureEncoding",
+        "SignatureVerificationFailed"
+      ],
+      "x-ms-enum": {
+        "name": "AdvertisedPublicPrefixPropertiesValidationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotConfigured",
+            "value": "NotConfigured",
+            "description": "NotConfigured"
+          },
+          {
+            "name": "Configuring",
+            "value": "Configuring",
+            "description": "Configuring"
+          },
+          {
+            "name": "Configured",
+            "value": "Configured",
+            "description": "Configured"
+          },
+          {
+            "name": "ValidationNeeded",
+            "value": "ValidationNeeded",
+            "description": "ValidationNeeded"
+          },
+          {
+            "name": "ValidationFailed",
+            "value": "ValidationFailed",
+            "description": "ValidationFailed"
+          },
+          {
+            "name": "ManualValidationNeeded",
+            "value": "ManualValidationNeeded",
+            "description": "ManualValidationNeeded"
+          },
+          {
+            "name": "AsnValidationFailed",
+            "value": "AsnValidationFailed",
+            "description": "AsnValidationFailed"
+          },
+          {
+            "name": "CertificateMissingInRoutingRegistry",
+            "value": "CertificateMissingInRoutingRegistry",
+            "description": "CertificateMissingInRoutingRegistry"
+          },
+          {
+            "name": "InvalidSignatureEncoding",
+            "value": "InvalidSignatureEncoding",
+            "description": "InvalidSignatureEncoding"
+          },
+          {
+            "name": "SignatureVerificationFailed",
+            "value": "SignatureVerificationFailed",
+            "description": "SignatureVerificationFailed"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayBackendHealthServerHealth": {
+      "type": "string",
+      "description": "Health of backend server.",
+      "enum": [
+        "Unknown",
+        "Up",
+        "Down",
+        "Partial",
+        "Draining"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayBackendHealthServerHealth",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "Up",
+            "value": "Up",
+            "description": "Up"
+          },
+          {
+            "name": "Down",
+            "value": "Down",
+            "description": "Down"
+          },
+          {
+            "name": "Partial",
+            "value": "Partial",
+            "description": "Partial"
+          },
+          {
+            "name": "Draining",
+            "value": "Draining",
+            "description": "Draining"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayClientAuthVerificationModes": {
+      "type": "string",
+      "description": "Verify client Authentication mode.",
+      "enum": [
+        "Strict",
+        "Passthrough"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayClientAuthVerificationModes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Strict",
+            "value": "Strict",
+            "description": "Strict"
+          },
+          {
+            "name": "Passthrough",
+            "value": "Passthrough",
+            "description": "Passthrough"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayClientRevocationOptions": {
+      "type": "string",
+      "description": "Verify client certificate revocation status.",
+      "enum": [
+        "None",
+        "OCSP"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayClientRevocationOptions",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "OCSP",
+            "value": "OCSP",
+            "description": "OCSP"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayCookieBasedAffinity": {
+      "type": "string",
+      "description": "Cookie based affinity.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayCookieBasedAffinity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayCustomErrorStatusCode": {
+      "type": "string",
+      "description": "Status code of the application gateway custom error.",
+      "enum": [
+        "HttpStatus400",
+        "HttpStatus403",
+        "HttpStatus404",
+        "HttpStatus405",
+        "HttpStatus408",
+        "HttpStatus500",
+        "HttpStatus502",
+        "HttpStatus503",
+        "HttpStatus504"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayCustomErrorStatusCode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "HttpStatus400",
+            "value": "HttpStatus400",
+            "description": "HttpStatus400"
+          },
+          {
+            "name": "HttpStatus403",
+            "value": "HttpStatus403",
+            "description": "HttpStatus403"
+          },
+          {
+            "name": "HttpStatus404",
+            "value": "HttpStatus404",
+            "description": "HttpStatus404"
+          },
+          {
+            "name": "HttpStatus405",
+            "value": "HttpStatus405",
+            "description": "HttpStatus405"
+          },
+          {
+            "name": "HttpStatus408",
+            "value": "HttpStatus408",
+            "description": "HttpStatus408"
+          },
+          {
+            "name": "HttpStatus500",
+            "value": "HttpStatus500",
+            "description": "HttpStatus500"
+          },
+          {
+            "name": "HttpStatus502",
+            "value": "HttpStatus502",
+            "description": "HttpStatus502"
+          },
+          {
+            "name": "HttpStatus503",
+            "value": "HttpStatus503",
+            "description": "HttpStatus503"
+          },
+          {
+            "name": "HttpStatus504",
+            "value": "HttpStatus504",
+            "description": "HttpStatus504"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayFirewallMode": {
+      "type": "string",
+      "description": "Web application firewall mode.",
+      "enum": [
+        "Detection",
+        "Prevention"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayFirewallMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Detection",
+            "value": "Detection",
+            "description": "Detection"
+          },
+          {
+            "name": "Prevention",
+            "value": "Prevention",
+            "description": "Prevention"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayFirewallRateLimitDuration": {
+      "type": "string",
+      "description": "Duration over which Rate Limit policy will be applied. Applies only when ruleType is RateLimitRule.",
+      "enum": [
+        "OneMin",
+        "FiveMins"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayFirewallRateLimitDuration",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OneMin",
+            "value": "OneMin",
+            "description": "OneMin"
+          },
+          {
+            "name": "FiveMins",
+            "value": "FiveMins",
+            "description": "FiveMins"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayFirewallUserSessionVariable": {
+      "type": "string",
+      "description": "User Session clause variable.",
+      "enum": [
+        "ClientAddr",
+        "GeoLocation",
+        "None",
+        "ClientAddrXFFHeader",
+        "GeoLocationXFFHeader"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayFirewallUserSessionVariable",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ClientAddr",
+            "value": "ClientAddr",
+            "description": "ClientAddr"
+          },
+          {
+            "name": "GeoLocation",
+            "value": "GeoLocation",
+            "description": "GeoLocation"
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "ClientAddrXFFHeader",
+            "value": "ClientAddrXFFHeader",
+            "description": "ClientAddrXFFHeader"
+          },
+          {
+            "name": "GeoLocationXFFHeader",
+            "value": "GeoLocationXFFHeader",
+            "description": "GeoLocationXFFHeader"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayLoadDistributionAlgorithm": {
+      "type": "string",
+      "description": "Load Distribution Algorithm enums.",
+      "enum": [
+        "RoundRobin",
+        "LeastConnections",
+        "IpHash"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayLoadDistributionAlgorithm",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "RoundRobin",
+            "value": "RoundRobin",
+            "description": "RoundRobin"
+          },
+          {
+            "name": "LeastConnections",
+            "value": "LeastConnections",
+            "description": "LeastConnections"
+          },
+          {
+            "name": "IpHash",
+            "value": "IpHash",
+            "description": "IpHash"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayOperationalState": {
+      "type": "string",
+      "description": "Operational state of the application gateway resource.",
+      "enum": [
+        "Stopped",
+        "Starting",
+        "Running",
+        "Stopping"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayOperationalState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Stopped",
+            "value": "Stopped",
+            "description": "Stopped"
+          },
+          {
+            "name": "Starting",
+            "value": "Starting",
+            "description": "Starting"
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Running"
+          },
+          {
+            "name": "Stopping",
+            "value": "Stopping",
+            "description": "Stopping"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayProtocol": {
+      "type": "string",
+      "description": "Application Gateway protocol.",
+      "enum": [
+        "Http",
+        "Https",
+        "Tcp",
+        "Tls"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Http",
+            "value": "Http",
+            "description": "Supported for httpListeners and  backendHttpSettingsCollection properties."
+          },
+          {
+            "name": "Https",
+            "value": "Https",
+            "description": "Supported for httpListeners and  backendHttpSettingsCollection properties."
+          },
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Supported for listeners and backendSettingsCollection properties."
+          },
+          {
+            "name": "Tls",
+            "value": "Tls",
+            "description": "Supported for listeners and backendSettingsCollection properties."
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayRedirectType": {
+      "type": "string",
+      "description": "Redirect type enum.",
+      "enum": [
+        "Permanent",
+        "Found",
+        "SeeOther",
+        "Temporary"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayRedirectType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Permanent",
+            "value": "Permanent",
+            "description": "Permanent"
+          },
+          {
+            "name": "Found",
+            "value": "Found",
+            "description": "Found"
+          },
+          {
+            "name": "SeeOther",
+            "value": "SeeOther",
+            "description": "SeeOther"
+          },
+          {
+            "name": "Temporary",
+            "value": "Temporary",
+            "description": "Temporary"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayRequestRoutingRuleType": {
+      "type": "string",
+      "description": "Rule type.",
+      "enum": [
+        "Basic",
+        "PathBasedRouting"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayRequestRoutingRuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          },
+          {
+            "name": "PathBasedRouting",
+            "value": "PathBasedRouting",
+            "description": "PathBasedRouting"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayRuleSetStatusOptions": {
+      "type": "string",
+      "description": "The rule set status",
+      "enum": [
+        "Preview",
+        "GA",
+        "Supported",
+        "Deprecated"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayRuleSetStatusOptions",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Preview",
+            "value": "Preview",
+            "description": "Preview"
+          },
+          {
+            "name": "GA",
+            "value": "GA",
+            "description": "GA"
+          },
+          {
+            "name": "Supported",
+            "value": "Supported",
+            "description": "Supported"
+          },
+          {
+            "name": "Deprecated",
+            "value": "Deprecated",
+            "description": "Deprecated"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewaySkuFamily": {
+      "type": "string",
+      "description": "Family of an application gateway SKU.",
+      "enum": [
+        "Generation_1",
+        "Generation_2"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewaySkuFamily",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Generation_1",
+            "value": "Generation_1",
+            "description": "Generation_1"
+          },
+          {
+            "name": "Generation_2",
+            "value": "Generation_2",
+            "description": "Generation_2"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewaySkuName": {
+      "type": "string",
+      "description": "Name of an application gateway SKU.",
+      "enum": [
+        "Standard_Small",
+        "Standard_Medium",
+        "Standard_Large",
+        "WAF_Medium",
+        "WAF_Large",
+        "Standard_v2",
+        "WAF_v2",
+        "Basic"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewaySkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard_Small",
+            "value": "Standard_Small",
+            "description": "Standard_Small"
+          },
+          {
+            "name": "Standard_Medium",
+            "value": "Standard_Medium",
+            "description": "Standard_Medium"
+          },
+          {
+            "name": "Standard_Large",
+            "value": "Standard_Large",
+            "description": "Standard_Large"
+          },
+          {
+            "name": "WAF_Medium",
+            "value": "WAF_Medium",
+            "description": "WAF_Medium"
+          },
+          {
+            "name": "WAF_Large",
+            "value": "WAF_Large",
+            "description": "WAF_Large"
+          },
+          {
+            "name": "Standard_v2",
+            "value": "Standard_v2",
+            "description": "Standard_v2"
+          },
+          {
+            "name": "WAF_v2",
+            "value": "WAF_v2",
+            "description": "WAF_v2"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewaySslCipherSuite": {
+      "type": "string",
+      "description": "Ssl cipher suites enums.",
+      "enum": [
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_RSA_WITH_AES_256_GCM_SHA384",
+        "TLS_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_RSA_WITH_AES_256_CBC_SHA256",
+        "TLS_RSA_WITH_AES_128_CBC_SHA256",
+        "TLS_RSA_WITH_AES_256_CBC_SHA",
+        "TLS_RSA_WITH_AES_128_CBC_SHA",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+        "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+        "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+        "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+        "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+        "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewaySslCipherSuite",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+            "value": "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+            "description": "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
+          },
+          {
+            "name": "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+            "value": "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+            "description": "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+          },
+          {
+            "name": "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "value": "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "description": "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
+          },
+          {
+            "name": "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+            "value": "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+            "description": "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+          },
+          {
+            "name": "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            "value": "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+            "description": "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"
+          },
+          {
+            "name": "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+            "value": "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+            "description": "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
+          },
+          {
+            "name": "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+            "value": "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+            "description": "TLS_DHE_RSA_WITH_AES_256_CBC_SHA"
+          },
+          {
+            "name": "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+            "value": "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+            "description": "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"
+          },
+          {
+            "name": "TLS_RSA_WITH_AES_256_GCM_SHA384",
+            "value": "TLS_RSA_WITH_AES_256_GCM_SHA384",
+            "description": "TLS_RSA_WITH_AES_256_GCM_SHA384"
+          },
+          {
+            "name": "TLS_RSA_WITH_AES_128_GCM_SHA256",
+            "value": "TLS_RSA_WITH_AES_128_GCM_SHA256",
+            "description": "TLS_RSA_WITH_AES_128_GCM_SHA256"
+          },
+          {
+            "name": "TLS_RSA_WITH_AES_256_CBC_SHA256",
+            "value": "TLS_RSA_WITH_AES_256_CBC_SHA256",
+            "description": "TLS_RSA_WITH_AES_256_CBC_SHA256"
+          },
+          {
+            "name": "TLS_RSA_WITH_AES_128_CBC_SHA256",
+            "value": "TLS_RSA_WITH_AES_128_CBC_SHA256",
+            "description": "TLS_RSA_WITH_AES_128_CBC_SHA256"
+          },
+          {
+            "name": "TLS_RSA_WITH_AES_256_CBC_SHA",
+            "value": "TLS_RSA_WITH_AES_256_CBC_SHA",
+            "description": "TLS_RSA_WITH_AES_256_CBC_SHA"
+          },
+          {
+            "name": "TLS_RSA_WITH_AES_128_CBC_SHA",
+            "value": "TLS_RSA_WITH_AES_128_CBC_SHA",
+            "description": "TLS_RSA_WITH_AES_128_CBC_SHA"
+          },
+          {
+            "name": "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "value": "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "description": "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
+          },
+          {
+            "name": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "value": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "description": "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
+          },
+          {
+            "name": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+            "value": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+            "description": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"
+          },
+          {
+            "name": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+            "value": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+            "description": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
+          },
+          {
+            "name": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+            "value": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+            "description": "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA"
+          },
+          {
+            "name": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+            "value": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+            "description": "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"
+          },
+          {
+            "name": "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+            "value": "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+            "description": "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256"
+          },
+          {
+            "name": "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+            "value": "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+            "description": "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256"
+          },
+          {
+            "name": "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+            "value": "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+            "description": "TLS_DHE_DSS_WITH_AES_256_CBC_SHA"
+          },
+          {
+            "name": "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+            "value": "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+            "description": "TLS_DHE_DSS_WITH_AES_128_CBC_SHA"
+          },
+          {
+            "name": "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+            "value": "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+            "description": "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
+          },
+          {
+            "name": "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+            "value": "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+            "description": "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA"
+          },
+          {
+            "name": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "value": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "description": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+          },
+          {
+            "name": "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "value": "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "description": "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewaySslPolicyName": {
+      "type": "string",
+      "description": "Ssl predefined policy name enums.",
+      "enum": [
+        "AppGwSslPolicy20150501",
+        "AppGwSslPolicy20170401",
+        "AppGwSslPolicy20170401S",
+        "AppGwSslPolicy20220101",
+        "AppGwSslPolicy20220101S"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewaySslPolicyName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AppGwSslPolicy20150501",
+            "value": "AppGwSslPolicy20150501",
+            "description": "AppGwSslPolicy20150501"
+          },
+          {
+            "name": "AppGwSslPolicy20170401",
+            "value": "AppGwSslPolicy20170401",
+            "description": "AppGwSslPolicy20170401"
+          },
+          {
+            "name": "AppGwSslPolicy20170401S",
+            "value": "AppGwSslPolicy20170401S",
+            "description": "AppGwSslPolicy20170401S"
+          },
+          {
+            "name": "AppGwSslPolicy20220101",
+            "value": "AppGwSslPolicy20220101",
+            "description": "AppGwSslPolicy20220101"
+          },
+          {
+            "name": "AppGwSslPolicy20220101S",
+            "value": "AppGwSslPolicy20220101S",
+            "description": "AppGwSslPolicy20220101S"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewaySslPolicyType": {
+      "type": "string",
+      "description": "Type of Ssl Policy.",
+      "enum": [
+        "Predefined",
+        "Custom",
+        "CustomV2"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewaySslPolicyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Predefined",
+            "value": "Predefined",
+            "description": "Predefined"
+          },
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "Custom"
+          },
+          {
+            "name": "CustomV2",
+            "value": "CustomV2",
+            "description": "CustomV2"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewaySslProtocol": {
+      "type": "string",
+      "description": "Ssl protocol enums.",
+      "enum": [
+        "TLSv1_0",
+        "TLSv1_1",
+        "TLSv1_2",
+        "TLSv1_3"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewaySslProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TLSv1_0",
+            "value": "TLSv1_0",
+            "description": "TLSv1_0"
+          },
+          {
+            "name": "TLSv1_1",
+            "value": "TLSv1_1",
+            "description": "TLSv1_1"
+          },
+          {
+            "name": "TLSv1_2",
+            "value": "TLSv1_2",
+            "description": "TLSv1_2"
+          },
+          {
+            "name": "TLSv1_3",
+            "value": "TLSv1_3",
+            "description": "TLSv1_3"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayTier": {
+      "type": "string",
+      "description": "Tier of an application gateway.",
+      "enum": [
+        "Standard",
+        "WAF",
+        "Standard_v2",
+        "WAF_v2",
+        "Basic"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "WAF",
+            "value": "WAF",
+            "description": "WAF"
+          },
+          {
+            "name": "Standard_v2",
+            "value": "Standard_v2",
+            "description": "Standard_v2"
+          },
+          {
+            "name": "WAF_v2",
+            "value": "WAF_v2",
+            "description": "WAF_v2"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayTierTypes": {
+      "type": "string",
+      "enum": [
+        "Standard",
+        "WAF",
+        "Standard_v2",
+        "WAF_v2"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayTierTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "WAF",
+            "value": "WAF",
+            "description": "WAF"
+          },
+          {
+            "name": "Standard_v2",
+            "value": "Standard_v2",
+            "description": "Standard_v2"
+          },
+          {
+            "name": "WAF_v2",
+            "value": "WAF_v2",
+            "description": "WAF_v2"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayUnAuthorizedRequestAction": {
+      "type": "string",
+      "description": "Unauthorized request action.",
+      "enum": [
+        "Deny",
+        "Allow"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayUnAuthorizedRequestAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Deny",
+            "value": "Deny",
+            "description": "Deny"
+          },
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayWafRuleActionTypes": {
+      "type": "string",
+      "description": "The string representation of the web application firewall rule action.",
+      "enum": [
+        "None",
+        "AnomalyScoring",
+        "Allow",
+        "Block",
+        "Log"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayWafRuleActionTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "AnomalyScoring",
+            "value": "AnomalyScoring",
+            "description": "AnomalyScoring"
+          },
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          },
+          {
+            "name": "Block",
+            "value": "Block",
+            "description": "Block"
+          },
+          {
+            "name": "Log",
+            "value": "Log",
+            "description": "Log"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayWafRuleSensitivityTypes": {
+      "type": "string",
+      "description": "The string representation of the web application firewall rule sensitivity.",
+      "enum": [
+        "Low",
+        "Medium",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayWafRuleSensitivityTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Low",
+            "value": "Low",
+            "description": "Low"
+          },
+          {
+            "name": "Medium",
+            "value": "Medium",
+            "description": "Medium"
+          },
+          {
+            "name": "High",
+            "value": "High",
+            "description": "High"
+          }
+        ]
+      }
+    },
+    "ApplicationGatewayWafRuleStateTypes": {
+      "type": "string",
+      "description": "The string representation of the web application firewall rule state.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "ApplicationGatewayWafRuleStateTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "AssociationAccessMode": {
+      "type": "string",
+      "description": "Access mode on the association.",
+      "enum": [
+        "Learning",
+        "Enforced",
+        "Audit"
+      ],
+      "x-ms-enum": {
+        "name": "AssociationAccessMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Learning",
+            "value": "Learning",
+            "description": "Learning"
+          },
+          {
+            "name": "Enforced",
+            "value": "Enforced",
+            "description": "Enforced"
+          },
+          {
+            "name": "Audit",
+            "value": "Audit",
+            "description": "Audit"
+          }
+        ]
+      }
+    },
+    "AssociationType": {
+      "type": "string",
+      "description": "The association type of the child resource to the parent resource.",
+      "enum": [
+        "Associated",
+        "Contains"
+      ],
+      "x-ms-enum": {
+        "name": "AssociationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Associated",
+            "value": "Associated",
+            "description": "Associated"
+          },
+          {
+            "name": "Contains",
+            "value": "Contains",
+            "description": "Contains"
+          }
+        ]
+      }
+    },
+    "AuthenticationMethod": {
+      "type": "string",
+      "description": "VPN client authentication method.",
+      "enum": [
+        "EAPTLS",
+        "EAPMSCHAPv2"
+      ],
+      "x-ms-enum": {
+        "name": "AuthenticationMethod",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EAPTLS",
+            "value": "EAPTLS",
+            "description": "EAPTLS"
+          },
+          {
+            "name": "EAPMSCHAPv2",
+            "value": "EAPMSCHAPv2",
+            "description": "EAPMSCHAPv2"
+          }
+        ]
+      }
+    },
+    "AuthorizationUseStatus": {
+      "type": "string",
+      "description": "The authorization use status.",
+      "enum": [
+        "Available",
+        "InUse"
+      ],
+      "x-ms-enum": {
+        "name": "AuthorizationUseStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Available",
+            "value": "Available",
+            "description": "Available"
+          },
+          {
+            "name": "InUse",
+            "value": "InUse",
+            "description": "InUse"
+          }
+        ]
+      }
+    },
+    "AutoLearnPrivateRangesMode": {
+      "type": "string",
+      "description": "The operation mode for automatically learning private ranges to not be SNAT",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "AutoLearnPrivateRangesMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "AzureFirewallApplicationRuleProtocolType": {
+      "type": "string",
+      "description": "The protocol type of a Application Rule resource.",
+      "enum": [
+        "Http",
+        "Https",
+        "Mssql"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallApplicationRuleProtocolType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Http",
+            "value": "Http",
+            "description": "Http"
+          },
+          {
+            "name": "Https",
+            "value": "Https",
+            "description": "Https"
+          },
+          {
+            "name": "Mssql",
+            "value": "Mssql",
+            "description": "Mssql"
+          }
+        ]
+      }
+    },
+    "AzureFirewallNatRCActionType": {
+      "type": "string",
+      "description": "The action type of a NAT rule collection.",
+      "enum": [
+        "Snat",
+        "Dnat"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallNatRCActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Snat",
+            "value": "Snat",
+            "description": "Snat"
+          },
+          {
+            "name": "Dnat",
+            "value": "Dnat",
+            "description": "Dnat"
+          }
+        ]
+      }
+    },
+    "AzureFirewallNetworkRuleProtocol": {
+      "type": "string",
+      "description": "The protocol of a Network Rule resource.",
+      "enum": [
+        "TCP",
+        "UDP",
+        "Any",
+        "ICMP"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallNetworkRuleProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "TCP",
+            "description": "TCP"
+          },
+          {
+            "name": "UDP",
+            "value": "UDP",
+            "description": "UDP"
+          },
+          {
+            "name": "Any",
+            "value": "Any",
+            "description": "Any"
+          },
+          {
+            "name": "ICMP",
+            "value": "ICMP",
+            "description": "ICMP"
+          }
+        ]
+      }
+    },
+    "AzureFirewallPacketCaptureFlagsType": {
+      "type": "string",
+      "description": "The flags type to be captured.",
+      "enum": [
+        "fin",
+        "syn",
+        "rst",
+        "push",
+        "ack",
+        "urg"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallPacketCaptureFlagsType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "fin",
+            "value": "fin",
+            "description": "fin"
+          },
+          {
+            "name": "syn",
+            "value": "syn",
+            "description": "syn"
+          },
+          {
+            "name": "rst",
+            "value": "rst",
+            "description": "rst"
+          },
+          {
+            "name": "push",
+            "value": "push",
+            "description": "push"
+          },
+          {
+            "name": "ack",
+            "value": "ack",
+            "description": "ack"
+          },
+          {
+            "name": "urg",
+            "value": "urg",
+            "description": "urg"
+          }
+        ]
+      }
+    },
+    "AzureFirewallPacketCaptureResponseCode": {
+      "type": "string",
+      "description": "The packet capture operation response codes.",
+      "enum": [
+        "NotImplemented",
+        "AzureFirewallPacketCaptureStartSucceeded",
+        "AzureFirewallPacketCaptureStartFailed",
+        "AzureFirewallPacketCaptureStartFailedToUpload",
+        "AzureFirewallPacketCaptureStartFailure",
+        "AzureFirewallPacketCaptureInProgress",
+        "AzureFirewallPacketCaptureNotInProgress",
+        "AzureFirewallPacketCaptureStopSucceeded",
+        "AzureFirewallPacketCaptureFailed",
+        "AzureFirewallPacketCaptureCompleted"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallPacketCaptureResponseCode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotImplemented",
+            "value": "NotImplemented",
+            "description": "NotImplemented"
+          },
+          {
+            "name": "AzureFirewallPacketCaptureStartSucceeded",
+            "value": "AzureFirewallPacketCaptureStartSucceeded",
+            "description": "AzureFirewallPacketCaptureStartSucceeded"
+          },
+          {
+            "name": "AzureFirewallPacketCaptureStartFailed",
+            "value": "AzureFirewallPacketCaptureStartFailed",
+            "description": "AzureFirewallPacketCaptureStartFailed"
+          },
+          {
+            "name": "AzureFirewallPacketCaptureStartFailedToUpload",
+            "value": "AzureFirewallPacketCaptureStartFailedToUpload",
+            "description": "AzureFirewallPacketCaptureStartFailedToUpload"
+          },
+          {
+            "name": "AzureFirewallPacketCaptureStartFailure",
+            "value": "AzureFirewallPacketCaptureStartFailure",
+            "description": "AzureFirewallPacketCaptureStartFailure"
+          },
+          {
+            "name": "AzureFirewallPacketCaptureInProgress",
+            "value": "AzureFirewallPacketCaptureInProgress",
+            "description": "AzureFirewallPacketCaptureInProgress"
+          },
+          {
+            "name": "AzureFirewallPacketCaptureNotInProgress",
+            "value": "AzureFirewallPacketCaptureNotInProgress",
+            "description": "AzureFirewallPacketCaptureNotInProgress"
+          },
+          {
+            "name": "AzureFirewallPacketCaptureStopSucceeded",
+            "value": "AzureFirewallPacketCaptureStopSucceeded",
+            "description": "AzureFirewallPacketCaptureStopSucceeded"
+          },
+          {
+            "name": "AzureFirewallPacketCaptureFailed",
+            "value": "AzureFirewallPacketCaptureFailed",
+            "description": "AzureFirewallPacketCaptureFailed"
+          },
+          {
+            "name": "AzureFirewallPacketCaptureCompleted",
+            "value": "AzureFirewallPacketCaptureCompleted",
+            "description": "AzureFirewallPacketCaptureCompleted"
+          }
+        ]
+      }
+    },
+    "AzureFirewallRCActionType": {
+      "type": "string",
+      "description": "The action type of a rule collection.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallRCActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny",
+            "description": "Deny"
+          }
+        ]
+      }
+    },
+    "AzureFirewallSkuName": {
+      "type": "string",
+      "description": "Name of an Azure Firewall SKU.",
+      "enum": [
+        "AZFW_VNet",
+        "AZFW_Hub"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallSkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AZFW_VNet",
+            "value": "AZFW_VNet",
+            "description": "AZFW_VNet"
+          },
+          {
+            "name": "AZFW_Hub",
+            "value": "AZFW_Hub",
+            "description": "AZFW_Hub"
+          }
+        ]
+      }
+    },
+    "AzureFirewallSkuTier": {
+      "type": "string",
+      "description": "Tier of an Azure Firewall.",
+      "enum": [
+        "Standard",
+        "Premium",
+        "Basic"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallSkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "Premium",
+            "value": "Premium",
+            "description": "Premium"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          }
+        ]
+      }
+    },
+    "AzureFirewallThreatIntelMode": {
+      "type": "string",
+      "description": "The operation mode for Threat Intel.",
+      "enum": [
+        "Alert",
+        "Deny",
+        "Off"
+      ],
+      "x-ms-enum": {
+        "name": "AzureFirewallThreatIntelMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Alert",
+            "value": "Alert",
+            "description": "Alert"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny",
+            "description": "Deny"
+          },
+          {
+            "name": "Off",
+            "value": "Off",
+            "description": "Off"
+          }
+        ]
+      }
+    },
+    "BastionConnectProtocol": {
+      "type": "string",
+      "description": "The protocol used to connect to the target.",
+      "enum": [
+        "SSH",
+        "RDP"
+      ],
+      "x-ms-enum": {
+        "name": "BastionConnectProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SSH",
+            "value": "SSH",
+            "description": "SSH"
+          },
+          {
+            "name": "RDP",
+            "value": "RDP",
+            "description": "RDP"
+          }
+        ]
+      }
+    },
+    "BgpPeerState": {
+      "type": "string",
+      "description": "The BGP peer state.",
+      "enum": [
+        "Unknown",
+        "Stopped",
+        "Idle",
+        "Connecting",
+        "Connected"
+      ],
+      "x-ms-enum": {
+        "name": "BgpPeerState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "Stopped",
+            "value": "Stopped",
+            "description": "Stopped"
+          },
+          {
+            "name": "Idle",
+            "value": "Idle",
+            "description": "Idle"
+          },
+          {
+            "name": "Connecting",
+            "value": "Connecting",
+            "description": "Connecting"
+          },
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected"
+          }
+        ]
+      }
+    },
+    "ChildResource": {
+      "type": "object",
+      "description": "Proxy resource representation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "CircuitConnectionStatus": {
+      "type": "string",
+      "description": "Express Route Circuit connection state.",
+      "enum": [
+        "Connected",
+        "Connecting",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "CircuitConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected"
+          },
+          {
+            "name": "Connecting",
+            "value": "Connecting",
+            "description": "Connecting"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Disconnected"
+          }
+        ]
+      }
+    },
+    "CloudError": {
+      "type": "object",
+      "description": "An error response from the service.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/CloudErrorBody",
+          "description": "Cloud error body."
+        }
+      },
+      "x-ms-external": true
+    },
+    "CloudErrorBody": {
+      "type": "object",
+      "description": "An error response from the service.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "An identifier for the error. Codes are invariant and are intended to be consumed programmatically."
+        },
+        "message": {
+          "type": "string",
+          "description": "A message describing the error, intended to be suitable for display in a user interface."
+        },
+        "target": {
+          "type": "string",
+          "description": "The target of the particular error. For example, the name of the property in error."
+        },
+        "details": {
+          "type": "array",
+          "description": "A list of additional details about the error.",
+          "items": {
+            "$ref": "#/definitions/CloudErrorBody"
+          }
+        }
+      },
+      "x-ms-external": true
+    },
+    "CommissionedState": {
+      "type": "string",
+      "description": "The commissioned state of the Custom IP Prefix.",
+      "enum": [
+        "Provisioning",
+        "Provisioned",
+        "Commissioning",
+        "CommissionedNoInternetAdvertise",
+        "Commissioned",
+        "Decommissioning",
+        "Deprovisioning",
+        "Deprovisioned"
+      ],
+      "x-ms-enum": {
+        "name": "CommissionedState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "Provisioning"
+          },
+          {
+            "name": "Provisioned",
+            "value": "Provisioned",
+            "description": "Provisioned"
+          },
+          {
+            "name": "Commissioning",
+            "value": "Commissioning",
+            "description": "Commissioning"
+          },
+          {
+            "name": "CommissionedNoInternetAdvertise",
+            "value": "CommissionedNoInternetAdvertise",
+            "description": "CommissionedNoInternetAdvertise"
+          },
+          {
+            "name": "Commissioned",
+            "value": "Commissioned",
+            "description": "Commissioned"
+          },
+          {
+            "name": "Decommissioning",
+            "value": "Decommissioning",
+            "description": "Decommissioning"
+          },
+          {
+            "name": "Deprovisioning",
+            "value": "Deprovisioning",
+            "description": "Deprovisioning"
+          },
+          {
+            "name": "Deprovisioned",
+            "value": "Deprovisioned",
+            "description": "Deprovisioned"
+          }
+        ]
+      }
+    },
+    "CommonErrorAdditionalInfo": {
+      "type": "object",
+      "description": "The resource management error additional info.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The additional info type.",
+          "readOnly": true
+        },
+        "info": {
+          "description": "The additional info.",
+          "readOnly": true
+        }
+      }
+    },
+    "CommonErrorDetail": {
+      "type": "object",
+      "description": "The error detail.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "The error target.",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "description": "The error details.",
+          "items": {
+            "$ref": "#/definitions/CommonErrorDetail"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "message",
+            "target"
+          ]
+        },
+        "additionalInfo": {
+          "type": "array",
+          "description": "The error additional info.",
+          "items": {
+            "$ref": "#/definitions/CommonErrorAdditionalInfo"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "CommonErrorResponse": {
+      "type": "object",
+      "title": "Error response",
+      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/CommonErrorDetail",
+          "description": "The error object."
+        }
+      }
+    },
+    "CommonProxyResource": {
+      "type": "object",
+      "title": "Proxy Resource",
+      "description": "The resource model definition for a Azure Resource Manager proxy resource. It will not have tags and a location",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommonResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "CommonResource": {
+      "type": "object",
+      "title": "Resource",
+      "description": "Common fields that are returned in the response for all Azure Resource Manager resources",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified resource ID for the resource. E.g. \"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\"",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the resource. E.g. \"Microsoft.Compute/virtualMachines\" or \"Microsoft.Storage/storageAccounts\"",
+          "readOnly": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "Azure Resource Manager metadata containing createdBy and modifiedBy information.",
+          "readOnly": true
+        }
+      }
+    },
+    "CommonTrackedResource": {
+      "type": "object",
+      "title": "Tracked Resource",
+      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/CommonResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "ConfigurationType": {
+      "type": "string",
+      "description": "Configuration Deployment Type.",
+      "enum": [
+        "SecurityAdmin",
+        "Connectivity",
+        "SecurityUser",
+        "Routing"
+      ],
+      "x-ms-enum": {
+        "name": "ConfigurationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SecurityAdmin",
+            "value": "SecurityAdmin",
+            "description": "SecurityAdmin"
+          },
+          {
+            "name": "Connectivity",
+            "value": "Connectivity",
+            "description": "Connectivity"
+          },
+          {
+            "name": "SecurityUser",
+            "value": "SecurityUser",
+            "description": "SecurityUser"
+          },
+          {
+            "name": "Routing",
+            "value": "Routing",
+            "description": "Routing"
+          }
+        ]
+      }
+    },
+    "ConnectionAnalyzerEndpointType": {
+      "type": "string",
+      "description": "The endpoint type for a connection analyzer source or destination.",
+      "enum": [
+        "VM",
+        "VMSS",
+        "ExternalAddress",
+        "BastionHost",
+        "ApplicationGateway"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionAnalyzerEndpointType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "VM",
+            "value": "VM",
+            "description": "An Azure virtual machine endpoint, identified by its ARM resource ID."
+          },
+          {
+            "name": "VMSS",
+            "value": "VMSS",
+            "description": "An Azure virtual machine scale set (or scale set instance) endpoint, identified by its ARM resource ID."
+          },
+          {
+            "name": "ExternalAddress",
+            "value": "ExternalAddress",
+            "description": "An external endpoint reachable from outside Azure, identified by an IP address or FQDN."
+          },
+          {
+            "name": "BastionHost",
+            "value": "BastionHost",
+            "description": "An Azure Bastion host endpoint, identified by its ARM resource ID."
+          },
+          {
+            "name": "ApplicationGateway",
+            "value": "ApplicationGateway",
+            "description": "An Application Gateway endpoint, identified by its ARM resource ID."
+          }
+        ]
+      }
+    },
+    "ConnectionAnalyzerStatus": {
+      "type": "string",
+      "description": "Current execution status of the connection analyzer.",
+      "enum": [
+        "NotStarted",
+        "Running",
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionAnalyzerStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "The connection analyzer has been created but execution has not yet begun."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The connection analyzer is currently running its diagnostic operations."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The connection analyzer completed all diagnostic operations successfully."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The connection analyzer failed to complete its diagnostic operations."
+          }
+        ]
+      }
+    },
+    "ConnectionAuthenticationType": {
+      "type": "string",
+      "description": "Gateway connection authentication type.",
+      "enum": [
+        "PSK",
+        "Certificate"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionAuthenticationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PSK",
+            "value": "PSK",
+            "description": "Pre-shared key authentication method for VPN gateway connections."
+          },
+          {
+            "name": "Certificate",
+            "value": "Certificate",
+            "description": "Certificate-based authentication method for VPN gateway connections."
+          }
+        ]
+      }
+    },
+    "ConnectionMonitorEndpointFilterItemType": {
+      "type": "string",
+      "description": "The type of item included in the filter. Currently only 'AgentAddress' is supported.",
+      "enum": [
+        "AgentAddress"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionMonitorEndpointFilterItemType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AgentAddress",
+            "value": "AgentAddress",
+            "description": "AgentAddress"
+          }
+        ]
+      }
+    },
+    "ConnectionMonitorEndpointFilterType": {
+      "type": "string",
+      "description": "The behavior of the endpoint filter. Currently only 'Include' is supported.",
+      "enum": [
+        "Include"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionMonitorEndpointFilterType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Include",
+            "value": "Include",
+            "description": "Include"
+          }
+        ]
+      }
+    },
+    "ConnectionMonitorTestConfigurationProtocol": {
+      "type": "string",
+      "description": "The protocol to use in test evaluation.",
+      "enum": [
+        "Tcp",
+        "Http",
+        "Icmp"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionMonitorTestConfigurationProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Tcp"
+          },
+          {
+            "name": "Http",
+            "value": "Http",
+            "description": "Http"
+          },
+          {
+            "name": "Icmp",
+            "value": "Icmp",
+            "description": "Icmp"
+          }
+        ]
+      }
+    },
+    "ConnectionMonitorType": {
+      "type": "string",
+      "description": "Type of connection monitor.",
+      "enum": [
+        "MultiEndpoint",
+        "SingleSourceDestination"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionMonitorType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MultiEndpoint",
+            "value": "MultiEndpoint",
+            "description": "MultiEndpoint"
+          },
+          {
+            "name": "SingleSourceDestination",
+            "value": "SingleSourceDestination",
+            "description": "SingleSourceDestination"
+          }
+        ]
+      }
+    },
+    "ConnectionStatus": {
+      "type": "string",
+      "description": "The connection status.",
+      "enum": [
+        "Unknown",
+        "Connected",
+        "Disconnected",
+        "Degraded"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Disconnected"
+          },
+          {
+            "name": "Degraded",
+            "value": "Degraded",
+            "description": "Degraded"
+          }
+        ]
+      }
+    },
+    "ConnectivityTopology": {
+      "type": "string",
+      "description": "Connectivity topology type.",
+      "enum": [
+        "HubAndSpoke",
+        "Mesh"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectivityTopology",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "HubAndSpoke",
+            "value": "HubAndSpoke",
+            "description": "HubAndSpoke"
+          },
+          {
+            "name": "Mesh",
+            "value": "Mesh",
+            "description": "Mesh"
+          }
+        ]
+      }
+    },
+    "CoverageLevel": {
+      "type": "string",
+      "description": "Test coverage for the endpoint.",
+      "enum": [
+        "Default",
+        "Low",
+        "BelowAverage",
+        "Average",
+        "AboveAverage",
+        "Full"
+      ],
+      "x-ms-enum": {
+        "name": "CoverageLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default"
+          },
+          {
+            "name": "Low",
+            "value": "Low",
+            "description": "Low"
+          },
+          {
+            "name": "BelowAverage",
+            "value": "BelowAverage",
+            "description": "BelowAverage"
+          },
+          {
+            "name": "Average",
+            "value": "Average",
+            "description": "Average"
+          },
+          {
+            "name": "AboveAverage",
+            "value": "AboveAverage",
+            "description": "AboveAverage"
+          },
+          {
+            "name": "Full",
+            "value": "Full",
+            "description": "Full"
+          }
+        ]
+      }
+    },
+    "CustomIpPrefixType": {
+      "type": "string",
+      "description": "Type of custom IP prefix. Should be Singular, Parent, or Child.",
+      "enum": [
+        "Singular",
+        "Parent",
+        "Child"
+      ],
+      "x-ms-enum": {
+        "name": "CustomIpPrefixType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Singular",
+            "value": "Singular",
+            "description": "Singular"
+          },
+          {
+            "name": "Parent",
+            "value": "Parent",
+            "description": "Parent"
+          },
+          {
+            "name": "Child",
+            "value": "Child",
+            "description": "Child"
+          }
+        ]
+      }
+    },
+    "DdosDetectionMode": {
+      "type": "string",
+      "description": "The detection mode for the DDoS detection rule.",
+      "enum": [
+        "TrafficThreshold"
+      ],
+      "x-ms-enum": {
+        "name": "DdosDetectionMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TrafficThreshold",
+            "value": "TrafficThreshold",
+            "description": "TrafficThreshold"
+          }
+        ]
+      }
+    },
+    "DdosFrontendIpConfigurationSettings": {
+      "type": "object",
+      "description": "DDoS protection settings for a frontend IP configuration.",
+      "properties": {
+        "ddosCustomPolicy": {
+          "$ref": "#/definitions/SubResource",
+          "description": "The reference to the DDoS Custom Policy resource."
+        }
+      }
+    },
+    "DdosSettingsProtectionMode": {
+      "type": "string",
+      "description": "The DDoS protection mode of the public IP",
+      "enum": [
+        "VirtualNetworkInherited",
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "DdosSettingsProtectionMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "VirtualNetworkInherited",
+            "value": "VirtualNetworkInherited",
+            "description": "VirtualNetworkInherited"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "DdosTrafficType": {
+      "type": "string",
+      "description": "The traffic type (one of Tcp, Udp, TcpSyn) that the detection rule will be applied upon.",
+      "enum": [
+        "Tcp",
+        "Udp",
+        "TcpSyn"
+      ],
+      "x-ms-enum": {
+        "name": "DdosTrafficType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Tcp"
+          },
+          {
+            "name": "Udp",
+            "value": "Udp",
+            "description": "Udp"
+          },
+          {
+            "name": "TcpSyn",
+            "value": "TcpSyn",
+            "description": "TcpSyn"
+          }
+        ]
+      }
+    },
+    "DeleteExistingPeering": {
+      "type": "string",
+      "description": "Flag if need to remove current existing peerings.",
+      "enum": [
+        "False",
+        "True"
+      ],
+      "x-ms-enum": {
+        "name": "DeleteExistingPeering",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "False",
+            "value": "False",
+            "description": "False"
+          },
+          {
+            "name": "True",
+            "value": "True",
+            "description": "True"
+          }
+        ]
+      }
+    },
+    "DeleteOptions": {
+      "type": "string",
+      "description": "Specify what happens to the public IP address when the VM using it is deleted",
+      "enum": [
+        "Delete",
+        "Detach"
+      ],
+      "x-ms-enum": {
+        "name": "DeleteOptions",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Delete",
+            "value": "Delete",
+            "description": "Delete"
+          },
+          {
+            "name": "Detach",
+            "value": "Detach",
+            "description": "Detach"
+          }
+        ]
+      }
+    },
+    "DeploymentStatus": {
+      "type": "string",
+      "description": "Deployment Status.",
+      "enum": [
+        "NotStarted",
+        "Deploying",
+        "Deployed",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "DeploymentStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "NotStarted"
+          },
+          {
+            "name": "Deploying",
+            "value": "Deploying",
+            "description": "Deploying"
+          },
+          {
+            "name": "Deployed",
+            "value": "Deployed",
+            "description": "Deployed"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "DestinationPortBehavior": {
+      "type": "string",
+      "description": "Destination port behavior.",
+      "enum": [
+        "None",
+        "ListenIfAvailable"
+      ],
+      "x-ms-enum": {
+        "name": "DestinationPortBehavior",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "ListenIfAvailable",
+            "value": "ListenIfAvailable",
+            "description": "ListenIfAvailable"
+          }
+        ]
+      }
+    },
+    "DhGroup": {
+      "type": "string",
+      "description": "The DH Groups used in IKE Phase 1 for initial SA.",
+      "enum": [
+        "None",
+        "DHGroup1",
+        "DHGroup2",
+        "DHGroup14",
+        "DHGroup2048",
+        "ECP256",
+        "ECP384",
+        "DHGroup24"
+      ],
+      "x-ms-enum": {
+        "name": "DhGroup",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "DHGroup1",
+            "value": "DHGroup1",
+            "description": "DHGroup1"
+          },
+          {
+            "name": "DHGroup2",
+            "value": "DHGroup2",
+            "description": "DHGroup2"
+          },
+          {
+            "name": "DHGroup14",
+            "value": "DHGroup14",
+            "description": "DHGroup14"
+          },
+          {
+            "name": "DHGroup2048",
+            "value": "DHGroup2048",
+            "description": "DHGroup2048"
+          },
+          {
+            "name": "ECP256",
+            "value": "ECP256",
+            "description": "ECP256"
+          },
+          {
+            "name": "ECP384",
+            "value": "ECP384",
+            "description": "ECP384"
+          },
+          {
+            "name": "DHGroup24",
+            "value": "DHGroup24",
+            "description": "DHGroup24"
+          }
+        ]
+      }
+    },
+    "DiagnosticOperation": {
+      "type": "string",
+      "description": "The type of diagnostic operation to run on a connection analyzer.",
+      "enum": [
+        "NextHop",
+        "NSG",
+        "PortScan",
+        "ConnectivityCheck",
+        "ExpressRouteDiagnostic"
+      ],
+      "x-ms-enum": {
+        "name": "DiagnosticOperation",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NextHop",
+            "value": "NextHop",
+            "description": "Determines the next hop for traffic from the source to the destination."
+          },
+          {
+            "name": "NSG",
+            "value": "NSG",
+            "description": "Evaluates the network security group rules that apply to the traffic."
+          },
+          {
+            "name": "PortScan",
+            "value": "PortScan",
+            "description": "Scans the destination ports to determine their reachability."
+          },
+          {
+            "name": "ConnectivityCheck",
+            "value": "ConnectivityCheck",
+            "description": "Performs an end-to-end connectivity check between the source and destination."
+          },
+          {
+            "name": "ExpressRouteDiagnostic",
+            "value": "ExpressRouteDiagnostic",
+            "description": "Runs Express Route specific diagnostics for the connection."
+          }
+        ]
+      }
+    },
+    "Direction": {
+      "type": "string",
+      "description": "The direction of the traffic.",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "Direction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound",
+            "description": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound",
+            "description": "Outbound"
+          }
+        ]
+      }
+    },
+    "DisableBgpRoutePropagation": {
+      "type": "string",
+      "description": "Determines whether BGP route propagation is enabled. Defaults to true.",
+      "enum": [
+        "False",
+        "True"
+      ],
+      "x-ms-enum": {
+        "name": "DisableBgpRoutePropagation",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "False",
+            "value": "False",
+            "description": "BGP route propagation is enabled."
+          },
+          {
+            "name": "True",
+            "value": "True",
+            "description": "BGP route propagation is disabled."
+          }
+        ]
+      }
+    },
+    "DisablePeeringRoute": {
+      "type": "string",
+      "description": "Whether to disable the routes learned by peering on the route table.",
+      "enum": [
+        "None",
+        "All"
+      ],
+      "x-ms-enum": {
+        "name": "DisablePeeringRoute",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "Peering routes are enabled."
+          },
+          {
+            "name": "All",
+            "value": "All",
+            "description": "All peering routes are disabled."
+          }
+        ]
+      }
+    },
+    "EffectiveAdminRuleKind": {
+      "type": "string",
+      "description": "Whether the rule is custom or default.",
+      "enum": [
+        "Custom",
+        "Default"
+      ],
+      "x-ms-enum": {
+        "name": "EffectiveAdminRuleKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "Custom"
+          },
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default"
+          }
+        ]
+      }
+    },
+    "EffectiveRouteSource": {
+      "type": "string",
+      "description": "Who created the route.",
+      "enum": [
+        "Unknown",
+        "User",
+        "VirtualNetworkGateway",
+        "Default"
+      ],
+      "x-ms-enum": {
+        "name": "EffectiveRouteSource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "User",
+            "value": "User",
+            "description": "User"
+          },
+          {
+            "name": "VirtualNetworkGateway",
+            "value": "VirtualNetworkGateway",
+            "description": "VirtualNetworkGateway"
+          },
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default"
+          }
+        ]
+      }
+    },
+    "EffectiveRouteState": {
+      "type": "string",
+      "description": "The value of effective route.",
+      "enum": [
+        "Active",
+        "Invalid"
+      ],
+      "x-ms-enum": {
+        "name": "EffectiveRouteState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Active",
+            "value": "Active",
+            "description": "Active"
+          },
+          {
+            "name": "Invalid",
+            "value": "Invalid",
+            "description": "Invalid"
+          }
+        ]
+      }
+    },
+    "EffectiveSecurityRuleProtocol": {
+      "type": "string",
+      "description": "The network protocol this rule applies to.",
+      "enum": [
+        "Tcp",
+        "Udp",
+        "All"
+      ],
+      "x-ms-enum": {
+        "name": "EffectiveSecurityRuleProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Tcp"
+          },
+          {
+            "name": "Udp",
+            "value": "Udp",
+            "description": "Udp"
+          },
+          {
+            "name": "All",
+            "value": "All",
+            "description": "All"
+          }
+        ]
+      }
+    },
+    "EnableOnlyIpv6PeeringState": {
+      "type": "string",
+      "description": "The state of IPv6 peering.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "EnableOnlyIpv6PeeringState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "IPv6 peering is enabled."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "IPv6 peering is disabled."
+          }
+        ]
+      }
+    },
+    "EndpointType": {
+      "type": "string",
+      "description": "The endpoint type.",
+      "enum": [
+        "AzureVM",
+        "AzureVNet",
+        "AzureSubnet",
+        "ExternalAddress",
+        "MMAWorkspaceMachine",
+        "MMAWorkspaceNetwork",
+        "AzureArcVM",
+        "AzureVMSS",
+        "AzureArcNetwork"
+      ],
+      "x-ms-enum": {
+        "name": "EndpointType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzureVM",
+            "value": "AzureVM",
+            "description": "AzureVM"
+          },
+          {
+            "name": "AzureVNet",
+            "value": "AzureVNet",
+            "description": "AzureVNet"
+          },
+          {
+            "name": "AzureSubnet",
+            "value": "AzureSubnet",
+            "description": "AzureSubnet"
+          },
+          {
+            "name": "ExternalAddress",
+            "value": "ExternalAddress",
+            "description": "ExternalAddress"
+          },
+          {
+            "name": "MMAWorkspaceMachine",
+            "value": "MMAWorkspaceMachine",
+            "description": "MMAWorkspaceMachine"
+          },
+          {
+            "name": "MMAWorkspaceNetwork",
+            "value": "MMAWorkspaceNetwork",
+            "description": "MMAWorkspaceNetwork"
+          },
+          {
+            "name": "AzureArcVM",
+            "value": "AzureArcVM",
+            "description": "AzureArcVM"
+          },
+          {
+            "name": "AzureVMSS",
+            "value": "AzureVMSS",
+            "description": "AzureVMSS"
+          },
+          {
+            "name": "AzureArcNetwork",
+            "value": "AzureArcNetwork",
+            "description": "AzureArcNetwork"
+          }
+        ]
+      }
+    },
+    "Error": {
+      "type": "object",
+      "description": "Common error representation.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "Error message."
+        },
+        "target": {
+          "type": "string",
+          "description": "Error target."
+        },
+        "details": {
+          "type": "array",
+          "description": "Error details.",
+          "items": {
+            "$ref": "#/definitions/ErrorDetails"
+          }
+        },
+        "innerError": {
+          "type": "string",
+          "description": "Inner error message."
+        }
+      }
+    },
+    "ErrorDetails": {
+      "type": "object",
+      "description": "Common error details representation.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Error code."
+        },
+        "target": {
+          "type": "string",
+          "description": "Error target."
+        },
+        "message": {
+          "type": "string",
+          "description": "Error message."
+        }
+      }
+    },
+    "ExceptionEntryMatchVariable": {
+      "type": "string",
+      "description": "The variable on which we evaluate the exception condition",
+      "enum": [
+        "RequestURI",
+        "RemoteAddr",
+        "RequestHeader"
+      ],
+      "x-ms-enum": {
+        "name": "ExceptionEntryMatchVariable",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "RequestURI",
+            "value": "RequestURI",
+            "description": "RequestURI"
+          },
+          {
+            "name": "RemoteAddr",
+            "value": "RemoteAddr",
+            "description": "RemoteAddr"
+          },
+          {
+            "name": "RequestHeader",
+            "value": "RequestHeader",
+            "description": "RequestHeader"
+          }
+        ]
+      }
+    },
+    "ExceptionEntrySelectorMatchOperator": {
+      "type": "string",
+      "description": "When the matchVariable points to a key-value pair (e.g, RequestHeader), this operates on the selector",
+      "enum": [
+        "Equals",
+        "Contains",
+        "StartsWith",
+        "EndsWith"
+      ],
+      "x-ms-enum": {
+        "name": "ExceptionEntrySelectorMatchOperator",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Equals",
+            "value": "Equals",
+            "description": "Equals"
+          },
+          {
+            "name": "Contains",
+            "value": "Contains",
+            "description": "Contains"
+          },
+          {
+            "name": "StartsWith",
+            "value": "StartsWith",
+            "description": "StartsWith"
+          },
+          {
+            "name": "EndsWith",
+            "value": "EndsWith",
+            "description": "EndsWith"
+          }
+        ]
+      }
+    },
+    "ExceptionEntryValueMatchOperator": {
+      "type": "string",
+      "description": "Operates on the allowed values for the matchVariable",
+      "enum": [
+        "Equals",
+        "Contains",
+        "StartsWith",
+        "EndsWith",
+        "IPMatch"
+      ],
+      "x-ms-enum": {
+        "name": "ExceptionEntryValueMatchOperator",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Equals",
+            "value": "Equals",
+            "description": "Equals"
+          },
+          {
+            "name": "Contains",
+            "value": "Contains",
+            "description": "Contains"
+          },
+          {
+            "name": "StartsWith",
+            "value": "StartsWith",
+            "description": "StartsWith"
+          },
+          {
+            "name": "EndsWith",
+            "value": "EndsWith",
+            "description": "EndsWith"
+          },
+          {
+            "name": "IPMatch",
+            "value": "IPMatch",
+            "description": "IPMatch"
+          }
+        ]
+      }
+    },
+    "ExpressRouteCircuitPeeringAdvertisedPublicPrefixState": {
+      "type": "string",
+      "description": "The advertised public prefix state of the Peering resource.",
+      "enum": [
+        "NotConfigured",
+        "Configuring",
+        "Configured",
+        "ValidationNeeded"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteCircuitPeeringAdvertisedPublicPrefixState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotConfigured",
+            "value": "NotConfigured",
+            "description": "NotConfigured"
+          },
+          {
+            "name": "Configuring",
+            "value": "Configuring",
+            "description": "Configuring"
+          },
+          {
+            "name": "Configured",
+            "value": "Configured",
+            "description": "Configured"
+          },
+          {
+            "name": "ValidationNeeded",
+            "value": "ValidationNeeded",
+            "description": "ValidationNeeded"
+          }
+        ]
+      }
+    },
+    "ExpressRouteCircuitPeeringState": {
+      "type": "string",
+      "description": "The state of peering.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteCircuitPeeringState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          }
+        ]
+      }
+    },
+    "ExpressRouteCircuitSkuFamily": {
+      "type": "string",
+      "description": "The family of the SKU.",
+      "enum": [
+        "UnlimitedData",
+        "MeteredData"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteCircuitSkuFamily",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "UnlimitedData",
+            "value": "UnlimitedData",
+            "description": "UnlimitedData"
+          },
+          {
+            "name": "MeteredData",
+            "value": "MeteredData",
+            "description": "MeteredData"
+          }
+        ]
+      }
+    },
+    "ExpressRouteCircuitSkuTier": {
+      "type": "string",
+      "description": "The tier of the SKU.",
+      "enum": [
+        "Standard",
+        "Premium",
+        "Basic",
+        "Local",
+        "MultiCloud"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteCircuitSkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "Premium",
+            "value": "Premium",
+            "description": "Premium"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          },
+          {
+            "name": "Local",
+            "value": "Local",
+            "description": "Local"
+          },
+          {
+            "name": "MultiCloud",
+            "value": "MultiCloud",
+            "description": "MultiCloud tier for cross-cloud connectivity."
+          }
+        ]
+      }
+    },
+    "ExpressRouteFailoverBgpStatusAddressFamily": {
+      "type": "string",
+      "description": "The address family type for BGP status.",
+      "enum": [
+        "IPv4",
+        "IPv6"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteFailoverBgpStatusAddressFamily",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "IPv4 address family."
+          },
+          {
+            "name": "IPv6",
+            "value": "IPv6",
+            "description": "IPv6 address family."
+          }
+        ]
+      }
+    },
+    "ExpressRouteFailoverLinkType": {
+      "type": "string",
+      "description": "The link on which the failover test is being performed.",
+      "enum": [
+        "Primary",
+        "Secondary"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteFailoverLinkType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Primary",
+            "value": "Primary",
+            "description": "Primary link."
+          },
+          {
+            "name": "Secondary",
+            "value": "Secondary",
+            "description": "Secondary link."
+          }
+        ]
+      }
+    },
+    "ExpressRouteLagBillingType": {
+      "type": "string",
+      "description": "The billing type of the ExpressRouteLag resource.",
+      "enum": [
+        "MeteredData",
+        "UnlimitedData"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteLagBillingType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MeteredData",
+            "value": "MeteredData",
+            "description": "Metered data transfer billing."
+          },
+          {
+            "name": "UnlimitedData",
+            "value": "UnlimitedData",
+            "description": "Unlimited data transfer billing."
+          }
+        ]
+      }
+    },
+    "ExpressRouteLagEncapsulation": {
+      "type": "string",
+      "description": "Encapsulation method on LAG.",
+      "enum": [
+        "Dot1Q",
+        "QinQ"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteLagEncapsulation",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Dot1Q",
+            "value": "Dot1Q",
+            "description": "IEEE 802.1Q encapsulation."
+          },
+          {
+            "name": "QinQ",
+            "value": "QinQ",
+            "description": "IEEE 802.1ad encapsulation."
+          }
+        ]
+      }
+    },
+    "ExpressRouteLagLacpTimer": {
+      "type": "string",
+      "description": "LACP timer configuration.",
+      "enum": [
+        "Fast",
+        "Slow"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteLagLacpTimer",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Fast",
+            "value": "Fast",
+            "description": "Fast LACP timer (30 seconds)."
+          },
+          {
+            "name": "Slow",
+            "value": "Slow",
+            "description": "Slow LACP timer (90 seconds)."
+          }
+        ]
+      }
+    },
+    "ExpressRouteLinkAdminState": {
+      "type": "string",
+      "description": "Administrative state of the physical port.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteLinkAdminState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "ExpressRouteLinkConnectorType": {
+      "type": "string",
+      "description": "Physical fiber port type.",
+      "enum": [
+        "LC",
+        "SC"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteLinkConnectorType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "LC",
+            "value": "LC",
+            "description": "LC"
+          },
+          {
+            "name": "SC",
+            "value": "SC",
+            "description": "SC"
+          }
+        ]
+      }
+    },
+    "ExpressRouteLinkFailoverBgpStatus": {
+      "type": "string",
+      "description": "The BGP status of an ExpressRoute link failover.",
+      "enum": [
+        "Undefined",
+        "Connected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteLinkFailoverBgpStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Undefined",
+            "value": "Undefined",
+            "description": "Undefined status."
+          },
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected status."
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Disconnected status."
+          }
+        ]
+      }
+    },
+    "ExpressRouteLinkMacSecCipher": {
+      "type": "string",
+      "description": "Mac security cipher.",
+      "enum": [
+        "GcmAes256",
+        "GcmAes128",
+        "GcmAesXpn128",
+        "GcmAesXpn256"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteLinkMacSecCipher",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "GcmAes256",
+            "value": "GcmAes256",
+            "description": "GcmAes256"
+          },
+          {
+            "name": "GcmAes128",
+            "value": "GcmAes128",
+            "description": "GcmAes128"
+          },
+          {
+            "name": "GcmAesXpn128",
+            "value": "GcmAesXpn128",
+            "description": "GcmAesXpn128"
+          },
+          {
+            "name": "GcmAesXpn256",
+            "value": "GcmAesXpn256",
+            "description": "GcmAesXpn256"
+          }
+        ]
+      }
+    },
+    "ExpressRouteLinkMacSecSciState": {
+      "type": "string",
+      "description": "Sci mode enabled/disabled.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRouteLinkMacSecSciState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          }
+        ]
+      }
+    },
+    "ExpressRoutePeeringState": {
+      "type": "string",
+      "description": "The state of peering.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRoutePeeringState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          }
+        ]
+      }
+    },
+    "ExpressRoutePeeringType": {
+      "type": "string",
+      "description": "The peering type.",
+      "enum": [
+        "AzurePublicPeering",
+        "AzurePrivatePeering",
+        "MicrosoftPeering"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRoutePeeringType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzurePublicPeering",
+            "value": "AzurePublicPeering",
+            "description": "AzurePublicPeering"
+          },
+          {
+            "name": "AzurePrivatePeering",
+            "value": "AzurePrivatePeering",
+            "description": "AzurePrivatePeering"
+          },
+          {
+            "name": "MicrosoftPeering",
+            "value": "MicrosoftPeering",
+            "description": "MicrosoftPeering"
+          }
+        ]
+      }
+    },
+    "ExpressRoutePortAuthorizationUseStatus": {
+      "type": "string",
+      "description": "The authorization use status.",
+      "enum": [
+        "Available",
+        "InUse"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRoutePortAuthorizationUseStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Available",
+            "value": "Available",
+            "description": "Available"
+          },
+          {
+            "name": "InUse",
+            "value": "InUse",
+            "description": "InUse"
+          }
+        ]
+      }
+    },
+    "ExpressRoutePortsBillingType": {
+      "type": "string",
+      "description": "The billing type of the ExpressRoutePort resource.",
+      "enum": [
+        "MeteredData",
+        "UnlimitedData"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRoutePortsBillingType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MeteredData",
+            "value": "MeteredData",
+            "description": "MeteredData"
+          },
+          {
+            "name": "UnlimitedData",
+            "value": "UnlimitedData",
+            "description": "UnlimitedData"
+          }
+        ]
+      }
+    },
+    "ExpressRoutePortsEncapsulation": {
+      "type": "string",
+      "description": "Encapsulation method on physical ports.",
+      "enum": [
+        "Dot1Q",
+        "QinQ"
+      ],
+      "x-ms-enum": {
+        "name": "ExpressRoutePortsEncapsulation",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Dot1Q",
+            "value": "Dot1Q",
+            "description": "Dot1Q"
+          },
+          {
+            "name": "QinQ",
+            "value": "QinQ",
+            "description": "QinQ"
+          }
+        ]
+      }
+    },
+    "ExtendedLocation": {
+      "type": "object",
+      "description": "ExtendedLocation complex type.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the extended location."
+        },
+        "type": {
+          "$ref": "#/definitions/ExtendedLocationTypes",
+          "description": "The type of the extended location."
+        }
+      }
+    },
+    "ExtendedLocationTypes": {
+      "type": "string",
+      "description": "The supported ExtendedLocation types. Currently only EdgeZone is supported in Microsoft.Network resources.",
+      "enum": [
+        "EdgeZone"
+      ],
+      "x-ms-enum": {
+        "name": "ExtendedLocationTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EdgeZone",
+            "value": "EdgeZone",
+            "description": "EdgeZone"
+          }
+        ]
+      }
+    },
+    "FailoverConnectionStatus": {
+      "type": "string",
+      "description": "The current status of the connection",
+      "enum": [
+        "Connected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "FailoverConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Disconnected"
+          }
+        ]
+      }
+    },
+    "FailoverTestStatus": {
+      "type": "string",
+      "description": "The current status of the test",
+      "enum": [
+        "NotStarted",
+        "Starting",
+        "Running",
+        "StartFailed",
+        "Stopping",
+        "Completed",
+        "StopFailed",
+        "Invalid",
+        "Expired"
+      ],
+      "x-ms-enum": {
+        "name": "FailoverTestStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "NotStarted"
+          },
+          {
+            "name": "Starting",
+            "value": "Starting",
+            "description": "Starting"
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Running"
+          },
+          {
+            "name": "StartFailed",
+            "value": "StartFailed",
+            "description": "StartFailed"
+          },
+          {
+            "name": "Stopping",
+            "value": "Stopping",
+            "description": "Stopping"
+          },
+          {
+            "name": "Completed",
+            "value": "Completed",
+            "description": "Completed"
+          },
+          {
+            "name": "StopFailed",
+            "value": "StopFailed",
+            "description": "StopFailed"
+          },
+          {
+            "name": "Invalid",
+            "value": "Invalid",
+            "description": "Invalid"
+          },
+          {
+            "name": "Expired",
+            "value": "Expired",
+            "description": "Expired"
+          }
+        ]
+      }
+    },
+    "FailoverTestStatusForSingleTest": {
+      "type": "string",
+      "description": "The current status of the test",
+      "enum": [
+        "NotStarted",
+        "Starting",
+        "Running",
+        "StartFailed",
+        "Stopping",
+        "Completed",
+        "StopFailed",
+        "Invalid",
+        "Expired"
+      ],
+      "x-ms-enum": {
+        "name": "FailoverTestStatusForSingleTest",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "NotStarted"
+          },
+          {
+            "name": "Starting",
+            "value": "Starting",
+            "description": "Starting"
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Running"
+          },
+          {
+            "name": "StartFailed",
+            "value": "StartFailed",
+            "description": "StartFailed"
+          },
+          {
+            "name": "Stopping",
+            "value": "Stopping",
+            "description": "Stopping"
+          },
+          {
+            "name": "Completed",
+            "value": "Completed",
+            "description": "Completed"
+          },
+          {
+            "name": "StopFailed",
+            "value": "StopFailed",
+            "description": "StopFailed"
+          },
+          {
+            "name": "Invalid",
+            "value": "Invalid",
+            "description": "Invalid"
+          },
+          {
+            "name": "Expired",
+            "value": "Expired",
+            "description": "Expired"
+          }
+        ]
+      }
+    },
+    "FailoverTestType": {
+      "type": "string",
+      "description": "The type of failover test",
+      "enum": [
+        "SingleSiteFailover",
+        "MultiSiteFailover",
+        "All"
+      ],
+      "x-ms-enum": {
+        "name": "FailoverTestType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SingleSiteFailover",
+            "value": "SingleSiteFailover",
+            "description": "SingleSiteFailover"
+          },
+          {
+            "name": "MultiSiteFailover",
+            "value": "MultiSiteFailover",
+            "description": "MultiSiteFailover"
+          },
+          {
+            "name": "All",
+            "value": "All",
+            "description": "All"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyFilterRuleCollectionActionType": {
+      "type": "string",
+      "description": "The action type of a rule.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyFilterRuleCollectionActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny",
+            "description": "Deny"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyIDPSQuerySortOrder": {
+      "type": "string",
+      "description": "Describes if results should be in ascending/descending order",
+      "enum": [
+        "Ascending",
+        "Descending"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyIDPSQuerySortOrder",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Ascending",
+            "value": "Ascending",
+            "description": "Ascending"
+          },
+          {
+            "name": "Descending",
+            "value": "Descending",
+            "description": "Descending"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyIDPSSignatureDirection": {
+      "type": "number",
+      "description": "Describes in which direction signature is being enforced: 0 - OutBound, 1 - InBound, 2 - Any, 3 - Internal, 4 - InternalOutbound, 5 - InternalInbound",
+      "enum": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyIDPSSignatureDirection",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "0",
+            "value": 0,
+            "description": "0"
+          },
+          {
+            "name": "1",
+            "value": 1,
+            "description": "1"
+          },
+          {
+            "name": "2",
+            "value": 2,
+            "description": "2"
+          },
+          {
+            "name": "3",
+            "value": 3,
+            "description": "3"
+          },
+          {
+            "name": "4",
+            "value": 4,
+            "description": "4"
+          },
+          {
+            "name": "5",
+            "value": 5,
+            "description": "5"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyIDPSSignatureMode": {
+      "type": "number",
+      "description": "The current mode enforced, 0 - Disabled, 1 - Alert, 2 -Deny",
+      "enum": [
+        0,
+        1,
+        2
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyIDPSSignatureMode",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "0",
+            "value": 0,
+            "description": "0"
+          },
+          {
+            "name": "1",
+            "value": 1,
+            "description": "1"
+          },
+          {
+            "name": "2",
+            "value": 2,
+            "description": "2"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyIDPSSignatureSeverity": {
+      "type": "number",
+      "description": "Describes the severity of signature: 1 - High, 2 - Medium, 3 - Low",
+      "enum": [
+        1,
+        2,
+        3
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyIDPSSignatureSeverity",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "1",
+            "value": 1,
+            "description": "1"
+          },
+          {
+            "name": "2",
+            "value": 2,
+            "description": "2"
+          },
+          {
+            "name": "3",
+            "value": 3,
+            "description": "3"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyIntrusionDetectionProfileType": {
+      "type": "string",
+      "description": "Specifies the Intrusion Detection signature profile to apply.\n\nValues:\n- Off: IDPS profiles disabled; uses the same signature set that existed before profiles.\n- Emerging: Signatures of the newest, most recent threats.\n- Core: Complete, modern, standard set of signatures.\n- Extended: Core signatures plus older legacy signatures for maximum coverage.",
+      "enum": [
+        "Off",
+        "Emerging",
+        "Core",
+        "Extended"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyIntrusionDetectionProfileType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Off",
+            "value": "Off",
+            "description": "Off"
+          },
+          {
+            "name": "Emerging",
+            "value": "Emerging",
+            "description": "Emerging"
+          },
+          {
+            "name": "Core",
+            "value": "Core",
+            "description": "Core"
+          },
+          {
+            "name": "Extended",
+            "value": "Extended",
+            "description": "Extended"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyIntrusionDetectionProtocol": {
+      "type": "string",
+      "description": "Possible intrusion detection bypass traffic protocols.",
+      "enum": [
+        "TCP",
+        "UDP",
+        "ICMP",
+        "ANY"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyIntrusionDetectionProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "TCP",
+            "description": "TCP"
+          },
+          {
+            "name": "UDP",
+            "value": "UDP",
+            "description": "UDP"
+          },
+          {
+            "name": "ICMP",
+            "value": "ICMP",
+            "description": "ICMP"
+          },
+          {
+            "name": "ANY",
+            "value": "ANY",
+            "description": "ANY"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyIntrusionDetectionStateType": {
+      "type": "string",
+      "description": "Possible state values.",
+      "enum": [
+        "Off",
+        "Alert",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyIntrusionDetectionStateType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Off",
+            "value": "Off",
+            "description": "Off"
+          },
+          {
+            "name": "Alert",
+            "value": "Alert",
+            "description": "Alert"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny",
+            "description": "Deny"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyNatRuleCollectionActionType": {
+      "type": "string",
+      "description": "The action type of a rule.",
+      "enum": [
+        "DNAT"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyNatRuleCollectionActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "DNAT",
+            "value": "DNAT",
+            "description": "DNAT"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyRuleApplicationProtocolType": {
+      "type": "string",
+      "description": "The application protocol type of a Rule.",
+      "enum": [
+        "Http",
+        "Https"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyRuleApplicationProtocolType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Http",
+            "value": "Http",
+            "description": "Http"
+          },
+          {
+            "name": "Https",
+            "value": "Https",
+            "description": "Https"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyRuleCollectionType": {
+      "type": "string",
+      "description": "The type of the rule collection.",
+      "enum": [
+        "FirewallPolicyNatRuleCollection",
+        "FirewallPolicyFilterRuleCollection"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyRuleCollectionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FirewallPolicyNatRuleCollection",
+            "value": "FirewallPolicyNatRuleCollection",
+            "description": "FirewallPolicyNatRuleCollection"
+          },
+          {
+            "name": "FirewallPolicyFilterRuleCollection",
+            "value": "FirewallPolicyFilterRuleCollection",
+            "description": "FirewallPolicyFilterRuleCollection"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyRuleNetworkProtocol": {
+      "type": "string",
+      "description": "The Network protocol of a Rule.",
+      "enum": [
+        "TCP",
+        "UDP",
+        "Any",
+        "ICMP"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyRuleNetworkProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "TCP",
+            "description": "TCP"
+          },
+          {
+            "name": "UDP",
+            "value": "UDP",
+            "description": "UDP"
+          },
+          {
+            "name": "Any",
+            "value": "Any",
+            "description": "Any"
+          },
+          {
+            "name": "ICMP",
+            "value": "ICMP",
+            "description": "ICMP"
+          }
+        ]
+      }
+    },
+    "FirewallPolicyRuleType": {
+      "type": "string",
+      "description": "Rule Type.",
+      "enum": [
+        "ApplicationRule",
+        "NetworkRule",
+        "NatRule"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicyRuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ApplicationRule",
+            "value": "ApplicationRule",
+            "description": "ApplicationRule"
+          },
+          {
+            "name": "NetworkRule",
+            "value": "NetworkRule",
+            "description": "NetworkRule"
+          },
+          {
+            "name": "NatRule",
+            "value": "NatRule",
+            "description": "NatRule"
+          }
+        ]
+      }
+    },
+    "FirewallPolicySkuTier": {
+      "type": "string",
+      "description": "Tier of Firewall Policy.",
+      "enum": [
+        "Standard",
+        "Premium",
+        "Basic"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallPolicySkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "Premium",
+            "value": "Premium",
+            "description": "Premium"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          }
+        ]
+      }
+    },
+    "FlowLogFormatType": {
+      "type": "string",
+      "description": "The file type of flow log.",
+      "enum": [
+        "JSON"
+      ],
+      "x-ms-enum": {
+        "name": "FlowLogFormatType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "JSON",
+            "value": "JSON",
+            "description": "JSON"
+          }
+        ]
+      }
+    },
+    "GatewayEffectiveRouteNextHopType": {
+      "type": "string",
+      "description": "The next hop type of a gateway effective route.",
+      "enum": [
+        "Tunnel",
+        "VirtualNetwork",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "GatewayEffectiveRouteNextHopType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Tunnel",
+            "value": "Tunnel",
+            "description": "The next hop is a VPN tunnel."
+          },
+          {
+            "name": "VirtualNetwork",
+            "value": "VirtualNetwork",
+            "description": "The next hop is within the local virtual network."
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "The next hop type could not be determined."
+          }
+        ]
+      }
+    },
+    "GatewayLoadBalancerTunnelInterfaceType": {
+      "type": "string",
+      "description": "Traffic type of gateway load balancer tunnel interface.",
+      "enum": [
+        "None",
+        "Internal",
+        "External"
+      ],
+      "x-ms-enum": {
+        "name": "GatewayLoadBalancerTunnelInterfaceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "Internal",
+            "value": "Internal",
+            "description": "Internal"
+          },
+          {
+            "name": "External",
+            "value": "External",
+            "description": "External"
+          }
+        ]
+      }
+    },
+    "GatewayLoadBalancerTunnelProtocol": {
+      "type": "string",
+      "description": "Protocol of gateway load balancer tunnel interface.",
+      "enum": [
+        "None",
+        "Native",
+        "VXLAN"
+      ],
+      "x-ms-enum": {
+        "name": "GatewayLoadBalancerTunnelProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "Native",
+            "value": "Native",
+            "description": "Native"
+          },
+          {
+            "name": "VXLAN",
+            "value": "VXLAN",
+            "description": "VXLAN"
+          }
+        ]
+      }
+    },
+    "Geo": {
+      "type": "string",
+      "description": "The Geo for CIDR advertising. Should be an Geo code.",
+      "enum": [
+        "GLOBAL",
+        "AFRI",
+        "APAC",
+        "EURO",
+        "LATAM",
+        "NAM",
+        "ME",
+        "OCEANIA",
+        "AQ"
+      ],
+      "x-ms-enum": {
+        "name": "Geo",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "GLOBAL",
+            "value": "GLOBAL",
+            "description": "GLOBAL"
+          },
+          {
+            "name": "AFRI",
+            "value": "AFRI",
+            "description": "AFRI"
+          },
+          {
+            "name": "APAC",
+            "value": "APAC",
+            "description": "APAC"
+          },
+          {
+            "name": "EURO",
+            "value": "EURO",
+            "description": "EURO"
+          },
+          {
+            "name": "LATAM",
+            "value": "LATAM",
+            "description": "LATAM"
+          },
+          {
+            "name": "NAM",
+            "value": "NAM",
+            "description": "NAM"
+          },
+          {
+            "name": "ME",
+            "value": "ME",
+            "description": "ME"
+          },
+          {
+            "name": "OCEANIA",
+            "value": "OCEANIA",
+            "description": "OCEANIA"
+          },
+          {
+            "name": "AQ",
+            "value": "AQ",
+            "description": "AQ"
+          }
+        ]
+      }
+    },
+    "GroupConnectivity": {
+      "type": "string",
+      "description": "Group connectivity type.",
+      "enum": [
+        "None",
+        "DirectlyConnected"
+      ],
+      "x-ms-enum": {
+        "name": "GroupConnectivity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "DirectlyConnected",
+            "value": "DirectlyConnected",
+            "description": "DirectlyConnected"
+          }
+        ]
+      }
+    },
+    "GroupMemberType": {
+      "type": "string",
+      "description": "Network Group member type",
+      "enum": [
+        "VirtualNetwork",
+        "Subnet"
+      ],
+      "x-ms-enum": {
+        "name": "GroupMemberType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "VirtualNetwork",
+            "value": "VirtualNetwork",
+            "description": "VirtualNetwork"
+          },
+          {
+            "name": "Subnet",
+            "value": "Subnet",
+            "description": "Subnet"
+          }
+        ]
+      }
+    },
+    "HTTPConfigurationMethod": {
+      "type": "string",
+      "description": "The HTTP method to use.",
+      "enum": [
+        "Get",
+        "Post"
+      ],
+      "x-ms-enum": {
+        "name": "HTTPConfigurationMethod",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Get",
+            "value": "Get",
+            "description": "Get"
+          },
+          {
+            "name": "Post",
+            "value": "Post",
+            "description": "Post"
+          }
+        ]
+      }
+    },
+    "HTTPMethod": {
+      "type": "string",
+      "description": "HTTP method.",
+      "enum": [
+        "Get"
+      ],
+      "x-ms-enum": {
+        "name": "HTTPMethod",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Get",
+            "value": "Get",
+            "description": "Get"
+          }
+        ]
+      }
+    },
+    "HubBgpConnectionStatus": {
+      "type": "string",
+      "description": "The current state of the VirtualHub to Peer.",
+      "enum": [
+        "Unknown",
+        "Connecting",
+        "Connected",
+        "NotConnected"
+      ],
+      "x-ms-enum": {
+        "name": "HubBgpConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "Connecting",
+            "value": "Connecting",
+            "description": "Connecting"
+          },
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected"
+          },
+          {
+            "name": "NotConnected",
+            "value": "NotConnected",
+            "description": "NotConnected"
+          }
+        ]
+      }
+    },
+    "HubRoutingPreference": {
+      "type": "string",
+      "description": "The hub routing preference gateway types",
+      "enum": [
+        "ExpressRoute",
+        "VpnGateway",
+        "ASPath"
+      ],
+      "x-ms-enum": {
+        "name": "HubRoutingPreference",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ExpressRoute",
+            "value": "ExpressRoute",
+            "description": "ExpressRoute"
+          },
+          {
+            "name": "VpnGateway",
+            "value": "VpnGateway",
+            "description": "VpnGateway"
+          },
+          {
+            "name": "ASPath",
+            "value": "ASPath",
+            "description": "ASPath"
+          }
+        ]
+      }
+    },
+    "IPAllocationMethod": {
+      "type": "string",
+      "description": "IP address allocation method.",
+      "enum": [
+        "Static",
+        "Dynamic"
+      ],
+      "x-ms-enum": {
+        "name": "IPAllocationMethod",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Static",
+            "value": "Static",
+            "description": "Static"
+          },
+          {
+            "name": "Dynamic",
+            "value": "Dynamic",
+            "description": "Dynamic"
+          }
+        ]
+      }
+    },
+    "IPVersion": {
+      "type": "string",
+      "description": "IP address version.",
+      "enum": [
+        "IPv4",
+        "IPv6"
+      ],
+      "x-ms-enum": {
+        "name": "IPVersion",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "IPv4"
+          },
+          {
+            "name": "IPv6",
+            "value": "IPv6",
+            "description": "IPv6"
+          }
+        ]
+      }
+    },
+    "IkeEncryption": {
+      "type": "string",
+      "description": "The IKE encryption algorithm (IKE phase 2).",
+      "enum": [
+        "DES",
+        "DES3",
+        "AES128",
+        "AES192",
+        "AES256",
+        "GCMAES256",
+        "GCMAES128"
+      ],
+      "x-ms-enum": {
+        "name": "IkeEncryption",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "DES",
+            "value": "DES",
+            "description": "DES"
+          },
+          {
+            "name": "DES3",
+            "value": "DES3",
+            "description": "DES3"
+          },
+          {
+            "name": "AES128",
+            "value": "AES128",
+            "description": "AES128"
+          },
+          {
+            "name": "AES192",
+            "value": "AES192",
+            "description": "AES192"
+          },
+          {
+            "name": "AES256",
+            "value": "AES256",
+            "description": "AES256"
+          },
+          {
+            "name": "GCMAES256",
+            "value": "GCMAES256",
+            "description": "GCMAES256"
+          },
+          {
+            "name": "GCMAES128",
+            "value": "GCMAES128",
+            "description": "GCMAES128"
+          }
+        ]
+      }
+    },
+    "IkeIntegrity": {
+      "type": "string",
+      "description": "The IKE integrity algorithm (IKE phase 2).",
+      "enum": [
+        "MD5",
+        "SHA1",
+        "SHA256",
+        "SHA384",
+        "GCMAES256",
+        "GCMAES128"
+      ],
+      "x-ms-enum": {
+        "name": "IkeIntegrity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MD5",
+            "value": "MD5",
+            "description": "MD5"
+          },
+          {
+            "name": "SHA1",
+            "value": "SHA1",
+            "description": "SHA1"
+          },
+          {
+            "name": "SHA256",
+            "value": "SHA256",
+            "description": "SHA256"
+          },
+          {
+            "name": "SHA384",
+            "value": "SHA384",
+            "description": "SHA384"
+          },
+          {
+            "name": "GCMAES256",
+            "value": "GCMAES256",
+            "description": "GCMAES256"
+          },
+          {
+            "name": "GCMAES128",
+            "value": "GCMAES128",
+            "description": "GCMAES128"
+          }
+        ]
+      }
+    },
+    "InboundSecurityRuleType": {
+      "type": "string",
+      "description": "Rule Type. This should be either AutoExpire or Permanent. Auto Expire Rule only creates NSG rules. Permanent Rule creates NSG rule and SLB LB Rule.",
+      "enum": [
+        "AutoExpire",
+        "Permanent"
+      ],
+      "x-ms-enum": {
+        "name": "InboundSecurityRuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AutoExpire",
+            "value": "AutoExpire",
+            "description": "AutoExpire"
+          },
+          {
+            "name": "Permanent",
+            "value": "Permanent",
+            "description": "Permanent"
+          }
+        ]
+      }
+    },
+    "InboundSecurityRulesProtocol": {
+      "type": "string",
+      "description": "Protocol. This should be either TCP or UDP.",
+      "enum": [
+        "TCP",
+        "UDP"
+      ],
+      "x-ms-enum": {
+        "name": "InboundSecurityRulesProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "TCP",
+            "description": "TCP"
+          },
+          {
+            "name": "UDP",
+            "value": "UDP",
+            "description": "UDP"
+          }
+        ]
+      }
+    },
+    "InterconnectGroupScope": {
+      "type": "string",
+      "description": "Scope of an interconnect group resource.",
+      "enum": [
+        "None",
+        "InfiniBand"
+      ],
+      "x-ms-enum": {
+        "name": "InterconnectGroupScope",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No interconnect group scope."
+          },
+          {
+            "name": "InfiniBand",
+            "value": "InfiniBand",
+            "description": "InfiniBand interconnect group scope."
+          }
+        ]
+      }
+    },
+    "IpAllocationType": {
+      "type": "string",
+      "description": "IpAllocation type.",
+      "enum": [
+        "Undefined",
+        "Hypernet"
+      ],
+      "x-ms-enum": {
+        "name": "IpAllocationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Undefined",
+            "value": "Undefined",
+            "description": "Undefined"
+          },
+          {
+            "name": "Hypernet",
+            "value": "Hypernet",
+            "description": "Hypernet"
+          }
+        ]
+      }
+    },
+    "IpFlowProtocol": {
+      "type": "string",
+      "description": "Protocol to be verified on.",
+      "enum": [
+        "TCP",
+        "UDP"
+      ],
+      "x-ms-enum": {
+        "name": "IpFlowProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "TCP",
+            "value": "TCP",
+            "description": "TCP"
+          },
+          {
+            "name": "UDP",
+            "value": "UDP",
+            "description": "UDP"
+          }
+        ]
+      }
+    },
+    "IpType": {
+      "type": "string",
+      "description": "Enumeration to indicate the IP type.",
+      "enum": [
+        "IPv4",
+        "IPv6"
+      ],
+      "x-ms-enum": {
+        "name": "IpType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "IPv4"
+          },
+          {
+            "name": "IPv6",
+            "value": "IPv6",
+            "description": "IPv6"
+          }
+        ]
+      }
+    },
+    "IpsecEncryption": {
+      "type": "string",
+      "description": "The IPSec encryption algorithm (IKE phase 1).",
+      "enum": [
+        "None",
+        "DES",
+        "DES3",
+        "AES128",
+        "AES192",
+        "AES256",
+        "GCMAES128",
+        "GCMAES192",
+        "GCMAES256"
+      ],
+      "x-ms-enum": {
+        "name": "IpsecEncryption",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "DES",
+            "value": "DES",
+            "description": "DES"
+          },
+          {
+            "name": "DES3",
+            "value": "DES3",
+            "description": "DES3"
+          },
+          {
+            "name": "AES128",
+            "value": "AES128",
+            "description": "AES128"
+          },
+          {
+            "name": "AES192",
+            "value": "AES192",
+            "description": "AES192"
+          },
+          {
+            "name": "AES256",
+            "value": "AES256",
+            "description": "AES256"
+          },
+          {
+            "name": "GCMAES128",
+            "value": "GCMAES128",
+            "description": "GCMAES128"
+          },
+          {
+            "name": "GCMAES192",
+            "value": "GCMAES192",
+            "description": "GCMAES192"
+          },
+          {
+            "name": "GCMAES256",
+            "value": "GCMAES256",
+            "description": "GCMAES256"
+          }
+        ]
+      }
+    },
+    "IpsecIntegrity": {
+      "type": "string",
+      "description": "The IPSec integrity algorithm (IKE phase 1).",
+      "enum": [
+        "MD5",
+        "SHA1",
+        "SHA256",
+        "GCMAES128",
+        "GCMAES192",
+        "GCMAES256"
+      ],
+      "x-ms-enum": {
+        "name": "IpsecIntegrity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MD5",
+            "value": "MD5",
+            "description": "MD5"
+          },
+          {
+            "name": "SHA1",
+            "value": "SHA1",
+            "description": "SHA1"
+          },
+          {
+            "name": "SHA256",
+            "value": "SHA256",
+            "description": "SHA256"
+          },
+          {
+            "name": "GCMAES128",
+            "value": "GCMAES128",
+            "description": "GCMAES128"
+          },
+          {
+            "name": "GCMAES192",
+            "value": "GCMAES192",
+            "description": "GCMAES192"
+          },
+          {
+            "name": "GCMAES256",
+            "value": "GCMAES256",
+            "description": "GCMAES256"
+          }
+        ]
+      }
+    },
+    "IsGlobal": {
+      "type": "string",
+      "description": "Flag if global mesh is supported.",
+      "enum": [
+        "False",
+        "True"
+      ],
+      "x-ms-enum": {
+        "name": "IsGlobal",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "False",
+            "value": "False",
+            "description": "False"
+          },
+          {
+            "name": "True",
+            "value": "True",
+            "description": "True"
+          }
+        ]
+      }
+    },
+    "IsRollback": {
+      "type": "string",
+      "description": "When true, reverts from Static to Dynamic allocation (undo reservation).",
+      "enum": [
+        "true",
+        "false"
+      ],
+      "x-ms-enum": {
+        "name": "IsRollback",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "true",
+            "value": "true",
+            "description": "true"
+          },
+          {
+            "name": "false",
+            "value": "false",
+            "description": "false"
+          }
+        ]
+      }
+    },
+    "IsWorkloadProtected": {
+      "type": "string",
+      "description": "Value indicating whether the IP address is DDoS workload protected or not.",
+      "enum": [
+        "False",
+        "True"
+      ],
+      "x-ms-enum": {
+        "name": "IsWorkloadProtected",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "False",
+            "value": "False",
+            "description": "False"
+          },
+          {
+            "name": "True",
+            "value": "True",
+            "description": "True"
+          }
+        ]
+      }
+    },
+    "IssueType": {
+      "type": "string",
+      "description": "The type of issue.",
+      "enum": [
+        "Unknown",
+        "AgentStopped",
+        "GuestFirewall",
+        "DnsResolution",
+        "SocketBind",
+        "NetworkSecurityRule",
+        "UserDefinedRoute",
+        "PortThrottled",
+        "Platform"
+      ],
+      "x-ms-enum": {
+        "name": "IssueType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "AgentStopped",
+            "value": "AgentStopped",
+            "description": "AgentStopped"
+          },
+          {
+            "name": "GuestFirewall",
+            "value": "GuestFirewall",
+            "description": "GuestFirewall"
+          },
+          {
+            "name": "DnsResolution",
+            "value": "DnsResolution",
+            "description": "DnsResolution"
+          },
+          {
+            "name": "SocketBind",
+            "value": "SocketBind",
+            "description": "SocketBind"
+          },
+          {
+            "name": "NetworkSecurityRule",
+            "value": "NetworkSecurityRule",
+            "description": "NetworkSecurityRule"
+          },
+          {
+            "name": "UserDefinedRoute",
+            "value": "UserDefinedRoute",
+            "description": "UserDefinedRoute"
+          },
+          {
+            "name": "PortThrottled",
+            "value": "PortThrottled",
+            "description": "PortThrottled"
+          },
+          {
+            "name": "Platform",
+            "value": "Platform",
+            "description": "Platform"
+          }
+        ]
+      }
+    },
+    "LabelSelectorOperator": {
+      "type": "string",
+      "description": "operator represents a Kubernetes label selector requirement's relationship to a set of values.",
+      "enum": [
+        "In",
+        "NotIn",
+        "Exists",
+        "DoesNotExist"
+      ],
+      "x-ms-enum": {
+        "name": "LabelSelectorOperator",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "In",
+            "value": "In",
+            "description": "The label value must be in the supplied set of values."
+          },
+          {
+            "name": "NotIn",
+            "value": "NotIn",
+            "description": "The label value must not be in the supplied set of values."
+          },
+          {
+            "name": "Exists",
+            "value": "Exists",
+            "description": "The label key must exist, regardless of its value."
+          },
+          {
+            "name": "DoesNotExist",
+            "value": "DoesNotExist",
+            "description": "The label key must not exist."
+          }
+        ]
+      }
+    },
+    "LoadBalancerBackendAddressAdminState": {
+      "type": "string",
+      "description": "A list of administrative states which once set can override health probe so that Load Balancer will always forward new connections to backend, or deny new connections and reset existing connections.",
+      "enum": [
+        "None",
+        "Up",
+        "Down"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerBackendAddressAdminState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "Up",
+            "value": "Up",
+            "description": "Up"
+          },
+          {
+            "name": "Down",
+            "value": "Down",
+            "description": "Down"
+          }
+        ]
+      }
+    },
+    "LoadBalancerMode": {
+      "type": "string",
+      "description": "The load balancer mode. Set to `Advanced` to enable additional capabilities on a Standard SKU load balancer. Advanced mode must be specified at creation and cannot be changed afterward.",
+      "enum": [
+        "Advanced"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Advanced",
+            "value": "Advanced",
+            "description": "Advanced mode, which enables additional capabilities on a Standard SKU load balancer."
+          }
+        ]
+      }
+    },
+    "LoadBalancerOutboundRuleProtocol": {
+      "type": "string",
+      "description": "The protocol for the outbound rule in load balancer.",
+      "enum": [
+        "Tcp",
+        "Udp",
+        "All"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerOutboundRuleProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Tcp"
+          },
+          {
+            "name": "Udp",
+            "value": "Udp",
+            "description": "Udp"
+          },
+          {
+            "name": "All",
+            "value": "All",
+            "description": "All"
+          }
+        ]
+      }
+    },
+    "LoadBalancerScope": {
+      "type": "string",
+      "description": "Indicates the scope of the load balancer: external (Public) or internal (Private).",
+      "enum": [
+        "Public",
+        "Private"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerScope",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Public",
+            "value": "Public",
+            "description": "Public"
+          },
+          {
+            "name": "Private",
+            "value": "Private",
+            "description": "Private"
+          }
+        ]
+      }
+    },
+    "LoadBalancerSkuName": {
+      "type": "string",
+      "description": "Name of a load balancer SKU.",
+      "enum": [
+        "Basic",
+        "Standard",
+        "Gateway",
+        "Service"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerSkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "Gateway",
+            "value": "Gateway",
+            "description": "Gateway"
+          },
+          {
+            "name": "Service",
+            "value": "Service",
+            "description": "Service load balancer SKU."
+          }
+        ]
+      }
+    },
+    "LoadBalancerSkuTier": {
+      "type": "string",
+      "description": "Tier of a load balancer SKU.",
+      "enum": [
+        "Regional",
+        "Global"
+      ],
+      "x-ms-enum": {
+        "name": "LoadBalancerSkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Regional",
+            "value": "Regional",
+            "description": "Regional"
+          },
+          {
+            "name": "Global",
+            "value": "Global",
+            "description": "Global"
+          }
+        ]
+      }
+    },
+    "LoadDistribution": {
+      "type": "string",
+      "description": "The load distribution policy for this rule.",
+      "enum": [
+        "Default",
+        "SourceIP",
+        "SourceIPProtocol"
+      ],
+      "x-ms-enum": {
+        "name": "LoadDistribution",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default"
+          },
+          {
+            "name": "SourceIP",
+            "value": "SourceIP",
+            "description": "SourceIP"
+          },
+          {
+            "name": "SourceIPProtocol",
+            "value": "SourceIPProtocol",
+            "description": "SourceIPProtocol"
+          }
+        ]
+      }
+    },
+    "MaintenanceTestCategory": {
+      "type": "string",
+      "description": "The type of maintenance that can occur during an ExpressRoute failover test.",
+      "enum": [
+        "BgpDisconnect",
+        "ASPathPrepend"
+      ],
+      "x-ms-enum": {
+        "name": "MaintenanceTestCategory",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "BgpDisconnect",
+            "value": "BgpDisconnect",
+            "description": "BGP disconnect test category."
+          },
+          {
+            "name": "ASPathPrepend",
+            "value": "ASPathPrepend",
+            "description": "AS path prepend test category."
+          }
+        ]
+      }
+    },
+    "ManagedRuleEnabledState": {
+      "type": "string",
+      "description": "The state of the managed rule. Defaults to Disabled if not specified.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedRuleEnabledState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          }
+        ]
+      }
+    },
+    "ManagedServiceIdentity": {
+      "type": "object",
+      "description": "Identity for the resource.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The principal id of the system assigned identity. This property will only be provided for a system assigned identity.",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The tenant id of the system assigned identity. This property will only be provided for a system assigned identity.",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/definitions/ResourceIdentityType",
+          "description": "The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The list of user identities associated with resource. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.",
+          "additionalProperties": {
+            "$ref": "#/definitions/ManagedServiceIdentityUserAssignedIdentities"
+          }
+        }
+      }
+    },
+    "ManagedServiceIdentityUserAssignedIdentities": {
+      "type": "object",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The principal id of user assigned identity.",
+          "readOnly": true
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The client id of user assigned identity.",
+          "readOnly": true
+        }
+      }
+    },
+    "MigrationType": {
+      "type": "string",
+      "description": "The type of migration workflow performed on a Network Virtual Appliance.",
+      "enum": [
+        "MigrateToNewOSVersion",
+        "MigrateToNewILBArchitecture"
+      ],
+      "x-ms-enum": {
+        "name": "MigrationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MigrateToNewOSVersion",
+            "value": "MigrateToNewOSVersion",
+            "description": "Migrate the Network Virtual Appliance to a new OS / marketplace image version."
+          },
+          {
+            "name": "MigrateToNewILBArchitecture",
+            "value": "MigrateToNewILBArchitecture",
+            "description": "Migrate the Network Virtual Appliance to the new internal load balancer architecture."
+          }
+        ]
+      }
+    },
+    "Nat64State": {
+      "type": "string",
+      "description": "Whether Nat64 is enabled for the NAT gateway resource.",
+      "enum": [
+        "None",
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "Nat64State",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "Nat64 Property is not set."
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Nat64 is enabled."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Nat64 is disabled."
+          }
+        ]
+      }
+    },
+    "NatGatewaySkuName": {
+      "type": "string",
+      "description": "Name of Nat Gateway SKU.",
+      "enum": [
+        "Standard",
+        "StandardV2"
+      ],
+      "x-ms-enum": {
+        "name": "NatGatewaySkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "StandardV2",
+            "value": "StandardV2",
+            "description": "StandardV2"
+          }
+        ]
+      }
+    },
+    "NetworkIntentPolicyBasedService": {
+      "type": "string",
+      "description": "Network intent policy based services.",
+      "enum": [
+        "None",
+        "All",
+        "AllowRulesOnly"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkIntentPolicyBasedService",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "All",
+            "value": "All",
+            "description": "All"
+          },
+          {
+            "name": "AllowRulesOnly",
+            "value": "AllowRulesOnly",
+            "description": "AllowRulesOnly"
+          }
+        ]
+      }
+    },
+    "NetworkInterfaceAuxiliaryMode": {
+      "type": "string",
+      "description": "Auxiliary mode of Network Interface resource.",
+      "enum": [
+        "None",
+        "MaxConnections",
+        "Floating",
+        "AcceleratedConnections"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkInterfaceAuxiliaryMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "MaxConnections",
+            "value": "MaxConnections",
+            "description": "MaxConnections"
+          },
+          {
+            "name": "Floating",
+            "value": "Floating",
+            "description": "Floating"
+          },
+          {
+            "name": "AcceleratedConnections",
+            "value": "AcceleratedConnections",
+            "description": "AcceleratedConnections"
+          }
+        ]
+      }
+    },
+    "NetworkInterfaceAuxiliarySku": {
+      "type": "string",
+      "description": "Auxiliary sku of Network Interface resource.",
+      "enum": [
+        "None",
+        "A1",
+        "A2",
+        "A4",
+        "A8"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkInterfaceAuxiliarySku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "A1",
+            "value": "A1",
+            "description": "A1"
+          },
+          {
+            "name": "A2",
+            "value": "A2",
+            "description": "A2"
+          },
+          {
+            "name": "A4",
+            "value": "A4",
+            "description": "A4"
+          },
+          {
+            "name": "A8",
+            "value": "A8",
+            "description": "A8"
+          }
+        ]
+      }
+    },
+    "NetworkInterfaceMigrationPhase": {
+      "type": "string",
+      "description": "Migration phase of Network Interface resource.",
+      "enum": [
+        "None",
+        "Prepare",
+        "Commit",
+        "Abort",
+        "Committed"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkInterfaceMigrationPhase",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "Prepare",
+            "value": "Prepare",
+            "description": "Prepare"
+          },
+          {
+            "name": "Commit",
+            "value": "Commit",
+            "description": "Commit"
+          },
+          {
+            "name": "Abort",
+            "value": "Abort",
+            "description": "Abort"
+          },
+          {
+            "name": "Committed",
+            "value": "Committed",
+            "description": "Committed"
+          }
+        ]
+      }
+    },
+    "NetworkInterfaceNicType": {
+      "type": "string",
+      "description": "Type of Network Interface resource.",
+      "enum": [
+        "Standard",
+        "Elastic"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkInterfaceNicType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "Elastic",
+            "value": "Elastic",
+            "description": "Elastic"
+          }
+        ]
+      }
+    },
+    "NetworkProtocol": {
+      "type": "string",
+      "description": "Network Protocol.",
+      "enum": [
+        "Any",
+        "TCP",
+        "UDP",
+        "ICMP"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Any",
+            "value": "Any",
+            "description": "Any"
+          },
+          {
+            "name": "TCP",
+            "value": "TCP",
+            "description": "TCP"
+          },
+          {
+            "name": "UDP",
+            "value": "UDP",
+            "description": "UDP"
+          },
+          {
+            "name": "ICMP",
+            "value": "ICMP",
+            "description": "ICMP"
+          }
+        ]
+      }
+    },
+    "NextHopType": {
+      "type": "string",
+      "description": "Next hop type.",
+      "enum": [
+        "Internet",
+        "VirtualAppliance",
+        "VirtualNetworkGateway",
+        "VnetLocal",
+        "HyperNetGateway",
+        "VirtualApplianceEcmp",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "NextHopType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Internet",
+            "value": "Internet",
+            "description": "Internet"
+          },
+          {
+            "name": "VirtualAppliance",
+            "value": "VirtualAppliance",
+            "description": "VirtualAppliance"
+          },
+          {
+            "name": "VirtualNetworkGateway",
+            "value": "VirtualNetworkGateway",
+            "description": "VirtualNetworkGateway"
+          },
+          {
+            "name": "VnetLocal",
+            "value": "VnetLocal",
+            "description": "VnetLocal"
+          },
+          {
+            "name": "HyperNetGateway",
+            "value": "HyperNetGateway",
+            "description": "HyperNetGateway"
+          },
+          {
+            "name": "VirtualApplianceEcmp",
+            "value": "VirtualApplianceEcmp",
+            "description": "Routes traffic to virtual appliances using Equal-Cost Multi-Path (ECMP) routing with multiple next hop IP addresses."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No next hop type."
+          }
+        ]
+      }
+    },
+    "NextStep": {
+      "type": "string",
+      "description": "Supported next step behaviors after a rule is applied to a matched route",
+      "enum": [
+        "Unknown",
+        "Continue",
+        "Terminate"
+      ],
+      "x-ms-enum": {
+        "name": "NextStep",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "Continue",
+            "value": "Continue",
+            "description": "Continue"
+          },
+          {
+            "name": "Terminate",
+            "value": "Terminate",
+            "description": "Terminate"
+          }
+        ]
+      }
+    },
+    "NicTypeInRequest": {
+      "type": "string",
+      "description": "NIC type. This should be either PublicNic or PrivateNic.",
+      "enum": [
+        "PublicNic",
+        "PrivateNic"
+      ],
+      "x-ms-enum": {
+        "name": "NicTypeInRequest",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PublicNic",
+            "value": "PublicNic",
+            "description": "PublicNic"
+          },
+          {
+            "name": "PrivateNic",
+            "value": "PrivateNic",
+            "description": "PrivateNic"
+          }
+        ]
+      }
+    },
+    "NicTypeInResponse": {
+      "type": "string",
+      "description": "NIC type - PublicNic, PrivateNic, or AdditionalNic; AdditionalPrivateNic and AdditionalPublicNic are only supported for NVAs deployed in VNets.",
+      "enum": [
+        "PublicNic",
+        "PrivateNic",
+        "AdditionalNic"
+      ],
+      "x-ms-enum": {
+        "name": "NicTypeInResponse",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PublicNic",
+            "value": "PublicNic",
+            "description": "PublicNic"
+          },
+          {
+            "name": "PrivateNic",
+            "value": "PrivateNic",
+            "description": "PrivateNic"
+          },
+          {
+            "name": "AdditionalNic",
+            "value": "AdditionalNic",
+            "description": "AdditionalNic"
+          }
+        ]
+      }
+    },
+    "NspCreateMode": {
+      "type": "string",
+      "description": "The creation mode of a network security perimeter.",
+      "enum": [
+        "Default",
+        "GeoLinkedPerimeter"
+      ],
+      "x-ms-enum": {
+        "name": "NspCreateMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "A normal independently created network security perimeter."
+          },
+          {
+            "name": "GeoLinkedPerimeter",
+            "value": "GeoLinkedPerimeter",
+            "description": "A network security perimeter created as a geo-linked peer of another perimeter."
+          }
+        ]
+      }
+    },
+    "NspLinkProvisioningState": {
+      "type": "string",
+      "description": "The current provisioning state of NSP Link/LinkReference.",
+      "enum": [
+        "Succeeded",
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Accepted",
+        "Failed",
+        "WaitForRemoteCompletion"
+      ],
+      "x-ms-enum": {
+        "name": "NspLinkProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "Accepted"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "WaitForRemoteCompletion",
+            "value": "WaitForRemoteCompletion",
+            "description": "WaitForRemoteCompletion"
+          }
+        ]
+      }
+    },
+    "NspLinkStatus": {
+      "type": "string",
+      "description": "The NSP link state.",
+      "enum": [
+        "Approved",
+        "Pending",
+        "Rejected",
+        "Disconnected",
+        "Dormant"
+      ],
+      "x-ms-enum": {
+        "name": "NspLinkStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Approved",
+            "value": "Approved",
+            "description": "Approved"
+          },
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Pending"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected",
+            "description": "Rejected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Disconnected"
+          },
+          {
+            "name": "Dormant",
+            "value": "Dormant",
+            "description": "A service-managed BCDR relationship that is awaiting peer reconciliation."
+          }
+        ]
+      }
+    },
+    "NspProvisioningState": {
+      "type": "string",
+      "description": "The current provisioning state.",
+      "enum": [
+        "Succeeded",
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Accepted",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "NspProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "Accepted"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "NspReadinessState": {
+      "type": "string",
+      "description": "The readiness state of the resource type for NSP support.",
+      "enum": [
+        "Onboarding",
+        "Preview",
+        "GA",
+        "NotReady"
+      ],
+      "x-ms-enum": {
+        "name": "NspReadinessState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Onboarding",
+            "value": "Onboarding",
+            "description": "Resource Provider is actively being onboarded to NSP"
+          },
+          {
+            "name": "Preview",
+            "value": "Preview",
+            "description": "Resource Provider supports NSP in Preview"
+          },
+          {
+            "name": "GA",
+            "value": "GA",
+            "description": "Resource Provider is generally available for NSP Integration"
+          },
+          {
+            "name": "NotReady",
+            "value": "NotReady",
+            "description": "NSP Onboarding is not started or not Supported"
+          }
+        ]
+      }
+    },
+    "NvaNicType": {
+      "type": "string",
+      "enum": [
+        "PrivateNic",
+        "PublicNic",
+        "AdditionalPrivateNic",
+        "AdditionalPublicNic"
+      ],
+      "x-ms-enum": {
+        "name": "NvaNicType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PrivateNic",
+            "value": "PrivateNic",
+            "description": "The private NIC type"
+          },
+          {
+            "name": "PublicNic",
+            "value": "PublicNic",
+            "description": "The public NIC type"
+          },
+          {
+            "name": "AdditionalPrivateNic",
+            "value": "AdditionalPrivateNic",
+            "description": "An additional private NIC type"
+          },
+          {
+            "name": "AdditionalPublicNic",
+            "value": "AdditionalPublicNic",
+            "description": "An additional public NIC type"
+          }
+        ]
+      }
+    },
+    "OfficeTrafficCategory": {
+      "type": "string",
+      "description": "The office traffic category.",
+      "enum": [
+        "Optimize",
+        "OptimizeAndAllow",
+        "All",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "OfficeTrafficCategory",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Optimize",
+            "value": "Optimize",
+            "description": "Optimize"
+          },
+          {
+            "name": "OptimizeAndAllow",
+            "value": "OptimizeAndAllow",
+            "description": "OptimizeAndAllow"
+          },
+          {
+            "name": "All",
+            "value": "All",
+            "description": "All"
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          }
+        ]
+      }
+    },
+    "Origin": {
+      "type": "string",
+      "description": "The origin of the issue.",
+      "enum": [
+        "Local",
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "Origin",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Local",
+            "value": "Local",
+            "description": "Local"
+          },
+          {
+            "name": "Inbound",
+            "value": "Inbound",
+            "description": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound",
+            "description": "Outbound"
+          }
+        ]
+      }
+    },
+    "OutputType": {
+      "type": "string",
+      "description": "Connection monitor output destination type. Currently, only \"Workspace\" is supported.",
+      "enum": [
+        "Workspace"
+      ],
+      "x-ms-enum": {
+        "name": "OutputType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Workspace",
+            "value": "Workspace",
+            "description": "Workspace"
+          }
+        ]
+      }
+    },
+    "OwaspCrsExclusionEntryMatchVariable": {
+      "type": "string",
+      "description": "The variable to be excluded.",
+      "enum": [
+        "RequestHeaderNames",
+        "RequestCookieNames",
+        "RequestArgNames",
+        "RequestHeaderKeys",
+        "RequestHeaderValues",
+        "RequestCookieKeys",
+        "RequestCookieValues",
+        "RequestArgKeys",
+        "RequestArgValues"
+      ],
+      "x-ms-enum": {
+        "name": "OwaspCrsExclusionEntryMatchVariable",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "RequestHeaderNames",
+            "value": "RequestHeaderNames",
+            "description": "RequestHeaderNames"
+          },
+          {
+            "name": "RequestCookieNames",
+            "value": "RequestCookieNames",
+            "description": "RequestCookieNames"
+          },
+          {
+            "name": "RequestArgNames",
+            "value": "RequestArgNames",
+            "description": "RequestArgNames"
+          },
+          {
+            "name": "RequestHeaderKeys",
+            "value": "RequestHeaderKeys",
+            "description": "RequestHeaderKeys"
+          },
+          {
+            "name": "RequestHeaderValues",
+            "value": "RequestHeaderValues",
+            "description": "RequestHeaderValues"
+          },
+          {
+            "name": "RequestCookieKeys",
+            "value": "RequestCookieKeys",
+            "description": "RequestCookieKeys"
+          },
+          {
+            "name": "RequestCookieValues",
+            "value": "RequestCookieValues",
+            "description": "RequestCookieValues"
+          },
+          {
+            "name": "RequestArgKeys",
+            "value": "RequestArgKeys",
+            "description": "RequestArgKeys"
+          },
+          {
+            "name": "RequestArgValues",
+            "value": "RequestArgValues",
+            "description": "RequestArgValues"
+          }
+        ]
+      }
+    },
+    "OwaspCrsExclusionEntrySelectorMatchOperator": {
+      "type": "string",
+      "description": "When matchVariable is a collection, operate on the selector to specify which elements in the collection this exclusion applies to.",
+      "enum": [
+        "Equals",
+        "Contains",
+        "StartsWith",
+        "EndsWith",
+        "EqualsAny"
+      ],
+      "x-ms-enum": {
+        "name": "OwaspCrsExclusionEntrySelectorMatchOperator",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Equals",
+            "value": "Equals",
+            "description": "Equals"
+          },
+          {
+            "name": "Contains",
+            "value": "Contains",
+            "description": "Contains"
+          },
+          {
+            "name": "StartsWith",
+            "value": "StartsWith",
+            "description": "StartsWith"
+          },
+          {
+            "name": "EndsWith",
+            "value": "EndsWith",
+            "description": "EndsWith"
+          },
+          {
+            "name": "EqualsAny",
+            "value": "EqualsAny",
+            "description": "EqualsAny"
+          }
+        ]
+      }
+    },
+    "PacketCaptureTargetType": {
+      "type": "string",
+      "description": "Target type of the resource provided.",
+      "enum": [
+        "AzureVM",
+        "AzureVMSS"
+      ],
+      "x-ms-enum": {
+        "name": "PacketCaptureTargetType",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "AzureVM",
+            "value": "AzureVM",
+            "description": "AzureVM"
+          },
+          {
+            "name": "AzureVMSS",
+            "value": "AzureVMSS",
+            "description": "AzureVMSS"
+          }
+        ]
+      }
+    },
+    "PcError": {
+      "type": "string",
+      "enum": [
+        "InternalError",
+        "AgentStopped",
+        "CaptureFailed",
+        "LocalFileFailed",
+        "StorageFailed"
+      ],
+      "x-ms-enum": {
+        "name": "PcError",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InternalError",
+            "value": "InternalError",
+            "description": "InternalError"
+          },
+          {
+            "name": "AgentStopped",
+            "value": "AgentStopped",
+            "description": "AgentStopped"
+          },
+          {
+            "name": "CaptureFailed",
+            "value": "CaptureFailed",
+            "description": "CaptureFailed"
+          },
+          {
+            "name": "LocalFileFailed",
+            "value": "LocalFileFailed",
+            "description": "LocalFileFailed"
+          },
+          {
+            "name": "StorageFailed",
+            "value": "StorageFailed",
+            "description": "StorageFailed"
+          }
+        ]
+      }
+    },
+    "PcStatus": {
+      "type": "string",
+      "description": "The status of the packet capture session.",
+      "enum": [
+        "NotStarted",
+        "Running",
+        "Stopped",
+        "Error",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "PcStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "NotStarted"
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Running"
+          },
+          {
+            "name": "Stopped",
+            "value": "Stopped",
+            "description": "Stopped"
+          },
+          {
+            "name": "Error",
+            "value": "Error",
+            "description": "Error"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          }
+        ]
+      }
+    },
+    "PfsGroup": {
+      "type": "string",
+      "description": "The Pfs Groups used in IKE Phase 2 for new child SA.",
+      "enum": [
+        "None",
+        "PFS1",
+        "PFS2",
+        "PFS2048",
+        "ECP256",
+        "ECP384",
+        "PFS24",
+        "PFS14",
+        "PFSMM"
+      ],
+      "x-ms-enum": {
+        "name": "PfsGroup",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "PFS1",
+            "value": "PFS1",
+            "description": "PFS1"
+          },
+          {
+            "name": "PFS2",
+            "value": "PFS2",
+            "description": "PFS2"
+          },
+          {
+            "name": "PFS2048",
+            "value": "PFS2048",
+            "description": "PFS2048"
+          },
+          {
+            "name": "ECP256",
+            "value": "ECP256",
+            "description": "ECP256"
+          },
+          {
+            "name": "ECP384",
+            "value": "ECP384",
+            "description": "ECP384"
+          },
+          {
+            "name": "PFS24",
+            "value": "PFS24",
+            "description": "PFS24"
+          },
+          {
+            "name": "PFS14",
+            "value": "PFS14",
+            "description": "PFS14"
+          },
+          {
+            "name": "PFSMM",
+            "value": "PFSMM",
+            "description": "PFSMM"
+          }
+        ]
+      }
+    },
+    "PreferredIPVersion": {
+      "type": "string",
+      "description": "The preferred IP version to use in test evaluation. The connection monitor may choose to use a different version depending on other parameters.",
+      "enum": [
+        "IPv4",
+        "IPv6"
+      ],
+      "x-ms-enum": {
+        "name": "PreferredIPVersion",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "IPv4"
+          },
+          {
+            "name": "IPv6",
+            "value": "IPv6",
+            "description": "IPv6"
+          }
+        ]
+      }
+    },
+    "PreferredRoutingGateway": {
+      "type": "string",
+      "description": "The preferred routing gateway types",
+      "enum": [
+        "ExpressRoute",
+        "VpnGateway",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "PreferredRoutingGateway",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ExpressRoute",
+            "value": "ExpressRoute",
+            "description": "ExpressRoute"
+          },
+          {
+            "name": "VpnGateway",
+            "value": "VpnGateway",
+            "description": "VpnGateway"
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          }
+        ]
+      }
+    },
+    "PrivateEndpointBillingSku": {
+      "type": "string",
+      "description": "The billing sku of the private endpoint.",
+      "enum": [
+        "PayAsYouGo",
+        "Fixed"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointBillingSku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PayAsYouGo",
+            "value": "PayAsYouGo",
+            "description": "PayAsYouGo sku is the default price for private endpoints."
+          },
+          {
+            "name": "Fixed",
+            "value": "Fixed",
+            "description": "Fixed sku is best for high data processing private endpoints."
+          }
+        ]
+      }
+    },
+    "PrivateEndpointVNetPolicies": {
+      "type": "string",
+      "description": "Private Endpoint VNet Policies.",
+      "enum": [
+        "Disabled",
+        "Basic"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointVNetPolicies",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          }
+        ]
+      }
+    },
+    "ProbeNoHealthyBackendsBehavior": {
+      "type": "string",
+      "description": "Determines how new connections are handled by the load balancer when all backend instances are probed down.",
+      "enum": [
+        "AllProbedDown",
+        "AllProbedUp"
+      ],
+      "x-ms-enum": {
+        "name": "ProbeNoHealthyBackendsBehavior",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AllProbedDown",
+            "value": "AllProbedDown",
+            "description": "No new flows will be sent to the backend pool."
+          },
+          {
+            "name": "AllProbedUp",
+            "value": "AllProbedUp",
+            "description": "When all backend instances are probed down, incoming packets will be sent to all instances."
+          }
+        ]
+      }
+    },
+    "ProbeProtocol": {
+      "type": "string",
+      "description": "The protocol of the end point. If 'Tcp' is specified, a received ACK is required for the probe to be successful. If 'Http' or 'Https' is specified, a 200 OK response from the specifies URI is required for the probe to be successful.",
+      "enum": [
+        "Http",
+        "Tcp",
+        "Https"
+      ],
+      "x-ms-enum": {
+        "name": "ProbeProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Http",
+            "value": "Http",
+            "description": "Http"
+          },
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Tcp"
+          },
+          {
+            "name": "Https",
+            "value": "Https",
+            "description": "Https"
+          }
+        ]
+      }
+    },
+    "ProcessorArchitecture": {
+      "type": "string",
+      "description": "VPN client Processor Architecture.",
+      "enum": [
+        "Amd64",
+        "X86"
+      ],
+      "x-ms-enum": {
+        "name": "ProcessorArchitecture",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Amd64",
+            "value": "Amd64",
+            "description": "Amd64"
+          },
+          {
+            "name": "X86",
+            "value": "X86",
+            "description": "X86"
+          }
+        ]
+      }
+    },
+    "Protocol": {
+      "type": "string",
+      "description": "Network protocol.",
+      "enum": [
+        "Tcp",
+        "Http",
+        "Https",
+        "Icmp"
+      ],
+      "x-ms-enum": {
+        "name": "Protocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Tcp"
+          },
+          {
+            "name": "Http",
+            "value": "Http",
+            "description": "Http"
+          },
+          {
+            "name": "Https",
+            "value": "Https",
+            "description": "Https"
+          },
+          {
+            "name": "Icmp",
+            "value": "Icmp",
+            "description": "Icmp"
+          }
+        ]
+      }
+    },
+    "ProtocolType": {
+      "type": "string",
+      "description": "RNM supported protocol types.",
+      "enum": [
+        "DoNotUse",
+        "Icmp",
+        "Tcp",
+        "Udp",
+        "Gre",
+        "Esp",
+        "Ah",
+        "Vxlan",
+        "All"
+      ],
+      "x-ms-enum": {
+        "name": "ProtocolType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "DoNotUse",
+            "value": "DoNotUse",
+            "description": "DoNotUse"
+          },
+          {
+            "name": "Icmp",
+            "value": "Icmp",
+            "description": "Icmp"
+          },
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Tcp"
+          },
+          {
+            "name": "Udp",
+            "value": "Udp",
+            "description": "Udp"
+          },
+          {
+            "name": "Gre",
+            "value": "Gre",
+            "description": "Gre"
+          },
+          {
+            "name": "Esp",
+            "value": "Esp",
+            "description": "Esp"
+          },
+          {
+            "name": "Ah",
+            "value": "Ah",
+            "description": "Ah"
+          },
+          {
+            "name": "Vxlan",
+            "value": "Vxlan",
+            "description": "Vxlan"
+          },
+          {
+            "name": "All",
+            "value": "All",
+            "description": "All"
+          }
+        ]
+      }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "Provisioning states of a resource.",
+      "enum": [
+        "Failed",
+        "Succeeded",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "ProxyResource": {
+      "type": "object",
+      "description": "Proxy resource representation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ProxyResourceWithReadOnlyID": {
+      "type": "object",
+      "description": "Proxy resource representation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ProxyResourceWithSettableId": {
+      "type": "object",
+      "description": "Proxy resource representation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "PublicIPAddressMigrationPhase": {
+      "type": "string",
+      "description": "Migration phase of Public IP Address.",
+      "enum": [
+        "None",
+        "Prepare",
+        "Commit",
+        "Abort",
+        "Committed"
+      ],
+      "x-ms-enum": {
+        "name": "PublicIPAddressMigrationPhase",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "Prepare",
+            "value": "Prepare",
+            "description": "Prepare"
+          },
+          {
+            "name": "Commit",
+            "value": "Commit",
+            "description": "Commit"
+          },
+          {
+            "name": "Abort",
+            "value": "Abort",
+            "description": "Abort"
+          },
+          {
+            "name": "Committed",
+            "value": "Committed",
+            "description": "Committed"
+          }
+        ]
+      }
+    },
+    "PublicIPAddressSkuName": {
+      "type": "string",
+      "description": "Name of a public IP address SKU.",
+      "enum": [
+        "Basic",
+        "Standard",
+        "StandardV2"
+      ],
+      "x-ms-enum": {
+        "name": "PublicIPAddressSkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "StandardV2",
+            "value": "StandardV2",
+            "description": "StandardV2"
+          }
+        ]
+      }
+    },
+    "PublicIPAddressSkuTier": {
+      "type": "string",
+      "description": "Tier of a public IP address SKU.",
+      "enum": [
+        "Regional",
+        "Global"
+      ],
+      "x-ms-enum": {
+        "name": "PublicIPAddressSkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Regional",
+            "value": "Regional",
+            "description": "Regional"
+          },
+          {
+            "name": "Global",
+            "value": "Global",
+            "description": "Global"
+          }
+        ]
+      }
+    },
+    "PublicIPPrefixSkuName": {
+      "type": "string",
+      "description": "Name of a public IP prefix SKU.",
+      "enum": [
+        "Standard",
+        "StandardV2"
+      ],
+      "x-ms-enum": {
+        "name": "PublicIPPrefixSkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "StandardV2",
+            "value": "StandardV2",
+            "description": "StandardV2"
+          }
+        ]
+      }
+    },
+    "PublicIPPrefixSkuTier": {
+      "type": "string",
+      "description": "Tier of a public IP prefix SKU.",
+      "enum": [
+        "Regional",
+        "Global"
+      ],
+      "x-ms-enum": {
+        "name": "PublicIPPrefixSkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Regional",
+            "value": "Regional",
+            "description": "Regional"
+          },
+          {
+            "name": "Global",
+            "value": "Global",
+            "description": "Global"
+          }
+        ]
+      }
+    },
+    "PublicIpAddressDnsSettingsDomainNameLabelScope": {
+      "type": "string",
+      "description": "The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN.",
+      "enum": [
+        "TenantReuse",
+        "SubscriptionReuse",
+        "ResourceGroupReuse",
+        "NoReuse"
+      ],
+      "x-ms-enum": {
+        "name": "PublicIpAddressDnsSettingsDomainNameLabelScope",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "TenantReuse",
+            "value": "TenantReuse",
+            "description": "TenantReuse"
+          },
+          {
+            "name": "SubscriptionReuse",
+            "value": "SubscriptionReuse",
+            "description": "SubscriptionReuse"
+          },
+          {
+            "name": "ResourceGroupReuse",
+            "value": "ResourceGroupReuse",
+            "description": "ResourceGroupReuse"
+          },
+          {
+            "name": "NoReuse",
+            "value": "NoReuse",
+            "description": "NoReuse"
+          }
+        ]
+      }
+    },
+    "ReadOnlySubResourceModel": {
+      "type": "object",
+      "description": "Reference to another subresource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ResiliencyLevel": {
+      "type": "string",
+      "description": "The resiliency level of the ExpressRoute circuit.",
+      "enum": [
+        "Standard",
+        "High",
+        "Maximum"
+      ],
+      "x-ms-enum": {
+        "name": "ResiliencyLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard resiliency level."
+          },
+          {
+            "name": "High",
+            "value": "High",
+            "description": "High resiliency level."
+          },
+          {
+            "name": "Maximum",
+            "value": "Maximum",
+            "description": "Maximum resiliency level."
+          }
+        ]
+      }
+    },
+    "ResiliencyModel": {
+      "type": "string",
+      "description": "Property to indicate if the Express Route Gateway has resiliency model of MultiHomed or SingleHomed",
+      "enum": [
+        "SingleHomed",
+        "MultiHomed"
+      ],
+      "x-ms-enum": {
+        "name": "ResiliencyModel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SingleHomed",
+            "value": "SingleHomed",
+            "description": "SingleHomed"
+          },
+          {
+            "name": "MultiHomed",
+            "value": "MultiHomed",
+            "description": "MultiHomed"
+          }
+        ]
+      }
+    },
+    "Resource": {
+      "type": "object",
+      "description": "Common resource representation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "ResourceIdentityType": {
+      "type": "string",
+      "description": "The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the virtual machine.",
+      "enum": [
+        "SystemAssigned",
+        "UserAssigned",
+        "SystemAssigned, UserAssigned",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceIdentityType",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
+            "description": "SystemAssigned"
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned",
+            "description": "UserAssigned"
+          },
+          {
+            "name": "SystemAssigned, UserAssigned",
+            "value": "SystemAssigned, UserAssigned",
+            "description": "SystemAssigned, UserAssigned"
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          }
+        ]
+      }
+    },
+    "RouteFilterRuleType": {
+      "type": "string",
+      "description": "The rule type of the rule.",
+      "enum": [
+        "Community"
+      ],
+      "x-ms-enum": {
+        "name": "RouteFilterRuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Community",
+            "value": "Community",
+            "description": "Community"
+          }
+        ]
+      }
+    },
+    "RouteMapActionType": {
+      "type": "string",
+      "description": "Kind of actions which can be taken on a matched route. Add, Replace, Remove refer to parameters on the route, like community or prefix",
+      "enum": [
+        "Unknown",
+        "Remove",
+        "Add",
+        "Replace",
+        "Drop"
+      ],
+      "x-ms-enum": {
+        "name": "RouteMapActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "Remove",
+            "value": "Remove",
+            "description": "Remove"
+          },
+          {
+            "name": "Add",
+            "value": "Add",
+            "description": "Add"
+          },
+          {
+            "name": "Replace",
+            "value": "Replace",
+            "description": "Replace"
+          },
+          {
+            "name": "Drop",
+            "value": "Drop",
+            "description": "Drop"
+          }
+        ]
+      }
+    },
+    "RouteMapMatchCondition": {
+      "type": "string",
+      "description": "Match condition to apply RouteMap rules.",
+      "enum": [
+        "Unknown",
+        "Contains",
+        "Equals",
+        "NotContains",
+        "NotEquals"
+      ],
+      "x-ms-enum": {
+        "name": "RouteMapMatchCondition",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "Contains",
+            "value": "Contains",
+            "description": "Contains"
+          },
+          {
+            "name": "Equals",
+            "value": "Equals",
+            "description": "Equals"
+          },
+          {
+            "name": "NotContains",
+            "value": "NotContains",
+            "description": "NotContains"
+          },
+          {
+            "name": "NotEquals",
+            "value": "NotEquals",
+            "description": "NotEquals"
+          }
+        ]
+      }
+    },
+    "RouteNextHopType": {
+      "type": "string",
+      "description": "The type of Azure hop the packet should be sent to.",
+      "enum": [
+        "VirtualNetworkGateway",
+        "VnetLocal",
+        "Internet",
+        "VirtualAppliance",
+        "VirtualApplianceEcmp",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "RouteNextHopType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "VirtualNetworkGateway",
+            "value": "VirtualNetworkGateway",
+            "description": "VirtualNetworkGateway"
+          },
+          {
+            "name": "VnetLocal",
+            "value": "VnetLocal",
+            "description": "VnetLocal"
+          },
+          {
+            "name": "Internet",
+            "value": "Internet",
+            "description": "Internet"
+          },
+          {
+            "name": "VirtualAppliance",
+            "value": "VirtualAppliance",
+            "description": "VirtualAppliance"
+          },
+          {
+            "name": "VirtualApplianceEcmp",
+            "value": "VirtualApplianceEcmp",
+            "description": "Routes traffic to virtual appliances using Equal-Cost Multi-Path (ECMP) routing with multiple next hop IP addresses."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No next hop type."
+          }
+        ]
+      }
+    },
+    "RoutingRuleDestinationType": {
+      "type": "string",
+      "description": "Routing rule destination type.",
+      "enum": [
+        "AddressPrefix",
+        "ServiceTag"
+      ],
+      "x-ms-enum": {
+        "name": "RoutingRuleDestinationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AddressPrefix",
+            "value": "AddressPrefix",
+            "description": "Destination specified as an IP address prefix (CIDR)."
+          },
+          {
+            "name": "ServiceTag",
+            "value": "ServiceTag",
+            "description": "Destination specified as an Azure service tag."
+          }
+        ]
+      }
+    },
+    "RoutingRuleNextHopType": {
+      "type": "string",
+      "description": "Routing rule next hop type.",
+      "enum": [
+        "Internet",
+        "NoNextHop",
+        "VirtualAppliance",
+        "VirtualNetworkGateway",
+        "VnetLocal"
+      ],
+      "x-ms-enum": {
+        "name": "RoutingRuleNextHopType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Internet",
+            "value": "Internet",
+            "description": "Forward traffic to the Internet."
+          },
+          {
+            "name": "NoNextHop",
+            "value": "NoNextHop",
+            "description": "No next hop will be used."
+          },
+          {
+            "name": "VirtualAppliance",
+            "value": "VirtualAppliance",
+            "description": "Forward traffic to a specified virtual appliance IP address."
+          },
+          {
+            "name": "VirtualNetworkGateway",
+            "value": "VirtualNetworkGateway",
+            "description": "Forward traffic to the virtual network gateway."
+          },
+          {
+            "name": "VnetLocal",
+            "value": "VnetLocal",
+            "description": "Keep traffic within the local virtual network"
+          }
+        ]
+      }
+    },
+    "RoutingState": {
+      "type": "string",
+      "description": "The current routing state of the VirtualHub.",
+      "enum": [
+        "None",
+        "Provisioned",
+        "Provisioning",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "RoutingState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "Provisioned",
+            "value": "Provisioned",
+            "description": "Provisioned"
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "Provisioning"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "ScopeConnectionState": {
+      "type": "string",
+      "description": "The current scope connection state.",
+      "enum": [
+        "Connected",
+        "Pending",
+        "Conflict",
+        "Revoked",
+        "Rejected"
+      ],
+      "x-ms-enum": {
+        "name": "ScopeConnectionState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected"
+          },
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Pending"
+          },
+          {
+            "name": "Conflict",
+            "value": "Conflict",
+            "description": "Conflict"
+          },
+          {
+            "name": "Revoked",
+            "value": "Revoked",
+            "description": "Revoked"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected",
+            "description": "Rejected"
+          }
+        ]
+      }
+    },
+    "ScrubbingRuleEntryMatchVariable": {
+      "type": "string",
+      "description": "The variable to be scrubbed from the logs.",
+      "enum": [
+        "RequestHeaderNames",
+        "RequestCookieNames",
+        "RequestArgNames",
+        "RequestPostArgNames",
+        "RequestJSONArgNames",
+        "RequestIPAddress"
+      ],
+      "x-ms-enum": {
+        "name": "ScrubbingRuleEntryMatchVariable",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "RequestHeaderNames",
+            "value": "RequestHeaderNames",
+            "description": "RequestHeaderNames"
+          },
+          {
+            "name": "RequestCookieNames",
+            "value": "RequestCookieNames",
+            "description": "RequestCookieNames"
+          },
+          {
+            "name": "RequestArgNames",
+            "value": "RequestArgNames",
+            "description": "RequestArgNames"
+          },
+          {
+            "name": "RequestPostArgNames",
+            "value": "RequestPostArgNames",
+            "description": "RequestPostArgNames"
+          },
+          {
+            "name": "RequestJSONArgNames",
+            "value": "RequestJSONArgNames",
+            "description": "RequestJSONArgNames"
+          },
+          {
+            "name": "RequestIPAddress",
+            "value": "RequestIPAddress",
+            "description": "RequestIPAddress"
+          }
+        ]
+      }
+    },
+    "SecurityConfigurationRuleAccess": {
+      "type": "string",
+      "description": "Whether network traffic is allowed or denied.",
+      "enum": [
+        "Allow",
+        "Deny",
+        "AlwaysAllow"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityConfigurationRuleAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny",
+            "description": "Deny"
+          },
+          {
+            "name": "AlwaysAllow",
+            "value": "AlwaysAllow",
+            "description": "AlwaysAllow"
+          }
+        ]
+      }
+    },
+    "SecurityConfigurationRuleDirection": {
+      "type": "string",
+      "description": "The direction of the rule. The direction specifies if the rule will be evaluated on incoming or outgoing traffic.",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityConfigurationRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound",
+            "description": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound",
+            "description": "Outbound"
+          }
+        ]
+      }
+    },
+    "SecurityConfigurationRuleProtocol": {
+      "type": "string",
+      "description": "Network protocol this rule applies to.",
+      "enum": [
+        "Tcp",
+        "Udp",
+        "Icmp",
+        "Esp",
+        "Any",
+        "Ah"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityConfigurationRuleProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Tcp"
+          },
+          {
+            "name": "Udp",
+            "value": "Udp",
+            "description": "Udp"
+          },
+          {
+            "name": "Icmp",
+            "value": "Icmp",
+            "description": "Icmp"
+          },
+          {
+            "name": "Esp",
+            "value": "Esp",
+            "description": "Esp"
+          },
+          {
+            "name": "Any",
+            "value": "Any",
+            "description": "Any"
+          },
+          {
+            "name": "Ah",
+            "value": "Ah",
+            "description": "Ah"
+          }
+        ]
+      }
+    },
+    "SecurityPartnerProviderConnectionStatus": {
+      "type": "string",
+      "description": "The current state of the connection with Security Partner Provider.",
+      "enum": [
+        "Unknown",
+        "PartiallyConnected",
+        "Connected",
+        "NotConnected"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityPartnerProviderConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "PartiallyConnected",
+            "value": "PartiallyConnected",
+            "description": "PartiallyConnected"
+          },
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected"
+          },
+          {
+            "name": "NotConnected",
+            "value": "NotConnected",
+            "description": "NotConnected"
+          }
+        ]
+      }
+    },
+    "SecurityPerimeterProxyResource": {
+      "type": "object",
+      "description": "The resource model definition for a Azure Resource Manager proxy resource. It will not have tags and a location",
+      "allOf": [
+        {
+          "$ref": "#/definitions/SecurityPerimeterResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "SecurityPerimeterResource": {
+      "type": "object",
+      "description": "Common fields that are returned in the response for all Azure Resource Manager resources",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified resource ID for the resource. E.g. \"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}\"",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the resource. E.g. \"Microsoft.Compute/virtualMachines\" or \"Microsoft.Storage/storageAccounts\"",
+          "readOnly": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "Azure Resource Manager metadata containing createdBy and modifiedBy information.",
+          "readOnly": true
+        }
+      }
+    },
+    "SecurityPerimeterTrackedResource": {
+      "type": "object",
+      "description": "The resource model definition for a Azure Resource Manager proxy resource. It will not have tags and a location",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/SecurityPerimeterResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "SecurityProviderName": {
+      "type": "string",
+      "description": "The Security Providers.",
+      "enum": [
+        "ZScaler",
+        "IBoss",
+        "Checkpoint"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityProviderName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ZScaler",
+            "value": "ZScaler",
+            "description": "ZScaler"
+          },
+          {
+            "name": "IBoss",
+            "value": "IBoss",
+            "description": "IBoss"
+          },
+          {
+            "name": "Checkpoint",
+            "value": "Checkpoint",
+            "description": "Checkpoint"
+          }
+        ]
+      }
+    },
+    "SecurityRuleAccess": {
+      "type": "string",
+      "description": "Whether network traffic is allowed or denied.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityRuleAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny",
+            "description": "Deny"
+          }
+        ]
+      }
+    },
+    "SecurityRuleDirection": {
+      "type": "string",
+      "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic.",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound",
+            "description": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound",
+            "description": "Outbound"
+          }
+        ]
+      }
+    },
+    "SecurityRuleProtocol": {
+      "type": "string",
+      "description": "Network protocol this rule applies to.",
+      "enum": [
+        "Tcp",
+        "Udp",
+        "Icmp",
+        "Esp",
+        "*",
+        "Ah"
+      ],
+      "x-ms-enum": {
+        "name": "SecurityRuleProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Tcp"
+          },
+          {
+            "name": "Udp",
+            "value": "Udp",
+            "description": "Udp"
+          },
+          {
+            "name": "Icmp",
+            "value": "Icmp",
+            "description": "Icmp"
+          },
+          {
+            "name": "Esp",
+            "value": "Esp",
+            "description": "Esp"
+          },
+          {
+            "name": "Asterisk",
+            "value": "*",
+            "description": "*"
+          },
+          {
+            "name": "Ah",
+            "value": "Ah",
+            "description": "Ah"
+          }
+        ]
+      }
+    },
+    "SensitivityType": {
+      "type": "string",
+      "description": "Defines the sensitivity for the rule.",
+      "enum": [
+        "Low",
+        "Medium",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "SensitivityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Low",
+            "value": "Low",
+            "description": "Low"
+          },
+          {
+            "name": "Medium",
+            "value": "Medium",
+            "description": "Medium"
+          },
+          {
+            "name": "High",
+            "value": "High",
+            "description": "High"
+          }
+        ]
+      }
+    },
+    "ServiceGatewayActionOkResponseBody": {
+      "type": "object",
+      "description": "Empty success response.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "The status of the operation.",
+          "readOnly": true
+        }
+      }
+    },
+    "ServiceGatewaySkuName": {
+      "type": "string",
+      "description": "Name of a service gateway SKU.",
+      "enum": [
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceGatewaySkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          }
+        ]
+      }
+    },
+    "ServiceGatewaySkuTier": {
+      "type": "string",
+      "description": "Tier of a service gateway SKU.",
+      "enum": [
+        "Regional"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceGatewaySkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Regional",
+            "value": "Regional",
+            "description": "Regional"
+          }
+        ]
+      }
+    },
+    "ServiceProviderProvisioningState": {
+      "type": "string",
+      "description": "The ServiceProviderProvisioningState state of the resource.",
+      "enum": [
+        "NotProvisioned",
+        "Provisioning",
+        "Provisioned",
+        "Deprovisioning",
+        "DeProvisioned"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceProviderProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotProvisioned",
+            "value": "NotProvisioned",
+            "description": "NotProvisioned"
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "Provisioning"
+          },
+          {
+            "name": "Provisioned",
+            "value": "Provisioned",
+            "description": "Provisioned"
+          },
+          {
+            "name": "Deprovisioning",
+            "value": "Deprovisioning",
+            "description": "Deprovisioning"
+          },
+          {
+            "name": "DeProvisioned",
+            "value": "DeProvisioned",
+            "description": "DeProvisioned State"
+          }
+        ]
+      }
+    },
+    "ServiceType": {
+      "type": "string",
+      "description": "Name of the service.",
+      "enum": [
+        "Inbound",
+        "Outbound",
+        "InboundOutbound"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound",
+            "description": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound",
+            "description": "Outbound"
+          },
+          {
+            "name": "InboundOutbound",
+            "value": "InboundOutbound",
+            "description": "InboundOutbound"
+          }
+        ]
+      }
+    },
+    "ServiceUpdateAction": {
+      "type": "string",
+      "description": "Specifies the type of update operation to perform on services within the service gateway.\n\n- FullUpdate: Replaces all existing services with the new list provided in the request. Any previously defined services not included will be removed.\n- PartialUpdate: Updates only the specified services.",
+      "enum": [
+        "FullUpdate",
+        "PartialUpdate"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceUpdateAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FullUpdate",
+            "value": "FullUpdate",
+            "description": "FullUpdate"
+          },
+          {
+            "name": "PartialUpdate",
+            "value": "PartialUpdate",
+            "description": "PartialUpdate"
+          }
+        ]
+      }
+    },
+    "Severity": {
+      "type": "string",
+      "description": "The severity of the issue.",
+      "enum": [
+        "Error",
+        "Warning"
+      ],
+      "x-ms-enum": {
+        "name": "Severity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Error",
+            "value": "Error",
+            "description": "Error"
+          },
+          {
+            "name": "Warning",
+            "value": "Warning",
+            "description": "Warning"
+          }
+        ]
+      }
+    },
+    "SharingScope": {
+      "type": "string",
+      "description": "Set this property to Tenant to allow sharing subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if subnet is empty.",
+      "enum": [
+        "Tenant",
+        "DelegatedServices"
+      ],
+      "x-ms-enum": {
+        "name": "SharingScope",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Tenant",
+            "value": "Tenant",
+            "description": "Tenant"
+          },
+          {
+            "name": "DelegatedServices",
+            "value": "DelegatedServices",
+            "description": "DelegatedServices"
+          }
+        ]
+      }
+    },
+    "SlotType": {
+      "type": "string",
+      "description": "Specifies slot info on a cloud service",
+      "enum": [
+        "Production",
+        "Staging"
+      ],
+      "x-ms-enum": {
+        "name": "SlotType",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Production",
+            "value": "Production",
+            "description": "Production"
+          },
+          {
+            "name": "Staging",
+            "value": "Staging",
+            "description": "Staging"
+          }
+        ]
+      }
+    },
+    "SubResource": {
+      "type": "object",
+      "description": "Reference to another subresource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        }
+      }
+    },
+    "SubResourceModel": {
+      "type": "object",
+      "description": "Reference to another subresource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource."
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SubResource"
+        }
+      ],
+      "x-ms-azure-resource": true
+    },
+    "SubgroupProfileScope": {
+      "type": "string",
+      "description": "Scope of the subgroup profile.",
+      "enum": [
+        "None",
+        "VerticalConnect"
+      ],
+      "x-ms-enum": {
+        "name": "SubgroupProfileScope",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No subgroup profile scope."
+          },
+          {
+            "name": "VerticalConnect",
+            "value": "VerticalConnect",
+            "description": "VerticalConnect subgroup profile scope."
+          }
+        ]
+      }
+    },
+    "SyncMode": {
+      "type": "string",
+      "description": "Backend address synchronous mode for the backend pool",
+      "enum": [
+        "Automatic",
+        "Manual"
+      ],
+      "x-ms-enum": {
+        "name": "SyncMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Automatic",
+            "value": "Automatic",
+            "description": "Automatic"
+          },
+          {
+            "name": "Manual",
+            "value": "Manual",
+            "description": "Manual"
+          }
+        ]
+      }
+    },
+    "TagsObject": {
+      "type": "object",
+      "description": "Tags object for patch operations.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TrackedResourceWithEtag": {
+      "type": "object",
+      "description": "Tracked resource with optional location.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "ID of the connection monitor.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the connection monitor.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Connection monitor type.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Connection monitor location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Connection monitor tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TrackedResourceWithOptionalLocation": {
+      "type": "object",
+      "description": "Common resource representation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TrackedResourceWithSettableIdOptionalLocation": {
+      "type": "object",
+      "description": "Common resource representation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TrackedResourceWithSettableName": {
+      "type": "object",
+      "description": "Common resource representation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name."
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "TransportProtocol": {
+      "type": "string",
+      "description": "The transport protocol for the endpoint.",
+      "enum": [
+        "Udp",
+        "Tcp",
+        "All",
+        "Quic"
+      ],
+      "x-ms-enum": {
+        "name": "TransportProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Udp",
+            "value": "Udp",
+            "description": "Udp"
+          },
+          {
+            "name": "Tcp",
+            "value": "Tcp",
+            "description": "Tcp"
+          },
+          {
+            "name": "All",
+            "value": "All",
+            "description": "All"
+          },
+          {
+            "name": "Quic",
+            "value": "Quic",
+            "description": "Quic"
+          }
+        ]
+      }
+    },
+    "UpdateAction": {
+      "type": "string",
+      "description": "Specifies the type of update operation to perform on address locations within the service gateway.\n\n- FullUpdate: Replaces all existing address location data with the new list provided in the request. Any previously defined locations not included will be removed.\n- PartialUpdate: Updates only the specified address locations.",
+      "enum": [
+        "FullUpdate",
+        "PartialUpdate"
+      ],
+      "x-ms-enum": {
+        "name": "UpdateAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FullUpdate",
+            "value": "FullUpdate",
+            "description": "FullUpdate"
+          },
+          {
+            "name": "PartialUpdate",
+            "value": "PartialUpdate",
+            "description": "PartialUpdate"
+          }
+        ]
+      }
+    },
+    "UsageUnit": {
+      "type": "string",
+      "description": "An enum describing the unit of measurement.",
+      "enum": [
+        "Count"
+      ],
+      "x-ms-enum": {
+        "name": "UsageUnit",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Count",
+            "value": "Count",
+            "description": "Count"
+          }
+        ]
+      }
+    },
+    "UseHubGateway": {
+      "type": "string",
+      "description": "Flag if need to use hub gateway.",
+      "enum": [
+        "False",
+        "True"
+      ],
+      "x-ms-enum": {
+        "name": "UseHubGateway",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "False",
+            "value": "False",
+            "description": "False"
+          },
+          {
+            "name": "True",
+            "value": "True",
+            "description": "True"
+          }
+        ]
+      }
+    },
+    "VerbosityLevel": {
+      "type": "string",
+      "description": "Verbosity level.",
+      "enum": [
+        "Normal",
+        "Minimum",
+        "Full"
+      ],
+      "x-ms-enum": {
+        "name": "VerbosityLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Normal",
+            "value": "Normal",
+            "description": "Normal"
+          },
+          {
+            "name": "Minimum",
+            "value": "Minimum",
+            "description": "Minimum"
+          },
+          {
+            "name": "Full",
+            "value": "Full",
+            "description": "Full"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkApplianceIpVersionType": {
+      "type": "string",
+      "description": "IP address version.",
+      "enum": [
+        "IPv4",
+        "DualStack"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkApplianceIpVersionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPv4",
+            "value": "IPv4",
+            "description": "IPv4 version"
+          },
+          {
+            "name": "DualStack",
+            "value": "DualStack",
+            "description": "Dual Stack version"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkEncryptionEnforcement": {
+      "type": "string",
+      "description": "If the encrypted VNet allows VM that does not support encryption. This field is for future support, AllowUnencrypted is the only supported value at general availability.",
+      "enum": [
+        "DropUnencrypted",
+        "AllowUnencrypted"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkEncryptionEnforcement",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "DropUnencrypted",
+            "value": "DropUnencrypted",
+            "description": "DropUnencrypted"
+          },
+          {
+            "name": "AllowUnencrypted",
+            "value": "AllowUnencrypted",
+            "description": "AllowUnencrypted"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkGatewayConnectionMode": {
+      "type": "string",
+      "description": "Gateway connection type.",
+      "enum": [
+        "Default",
+        "ResponderOnly",
+        "InitiatorOnly"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkGatewayConnectionMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default"
+          },
+          {
+            "name": "ResponderOnly",
+            "value": "ResponderOnly",
+            "description": "ResponderOnly"
+          },
+          {
+            "name": "InitiatorOnly",
+            "value": "InitiatorOnly",
+            "description": "InitiatorOnly"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkGatewayConnectionProtocol": {
+      "type": "string",
+      "description": "Gateway connection protocol.",
+      "enum": [
+        "IKEv2",
+        "IKEv1"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkGatewayConnectionProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IKEv2",
+            "value": "IKEv2",
+            "description": "IKEv2"
+          },
+          {
+            "name": "IKEv1",
+            "value": "IKEv1",
+            "description": "IKEv1"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkGatewayConnectionStatus": {
+      "type": "string",
+      "description": "Virtual Network Gateway connection status.",
+      "enum": [
+        "Unknown",
+        "Connecting",
+        "Connected",
+        "NotConnected"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkGatewayConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "Connecting",
+            "value": "Connecting",
+            "description": "Connecting"
+          },
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected"
+          },
+          {
+            "name": "NotConnected",
+            "value": "NotConnected",
+            "description": "NotConnected"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkGatewayConnectionType": {
+      "type": "string",
+      "description": "Gateway connection type.",
+      "enum": [
+        "IPsec",
+        "Vnet2Vnet",
+        "ExpressRoute",
+        "VPNClient"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkGatewayConnectionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPsec",
+            "value": "IPsec",
+            "description": "IPsec"
+          },
+          {
+            "name": "Vnet2Vnet",
+            "value": "Vnet2Vnet",
+            "description": "Vnet2Vnet"
+          },
+          {
+            "name": "ExpressRoute",
+            "value": "ExpressRoute",
+            "description": "ExpressRoute"
+          },
+          {
+            "name": "VPNClient",
+            "value": "VPNClient",
+            "description": "VPNClient"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkGatewayMigrationPhase": {
+      "type": "string",
+      "description": "Represent the current migration phase of gateway.",
+      "enum": [
+        "None",
+        "Prepare",
+        "PrepareSucceeded",
+        "Execute",
+        "ExecuteSucceeded",
+        "Commit",
+        "CommitSucceeded",
+        "AbortSucceeded",
+        "Abort"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkGatewayMigrationPhase",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No migration phase set on gateway."
+          },
+          {
+            "name": "Prepare",
+            "value": "Prepare",
+            "description": "Gateway is going through prepare migration or prepare has failed. Please see state and error details for more information."
+          },
+          {
+            "name": "PrepareSucceeded",
+            "value": "PrepareSucceeded",
+            "description": "Prepare succeeded on gateway."
+          },
+          {
+            "name": "Execute",
+            "value": "Execute",
+            "description": "Gateway is going through execute migration or execute has failed. Please see state and error details for more information."
+          },
+          {
+            "name": "ExecuteSucceeded",
+            "value": "ExecuteSucceeded",
+            "description": "Execute succeeded on gateway."
+          },
+          {
+            "name": "Commit",
+            "value": "Commit",
+            "description": "Gateway is going through commit migration or commit has failed. Please see state and error details for more information."
+          },
+          {
+            "name": "CommitSucceeded",
+            "value": "CommitSucceeded",
+            "description": "Commit succeeded, represent migration is complete for the gateway."
+          },
+          {
+            "name": "AbortSucceeded",
+            "value": "AbortSucceeded",
+            "description": "Represent abort succeeded on gateway, start with prepare to retrigger migration."
+          },
+          {
+            "name": "Abort",
+            "value": "Abort",
+            "description": "Gateway is going through abort migration or abort has failed. Please see state and error details for more information."
+          }
+        ]
+      }
+    },
+    "VirtualNetworkGatewayMigrationState": {
+      "type": "string",
+      "description": "Represent the current state of gateway migration.",
+      "enum": [
+        "None",
+        "InProgress",
+        "Succeeded",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkGatewayMigrationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "InProgress"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkGatewayMigrationType": {
+      "type": "string",
+      "description": "MigrationType for the virtual network gateway.",
+      "enum": [
+        "UpgradeDeploymentToStandardIP"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkGatewayMigrationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "UpgradeDeploymentToStandardIP",
+            "value": "UpgradeDeploymentToStandardIP",
+            "description": "Indicates that it is a migration process from basic IP CSES to standard IP VMSS."
+          }
+        ]
+      }
+    },
+    "VirtualNetworkGatewaySkuName": {
+      "type": "string",
+      "description": "Gateway SKU name.",
+      "enum": [
+        "Basic",
+        "HighPerformance",
+        "Standard",
+        "UltraPerformance",
+        "VpnGw1",
+        "VpnGw2",
+        "VpnGw3",
+        "VpnGw4",
+        "VpnGw5",
+        "VpnGw1AZ",
+        "VpnGw2AZ",
+        "VpnGw3AZ",
+        "VpnGw4AZ",
+        "VpnGw5AZ",
+        "ErGw1AZ",
+        "ErGw2AZ",
+        "ErGw3AZ",
+        "ErGwScale"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkGatewaySkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          },
+          {
+            "name": "HighPerformance",
+            "value": "HighPerformance",
+            "description": "HighPerformance"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "UltraPerformance",
+            "value": "UltraPerformance",
+            "description": "UltraPerformance"
+          },
+          {
+            "name": "VpnGw1",
+            "value": "VpnGw1",
+            "description": "VpnGw1"
+          },
+          {
+            "name": "VpnGw2",
+            "value": "VpnGw2",
+            "description": "VpnGw2"
+          },
+          {
+            "name": "VpnGw3",
+            "value": "VpnGw3",
+            "description": "VpnGw3"
+          },
+          {
+            "name": "VpnGw4",
+            "value": "VpnGw4",
+            "description": "VpnGw4"
+          },
+          {
+            "name": "VpnGw5",
+            "value": "VpnGw5",
+            "description": "VpnGw5"
+          },
+          {
+            "name": "VpnGw1AZ",
+            "value": "VpnGw1AZ",
+            "description": "VpnGw1AZ"
+          },
+          {
+            "name": "VpnGw2AZ",
+            "value": "VpnGw2AZ",
+            "description": "VpnGw2AZ"
+          },
+          {
+            "name": "VpnGw3AZ",
+            "value": "VpnGw3AZ",
+            "description": "VpnGw3AZ"
+          },
+          {
+            "name": "VpnGw4AZ",
+            "value": "VpnGw4AZ",
+            "description": "VpnGw4AZ"
+          },
+          {
+            "name": "VpnGw5AZ",
+            "value": "VpnGw5AZ",
+            "description": "VpnGw5AZ"
+          },
+          {
+            "name": "ErGw1AZ",
+            "value": "ErGw1AZ",
+            "description": "ErGw1AZ"
+          },
+          {
+            "name": "ErGw2AZ",
+            "value": "ErGw2AZ",
+            "description": "ErGw2AZ"
+          },
+          {
+            "name": "ErGw3AZ",
+            "value": "ErGw3AZ",
+            "description": "ErGw3AZ"
+          },
+          {
+            "name": "ErGwScale",
+            "value": "ErGwScale",
+            "description": "ErGwScale"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkGatewaySkuTier": {
+      "type": "string",
+      "description": "Gateway SKU tier.",
+      "enum": [
+        "Basic",
+        "HighPerformance",
+        "Standard",
+        "UltraPerformance",
+        "VpnGw1",
+        "VpnGw2",
+        "VpnGw3",
+        "VpnGw4",
+        "VpnGw5",
+        "VpnGw1AZ",
+        "VpnGw2AZ",
+        "VpnGw3AZ",
+        "VpnGw4AZ",
+        "VpnGw5AZ",
+        "ErGw1AZ",
+        "ErGw2AZ",
+        "ErGw3AZ",
+        "ErGwScale"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkGatewaySkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Basic",
+            "value": "Basic",
+            "description": "Basic"
+          },
+          {
+            "name": "HighPerformance",
+            "value": "HighPerformance",
+            "description": "HighPerformance"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "UltraPerformance",
+            "value": "UltraPerformance",
+            "description": "UltraPerformance"
+          },
+          {
+            "name": "VpnGw1",
+            "value": "VpnGw1",
+            "description": "VpnGw1"
+          },
+          {
+            "name": "VpnGw2",
+            "value": "VpnGw2",
+            "description": "VpnGw2"
+          },
+          {
+            "name": "VpnGw3",
+            "value": "VpnGw3",
+            "description": "VpnGw3"
+          },
+          {
+            "name": "VpnGw4",
+            "value": "VpnGw4",
+            "description": "VpnGw4"
+          },
+          {
+            "name": "VpnGw5",
+            "value": "VpnGw5",
+            "description": "VpnGw5"
+          },
+          {
+            "name": "VpnGw1AZ",
+            "value": "VpnGw1AZ",
+            "description": "VpnGw1AZ"
+          },
+          {
+            "name": "VpnGw2AZ",
+            "value": "VpnGw2AZ",
+            "description": "VpnGw2AZ"
+          },
+          {
+            "name": "VpnGw3AZ",
+            "value": "VpnGw3AZ",
+            "description": "VpnGw3AZ"
+          },
+          {
+            "name": "VpnGw4AZ",
+            "value": "VpnGw4AZ",
+            "description": "VpnGw4AZ"
+          },
+          {
+            "name": "VpnGw5AZ",
+            "value": "VpnGw5AZ",
+            "description": "VpnGw5AZ"
+          },
+          {
+            "name": "ErGw1AZ",
+            "value": "ErGw1AZ",
+            "description": "ErGw1AZ"
+          },
+          {
+            "name": "ErGw2AZ",
+            "value": "ErGw2AZ",
+            "description": "ErGw2AZ"
+          },
+          {
+            "name": "ErGw3AZ",
+            "value": "ErGw3AZ",
+            "description": "ErGw3AZ"
+          },
+          {
+            "name": "ErGwScale",
+            "value": "ErGwScale",
+            "description": "ErGwScale"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkGatewayType": {
+      "type": "string",
+      "description": "The type of this virtual network gateway.",
+      "enum": [
+        "Vpn",
+        "ExpressRoute",
+        "LocalGateway"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkGatewayType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Vpn",
+            "value": "Vpn",
+            "description": "Vpn"
+          },
+          {
+            "name": "ExpressRoute",
+            "value": "ExpressRoute",
+            "description": "ExpressRoute"
+          },
+          {
+            "name": "LocalGateway",
+            "value": "LocalGateway",
+            "description": "LocalGateway"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkPeeringLevel": {
+      "type": "string",
+      "description": "The peering sync status of the virtual network peering.",
+      "enum": [
+        "FullyInSync",
+        "RemoteNotInSync",
+        "LocalNotInSync",
+        "LocalAndRemoteNotInSync"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkPeeringLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FullyInSync",
+            "value": "FullyInSync",
+            "description": "FullyInSync"
+          },
+          {
+            "name": "RemoteNotInSync",
+            "value": "RemoteNotInSync",
+            "description": "RemoteNotInSync"
+          },
+          {
+            "name": "LocalNotInSync",
+            "value": "LocalNotInSync",
+            "description": "LocalNotInSync"
+          },
+          {
+            "name": "LocalAndRemoteNotInSync",
+            "value": "LocalAndRemoteNotInSync",
+            "description": "LocalAndRemoteNotInSync"
+          }
+        ]
+      }
+    },
+    "VirtualNetworkPeeringState": {
+      "type": "string",
+      "description": "The status of the virtual network peering.",
+      "enum": [
+        "Initiated",
+        "Connected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualNetworkPeeringState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Initiated",
+            "value": "Initiated",
+            "description": "Initiated"
+          },
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Disconnected"
+          }
+        ]
+      }
+    },
+    "VirtualWanSecurityProviderType": {
+      "type": "string",
+      "description": "The virtual wan security provider type.",
+      "enum": [
+        "External",
+        "Native"
+      ],
+      "x-ms-enum": {
+        "name": "VirtualWanSecurityProviderType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "External",
+            "value": "External",
+            "description": "External"
+          },
+          {
+            "name": "Native",
+            "value": "Native",
+            "description": "Native"
+          }
+        ]
+      }
+    },
+    "VnetLocalRouteOverrideCriteria": {
+      "type": "string",
+      "description": "Parameter determining whether NVA in spoke vnet is bypassed for traffic with destination in spoke vnet.",
+      "enum": [
+        "Contains",
+        "Equal"
+      ],
+      "x-ms-enum": {
+        "name": "VnetLocalRouteOverrideCriteria",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Contains",
+            "value": "Contains",
+            "description": "Contains"
+          },
+          {
+            "name": "Equal",
+            "value": "Equal",
+            "description": "Equal"
+          }
+        ]
+      }
+    },
+    "VpnAuthenticationType": {
+      "type": "string",
+      "description": "VPN authentication types enabled for the virtual network gateway.",
+      "enum": [
+        "Certificate",
+        "Radius",
+        "AAD"
+      ],
+      "x-ms-enum": {
+        "name": "VpnAuthenticationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Certificate",
+            "value": "Certificate",
+            "description": "Certificate"
+          },
+          {
+            "name": "Radius",
+            "value": "Radius",
+            "description": "Radius"
+          },
+          {
+            "name": "AAD",
+            "value": "AAD",
+            "description": "AAD"
+          }
+        ]
+      }
+    },
+    "VpnClientProtocol": {
+      "type": "string",
+      "description": "VPN client protocol enabled for the virtual network gateway.",
+      "enum": [
+        "IkeV2",
+        "SSTP",
+        "OpenVPN"
+      ],
+      "x-ms-enum": {
+        "name": "VpnClientProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IkeV2",
+            "value": "IkeV2",
+            "description": "IkeV2"
+          },
+          {
+            "name": "SSTP",
+            "value": "SSTP",
+            "description": "SSTP"
+          },
+          {
+            "name": "OpenVPN",
+            "value": "OpenVPN",
+            "description": "OpenVPN"
+          }
+        ]
+      }
+    },
+    "VpnConnectionStatus": {
+      "type": "string",
+      "description": "The current state of the vpn connection.",
+      "enum": [
+        "Unknown",
+        "Connecting",
+        "Connected",
+        "NotConnected"
+      ],
+      "x-ms-enum": {
+        "name": "VpnConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "Connecting",
+            "value": "Connecting",
+            "description": "Connecting"
+          },
+          {
+            "name": "Connected",
+            "value": "Connected",
+            "description": "Connected"
+          },
+          {
+            "name": "NotConnected",
+            "value": "NotConnected",
+            "description": "NotConnected"
+          }
+        ]
+      }
+    },
+    "VpnGatewayGeneration": {
+      "type": "string",
+      "description": "The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN.",
+      "enum": [
+        "None",
+        "Generation1",
+        "Generation2"
+      ],
+      "x-ms-enum": {
+        "name": "VpnGatewayGeneration",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          },
+          {
+            "name": "Generation1",
+            "value": "Generation1",
+            "description": "Generation1"
+          },
+          {
+            "name": "Generation2",
+            "value": "Generation2",
+            "description": "Generation2"
+          }
+        ]
+      }
+    },
+    "VpnGatewayTunnelingProtocol": {
+      "type": "string",
+      "description": "VPN protocol enabled for the VpnServerConfiguration.",
+      "enum": [
+        "IkeV2",
+        "OpenVPN"
+      ],
+      "x-ms-enum": {
+        "name": "VpnGatewayTunnelingProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IkeV2",
+            "value": "IkeV2",
+            "description": "IkeV2"
+          },
+          {
+            "name": "OpenVPN",
+            "value": "OpenVPN",
+            "description": "OpenVPN"
+          }
+        ]
+      }
+    },
+    "VpnLinkConnectionMode": {
+      "type": "string",
+      "description": "Vpn link connection mode.",
+      "enum": [
+        "Default",
+        "ResponderOnly",
+        "InitiatorOnly"
+      ],
+      "x-ms-enum": {
+        "name": "VpnLinkConnectionMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default"
+          },
+          {
+            "name": "ResponderOnly",
+            "value": "ResponderOnly",
+            "description": "ResponderOnly"
+          },
+          {
+            "name": "InitiatorOnly",
+            "value": "InitiatorOnly",
+            "description": "InitiatorOnly"
+          }
+        ]
+      }
+    },
+    "VpnNatRuleMode": {
+      "type": "string",
+      "description": "The Source NAT direction of a VPN NAT.",
+      "enum": [
+        "EgressSnat",
+        "IngressSnat"
+      ],
+      "x-ms-enum": {
+        "name": "VpnNatRuleMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EgressSnat",
+            "value": "EgressSnat",
+            "description": "EgressSnat"
+          },
+          {
+            "name": "IngressSnat",
+            "value": "IngressSnat",
+            "description": "IngressSnat"
+          }
+        ]
+      }
+    },
+    "VpnNatRuleType": {
+      "type": "string",
+      "description": "The type of NAT rule for VPN NAT.",
+      "enum": [
+        "Static",
+        "Dynamic"
+      ],
+      "x-ms-enum": {
+        "name": "VpnNatRuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Static",
+            "value": "Static",
+            "description": "Static"
+          },
+          {
+            "name": "Dynamic",
+            "value": "Dynamic",
+            "description": "Dynamic"
+          }
+        ]
+      }
+    },
+    "VpnPolicyMemberAttributeType": {
+      "type": "string",
+      "description": "The Vpn Policy member attribute type.",
+      "enum": [
+        "CertificateGroupId",
+        "AADGroupId",
+        "RadiusAzureGroupId"
+      ],
+      "x-ms-enum": {
+        "name": "VpnPolicyMemberAttributeType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "CertificateGroupId",
+            "value": "CertificateGroupId",
+            "description": "CertificateGroupId"
+          },
+          {
+            "name": "AADGroupId",
+            "value": "AADGroupId",
+            "description": "AADGroupId"
+          },
+          {
+            "name": "RadiusAzureGroupId",
+            "value": "RadiusAzureGroupId",
+            "description": "RadiusAzureGroupId"
+          }
+        ]
+      }
+    },
+    "VpnType": {
+      "type": "string",
+      "description": "The type of this virtual network gateway.",
+      "enum": [
+        "PolicyBased",
+        "RouteBased"
+      ],
+      "x-ms-enum": {
+        "name": "VpnType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PolicyBased",
+            "value": "PolicyBased",
+            "description": "PolicyBased"
+          },
+          {
+            "name": "RouteBased",
+            "value": "RouteBased",
+            "description": "RouteBased"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallAction": {
+      "type": "string",
+      "description": "Type of Actions.",
+      "enum": [
+        "Allow",
+        "Block",
+        "Log",
+        "JSChallenge",
+        "CAPTCHA"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          },
+          {
+            "name": "Block",
+            "value": "Block",
+            "description": "Block"
+          },
+          {
+            "name": "Log",
+            "value": "Log",
+            "description": "Log"
+          },
+          {
+            "name": "JSChallenge",
+            "value": "JSChallenge",
+            "description": "JSChallenge"
+          },
+          {
+            "name": "CAPTCHA",
+            "value": "CAPTCHA",
+            "description": "CAPTCHA"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallEnabledState": {
+      "type": "string",
+      "description": "The state of the policy.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallEnabledState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallMatchVariable": {
+      "type": "string",
+      "description": "Match Variable.",
+      "enum": [
+        "RemoteAddr",
+        "RequestMethod",
+        "QueryString",
+        "PostArgs",
+        "RequestUri",
+        "RequestHeaders",
+        "RequestBody",
+        "RequestCookies"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallMatchVariable",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "RemoteAddr",
+            "value": "RemoteAddr",
+            "description": "RemoteAddr"
+          },
+          {
+            "name": "RequestMethod",
+            "value": "RequestMethod",
+            "description": "RequestMethod"
+          },
+          {
+            "name": "QueryString",
+            "value": "QueryString",
+            "description": "QueryString"
+          },
+          {
+            "name": "PostArgs",
+            "value": "PostArgs",
+            "description": "PostArgs"
+          },
+          {
+            "name": "RequestUri",
+            "value": "RequestUri",
+            "description": "RequestUri"
+          },
+          {
+            "name": "RequestHeaders",
+            "value": "RequestHeaders",
+            "description": "RequestHeaders"
+          },
+          {
+            "name": "RequestBody",
+            "value": "RequestBody",
+            "description": "RequestBody"
+          },
+          {
+            "name": "RequestCookies",
+            "value": "RequestCookies",
+            "description": "RequestCookies"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallMode": {
+      "type": "string",
+      "description": "The mode of the policy.",
+      "enum": [
+        "Prevention",
+        "Detection"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Prevention",
+            "value": "Prevention",
+            "description": "Prevention"
+          },
+          {
+            "name": "Detection",
+            "value": "Detection",
+            "description": "Detection"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallOperator": {
+      "type": "string",
+      "description": "The operator to be matched.",
+      "enum": [
+        "IPMatch",
+        "Equal",
+        "Contains",
+        "LessThan",
+        "GreaterThan",
+        "LessThanOrEqual",
+        "GreaterThanOrEqual",
+        "BeginsWith",
+        "EndsWith",
+        "Regex",
+        "GeoMatch",
+        "Any"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallOperator",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "IPMatch",
+            "value": "IPMatch",
+            "description": "IPMatch"
+          },
+          {
+            "name": "Equal",
+            "value": "Equal",
+            "description": "Equal"
+          },
+          {
+            "name": "Contains",
+            "value": "Contains",
+            "description": "Contains"
+          },
+          {
+            "name": "LessThan",
+            "value": "LessThan",
+            "description": "LessThan"
+          },
+          {
+            "name": "GreaterThan",
+            "value": "GreaterThan",
+            "description": "GreaterThan"
+          },
+          {
+            "name": "LessThanOrEqual",
+            "value": "LessThanOrEqual",
+            "description": "LessThanOrEqual"
+          },
+          {
+            "name": "GreaterThanOrEqual",
+            "value": "GreaterThanOrEqual",
+            "description": "GreaterThanOrEqual"
+          },
+          {
+            "name": "BeginsWith",
+            "value": "BeginsWith",
+            "description": "BeginsWith"
+          },
+          {
+            "name": "EndsWith",
+            "value": "EndsWith",
+            "description": "EndsWith"
+          },
+          {
+            "name": "Regex",
+            "value": "Regex",
+            "description": "Regex"
+          },
+          {
+            "name": "GeoMatch",
+            "value": "GeoMatch",
+            "description": "GeoMatch"
+          },
+          {
+            "name": "Any",
+            "value": "Any",
+            "description": "Any"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallPolicyResourceState": {
+      "type": "string",
+      "description": "Resource status of the policy.",
+      "enum": [
+        "Creating",
+        "Enabling",
+        "Enabled",
+        "Disabling",
+        "Disabled",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallPolicyResourceState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Enabling",
+            "value": "Enabling",
+            "description": "Enabling"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabling",
+            "value": "Disabling",
+            "description": "Disabling"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallRuleType": {
+      "type": "string",
+      "description": "The rule type.",
+      "enum": [
+        "MatchRule",
+        "RateLimitRule",
+        "Invalid"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallRuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "MatchRule",
+            "value": "MatchRule",
+            "description": "MatchRule"
+          },
+          {
+            "name": "RateLimitRule",
+            "value": "RateLimitRule",
+            "description": "RateLimitRule"
+          },
+          {
+            "name": "Invalid",
+            "value": "Invalid",
+            "description": "Invalid"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallScrubbingState": {
+      "type": "string",
+      "description": "State of the log scrubbing config. Default value is Enabled.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallScrubbingState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallState": {
+      "type": "string",
+      "description": "Describes if the custom rule is in enabled or disabled state. Defaults to Enabled if not specified.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          }
+        ]
+      }
+    },
+    "WebApplicationFirewallTransform": {
+      "type": "string",
+      "description": "Transforms applied before matching.",
+      "enum": [
+        "Uppercase",
+        "Lowercase",
+        "Trim",
+        "UrlDecode",
+        "UrlEncode",
+        "RemoveNulls",
+        "HtmlEntityDecode"
+      ],
+      "x-ms-enum": {
+        "name": "WebApplicationFirewallTransform",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Uppercase",
+            "value": "Uppercase",
+            "description": "Uppercase"
+          },
+          {
+            "name": "Lowercase",
+            "value": "Lowercase",
+            "description": "Lowercase"
+          },
+          {
+            "name": "Trim",
+            "value": "Trim",
+            "description": "Trim"
+          },
+          {
+            "name": "UrlDecode",
+            "value": "UrlDecode",
+            "description": "UrlDecode"
+          },
+          {
+            "name": "UrlEncode",
+            "value": "UrlEncode",
+            "description": "UrlEncode"
+          },
+          {
+            "name": "RemoveNulls",
+            "value": "RemoveNulls",
+            "description": "RemoveNulls"
+          },
+          {
+            "name": "HtmlEntityDecode",
+            "value": "HtmlEntityDecode",
+            "description": "HtmlEntityDecode"
+          }
+        ]
+      }
+    },
+    "WritableResource": {
+      "type": "object",
+      "description": "Common resource representation.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name."
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type."
+        }
+      },
+      "x-ms-azure-resource": true
+    },
+    "scrubbingRuleEntryMatchOperator": {
+      "type": "string",
+      "description": "When matchVariable is a collection, operate on the selector to specify which elements in the collection this rule applies to.",
+      "enum": [
+        "Equals",
+        "EqualsAny"
+      ],
+      "x-ms-enum": {
+        "name": "scrubbingRuleEntryMatchOperator",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Equals",
+            "value": "Equals",
+            "description": "Equals"
+          },
+          {
+            "name": "EqualsAny",
+            "value": "EqualsAny",
+            "description": "EqualsAny"
+          }
+        ]
+      }
+    },
+    "scrubbingRuleEntryState": {
+      "type": "string",
+      "description": "Defines the state of log scrubbing rule. Default value is Enabled.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "scrubbingRuleEntryState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "stringApplicationJson": {
+      "type": "string"
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterDelete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "testNSP1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NetworkSecurityPerimeterDelete",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/networkSecurityPerimeterOperationStatuses/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeters_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterGet.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NetworkSecurityPerimeterGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "nsp1",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+        "location": "East US 2 EUAP",
+        "properties": {
+          "perimeterGuid": "guid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterList.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "List Network Security Perimeter",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "testNSP1",
+            "type": "Microsoft.Network/networkSecurityPerimeters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/testNSP1",
+            "location": "East US 2 EUAP",
+            "properties": {
+              "perimeterGuid": "guid",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          },
+          {
+            "name": "testNSP2",
+            "type": "Microsoft.Network/networkSecurityPerimeters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/testNSP2",
+            "location": "East US 2 EUAP",
+            "properties": {
+              "perimeterGuid": "guid",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterListAll.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterListAll.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NetworkSecurityPerimetersList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/networkSecurityPerimeters?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "testNSP1",
+            "type": "Microsoft.Network/networkSecurityPerimeters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/testNSP1",
+            "location": "East US 2 EUAP",
+            "properties": {
+              "perimeterGuid": "guid",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          },
+          {
+            "name": "testNSP2",
+            "type": "Microsoft.Network/networkSecurityPerimeters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/testNSP2",
+            "location": "East US 2 EUAP",
+            "properties": {
+              "perimeterGuid": "guid",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_ListBySubscription"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterPatch.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterPatch.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "tags": {
+        "description": "nsp1"
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Patch Network Security Perimeter",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "TestNetworkSecurityPerimeter",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/TestNetworkSecurityPerimeter",
+        "location": "East US 2 EUAP",
+        "properties": {
+          "perimeterGuid": "guid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        },
+        "tags": {
+          "description": "nsp1"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_Patch"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterPut.json
@@ -1,0 +1,58 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "location": "location1",
+      "properties": {}
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Put Network Security Perimeter",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "TestNetworkSecurityPerimeter",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/TestNetworkSecurityPerimeter",
+        "location": "East US 2 EUAP",
+        "properties": {
+          "perimeterGuid": "guid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "TestNetworkSecurityPerimeter",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/TestNetworkSecurityPerimeter",
+        "location": "East US 2 EUAP",
+        "properties": {
+          "perimeterGuid": "guid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterPutGeoLinked.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NetworkSecurityPerimeterPutGeoLinked.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "geoLinkedNsp",
+    "parameters": {
+      "location": "eastus2",
+      "properties": {
+        "createMode": "GeoLinkedPerimeter",
+        "remotePerimeterId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/source-rg/providers/Microsoft.Network/networkSecurityPerimeters/source-nsp"
+      }
+    },
+    "resourceGroupName": "geo-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Create a geo-linked Network Security Perimeter",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "geoLinkedNsp",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/geo-rg/providers/Microsoft.Network/networkSecurityPerimeters/geoLinkedNsp",
+        "location": "eastus2",
+        "properties": {
+          "createMode": "GeoLinkedPerimeter",
+          "remotePerimeterId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/source-rg/providers/Microsoft.Network/networkSecurityPerimeters/source-nsp",
+          "perimeterGuid": "00000000-0000-0000-0000-000000000001",
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "geoLinkedNsp",
+        "type": "Microsoft.Network/networkSecurityPerimeters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/geo-rg/providers/Microsoft.Network/networkSecurityPerimeters/geoLinkedNsp",
+        "location": "eastus2",
+        "properties": {
+          "createMode": "GeoLinkedPerimeter",
+          "remotePerimeterId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/source-rg/providers/Microsoft.Network/networkSecurityPerimeters/source-nsp",
+          "perimeterGuid": "00000000-0000-0000-0000-000000000001",
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeters_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAccessRuleDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAccessRuleDelete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "accessRuleName": "accessRule1",
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAccessRulesDelete",
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterAccessRules_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAccessRuleGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAccessRuleGet.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "accessRuleName": "accessRule1",
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAccessRuleGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "accessRule1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules/accessRule1",
+        "properties": {
+          "addressPrefixes": [],
+          "direction": "Outbound",
+          "emailAddresses": [],
+          "fullyQualifiedDomainNames": [
+            "paasrp1.contoso.org",
+            "paasrp2.contoso.org"
+          ],
+          "networkSecurityPerimeters": [],
+          "phoneNumbers": [],
+          "provisioningState": "Succeeded",
+          "serviceTags": [],
+          "subscriptions": []
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAccessRules_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAccessRuleList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAccessRuleList.json
@@ -1,0 +1,74 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAccessRulesList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "accessRule1",
+            "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules",
+            "id": "/subscriptions/rg1/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules/accessRule1",
+            "properties": {
+              "addressPrefixes": [
+                "10.11.0.0/16",
+                "10.10.1.0/24"
+              ],
+              "direction": "Inbound",
+              "emailAddresses": [],
+              "fullyQualifiedDomainNames": [],
+              "networkSecurityPerimeters": [],
+              "phoneNumbers": [],
+              "provisioningState": "Succeeded",
+              "serviceTags": [],
+              "subscriptions": []
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "accessRule2",
+            "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules/accessRule2",
+            "properties": {
+              "addressPrefixes": [],
+              "direction": "Outbound",
+              "emailAddresses": [],
+              "fullyQualifiedDomainNames": [
+                "paasrp1.contoso.org",
+                "paasrp2.contoso.org"
+              ],
+              "networkSecurityPerimeters": [],
+              "phoneNumbers": [],
+              "provisioningState": "Succeeded",
+              "serviceTags": [],
+              "subscriptions": []
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAccessRules_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAccessRulePut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAccessRulePut.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "accessRuleName": "accessRule1",
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {
+        "addressPrefixes": [
+          "10.11.0.0/16",
+          "10.10.1.0/24"
+        ],
+        "direction": "Inbound"
+      }
+    },
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAccessRulePut",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "accessRule1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules/accessRule1",
+        "properties": {
+          "addressPrefixes": [
+            "10.11.0.0/16",
+            "10.10.1.0/24"
+          ],
+          "direction": "Inbound",
+          "emailAddresses": [],
+          "fullyQualifiedDomainNames": [],
+          "networkSecurityPerimeters": [],
+          "phoneNumbers": [],
+          "provisioningState": "Succeeded",
+          "serviceTags": [],
+          "subscriptions": []
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "accessRule1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles/accessRules",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1/accessRules/accessRule1",
+        "properties": {
+          "addressPrefixes": [
+            "10.11.0.0/16",
+            "10.10.1.0/24"
+          ],
+          "direction": "Inbound",
+          "emailAddresses": [],
+          "fullyQualifiedDomainNames": [],
+          "networkSecurityPerimeters": [],
+          "phoneNumbers": [],
+          "provisioningState": "Succeeded",
+          "serviceTags": [],
+          "subscriptions": []
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAccessRules_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAccessRuleReconcile.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAccessRuleReconcile.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "accessRuleName": "accessRuleName1",
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {}
+    },
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAccessRuleReconcile",
+  "responses": {
+    "200": {
+      "body": {}
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAccessRules_Reconcile"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAssociationDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAssociationDelete.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "operationId": "operationId1",
+    "api-version": "2026-08-01-preview",
+    "associationName": "association1",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAssociationDelete",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/networkSecurityPerimeterOperationStatuses/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterAssociations_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAssociationGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAssociationGet.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "associationName": "association1",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAssociationGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "association1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association1",
+        "properties": {
+          "accessMode": "Enforced",
+          "hasProvisioningIssues": "no",
+          "privateLinkResource": {
+            "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+          },
+          "profile": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAssociations_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAssociationList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAssociationList.json
@@ -1,0 +1,91 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAssociationList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "association1",
+            "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association1",
+            "properties": {
+              "accessMode": "Enforced",
+              "hasProvisioningIssues": "no",
+              "privateLinkResource": {
+                "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+              },
+              "profile": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "association2",
+            "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association2",
+            "properties": {
+              "accessMode": "Audit",
+              "hasProvisioningIssues": "no",
+              "privateLinkResource": {
+                "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+              },
+              "profile": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "association3",
+            "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association3",
+            "properties": {
+              "accessMode": "Learning",
+              "hasProvisioningIssues": "yes",
+              "privateLinkResource": {
+                "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+              },
+              "profile": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+              },
+              "provisioningState": "Failed"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAssociations_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAssociationPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAssociationPut.json
@@ -1,0 +1,105 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "associationName": "association1",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {
+        "accessMode": "Enforced",
+        "privateLinkResource": {
+          "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+        },
+        "profile": {
+          "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+        }
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAssociationPut",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "association1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association1",
+        "properties": {
+          "accessMode": "Enforced",
+          "hasProvisioningIssues": "no",
+          "privateLinkResource": {
+            "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+          },
+          "profile": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "association1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association1",
+        "properties": {
+          "accessMode": "Enforced",
+          "hasProvisioningIssues": "no",
+          "privateLinkResource": {
+            "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+          },
+          "profile": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "association1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/resourceAssociations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/resourceAssociations/association1",
+        "properties": {
+          "accessMode": "Learning",
+          "hasProvisioningIssues": "no",
+          "privateLinkResource": {
+            "id": "/subscriptions/{paasSubscriptionId}/resourceGroups/{paasResourceGroupName}/providers/{providerName}/{resourceType}/{resourceName}"
+          },
+          "profile": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/{profileName}"
+          },
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/networkSecurityPerimeterOperationStatuses/{operationId}?api-version={api-version}"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAssociations_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAssociationReconcile.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspAssociationReconcile.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "associationName": "association1",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {}
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspAssociationReconcile",
+  "responses": {
+    "200": {
+      "body": {}
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAssociations_Reconcile"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkDelete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "linkName": "link1",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinkDelete",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/links/{linkName}/operationResults/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterLinks_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkGet.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "linkName": "link1",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinksGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "link1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/links",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/links/link1",
+        "properties": {
+          "description": "Auto Approved",
+          "autoApprovedRemotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2",
+          "localInboundProfiles": [
+            "*"
+          ],
+          "localOutboundProfiles": [
+            "*"
+          ],
+          "provisioningState": "Succeeded",
+          "remoteInboundProfiles": [
+            "*"
+          ],
+          "remoteOutboundProfiles": [
+            "*"
+          ],
+          "remotePerimeterGuid": "guid",
+          "remotePerimeterLocation": "westus2",
+          "status": "Approved"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLinks_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkList.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinkList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/links?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "link1",
+            "type": "Microsoft.Network/networkSecurityPerimeters/links",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/links/link1",
+            "properties": {
+              "description": "Auto Approved",
+              "autoApprovedRemotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2",
+              "localInboundProfiles": [
+                "*"
+              ],
+              "localOutboundProfiles": [
+                "*"
+              ],
+              "provisioningState": "Succeeded",
+              "remoteInboundProfiles": [
+                "*"
+              ],
+              "remoteOutboundProfiles": [
+                "*"
+              ],
+              "remotePerimeterGuid": "guid",
+              "remotePerimeterLocation": "westus2",
+              "status": "Approved"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLinks_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkPut.json
@@ -1,0 +1,94 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "linkName": "link1",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {
+        "autoApprovedRemotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2",
+        "localInboundProfiles": [
+          "*"
+        ],
+        "remoteInboundProfiles": [
+          "*"
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinksPut",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "link1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/links",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/links/link1",
+        "properties": {
+          "description": "Auto Approved",
+          "autoApprovedRemotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2",
+          "localInboundProfiles": [
+            "*"
+          ],
+          "localOutboundProfiles": [
+            "*"
+          ],
+          "provisioningState": "Succeeded",
+          "remoteInboundProfiles": [
+            "*"
+          ],
+          "remoteOutboundProfiles": [
+            "*"
+          ],
+          "remotePerimeterGuid": "guid",
+          "remotePerimeterLocation": "westus2",
+          "status": "Approved"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "link1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/links",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/links/link1",
+        "properties": {
+          "description": "Auto Approved",
+          "autoApprovedRemotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2",
+          "localInboundProfiles": [
+            "*"
+          ],
+          "localOutboundProfiles": [
+            "*"
+          ],
+          "provisioningState": "Succeeded",
+          "remoteInboundProfiles": [
+            "*"
+          ],
+          "remoteOutboundProfiles": [
+            "*"
+          ],
+          "remotePerimeterGuid": "guid",
+          "remotePerimeterLocation": "westus2",
+          "status": "Approved"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLinks_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkReferenceDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkReferenceDelete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "linkReferenceName": "link1-guid",
+    "networkSecurityPerimeterName": "nsp2",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinkReferenceDelete",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/linkreferences/{linkReferenceName}/operationResults/{operationId}?api-version={api-version}"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterLinkReferences_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkReferenceGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkReferenceGet.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "linkReferenceName": "link1-guid",
+    "networkSecurityPerimeterName": "nsp2",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinkReferencesGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "link1-guid",
+        "type": "Microsoft.Network/networkSecurityPerimeters/linkreferences",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2/linkreferences/link1-guid",
+        "properties": {
+          "description": "Auto Approved",
+          "localInboundProfiles": [
+            "*"
+          ],
+          "localOutboundProfiles": [
+            "*"
+          ],
+          "provisioningState": "Succeeded",
+          "remoteInboundProfiles": [
+            "*"
+          ],
+          "remoteOutboundProfiles": [
+            "*"
+          ],
+          "remotePerimeterGuid": "guid",
+          "remotePerimeterLocation": "westus2",
+          "remotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+          "status": "Approved"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLinkReferences_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkReferenceList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLinkReferenceList.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp2",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLinkReferenceList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2/linkreferences?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "link1-guid",
+            "type": "Microsoft.Network/networkSecurityPerimeters/linkreferences",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp2/linkreferences/link1-guid",
+            "properties": {
+              "description": "Auto Approved",
+              "localInboundProfiles": [
+                "*"
+              ],
+              "localOutboundProfiles": [
+                "*"
+              ],
+              "provisioningState": "Succeeded",
+              "remoteInboundProfiles": [
+                "*"
+              ],
+              "remoteOutboundProfiles": [
+                "*"
+              ],
+              "remotePerimeterGuid": "guid",
+              "remotePerimeterLocation": "westus2",
+              "remotePerimeterResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1",
+              "status": "Approved"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLinkReferences_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLoggingConfigurationDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLoggingConfigurationDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "loggingConfigurationName": "instance",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLoggingConfigurationDelete",
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterLoggingConfigurations_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLoggingConfigurationGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLoggingConfigurationGet.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "loggingConfigurationName": "instance",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLoggingConfigurationGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "instance",
+        "type": "Microsoft.Network/networkSecurityPerimeters/loggingConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/loggingConfigurations/instance",
+        "properties": {
+          "enabledLogCategories": [
+            "NspPublicInboundPerimeterRulesDenied",
+            "NspPublicOutboundPerimeterRulesDenied"
+          ],
+          "version": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLoggingConfigurations_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLoggingConfigurationList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLoggingConfigurationList.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLoggingConfigurationList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/loggingConfigurations?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "instance",
+            "type": "Microsoft.Network/networkSecurityPerimeters/loggingConfigurations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/loggingConfigurations/instance",
+            "properties": {
+              "enabledLogCategories": [
+                "NspPublicInboundPerimeterRulesDenied",
+                "NspPublicOutboundPerimeterRulesDenied"
+              ],
+              "version": "0"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLoggingConfigurations_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLoggingConfigurationPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspLoggingConfigurationPut.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "loggingConfigurationName": "instance",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {
+        "enabledLogCategories": [
+          "NspPublicInboundPerimeterRulesDenied",
+          "NspPublicOutboundPerimeterRulesDenied"
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspLoggingConfigurationPut",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "instance",
+        "type": "Microsoft.Network/networkSecurityPerimeters/loggingConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/loggingConfigurations/instance",
+        "properties": {
+          "enabledLogCategories": [
+            "NspPublicInboundPerimeterRulesDenied",
+            "NspPublicOutboundPerimeterRulesDenied"
+          ],
+          "version": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "instance",
+        "type": "Microsoft.Network/networkSecurityPerimeters/loggingConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/loggingConfigurations/instance",
+        "properties": {
+          "enabledLogCategories": [
+            "NspPublicInboundPerimeterRulesDenied",
+            "NspPublicOutboundPerimeterRulesDenied"
+          ],
+          "version": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterLoggingConfigurations_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspOperationStatusGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspOperationStatusGet.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "operationId": "operationId1",
+    "api-version": "2026-08-01-preview",
+    "location": "location1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspOperationStatusGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "operationId1",
+        "endTime": "2025-01-09T10:46:55.0948652Z",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/location1/networkSecurityPerimeterOperationStatuses/operationId1",
+        "startTime": "2025-01-09T10:46:51.0988675Z",
+        "status": "Succeeded"
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterOperationStatuses_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspProfileDelete.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspProfileDelete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspProfilesDelete",
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "NetworkSecurityPerimeterProfiles_Delete"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspProfileGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspProfileGet.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspProfilesGet",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "nsp1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1",
+        "properties": {
+          "accessRulesVersion": "0",
+          "diagnosticSettingsVersion": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterProfiles_Get"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspProfileList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspProfileList.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspProfilesList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "profile1",
+            "type": "Microsoft.Network/networkSecurityPerimeters/profiles",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1",
+            "properties": {
+              "accessRulesVersion": "0",
+              "diagnosticSettingsVersion": "0"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "profile2",
+            "type": "Microsoft.Network/networkSecurityPerimeters/profiles",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile2",
+            "properties": {
+              "accessRulesVersion": "0",
+              "diagnosticSettingsVersion": "0"
+            },
+            "systemData": {
+              "createdAt": "2024-02-07T18:07:36.3446713Z",
+              "createdBy": "user",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+              "lastModifiedBy": "user",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterProfiles_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspProfilePut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspProfilePut.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "networkSecurityPerimeterName": "nsp1",
+    "parameters": {
+      "properties": {}
+    },
+    "profileName": "profile1",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NspProfilesPut",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "profile1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1",
+        "properties": {
+          "accessRulesVersion": "0",
+          "diagnosticSettingsVersion": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "profile1",
+        "type": "Microsoft.Network/networkSecurityPerimeters/profiles",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/networkSecurityPerimeters/nsp1/profiles/profile1",
+        "properties": {
+          "accessRulesVersion": "0",
+          "diagnosticSettingsVersion": "0"
+        },
+        "systemData": {
+          "createdAt": "2024-02-07T18:07:36.3446713Z",
+          "createdBy": "user",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-02-07T18:07:36.3446713Z",
+          "lastModifiedBy": "user",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterProfiles_CreateOrUpdate"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspServiceTagsList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/NspServiceTagsList.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "location": "westus",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NSPServiceTagsList",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/nspServiceTags?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "serviceTags": [
+              "ActionGroup",
+              "AppConfigurationInternal",
+              "AzureCloud",
+              "PRIVATE",
+              "ApiManagement",
+              "MicrosoftPublicIPSpace",
+              "MicrosoftPrivateIPSpace"
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterServiceTags_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/PerimeterAssociableResourcesList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/examples/PerimeterAssociableResourcesList.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "location": "westus",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "NetworkSecurityPerimeterAssociableResourceTypes",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/locations/westus/perimeterAssociableResourceTypes?api-version=2025-07-01&$skipToken=10",
+        "value": [
+          {
+            "name": "Microsoft.Sql.servers",
+            "type": "Microsoft.Network/PerimeterAssociableResourceTypes",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Network/perimeterAssociableResourceTypes/Microsoft.Sql.servers",
+            "properties": {
+              "displayName": "Microsoft.Sql/servers",
+              "publicDnsZones": [
+                "database.windows.net"
+              ],
+              "resourceType": "Microsoft.Sql/servers",
+              "serviceTags": [
+                "Sql"
+              ],
+              "readinessState": "GA",
+              "outboundSupported": true,
+              "description": ""
+            }
+          },
+          {
+            "name": "Microsoft.Storage.accounts",
+            "type": "Microsoft.Network/PerimeterAssociableResourceTypes",
+            "id": "/subscriptions/{subscriptionId}/providers/Microsoft.Network/perimeterAssociableResourceTypes/Microsoft.Storage.storageAccounts",
+            "properties": {
+              "displayName": "Microsoft.Storage/accounts",
+              "publicDnsZones": [
+                "blob.core.windows.net",
+                "table.core.windows.net",
+                "queue.core.windows.net",
+                "file.core.windows.net"
+              ],
+              "resourceType": "Microsoft.Storage/accounts",
+              "serviceTags": [
+                "Storage"
+              ],
+              "readinessState": "GA",
+              "outboundSupported": true,
+              "description": ""
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "NetworkSecurityPerimeterAssociableResourceTypes_List"
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/expressRoute.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/expressRoute.json
@@ -1,0 +1,7816 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "ExpressRouteProviderPorts"
+    },
+    {
+      "name": "ExpressRouteCircuitAuthorizations"
+    },
+    {
+      "name": "ExpressRouteCircuits"
+    },
+    {
+      "name": "ExpressRouteCircuitStats"
+    },
+    {
+      "name": "ExpressRouteCircuitPeerings"
+    },
+    {
+      "name": "ExpressRouteCircuitArpTable"
+    },
+    {
+      "name": "ExpressRouteCircuitRoutesTable"
+    },
+    {
+      "name": "ExpressRouteCircuitRoutesTableSummary"
+    },
+    {
+      "name": "ExpressRouteCircuitConnections"
+    },
+    {
+      "name": "PeerExpressRouteCircuitConnections"
+    },
+    {
+      "name": "ExpressRouteCrossConnections"
+    },
+    {
+      "name": "ExpressRouteCrossConnectionArpTable"
+    },
+    {
+      "name": "ExpressRouteCrossConnectionRouteTableSummary"
+    },
+    {
+      "name": "ExpressRouteCrossConnectionRouteTable"
+    },
+    {
+      "name": "ExpressRouteCrossConnectionPeerings"
+    },
+    {
+      "name": "ExpressRoutePortsLocations"
+    },
+    {
+      "name": "ExpressRoutePorts"
+    },
+    {
+      "name": "ExpressRouteLinks"
+    },
+    {
+      "name": "ExpressRoutePortAuthorizations"
+    },
+    {
+      "name": "ExpressRouteLags"
+    },
+    {
+      "name": "ExpressRouteLagLinks"
+    },
+    {
+      "name": "ExpressRouteLagMembers"
+    },
+    {
+      "name": "RouteFilters"
+    },
+    {
+      "name": "RouteFilterRules"
+    },
+    {
+      "name": "ServiceEndpointPolicies"
+    },
+    {
+      "name": "serviceEndpointPolicyDefinitions"
+    },
+    {
+      "name": "ServiceEndpointPolicyDefinitions"
+    },
+    {
+      "name": "ExpressRouteServiceProviders"
+    },
+    {
+      "name": "BgpServiceCommunities"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePorts": {
+      "get": {
+        "operationId": "ExpressRoutePorts_List",
+        "tags": [
+          "ExpressRoutePorts"
+        ],
+        "description": "List all the ExpressRoutePort resources in the specified subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePortListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePortsLocations": {
+      "get": {
+        "operationId": "ExpressRoutePortsLocations_List",
+        "tags": [
+          "ExpressRoutePortsLocations"
+        ],
+        "description": "Retrieves all ExpressRoutePort peering locations. Does not return available bandwidths for each location. Available bandwidths can only be obtained when retrieving a specific peering location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePortsLocationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ExpressRoutePortsLocations/{locationName}": {
+      "get": {
+        "operationId": "ExpressRoutePortsLocations_Get",
+        "tags": [
+          "ExpressRoutePortsLocations"
+        ],
+        "description": "Retrieves a single ExpressRoutePort peering location, including the list of available bandwidths available at said peering location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "locationName",
+            "in": "path",
+            "description": "Name of the requested ExpressRoutePort peering location.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePortsLocation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bgpServiceCommunities": {
+      "get": {
+        "operationId": "BgpServiceCommunities_List",
+        "tags": [
+          "BgpServiceCommunities"
+        ],
+        "description": "Gets all the available bgp service communities.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/BgpServiceCommunityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCircuits": {
+      "get": {
+        "operationId": "ExpressRouteCircuits_ListAll",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Gets all the express route circuits in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteCrossConnections": {
+      "get": {
+        "operationId": "ExpressRouteCrossConnections_List",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Retrieves all the ExpressRouteCrossConnections in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. For example, you can use $filter=name eq '{circuitServiceKey}'.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteLags": {
+      "get": {
+        "operationId": "ExpressRouteLags_List",
+        "tags": [
+          "ExpressRouteLags"
+        ],
+        "description": "List all the ExpressRouteLag resources in the specified subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLagListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteProviderPorts": {
+      "get": {
+        "operationId": "ExpressRouteProviderPortsLocation_List",
+        "tags": [
+          "ExpressRouteProviderPorts"
+        ],
+        "description": "Retrieves all the ExpressRouteProviderPorts in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. For example, you can use $filter=location eq '{state}'.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteProviderPortListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteProviderPorts/{providerport}": {
+      "get": {
+        "operationId": "ExpressRouteProviderPort",
+        "tags": [
+          "ExpressRouteProviderPorts"
+        ],
+        "description": "Retrieves detail of a provider port.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "providerport",
+            "in": "path",
+            "description": "The name of the provider port.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteProviderPort"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteServiceProviders": {
+      "get": {
+        "operationId": "ExpressRouteServiceProviders_List",
+        "tags": [
+          "ExpressRouteServiceProviders"
+        ],
+        "description": "Gets all the available express route service providers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteServiceProviderListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeFilters": {
+      "get": {
+        "operationId": "RouteFilters_List",
+        "tags": [
+          "RouteFilters"
+        ],
+        "description": "Gets all route filters in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteFilterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/serviceEndpointPolicies": {
+      "get": {
+        "operationId": "ServiceEndpointPolicies_List",
+        "tags": [
+          "ServiceEndpointPolicies"
+        ],
+        "description": "Gets all the service endpoint policies in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts": {
+      "get": {
+        "operationId": "ExpressRoutePorts_ListByResourceGroup",
+        "tags": [
+          "ExpressRoutePorts"
+        ],
+        "description": "List all the ExpressRoutePort resources in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePortListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}": {
+      "get": {
+        "operationId": "ExpressRoutePorts_Get",
+        "tags": [
+          "ExpressRoutePorts"
+        ],
+        "description": "Retrieves the requested ExpressRoutePort resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of ExpressRoutePort.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePort"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRoutePorts_CreateOrUpdate",
+        "tags": [
+          "ExpressRoutePorts"
+        ],
+        "description": "Creates or updates the specified ExpressRoutePort resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of ExpressRoutePort.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create ExpressRoutePort operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePort"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ExpressRoutePort' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePort"
+            }
+          },
+          "201": {
+            "description": "Resource 'ExpressRoutePort' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePort"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRoutePort"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ExpressRoutePorts_UpdateTags",
+        "tags": [
+          "ExpressRoutePorts"
+        ],
+        "description": "Update ExpressRoutePort tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of ExpressRoutePort.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update ExpressRoutePort resource tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePort"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ExpressRoutePorts_Delete",
+        "tags": [
+          "ExpressRoutePorts"
+        ],
+        "description": "Deletes the specified ExpressRoutePort resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of ExpressRoutePort.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}/generateLoa": {
+      "post": {
+        "operationId": "ExpressRoutePorts_GenerateLOA",
+        "tags": [
+          "ExpressRoutePorts"
+        ],
+        "description": "Generate a letter of authorization for the requested ExpressRoutePort resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of ExpressRoutePort.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "Request parameters supplied to generate a letter of authorization.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GenerateExpressRoutePortsLOARequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GenerateExpressRoutePortsLOAResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}/links": {
+      "get": {
+        "operationId": "ExpressRouteLinks_List",
+        "tags": [
+          "ExpressRouteLinks"
+        ],
+        "description": "Retrieve the ExpressRouteLink sub-resources of the specified ExpressRoutePort resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of ExpressRoutePort.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLinkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ExpressRoutePorts/{expressRoutePortName}/links/{linkName}": {
+      "get": {
+        "operationId": "ExpressRouteLinks_Get",
+        "tags": [
+          "ExpressRouteLinks"
+        ],
+        "description": "Retrieves the specified ExpressRouteLink resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of the express route port.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkName",
+            "in": "path",
+            "description": "The name of the express route link.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLink"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits": {
+      "get": {
+        "operationId": "ExpressRouteCircuits_List",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Gets all the express route circuits in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}": {
+      "get": {
+        "operationId": "ExpressRouteCircuits_Get",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Gets information about the specified express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuit"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRouteCircuits_CreateOrUpdate",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Creates or updates an express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update express route circuit operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ExpressRouteCircuit' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuit"
+            }
+          },
+          "201": {
+            "description": "Resource 'ExpressRouteCircuit' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuit"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRouteCircuit"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ExpressRouteCircuits_UpdateTags",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Updates an express route circuit tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update express route circuit tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuit"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ExpressRouteCircuits_Delete",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Deletes the specified express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations": {
+      "get": {
+        "operationId": "ExpressRouteCircuitAuthorizations_List",
+        "tags": [
+          "ExpressRouteCircuitAuthorizations"
+        ],
+        "description": "Gets all authorizations in an express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AuthorizationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/authorizations/{authorizationName}": {
+      "get": {
+        "operationId": "ExpressRouteCircuitAuthorizations_Get",
+        "tags": [
+          "ExpressRouteCircuitAuthorizations"
+        ],
+        "description": "Gets the specified authorization from the specified express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authorizationName",
+            "in": "path",
+            "description": "The name of the authorization.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRouteCircuitAuthorizations_CreateOrUpdate",
+        "tags": [
+          "ExpressRouteCircuitAuthorizations"
+        ],
+        "description": "Creates or updates an authorization in the specified express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authorizationName",
+            "in": "path",
+            "description": "The name of the authorization.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authorizationParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update express route circuit authorization operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ExpressRouteCircuitAuthorization' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+            }
+          },
+          "201": {
+            "description": "Resource 'ExpressRouteCircuitAuthorization' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRouteCircuitAuthorization"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ExpressRouteCircuitAuthorizations_Delete",
+        "tags": [
+          "ExpressRouteCircuitAuthorizations"
+        ],
+        "description": "Deletes the specified authorization from the specified express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authorizationName",
+            "in": "path",
+            "description": "The name of the authorization.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/getCircuitLinkFailoverAllTestsDetails": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_GetCircuitLinkFailoverAllTestsDetails",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Retrieves the details of all the link failover tests performed on the express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "failoverTestType",
+            "in": "query",
+            "description": "The type of failover test.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "fetchLatest",
+            "in": "query",
+            "description": "Fetch only the latest tests.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExpressRouteLinkFailoverAllTestsDetails"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteLinkFailoverAllTestsDetailsArray"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/getCircuitLinkFailoverSingleTestDetails": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_GetCircuitLinkFailoverSingleTestDetails",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Retrieves the details of a particular link failover test performed on the express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkType",
+            "in": "query",
+            "description": "The link type.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "circuitTestCategory",
+            "in": "query",
+            "description": "The circuit test category.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "failoverTestId",
+            "in": "query",
+            "description": "The unique Guid value which identifies the test.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExpressRouteLinkFailoverSingleTestDetails"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteLinkFailoverSingleTestDetailsArray"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings": {
+      "get": {
+        "operationId": "ExpressRouteCircuitPeerings_List",
+        "tags": [
+          "ExpressRouteCircuitPeerings"
+        ],
+        "description": "Gets all peerings in a specified express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitPeeringListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}": {
+      "get": {
+        "operationId": "ExpressRouteCircuitPeerings_Get",
+        "tags": [
+          "ExpressRouteCircuitPeerings"
+        ],
+        "description": "Gets the specified peering for the express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitPeering"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRouteCircuitPeerings_CreateOrUpdate",
+        "tags": [
+          "ExpressRouteCircuitPeerings"
+        ],
+        "description": "Creates or updates a peering in the specified express route circuits.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update express route circuit peering operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitPeering"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ExpressRouteCircuitPeering' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitPeering"
+            }
+          },
+          "201": {
+            "description": "Resource 'ExpressRouteCircuitPeering' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitPeering"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRouteCircuitPeering"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ExpressRouteCircuitPeerings_Delete",
+        "tags": [
+          "ExpressRouteCircuitPeerings"
+        ],
+        "description": "Deletes the specified peering from the specified express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/arpTables/{devicePath}": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_ListArpTable",
+        "tags": [
+          "ExpressRouteCircuitArpTable"
+        ],
+        "description": "Gets the currently advertised ARP table associated with the express route circuit in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of the express route port.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "devicePath",
+            "in": "path",
+            "description": "The name of the arpTables.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitsArpTableListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteCircuitsArpTableListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections": {
+      "get": {
+        "operationId": "ExpressRouteCircuitConnections_List",
+        "tags": [
+          "ExpressRouteCircuitConnections"
+        ],
+        "description": "Gets all global reach connections associated with a private peering in an express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/connections/{connectionName}": {
+      "get": {
+        "operationId": "ExpressRouteCircuitConnections_Get",
+        "tags": [
+          "ExpressRouteCircuitConnections"
+        ],
+        "description": "Gets the specified Express Route Circuit Connection from the specified express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the express route circuit connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRouteCircuitConnections_CreateOrUpdate",
+        "tags": [
+          "ExpressRouteCircuitConnections"
+        ],
+        "description": "Creates or updates a Express Route Circuit Connection in the specified express route circuits.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the express route circuit connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "expressRouteCircuitConnectionParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update express route circuit connection operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ExpressRouteCircuitConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'ExpressRouteCircuitConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitConnection"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRouteCircuitConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ExpressRouteCircuitConnections_Delete",
+        "tags": [
+          "ExpressRouteCircuitConnections"
+        ],
+        "description": "Deletes the specified Express Route Circuit Connection from the specified express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the express route circuit connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/peerConnections": {
+      "get": {
+        "operationId": "PeerExpressRouteCircuitConnections_List",
+        "tags": [
+          "PeerExpressRouteCircuitConnections"
+        ],
+        "description": "Gets all global reach peer connections associated with a private peering in an express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PeerExpressRouteCircuitConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/peerConnections/{connectionName}": {
+      "get": {
+        "operationId": "PeerExpressRouteCircuitConnections_Get",
+        "tags": [
+          "PeerExpressRouteCircuitConnections"
+        ],
+        "description": "Gets the specified Peer Express Route Circuit Connection from the specified express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PeerExpressRouteCircuitConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/routeTables/{devicePath}": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_ListRoutesTable",
+        "tags": [
+          "ExpressRouteCircuitRoutesTable"
+        ],
+        "description": "Gets the currently advertised routes table associated with the express route circuit in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of the express route port.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "devicePath",
+            "in": "path",
+            "description": "The name of the routeTables.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitsRoutesTableListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteCircuitsRoutesTableListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/routeTablesSummary/{devicePath}": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_ListRoutesTableSummary",
+        "tags": [
+          "ExpressRouteCircuitRoutesTableSummary"
+        ],
+        "description": "Gets the currently advertised routes table summary associated with the express route circuit in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of the express route port.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "devicePath",
+            "in": "path",
+            "description": "The name of the routeTablesSummary.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitsRoutesTableSummaryListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteCircuitsRoutesTableSummaryListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/peerings/{peeringName}/stats": {
+      "get": {
+        "operationId": "ExpressRouteCircuits_GetPeeringStats",
+        "tags": [
+          "ExpressRouteCircuitStats"
+        ],
+        "description": "Gets all stats from an express route circuit in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitStats"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/startCircuitLinkFailoverTest": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_StartCircuitLinkFailoverTest",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Starts link failover simulation on the express route circuit for the specified link type and test category.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkType",
+            "in": "query",
+            "description": "The link type.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "circuitTestCategory",
+            "in": "query",
+            "description": "The circuit test category.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/stats": {
+      "get": {
+        "operationId": "ExpressRouteCircuits_GetStats",
+        "tags": [
+          "ExpressRouteCircuitStats"
+        ],
+        "description": "Gets all the stats from an express route circuit in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitStats"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCircuits/{circuitName}/stopCircuitLinkFailoverTest": {
+      "post": {
+        "operationId": "ExpressRouteCircuits_StopCircuitLinkFailoverTest",
+        "tags": [
+          "ExpressRouteCircuits"
+        ],
+        "description": "Stops link failover simulation on the express route circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "circuitName",
+            "in": "path",
+            "description": "The name of express route circuit.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "stopParameters",
+            "in": "body",
+            "description": "Parameters supplied to stop the link failover simulation on the express route circuit.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLinkFailoverStopApiParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections": {
+      "get": {
+        "operationId": "ExpressRouteCrossConnections_ListByResourceGroup",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Retrieves all the ExpressRouteCrossConnections in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}": {
+      "get": {
+        "operationId": "ExpressRouteCrossConnections_Get",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Gets details about the specified ExpressRouteCrossConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRouteCrossConnections_CreateOrUpdate",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Update the specified ExpressRouteCrossConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the update express route crossConnection operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnection"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRouteCrossConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ExpressRouteCrossConnections_UpdateTags",
+        "tags": [
+          "ExpressRouteCrossConnections"
+        ],
+        "description": "Updates an express route cross connection tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "crossConnectionParameters",
+            "in": "body",
+            "description": "Parameters supplied to update express route cross connection tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings": {
+      "get": {
+        "operationId": "ExpressRouteCrossConnectionPeerings_List",
+        "tags": [
+          "ExpressRouteCrossConnectionPeerings"
+        ],
+        "description": "Gets all peerings in a specified ExpressRouteCrossConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnectionPeeringList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}": {
+      "get": {
+        "operationId": "ExpressRouteCrossConnectionPeerings_Get",
+        "tags": [
+          "ExpressRouteCrossConnectionPeerings"
+        ],
+        "description": "Gets the specified peering for the ExpressRouteCrossConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "Name for the express route cross connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnectionPeering"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRouteCrossConnectionPeerings_CreateOrUpdate",
+        "tags": [
+          "ExpressRouteCrossConnectionPeerings"
+        ],
+        "description": "Creates or updates a peering in the specified ExpressRouteCrossConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "Name for the express route cross connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update ExpressRouteCrossConnection peering operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnectionPeering"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnectionPeering"
+            }
+          },
+          "201": {
+            "description": "Resource 'ExpressRouteCrossConnectionPeering' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnectionPeering"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRouteCrossConnectionPeering"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ExpressRouteCrossConnectionPeerings_Delete",
+        "tags": [
+          "ExpressRouteCrossConnectionPeerings"
+        ],
+        "description": "Deletes the specified peering from the ExpressRouteCrossConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "Name for the express route cross connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/arpTables/{devicePath}": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_ListArpTable",
+        "tags": [
+          "ExpressRouteCrossConnectionArpTable"
+        ],
+        "description": "Gets the currently advertised ARP table associated with the express route cross connection in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "devicePath",
+            "in": "path",
+            "description": "The path of the device.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitsArpTableListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteCircuitsArpTableListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/routeTables/{devicePath}": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_ListRoutesTable",
+        "tags": [
+          "ExpressRouteCrossConnectionRouteTable"
+        ],
+        "description": "Gets the currently advertised routes table associated with the express route cross connection in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "devicePath",
+            "in": "path",
+            "description": "The path of the device.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCircuitsRoutesTableListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteCircuitsRoutesTableListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteCrossConnections/{crossConnectionName}/peerings/{peeringName}/routeTablesSummary/{devicePath}": {
+      "post": {
+        "operationId": "ExpressRouteCrossConnections_ListRoutesTableSummary",
+        "tags": [
+          "ExpressRouteCrossConnectionRouteTableSummary"
+        ],
+        "description": "Gets the route table summary associated with the express route cross connection in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "crossConnectionName",
+            "in": "path",
+            "description": "The name of the ExpressRouteCrossConnection (service key of the circuit).",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "devicePath",
+            "in": "path",
+            "description": "The path of the device.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteCrossConnectionsRoutesTableSummaryListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteCrossConnectionsRoutesTableSummaryListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteLags": {
+      "get": {
+        "operationId": "ExpressRouteLags_ListByResourceGroup",
+        "tags": [
+          "ExpressRouteLags"
+        ],
+        "description": "List all the ExpressRouteLag resources in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLagListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteLags/{expressRouteLagName}": {
+      "get": {
+        "operationId": "ExpressRouteLags_Get",
+        "tags": [
+          "ExpressRouteLags"
+        ],
+        "description": "Retrieves the requested ExpressRouteLag resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteLagName",
+            "in": "path",
+            "description": "The name of ExpressRouteLag.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLag"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRouteLags_CreateOrUpdate",
+        "tags": [
+          "ExpressRouteLags"
+        ],
+        "description": "Creates or updates the specified ExpressRouteLag resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteLagName",
+            "in": "path",
+            "description": "The name of ExpressRouteLag.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Parameters supplied to the create ExpressRouteLag operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLag"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ExpressRouteLag' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLag"
+            }
+          },
+          "201": {
+            "description": "Resource 'ExpressRouteLag' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLag"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRouteLag"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ExpressRouteLags_Update",
+        "tags": [
+          "ExpressRouteLags"
+        ],
+        "description": "Update ExpressRouteLag tags or identity.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteLagName",
+            "in": "path",
+            "description": "The name of ExpressRouteLag.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "Parameters supplied to update ExpressRouteLag resource tags or identity.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLagUpdateTagsOrIdentityRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLag"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ExpressRouteLags_Delete",
+        "tags": [
+          "ExpressRouteLags"
+        ],
+        "description": "Deletes the specified ExpressRouteLag resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteLagName",
+            "in": "path",
+            "description": "The name of ExpressRouteLag.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteLags/{expressRouteLagName}/generateLoa": {
+      "post": {
+        "operationId": "ExpressRouteLags_GenerateLoa",
+        "tags": [
+          "ExpressRouteLags"
+        ],
+        "description": "Generate a letter of authorization for the requested ExpressRouteLag resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteLagName",
+            "in": "path",
+            "description": "The name of ExpressRouteLag.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Request parameters supplied to generate a letter of authorization.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GenerateExpressRouteLagsLOARequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GenerateExpressRouteLagsLOAResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteLags/{expressRouteLagName}/links": {
+      "get": {
+        "operationId": "ExpressRouteLags_LinksList",
+        "tags": [
+          "ExpressRouteLagLinks"
+        ],
+        "description": "Retrieve the ExpressRouteLagLink sub-resources of the specified ExpressRouteLag resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteLagName",
+            "in": "path",
+            "description": "The name of ExpressRouteLag.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLagLinkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteLags/{expressRouteLagName}/links/{linkName}": {
+      "get": {
+        "operationId": "ExpressRouteLags_LinksGet",
+        "tags": [
+          "ExpressRouteLagLinks"
+        ],
+        "description": "Retrieves the specified ExpressRouteLagLink resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteLagName",
+            "in": "path",
+            "description": "The name of the express route LAG.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          },
+          {
+            "name": "linkName",
+            "in": "path",
+            "description": "The name of the express route LAG link.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLagLink"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteLags/{expressRouteLagName}/links/{linkName}/members": {
+      "get": {
+        "operationId": "ExpressRouteLags_MembersList",
+        "tags": [
+          "ExpressRouteLagMembers"
+        ],
+        "description": "Retrieve the ExpressRouteLagMember sub-resources of the specified ExpressRouteLagLink resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteLagName",
+            "in": "path",
+            "description": "The name of the express route LAG.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          },
+          {
+            "name": "linkName",
+            "in": "path",
+            "description": "The name of the express route LAG link.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLagMemberListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteLags/{expressRouteLagName}/links/{linkName}/members/{memberName}": {
+      "get": {
+        "operationId": "ExpressRouteLags_MembersGet",
+        "tags": [
+          "ExpressRouteLagMembers"
+        ],
+        "description": "Retrieves the specified ExpressRouteLagMember resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteLagName",
+            "in": "path",
+            "description": "The name of the express route LAG.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          },
+          {
+            "name": "linkName",
+            "in": "path",
+            "description": "The name of the express route LAG link.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          },
+          {
+            "name": "memberName",
+            "in": "path",
+            "description": "The name of the express route LAG member.",
+            "required": true,
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteLagMember"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRoutePorts/{expressRoutePortName}/authorizations": {
+      "get": {
+        "operationId": "ExpressRoutePortAuthorizations_List",
+        "tags": [
+          "ExpressRoutePortAuthorizations"
+        ],
+        "description": "Gets all authorizations in an express route port.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of the express route port.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePortAuthorizationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRoutePorts/{expressRoutePortName}/authorizations/{authorizationName}": {
+      "get": {
+        "operationId": "ExpressRoutePortAuthorizations_Get",
+        "tags": [
+          "ExpressRoutePortAuthorizations"
+        ],
+        "description": "Gets the specified authorization from the specified express route port.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of the express route port.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authorizationName",
+            "in": "path",
+            "description": "The name of the authorization.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePortAuthorization"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRoutePortAuthorizations_CreateOrUpdate",
+        "tags": [
+          "ExpressRoutePortAuthorizations"
+        ],
+        "description": "Creates or updates an authorization in the specified express route port.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of the express route port.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authorizationName",
+            "in": "path",
+            "description": "The name of the authorization.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authorizationParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update express route port authorization operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePortAuthorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ExpressRoutePortAuthorization' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePortAuthorization"
+            }
+          },
+          "201": {
+            "description": "Resource 'ExpressRoutePortAuthorization' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRoutePortAuthorization"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRoutePortAuthorization"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ExpressRoutePortAuthorizations_Delete",
+        "tags": [
+          "ExpressRoutePortAuthorizations"
+        ],
+        "description": "Deletes the specified authorization from the specified express route port.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRoutePortName",
+            "in": "path",
+            "description": "The name of the express route port.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authorizationName",
+            "in": "path",
+            "description": "The name of the authorization.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters": {
+      "get": {
+        "operationId": "RouteFilters_ListByResourceGroup",
+        "tags": [
+          "RouteFilters"
+        ],
+        "description": "Gets all route filters in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteFilterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}": {
+      "get": {
+        "operationId": "RouteFilters_Get",
+        "tags": [
+          "RouteFilters"
+        ],
+        "description": "Gets the specified route filter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeFilterName",
+            "in": "path",
+            "description": "The name of the route filter.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced express route bgp peering resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteFilter"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RouteFilters_CreateOrUpdate",
+        "tags": [
+          "RouteFilters"
+        ],
+        "description": "Creates or updates a route filter in a specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeFilterName",
+            "in": "path",
+            "description": "The name of the route filter.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeFilterParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update route filter operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RouteFilter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RouteFilter' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RouteFilter"
+            }
+          },
+          "201": {
+            "description": "Resource 'RouteFilter' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RouteFilter"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/RouteFilter"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "RouteFilters_UpdateTags",
+        "tags": [
+          "RouteFilters"
+        ],
+        "description": "Updates tags of a route filter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeFilterName",
+            "in": "path",
+            "description": "The name of the route filter.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update route filter tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteFilter"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RouteFilters_Delete",
+        "tags": [
+          "RouteFilters"
+        ],
+        "description": "Deletes the specified route filter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeFilterName",
+            "in": "path",
+            "description": "The name of the route filter.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules": {
+      "get": {
+        "operationId": "RouteFilterRules_ListByRouteFilter",
+        "tags": [
+          "RouteFilterRules"
+        ],
+        "description": "Gets all RouteFilterRules in a route filter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeFilterName",
+            "in": "path",
+            "description": "The name of the route filter.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteFilterRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeFilters/{routeFilterName}/routeFilterRules/{ruleName}": {
+      "get": {
+        "operationId": "RouteFilterRules_Get",
+        "tags": [
+          "RouteFilterRules"
+        ],
+        "description": "Gets the specified rule from a route filter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeFilterName",
+            "in": "path",
+            "description": "The name of the route filter.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the route filter rule.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteFilterRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RouteFilterRules_CreateOrUpdate",
+        "tags": [
+          "RouteFilterRules"
+        ],
+        "description": "Creates or updates a route in the specified route filter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeFilterName",
+            "in": "path",
+            "description": "The name of the route filter.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the route filter rule.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeFilterRuleParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update route filter rule operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RouteFilterRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteFilterRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'RouteFilterRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RouteFilterRule"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/RouteFilterRule"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "RouteFilterRules_Delete",
+        "tags": [
+          "RouteFilterRules"
+        ],
+        "description": "Deletes the specified rule from a route filter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeFilterName",
+            "in": "path",
+            "description": "The name of the route filter.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the route filter rule.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies": {
+      "get": {
+        "operationId": "ServiceEndpointPolicies_ListByResourceGroup",
+        "tags": [
+          "ServiceEndpointPolicies"
+        ],
+        "description": "Gets all service endpoint Policies in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}": {
+      "get": {
+        "operationId": "ServiceEndpointPolicies_Get",
+        "tags": [
+          "ServiceEndpointPolicies"
+        ],
+        "description": "Gets the specified service Endpoint Policies in a specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceEndpointPolicyName",
+            "in": "path",
+            "description": "The name of the service endpoint policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ServiceEndpointPolicies_CreateOrUpdate",
+        "tags": [
+          "ServiceEndpointPolicies"
+        ],
+        "description": "Creates or updates a service Endpoint Policies.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceEndpointPolicyName",
+            "in": "path",
+            "description": "The name of the service endpoint policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update service endpoint policy operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ServiceEndpointPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'ServiceEndpointPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicy"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ServiceEndpointPolicy"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ServiceEndpointPolicies_UpdateTags",
+        "tags": [
+          "ServiceEndpointPolicies"
+        ],
+        "description": "Updates tags of a service endpoint policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceEndpointPolicyName",
+            "in": "path",
+            "description": "The name of the service endpoint policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update service endpoint policy tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ServiceEndpointPolicies_Delete",
+        "tags": [
+          "ServiceEndpointPolicies"
+        ],
+        "description": "Deletes the specified service endpoint policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceEndpointPolicyName",
+            "in": "path",
+            "description": "The name of the service endpoint policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions": {
+      "get": {
+        "operationId": "ServiceEndpointPolicyDefinitions_ListByResourceGroup",
+        "tags": [
+          "ServiceEndpointPolicyDefinitions"
+        ],
+        "description": "Gets all service endpoint policy definitions in a service end point policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceEndpointPolicyName",
+            "in": "path",
+            "description": "The name of the service endpoint policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicyDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceEndpointPolicies/{serviceEndpointPolicyName}/serviceEndpointPolicyDefinitions/{serviceEndpointPolicyDefinitionName}": {
+      "get": {
+        "operationId": "ServiceEndpointPolicyDefinitions_Get",
+        "tags": [
+          "serviceEndpointPolicyDefinitions"
+        ],
+        "description": "Get a ServiceEndpointPolicyDefinition",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceEndpointPolicyName",
+            "in": "path",
+            "description": "The name of the service endpoint policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "serviceEndpointPolicyDefinitionName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicyDefinition"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ServiceEndpointPolicyDefinitions_CreateOrUpdate",
+        "tags": [
+          "serviceEndpointPolicyDefinitions"
+        ],
+        "description": "Creates or updates a service endpoint policy definition in the specified service endpoint policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceEndpointPolicyName",
+            "in": "path",
+            "description": "The name of the service endpoint policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "serviceEndpointPolicyDefinitionName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ServiceEndpointPolicyDefinitions",
+            "in": "body",
+            "description": "Parameters supplied to the create or update service endpoint policy operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicyDefinition"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ServiceEndpointPolicyDefinition' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicyDefinition"
+            }
+          },
+          "201": {
+            "description": "Resource 'ServiceEndpointPolicyDefinition' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ServiceEndpointPolicyDefinition"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ServiceEndpointPolicyDefinition"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ServiceEndpointPolicyDefinitions_Delete",
+        "tags": [
+          "ServiceEndpointPolicyDefinitions"
+        ],
+        "description": "Deletes the specified ServiceEndpoint policy definitions.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceEndpointPolicyName",
+            "in": "path",
+            "description": "The name of the service endpoint policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "serviceEndpointPolicyDefinitionName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "AdvertisedPublicPrefixProperties": {
+      "type": "object",
+      "description": "Prefix properties required to perform validation using openssl signature.",
+      "properties": {
+        "prefix": {
+          "type": "string",
+          "description": "Advertised Public Prefix."
+        },
+        "validationId": {
+          "type": "string",
+          "description": "Validation string that contains circuit peering info."
+        },
+        "signature": {
+          "type": "string",
+          "description": "Signed string generated by encrypting validationId with a private key."
+        },
+        "validationState": {
+          "$ref": "./common.json#/definitions/AdvertisedPublicPrefixPropertiesValidationState",
+          "description": "Advertised Public Prefix State that denotes if the prefix is validated or not.",
+          "readOnly": true
+        }
+      }
+    },
+    "AuthorizationListResult": {
+      "type": "object",
+      "description": "Paged collection of ExpressRouteCircuitAuthorization items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteCircuitAuthorization items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AuthorizationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of ExpressRouteCircuitAuthorization.",
+      "properties": {
+        "authorizationKey": {
+          "type": "string",
+          "description": "The authorization key."
+        },
+        "authorizationUseStatus": {
+          "$ref": "./common.json#/definitions/AuthorizationUseStatus",
+          "description": "The authorization use status."
+        },
+        "connectionResourceUri": {
+          "type": "string",
+          "description": "The reference to the ExpressRoute connection resource using the authorization.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the authorization resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "BGPCommunity": {
+      "type": "object",
+      "description": "Contains bgp community information offered in Service Community resources.",
+      "properties": {
+        "serviceSupportedRegion": {
+          "type": "string",
+          "description": "The region which the service support. e.g. For O365, region is Global."
+        },
+        "communityName": {
+          "type": "string",
+          "description": "The name of the bgp community. e.g. Skype."
+        },
+        "communityValue": {
+          "type": "string",
+          "description": "The value of the bgp community. For more information: https://docs.microsoft.com/en-us/azure/expressroute/expressroute-routing."
+        },
+        "communityPrefixes": {
+          "type": "array",
+          "description": "The prefixes that the bgp community contains.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "isAuthorizedToUse": {
+          "type": "boolean",
+          "description": "Customer is authorized to use bgp community or not."
+        },
+        "serviceGroup": {
+          "type": "string",
+          "description": "The service group of the bgp community contains."
+        }
+      }
+    },
+    "BgpServiceCommunity": {
+      "type": "object",
+      "description": "Service Community Properties.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BgpServiceCommunityPropertiesFormat",
+          "description": "Properties of the BGP service community.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "BgpServiceCommunityListResult": {
+      "type": "object",
+      "description": "The response of a BgpServiceCommunity list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BgpServiceCommunity items on this page",
+          "items": {
+            "$ref": "#/definitions/BgpServiceCommunity"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BgpServiceCommunityPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of Service Community.",
+      "properties": {
+        "serviceName": {
+          "type": "string",
+          "description": "The name of the bgp community. e.g. Skype."
+        },
+        "bgpCommunities": {
+          "type": "array",
+          "description": "A list of bgp communities.",
+          "items": {
+            "$ref": "#/definitions/BGPCommunity"
+          }
+        }
+      }
+    },
+    "ExpressRouteCircuit": {
+      "type": "object",
+      "description": "ExpressRouteCircuit resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteCircuitPropertiesFormat",
+          "description": "Properties of the express route circuit.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "sku": {
+          "$ref": "#/definitions/ExpressRouteCircuitSku",
+          "description": "The SKU."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ExpressRouteCircuitArpTable": {
+      "type": "object",
+      "description": "The ARP table associated with the ExpressRouteCircuit.",
+      "properties": {
+        "age": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Entry age in minutes."
+        },
+        "interface": {
+          "type": "string",
+          "description": "Interface address."
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "The IP address."
+        },
+        "macAddress": {
+          "type": "string",
+          "description": "The MAC address."
+        }
+      }
+    },
+    "ExpressRouteCircuitAuthorization": {
+      "type": "object",
+      "description": "Authorization in an ExpressRouteCircuit resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AuthorizationPropertiesFormat",
+          "description": "Properties of the express route circuit authorization.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "ExpressRouteCircuitConnection": {
+      "type": "object",
+      "description": "Express Route Circuit Connection in an ExpressRouteCircuitPeering resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteCircuitConnectionPropertiesFormat",
+          "description": "Properties of the express route circuit connection.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "ExpressRouteCircuitConnectionListResult": {
+      "type": "object",
+      "description": "The response of a ExpressRouteCircuitConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteCircuitConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteCircuitConnectionPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the express route circuit connection.",
+      "properties": {
+        "expressRouteCircuitPeering": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to Express Route Circuit Private Peering Resource of the circuit initiating connection."
+        },
+        "peerExpressRouteCircuitPeering": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to Express Route Circuit Private Peering Resource of the peered circuit."
+        },
+        "addressPrefix": {
+          "type": "string",
+          "description": "/29 IP address space to carve out Customer addresses for tunnels."
+        },
+        "authorizationKey": {
+          "type": "string",
+          "description": "The authorization key."
+        },
+        "ipv6CircuitConnectionConfig": {
+          "$ref": "#/definitions/Ipv6CircuitConnectionConfig",
+          "description": "IPv6 Address PrefixProperties of the express route circuit connection."
+        },
+        "circuitConnectionStatus": {
+          "$ref": "./common.json#/definitions/CircuitConnectionStatus",
+          "description": "Express Route Circuit connection state.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route circuit connection resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ExpressRouteCircuitListResult": {
+      "type": "object",
+      "description": "The response of a ExpressRouteCircuit list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteCircuit items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuit"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteCircuitPeering": {
+      "type": "object",
+      "description": "Peering in an ExpressRouteCircuit resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteCircuitPeeringPropertiesFormat",
+          "description": "Properties of the express route circuit peering.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "ExpressRouteCircuitPeeringConfig": {
+      "type": "object",
+      "description": "Specifies the peering configuration.",
+      "properties": {
+        "advertisedPublicPrefixes": {
+          "type": "array",
+          "description": "The reference to AdvertisedPublicPrefixes.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "advertisedCommunities": {
+          "type": "array",
+          "description": "The communities of bgp peering. Specified for microsoft peering.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "advertisedPublicPrefixesState": {
+          "$ref": "./common.json#/definitions/ExpressRouteCircuitPeeringAdvertisedPublicPrefixState",
+          "description": "The advertised public prefix state of the Peering resource.",
+          "readOnly": true
+        },
+        "legacyMode": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The legacy mode of the peering."
+        },
+        "customerASN": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The CustomerASN of the peering."
+        },
+        "routingRegistryName": {
+          "type": "string",
+          "description": "The RoutingRegistryName of the configuration."
+        },
+        "advertisedPublicPrefixInfo": {
+          "type": "array",
+          "description": "List of Prefix information required to perform validation.",
+          "items": {
+            "$ref": "#/definitions/AdvertisedPublicPrefixProperties"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ExpressRouteCircuitPeeringListResult": {
+      "type": "object",
+      "description": "The response of a ExpressRouteCircuitPeering list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteCircuitPeering items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitPeering"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteCircuitPeeringPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the express route circuit peering.",
+      "properties": {
+        "peeringType": {
+          "$ref": "./common.json#/definitions/ExpressRoutePeeringType",
+          "description": "The peering type."
+        },
+        "state": {
+          "$ref": "./common.json#/definitions/ExpressRoutePeeringState",
+          "description": "The peering state."
+        },
+        "azureASN": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The Azure ASN."
+        },
+        "peerASN": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The peer ASN.",
+          "minimum": 1,
+          "maximum": 4294967295
+        },
+        "primaryPeerAddressPrefix": {
+          "type": "string",
+          "description": "The primary address prefix."
+        },
+        "secondaryPeerAddressPrefix": {
+          "type": "string",
+          "description": "The secondary address prefix."
+        },
+        "primaryAzurePort": {
+          "type": "string",
+          "description": "The primary port."
+        },
+        "secondaryAzurePort": {
+          "type": "string",
+          "description": "The secondary port."
+        },
+        "sharedKey": {
+          "type": "string",
+          "description": "The shared key."
+        },
+        "vlanId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The VLAN ID."
+        },
+        "microsoftPeeringConfig": {
+          "$ref": "#/definitions/ExpressRouteCircuitPeeringConfig",
+          "description": "The Microsoft peering configuration."
+        },
+        "stats": {
+          "$ref": "#/definitions/ExpressRouteCircuitStats",
+          "description": "The peering stats of express route circuit."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route circuit peering resource.",
+          "readOnly": true
+        },
+        "gatewayManagerEtag": {
+          "type": "string",
+          "description": "The GatewayManager Etag."
+        },
+        "lastModifiedBy": {
+          "type": "string",
+          "description": "Who was the last to modify the peering.",
+          "readOnly": true
+        },
+        "routeFilter": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the RouteFilter resource."
+        },
+        "ipv6PeeringConfig": {
+          "$ref": "#/definitions/Ipv6ExpressRouteCircuitPeeringConfig",
+          "description": "The IPv6 peering configuration."
+        },
+        "expressRouteConnection": {
+          "$ref": "./virtualWan.json#/definitions/ExpressRouteConnectionId",
+          "description": "The ExpressRoute connection."
+        },
+        "connections": {
+          "type": "array",
+          "description": "The list of circuit connections associated with Azure Private Peering for this circuit.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitConnection"
+          }
+        },
+        "peeredConnections": {
+          "type": "array",
+          "description": "The list of peered circuit connections associated with Azure Private Peering for this circuit.",
+          "items": {
+            "$ref": "#/definitions/PeerExpressRouteCircuitConnection"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ExpressRouteCircuitPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of ExpressRouteCircuit.",
+      "properties": {
+        "allowClassicOperations": {
+          "type": "boolean",
+          "description": "Allow classic operations."
+        },
+        "circuitProvisioningState": {
+          "type": "string",
+          "description": "The CircuitProvisioningState state of the resource."
+        },
+        "serviceProviderProvisioningState": {
+          "$ref": "./common.json#/definitions/ServiceProviderProvisioningState",
+          "description": "The ServiceProviderProvisioningState state of the resource."
+        },
+        "authorizations": {
+          "type": "array",
+          "description": "The list of authorizations.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitAuthorization"
+          }
+        },
+        "peerings": {
+          "type": "array",
+          "description": "The list of peerings.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitPeering"
+          }
+        },
+        "serviceKey": {
+          "type": "string",
+          "description": "The ServiceKey."
+        },
+        "serviceProviderNotes": {
+          "type": "string",
+          "description": "The ServiceProviderNotes."
+        },
+        "serviceProviderProperties": {
+          "$ref": "#/definitions/ExpressRouteCircuitServiceProviderProperties",
+          "description": "The ServiceProviderProperties."
+        },
+        "expressRoutePort": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the ExpressRoutePort resource when the circuit is provisioned on an ExpressRoutePort resource."
+        },
+        "bandwidthInGbps": {
+          "type": "number",
+          "format": "float",
+          "description": "The bandwidth of the circuit when the circuit is provisioned on an ExpressRoutePort resource."
+        },
+        "stag": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The identifier of the circuit traffic. Outer tag for QinQ encapsulation.",
+          "readOnly": true
+        },
+        "resiliencyLevel": {
+          "$ref": "./common.json#/definitions/ResiliencyLevel",
+          "description": "The resiliency level of the ExpressRoute circuit.",
+          "readOnly": true
+        },
+        "partnerAccountId": {
+          "type": "string",
+          "description": "Account ID of customer account on partner cloud provider."
+        },
+        "activationKey": {
+          "type": "string",
+          "description": "Activation Key from partner cloud provider."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route circuit resource.",
+          "readOnly": true
+        },
+        "gatewayManagerEtag": {
+          "type": "string",
+          "description": "The GatewayManager Etag."
+        },
+        "globalReachEnabled": {
+          "type": "boolean",
+          "description": "Flag denoting global reach status."
+        },
+        "authorizationKey": {
+          "type": "string",
+          "description": "The authorizationKey."
+        },
+        "authorizationStatus": {
+          "type": "string",
+          "description": "The authorization status of the Circuit.",
+          "readOnly": true
+        },
+        "enableDirectPortRateLimit": {
+          "type": "boolean",
+          "description": "Flag denoting rate-limiting status of the ExpressRoute direct-port circuit."
+        }
+      }
+    },
+    "ExpressRouteCircuitReference": {
+      "type": "object",
+      "description": "Reference to an express route circuit.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Corresponding Express Route Circuit Id."
+        }
+      }
+    },
+    "ExpressRouteCircuitRoutesTable": {
+      "type": "object",
+      "description": "The routes table associated with the ExpressRouteCircuit.",
+      "properties": {
+        "network": {
+          "type": "string",
+          "description": "IP address of a network entity."
+        },
+        "nextHop": {
+          "type": "string",
+          "description": "NextHop address."
+        },
+        "locPrf": {
+          "type": "string",
+          "description": "Local preference value as set with the set local-preference route-map configuration command."
+        },
+        "weight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Route Weight."
+        },
+        "path": {
+          "type": "string",
+          "description": "Autonomous system paths to the destination network."
+        }
+      }
+    },
+    "ExpressRouteCircuitRoutesTableSummary": {
+      "type": "object",
+      "description": "The routes table associated with the ExpressRouteCircuit.",
+      "properties": {
+        "neighbor": {
+          "type": "string",
+          "description": "IP address of the neighbor."
+        },
+        "v": {
+          "type": "integer",
+          "format": "int32",
+          "description": "BGP version number spoken to the neighbor."
+        },
+        "as": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Autonomous system number."
+        },
+        "upDown": {
+          "type": "string",
+          "description": "The length of time that the BGP session has been in the Established state, or the current status if not in the Established state."
+        },
+        "statePfxRcd": {
+          "type": "string",
+          "description": "Current state of the BGP session, and the number of prefixes that have been received from a neighbor or peer group."
+        }
+      }
+    },
+    "ExpressRouteCircuitServiceProviderProperties": {
+      "type": "object",
+      "description": "Contains ServiceProviderProperties in an ExpressRouteCircuit.",
+      "properties": {
+        "serviceProviderName": {
+          "type": "string",
+          "description": "The serviceProviderName."
+        },
+        "peeringLocation": {
+          "type": "string",
+          "description": "The peering location."
+        },
+        "bandwidthInMbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The BandwidthInMbps."
+        }
+      }
+    },
+    "ExpressRouteCircuitSku": {
+      "type": "object",
+      "description": "Contains SKU in an ExpressRouteCircuit.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU."
+        },
+        "tier": {
+          "$ref": "./common.json#/definitions/ExpressRouteCircuitSkuTier",
+          "description": "The tier of the SKU."
+        },
+        "family": {
+          "$ref": "./common.json#/definitions/ExpressRouteCircuitSkuFamily",
+          "description": "The family of the SKU."
+        }
+      }
+    },
+    "ExpressRouteCircuitStats": {
+      "type": "object",
+      "description": "Contains stats associated with the peering.",
+      "properties": {
+        "primarybytesIn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The Primary BytesIn of the peering."
+        },
+        "primarybytesOut": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The primary BytesOut of the peering."
+        },
+        "secondarybytesIn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The secondary BytesIn of the peering."
+        },
+        "secondarybytesOut": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The secondary BytesOut of the peering."
+        }
+      }
+    },
+    "ExpressRouteCircuitsArpTableListResult": {
+      "type": "object",
+      "description": "Response for ListArpTable associated with the Express Route Circuits API.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteCircuitArpTable items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitArpTable"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteCircuitsRoutesTableListResult": {
+      "type": "object",
+      "description": "Response for ListRoutesTable associated with the Express Route Circuits API.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteCircuitRoutesTable items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitRoutesTable"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteCircuitsRoutesTableSummaryListResult": {
+      "type": "object",
+      "description": "Response for ListRoutesTable associated with the Express Route Circuits API.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteCircuitRoutesTableSummary items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitRoutesTableSummary"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteCrossConnection": {
+      "type": "object",
+      "description": "ExpressRouteCrossConnection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteCrossConnectionProperties",
+          "description": "Properties of the express route cross connection.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ExpressRouteCrossConnectionListResult": {
+      "type": "object",
+      "description": "The response of a ExpressRouteCrossConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteCrossConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCrossConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteCrossConnectionPeering": {
+      "type": "object",
+      "description": "Peering in an ExpressRoute Cross Connection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteCrossConnectionPeeringProperties",
+          "description": "Properties of the express route cross connection peering.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ExpressRouteCrossConnectionPeeringList": {
+      "type": "object",
+      "description": "Response for ListPeering API service call retrieves all peerings that belong to an ExpressRouteCrossConnection.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteCrossConnectionPeering items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCrossConnectionPeering"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteCrossConnectionPeeringProperties": {
+      "type": "object",
+      "description": "Properties of express route cross connection peering.",
+      "properties": {
+        "peeringType": {
+          "$ref": "./common.json#/definitions/ExpressRoutePeeringType",
+          "description": "The peering type."
+        },
+        "state": {
+          "$ref": "./common.json#/definitions/ExpressRoutePeeringState",
+          "description": "The peering state."
+        },
+        "azureASN": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The Azure ASN.",
+          "readOnly": true
+        },
+        "peerASN": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The peer ASN.",
+          "minimum": 1,
+          "maximum": 4294967295
+        },
+        "primaryPeerAddressPrefix": {
+          "type": "string",
+          "description": "The primary address prefix."
+        },
+        "secondaryPeerAddressPrefix": {
+          "type": "string",
+          "description": "The secondary address prefix."
+        },
+        "primaryAzurePort": {
+          "type": "string",
+          "description": "The primary port.",
+          "readOnly": true
+        },
+        "secondaryAzurePort": {
+          "type": "string",
+          "description": "The secondary port.",
+          "readOnly": true
+        },
+        "sharedKey": {
+          "type": "string",
+          "description": "The shared key."
+        },
+        "vlanId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The VLAN ID."
+        },
+        "microsoftPeeringConfig": {
+          "$ref": "#/definitions/ExpressRouteCircuitPeeringConfig",
+          "description": "The Microsoft peering configuration."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route cross connection peering resource.",
+          "readOnly": true
+        },
+        "gatewayManagerEtag": {
+          "type": "string",
+          "description": "The GatewayManager Etag."
+        },
+        "lastModifiedBy": {
+          "type": "string",
+          "description": "Who was the last to modify the peering.",
+          "readOnly": true
+        },
+        "ipv6PeeringConfig": {
+          "$ref": "#/definitions/Ipv6ExpressRouteCircuitPeeringConfig",
+          "description": "The IPv6 peering configuration."
+        }
+      }
+    },
+    "ExpressRouteCrossConnectionProperties": {
+      "type": "object",
+      "description": "Properties of ExpressRouteCrossConnection.",
+      "properties": {
+        "primaryAzurePort": {
+          "type": "string",
+          "description": "The name of the primary port.",
+          "readOnly": true
+        },
+        "secondaryAzurePort": {
+          "type": "string",
+          "description": "The name of the secondary port.",
+          "readOnly": true
+        },
+        "sTag": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The identifier of the circuit traffic.",
+          "readOnly": true
+        },
+        "peeringLocation": {
+          "type": "string",
+          "description": "The peering location of the ExpressRoute circuit.",
+          "readOnly": true
+        },
+        "bandwidthInMbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The circuit bandwidth In Mbps.",
+          "readOnly": true
+        },
+        "expressRouteCircuit": {
+          "$ref": "#/definitions/ExpressRouteCircuitReference",
+          "description": "The ExpressRouteCircuit."
+        },
+        "serviceProviderProvisioningState": {
+          "$ref": "./common.json#/definitions/ServiceProviderProvisioningState",
+          "description": "The provisioning state of the circuit in the connectivity provider system."
+        },
+        "serviceProviderNotes": {
+          "type": "string",
+          "description": "Additional read only notes set by the connectivity provider."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route cross connection resource.",
+          "readOnly": true
+        },
+        "peerings": {
+          "type": "array",
+          "description": "The list of peerings.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCrossConnectionPeering"
+          }
+        }
+      }
+    },
+    "ExpressRouteCrossConnectionRoutesTableSummary": {
+      "type": "object",
+      "description": "The routes table associated with the ExpressRouteCircuit.",
+      "properties": {
+        "neighbor": {
+          "type": "string",
+          "description": "IP address of Neighbor router."
+        },
+        "asn": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Autonomous system number."
+        },
+        "upDown": {
+          "type": "string",
+          "description": "The length of time that the BGP session has been in the Established state, or the current status if not in the Established state."
+        },
+        "stateOrPrefixesReceived": {
+          "type": "string",
+          "description": "Current state of the BGP session, and the number of prefixes that have been received from a neighbor or peer group."
+        }
+      }
+    },
+    "ExpressRouteCrossConnectionsRoutesTableSummaryListResult": {
+      "type": "object",
+      "description": "Response for ListRoutesTable associated with the Express Route Cross Connections.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteCrossConnectionRoutesTableSummary items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCrossConnectionRoutesTableSummary"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteLag": {
+      "type": "object",
+      "title": "ExpressRoute LAG",
+      "description": "ExpressRouteLag resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteLagPropertiesFormat",
+          "description": "ExpressRouteLag properties."
+        },
+        "id": {
+          "type": "string",
+          "description": "The unique identifier of the resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the resource.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "identity": {
+          "$ref": "./common.json#/definitions/ManagedServiceIdentity",
+          "description": "The identity of ExpressRouteLag, if configured."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ExpressRouteLagLink": {
+      "type": "object",
+      "title": "ExpressRouteLagLink",
+      "description": "ExpressRouteLagLink child resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteLagLinkPropertiesFormat",
+          "description": "ExpressRouteLagLink properties."
+        },
+        "id": {
+          "type": "string",
+          "description": "The unique identifier of the resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the resource.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of child link resource that is unique among child link resources of the parent.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "name"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ExpressRouteLagLinkListResult": {
+      "type": "object",
+      "title": "ExpressRoute LAG Link List Result",
+      "description": "Paged collection of ExpressRouteLagLink items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteLagLink items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLagLink"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteLagLinkPropertiesFormat": {
+      "type": "object",
+      "title": "ExpressRouteLagLink Resource Properties",
+      "description": "Properties specific to ExpressRouteLagLink resources.",
+      "properties": {
+        "routerName": {
+          "type": "string",
+          "description": "Name of Azure router associated with link.",
+          "readOnly": true
+        },
+        "interfaceName": {
+          "type": "string",
+          "description": "Name of Azure router interface.",
+          "readOnly": true
+        },
+        "adminState": {
+          "$ref": "./common.json#/definitions/ExpressRouteLinkAdminState",
+          "description": "Administrative state of the link."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route LAG link resource.",
+          "readOnly": true
+        },
+        "macSecConfig": {
+          "$ref": "#/definitions/ExpressRouteLinkMacSecConfig",
+          "description": "MacSec configuration."
+        },
+        "members": {
+          "type": "array",
+          "title": "ExpressRouteLagMember Sub-Resources",
+          "description": "The set of members of the ExpressRouteLagLink resource.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLagMember"
+          }
+        }
+      }
+    },
+    "ExpressRouteLagListResult": {
+      "type": "object",
+      "title": "ExpressRoute LAG List Result",
+      "description": "Paged collection of ExpressRouteLag items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteLag items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLag"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteLagMember": {
+      "type": "object",
+      "title": "ExpressRouteLagMember",
+      "description": "ExpressRouteLagMember child resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteLagMemberPropertiesFormat",
+          "description": "ExpressRouteLagMember properties."
+        },
+        "id": {
+          "type": "string",
+          "description": "The unique identifier of the resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the resource.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of child member resource that is unique among child member resources of the parent.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "name"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ExpressRouteLagMemberListResult": {
+      "type": "object",
+      "title": "ExpressRoute LAG Member List Result",
+      "description": "Paged collection of ExpressRouteLagMember items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteLagMember items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLagMember"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteLagMemberPropertiesFormat": {
+      "type": "object",
+      "title": "ExpressRouteLagMember Resource Properties",
+      "description": "Properties specific to ExpressRouteLagMember resources.",
+      "properties": {
+        "interfaceName": {
+          "type": "string",
+          "description": "Name of Azure router interface.",
+          "readOnly": true
+        },
+        "patchPanelId": {
+          "type": "string",
+          "description": "Mapping between physical port to patch panel port.",
+          "readOnly": true
+        },
+        "rackId": {
+          "type": "string",
+          "description": "Mapping of physical patch panel to rack.",
+          "readOnly": true
+        },
+        "coloLocation": {
+          "type": "string",
+          "description": "Cololocation for ExpressRoute member.",
+          "readOnly": true
+        },
+        "connectorType": {
+          "$ref": "./common.json#/definitions/ExpressRouteLinkConnectorType",
+          "description": "Physical fiber port type.",
+          "readOnly": true
+        },
+        "adminState": {
+          "$ref": "./common.json#/definitions/ExpressRouteLinkAdminState",
+          "description": "Administrative state of the member port."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route LAG member resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ExpressRouteLagPropertiesFormat": {
+      "type": "object",
+      "title": "ExpressRouteLag Resource Properties",
+      "description": "Properties specific to ExpressRouteLag resources.",
+      "properties": {
+        "peeringLocation": {
+          "type": "string",
+          "description": "The name of the peering location that the ExpressRouteLag is mapped to physically."
+        },
+        "bandwidthInGbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Bandwidth of procured LAG in Gbps."
+        },
+        "provisionedBandwidthInGbps": {
+          "type": "number",
+          "format": "double",
+          "description": "Aggregate Gbps of associated circuit bandwidths.",
+          "readOnly": true
+        },
+        "mtu": {
+          "type": "string",
+          "description": "Maximum transmission unit of the LAG.",
+          "readOnly": true
+        },
+        "encapsulation": {
+          "$ref": "./common.json#/definitions/ExpressRouteLagEncapsulation",
+          "description": "Encapsulation method on LAG."
+        },
+        "etherType": {
+          "type": "string",
+          "description": "Ether type of the LAG.",
+          "readOnly": true
+        },
+        "links": {
+          "type": "array",
+          "title": "ExpressRouteLagLink Sub-Resources",
+          "description": "The set of links of the ExpressRouteLag resource.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLagLink"
+          }
+        },
+        "allocationDate": {
+          "type": "string",
+          "description": "The date and time when the ExpressRouteLag was allocated.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route LAG resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the express route LAG resource.",
+          "readOnly": true
+        },
+        "billingType": {
+          "$ref": "./common.json#/definitions/ExpressRouteLagBillingType",
+          "description": "The billing type of the ExpressRouteLag resource."
+        },
+        "numberOfPorts": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of ports in the LAG.",
+          "minimum": 1
+        },
+        "minimumActivePortsRequired": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of active ports required for LAG.",
+          "minimum": 1
+        },
+        "lacpTimer": {
+          "$ref": "./common.json#/definitions/ExpressRouteLagLacpTimer",
+          "description": "LACP timer configuration."
+        }
+      }
+    },
+    "ExpressRouteLagUpdateTagsOrIdentityRequest": {
+      "type": "object",
+      "title": "ExpressRouteLag Update Tags or Identity Request",
+      "description": "Parameters for updating ExpressRouteLag tags or identity.",
+      "properties": {
+        "identity": {
+          "$ref": "./common.json#/definitions/ManagedServiceIdentity",
+          "description": "The identity of ExpressRouteLag, if configured."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ExpressRouteLink": {
+      "type": "object",
+      "title": "ExpressRouteLink",
+      "description": "ExpressRouteLink child resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteLinkPropertiesFormat",
+          "description": "ExpressRouteLink properties.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of child port resource that is unique among child port resources of the parent."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ExpressRouteLinkFailoverAllTestsDetails": {
+      "type": "object",
+      "description": "ExpressRoute circuit link failover test details for all tests.",
+      "properties": {
+        "status": {
+          "$ref": "./common.json#/definitions/FailoverTestStatus",
+          "description": "The current status of the test."
+        },
+        "startTime": {
+          "type": "string",
+          "description": "Time when the test was started."
+        },
+        "endTime": {
+          "type": "string",
+          "description": "Time when the test was completed."
+        },
+        "testGuid": {
+          "type": "string",
+          "description": "The unique GUID associated with the test."
+        },
+        "testType": {
+          "$ref": "./common.json#/definitions/FailoverTestType",
+          "description": "The type of failover test."
+        },
+        "issues": {
+          "type": "array",
+          "description": "A list of all issues with the test.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "wasSimulationSuccessful": {
+          "type": "boolean",
+          "description": "Whether the failover simulation was successful or not."
+        },
+        "circuitTestCategory": {
+          "$ref": "./common.json#/definitions/MaintenanceTestCategory",
+          "description": "The maintenance test category."
+        },
+        "linkType": {
+          "$ref": "./common.json#/definitions/ExpressRouteFailoverLinkType",
+          "description": "The link type."
+        },
+        "bgpStatus": {
+          "type": "array",
+          "description": "The BGP status details.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLinkFailoverTestBgpStatus"
+          }
+        }
+      }
+    },
+    "ExpressRouteLinkFailoverAllTestsDetailsArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ExpressRouteLinkFailoverAllTestsDetails"
+      }
+    },
+    "ExpressRouteLinkFailoverRoute": {
+      "type": "object",
+      "description": "Represents a failover route for an ExpressRoute link.",
+      "properties": {
+        "route": {
+          "type": "string",
+          "description": "The route."
+        },
+        "nextHop": {
+          "type": "string",
+          "description": "The next hop."
+        },
+        "primaryASPath": {
+          "type": "string",
+          "description": "The AS path for primary link."
+        },
+        "secondaryASPath": {
+          "type": "string",
+          "description": "The AS path for secondary link."
+        }
+      }
+    },
+    "ExpressRouteLinkFailoverRouteList": {
+      "type": "object",
+      "description": "Represents a list of failover routes for an ExpressRoute link.",
+      "properties": {
+        "beforeSimulation": {
+          "type": "array",
+          "description": "The routes before the simulation.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLinkFailoverRoute"
+          }
+        },
+        "duringSimulation": {
+          "type": "array",
+          "description": "The routes during the simulation.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLinkFailoverRoute"
+          }
+        }
+      }
+    },
+    "ExpressRouteLinkFailoverSingleTestDetails": {
+      "type": "object",
+      "description": "ExpressRoute circuit link failover single test details.",
+      "properties": {
+        "startTimeUtc": {
+          "type": "string",
+          "description": "Time when the test was started in UTC."
+        },
+        "endTimeUtc": {
+          "type": "string",
+          "description": "Time when the test was completed in UTC."
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/FailoverTestStatus",
+          "description": "The current status of the test."
+        },
+        "wasSimulationSuccessful": {
+          "type": "boolean",
+          "description": "Whether the failover simulation was successful or not."
+        },
+        "linkType": {
+          "$ref": "./common.json#/definitions/ExpressRouteFailoverLinkType",
+          "description": "The link type."
+        },
+        "circuitTestCategory": {
+          "$ref": "./common.json#/definitions/MaintenanceTestCategory",
+          "description": "The circuit test category."
+        },
+        "isSimulationVerified": {
+          "type": "boolean",
+          "description": "Whether the simulation was verified."
+        },
+        "redundantRoutes": {
+          "$ref": "#/definitions/ExpressRouteLinkFailoverRouteList",
+          "description": "The redundant routes for link failover tests."
+        },
+        "nonRedundantRoutes": {
+          "$ref": "#/definitions/ExpressRouteLinkFailoverRouteList",
+          "description": "The non-redundant routes for link failover tests."
+        },
+        "bgpStatus": {
+          "type": "array",
+          "description": "The BGP status details.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLinkFailoverTestBgpStatus"
+          }
+        }
+      }
+    },
+    "ExpressRouteLinkFailoverSingleTestDetailsArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ExpressRouteLinkFailoverSingleTestDetails"
+      }
+    },
+    "ExpressRouteLinkFailoverStopApiParameters": {
+      "type": "object",
+      "description": "Parameters for stopping an ExpressRoute circuit link failover test.",
+      "properties": {
+        "circuitTestCategory": {
+          "type": "string",
+          "description": "The category of the circuit test."
+        },
+        "linkType": {
+          "type": "string",
+          "description": "The type of the link."
+        },
+        "wasSimulationSuccessful": {
+          "type": "boolean",
+          "description": "Whether the simulation was successful."
+        },
+        "isVerified": {
+          "type": "boolean",
+          "description": "Whether the link is verified."
+        }
+      }
+    },
+    "ExpressRouteLinkFailoverTestBgpStatus": {
+      "type": "object",
+      "description": "Represents the BGP status of an ExpressRoute link failover test.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/ExpressRouteFailoverBgpStatusAddressFamily",
+          "description": "The address family type."
+        },
+        "link": {
+          "$ref": "./common.json#/definitions/ExpressRouteFailoverLinkType",
+          "description": "The link type."
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/ExpressRouteLinkFailoverBgpStatus",
+          "description": "The BGP status."
+        },
+        "checkTimeUtc": {
+          "type": "string",
+          "description": "The check time in UTC."
+        }
+      }
+    },
+    "ExpressRouteLinkListResult": {
+      "type": "object",
+      "title": "ExpressRouteLink List Result",
+      "description": "Response for ListExpressRouteLinks API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteLink items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLink"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteLinkMacSecConfig": {
+      "type": "object",
+      "title": "Definition of ExpressRouteLink Mac Security configuration.",
+      "description": "ExpressRouteLink Mac Security Configuration.",
+      "properties": {
+        "cknSecretIdentifier": {
+          "type": "string",
+          "description": "Keyvault Secret Identifier URL containing Mac security CKN key."
+        },
+        "cakSecretIdentifier": {
+          "type": "string",
+          "description": "Keyvault Secret Identifier URL containing Mac security CAK key."
+        },
+        "cipher": {
+          "$ref": "./common.json#/definitions/ExpressRouteLinkMacSecCipher",
+          "description": "Mac security cipher."
+        },
+        "sciState": {
+          "$ref": "./common.json#/definitions/ExpressRouteLinkMacSecSciState",
+          "description": "Sci mode enabled/disabled."
+        }
+      }
+    },
+    "ExpressRouteLinkPropertiesFormat": {
+      "type": "object",
+      "title": "ExpressRouteLink Resource Properties",
+      "description": "Properties specific to ExpressRouteLink resources.",
+      "properties": {
+        "routerName": {
+          "type": "string",
+          "description": "Name of Azure router associated with physical port.",
+          "readOnly": true
+        },
+        "interfaceName": {
+          "type": "string",
+          "description": "Name of Azure router interface.",
+          "readOnly": true
+        },
+        "patchPanelId": {
+          "type": "string",
+          "description": "Mapping between physical port to patch panel port.",
+          "readOnly": true
+        },
+        "rackId": {
+          "type": "string",
+          "description": "Mapping of physical patch panel to rack.",
+          "readOnly": true
+        },
+        "coloLocation": {
+          "type": "string",
+          "description": "Cololocation for ExpressRoute Hybrid Direct.",
+          "readOnly": true
+        },
+        "connectorType": {
+          "$ref": "./common.json#/definitions/ExpressRouteLinkConnectorType",
+          "description": "Physical fiber port type.",
+          "readOnly": true
+        },
+        "adminState": {
+          "$ref": "./common.json#/definitions/ExpressRouteLinkAdminState",
+          "description": "Administrative state of the physical port."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route link resource.",
+          "readOnly": true
+        },
+        "macSecConfig": {
+          "$ref": "#/definitions/ExpressRouteLinkMacSecConfig",
+          "description": "MacSec configuration."
+        }
+      }
+    },
+    "ExpressRoutePort": {
+      "type": "object",
+      "title": "ExpressRoute Port",
+      "description": "ExpressRoutePort resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRoutePortPropertiesFormat",
+          "description": "ExpressRoutePort properties.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "identity": {
+          "$ref": "./common.json#/definitions/ManagedServiceIdentity",
+          "description": "The identity of ExpressRoutePort, if configured."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ExpressRoutePortAuthorization": {
+      "type": "object",
+      "title": "ExpressRoute Port Authorization",
+      "description": "ExpressRoutePort Authorization resource definition.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRoutePortAuthorizationPropertiesFormat",
+          "description": "ExpressRoutePort properties.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "ExpressRoutePortAuthorizationListResult": {
+      "type": "object",
+      "title": "ExpressRoute Port Authorization List Result",
+      "description": "Paged collection of ExpressRoutePortAuthorization items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRoutePortAuthorization items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRoutePortAuthorization"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRoutePortAuthorizationPropertiesFormat": {
+      "type": "object",
+      "title": "ExpressRoute Port Authorization Properties",
+      "description": "Properties of ExpressRoutePort Authorization.",
+      "properties": {
+        "authorizationKey": {
+          "type": "string",
+          "description": "The authorization key.",
+          "readOnly": true
+        },
+        "authorizationUseStatus": {
+          "$ref": "./common.json#/definitions/ExpressRoutePortAuthorizationUseStatus",
+          "description": "The authorization use status.",
+          "readOnly": true
+        },
+        "circuitResourceUri": {
+          "type": "string",
+          "description": "The reference to the ExpressRoute circuit resource using the authorization.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the authorization resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ExpressRoutePortListResult": {
+      "type": "object",
+      "title": "ExpressRoute Port List Result",
+      "description": "Paged collection of ExpressRoutePort items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRoutePort items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRoutePort"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRoutePortPropertiesFormat": {
+      "type": "object",
+      "title": "ExpressRoutePort Properties",
+      "description": "Properties specific to ExpressRoutePort resources.",
+      "properties": {
+        "peeringLocation": {
+          "type": "string",
+          "description": "The name of the peering location that the ExpressRoutePort is mapped to physically."
+        },
+        "bandwidthInGbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Bandwidth of procured ports in Gbps."
+        },
+        "provisionedBandwidthInGbps": {
+          "type": "number",
+          "format": "float",
+          "description": "Aggregate Gbps of associated circuit bandwidths.",
+          "readOnly": true
+        },
+        "mtu": {
+          "type": "string",
+          "description": "Maximum transmission unit of the physical port pair(s).",
+          "readOnly": true
+        },
+        "encapsulation": {
+          "$ref": "./common.json#/definitions/ExpressRoutePortsEncapsulation",
+          "description": "Encapsulation method on physical ports."
+        },
+        "etherType": {
+          "type": "string",
+          "description": "Ether type of the physical port.",
+          "readOnly": true
+        },
+        "allocationDate": {
+          "type": "string",
+          "description": "Date of the physical port allocation to be used in Letter of Authorization.",
+          "readOnly": true
+        },
+        "links": {
+          "type": "array",
+          "title": "ExpressRouteLink Sub-Resources",
+          "description": "The set of physical links of the ExpressRoutePort resource.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteLink"
+          }
+        },
+        "circuits": {
+          "type": "array",
+          "description": "Reference the ExpressRoute circuit(s) that are provisioned on this ExpressRoutePort resource.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route port resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the express route port resource.",
+          "readOnly": true
+        },
+        "billingType": {
+          "$ref": "./common.json#/definitions/ExpressRoutePortsBillingType",
+          "description": "The billing type of the ExpressRoutePort resource."
+        }
+      }
+    },
+    "ExpressRoutePortsLocation": {
+      "type": "object",
+      "title": "ExpressRoutePorts Peering Location",
+      "description": "Definition of the ExpressRoutePorts peering location resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRoutePortsLocationPropertiesFormat",
+          "description": "ExpressRoutePort peering location properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ExpressRoutePortsLocationBandwidths": {
+      "type": "object",
+      "title": "ExpressRoutePorts Location Bandwidths",
+      "description": "Real-time inventory of available ExpressRoute port bandwidths.",
+      "properties": {
+        "offerName": {
+          "type": "string",
+          "description": "Bandwidth descriptive name.",
+          "readOnly": true
+        },
+        "valueInGbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Bandwidth value in Gbps.",
+          "readOnly": true
+        }
+      }
+    },
+    "ExpressRoutePortsLocationListResult": {
+      "type": "object",
+      "title": "ExpressRoutePorts Location List Result",
+      "description": "Paged collection of ExpressRoutePortsLocation items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRoutePortsLocation items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRoutePortsLocation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRoutePortsLocationPropertiesFormat": {
+      "type": "object",
+      "title": "ExpressRoutePorts Location Properties",
+      "description": "Properties specific to ExpressRoutePorts peering location resources.",
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "Address of peering location.",
+          "readOnly": true
+        },
+        "contact": {
+          "type": "string",
+          "description": "Contact details of peering locations.",
+          "readOnly": true
+        },
+        "availableBandwidths": {
+          "type": "array",
+          "description": "The inventory of available ExpressRoutePort bandwidths.",
+          "items": {
+            "$ref": "#/definitions/ExpressRoutePortsLocationBandwidths"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route port location resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ExpressRouteProviderPort": {
+      "type": "object",
+      "description": "ExpressRouteProviderPort resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteProviderPortProperties",
+          "description": "Properties of the express route Service Provider Port.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/TrackedResourceWithOptionalLocation"
+        }
+      ]
+    },
+    "ExpressRouteProviderPortListResult": {
+      "type": "object",
+      "description": "Response for ListExpressRouteProviderPort API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteProviderPort items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteProviderPort"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteProviderPortProperties": {
+      "type": "object",
+      "description": "Properties of ExpressRouteProviderPort.",
+      "properties": {
+        "portPairDescriptor": {
+          "type": "string",
+          "description": "The name of the port pair.",
+          "readOnly": true
+        },
+        "primaryAzurePort": {
+          "type": "string",
+          "description": "The name of the primary port.",
+          "readOnly": true
+        },
+        "secondaryAzurePort": {
+          "type": "string",
+          "description": "The name of the secondary port.",
+          "readOnly": true
+        },
+        "peeringLocation": {
+          "type": "string",
+          "description": "The peering location of the port pair."
+        },
+        "overprovisionFactor": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Overprovisioning factor for the port pair."
+        },
+        "portBandwidthInMbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Bandwidth of the port in Mbps"
+        },
+        "usedBandwidthInMbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Used Bandwidth of the port in Mbps"
+        },
+        "remainingBandwidthInMbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Remaining Bandwidth of the port in Mbps"
+        }
+      }
+    },
+    "ExpressRouteServiceProvider": {
+      "type": "object",
+      "description": "A ExpressRouteResourceProvider object.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteServiceProviderPropertiesFormat",
+          "description": "Properties of the express route service provider.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ExpressRouteServiceProviderBandwidthsOffered": {
+      "type": "object",
+      "description": "Contains bandwidths offered in ExpressRouteServiceProvider resources.",
+      "properties": {
+        "offerName": {
+          "type": "string",
+          "description": "The OfferName."
+        },
+        "valueInMbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The ValueInMbps."
+        }
+      }
+    },
+    "ExpressRouteServiceProviderListResult": {
+      "type": "object",
+      "description": "The response of a ExpressRouteServiceProvider list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ExpressRouteServiceProvider items on this page",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteServiceProvider"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ExpressRouteServiceProviderPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of ExpressRouteServiceProvider.",
+      "properties": {
+        "peeringLocations": {
+          "type": "array",
+          "description": "A list of peering locations.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "bandwidthsOffered": {
+          "type": "array",
+          "description": "A list of bandwidths offered.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteServiceProviderBandwidthsOffered"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route service provider resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "GenerateExpressRouteLagsLOARequest": {
+      "type": "object",
+      "description": "The customer name to be printed on a letter of authorization for ExpressRouteLag.",
+      "properties": {
+        "customerName": {
+          "type": "string",
+          "description": "The customer name."
+        },
+        "members": {
+          "type": "array",
+          "description": "The list of member names for which LOA should be generated.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "customerName"
+      ]
+    },
+    "GenerateExpressRouteLagsLOAResult": {
+      "type": "object",
+      "description": "Response for GenerateExpressRouteLagsLOA API service call.",
+      "properties": {
+        "encodedContent": {
+          "type": "string",
+          "description": "The content as a base64 encoded string."
+        }
+      }
+    },
+    "GenerateExpressRoutePortsLOARequest": {
+      "type": "object",
+      "description": "The customer name to be printed on a letter of authorization.",
+      "properties": {
+        "customerName": {
+          "type": "string",
+          "description": "The customer name."
+        }
+      },
+      "required": [
+        "customerName"
+      ]
+    },
+    "GenerateExpressRoutePortsLOAResult": {
+      "type": "object",
+      "description": "Response for GenerateExpressRoutePortsLOA API service call.",
+      "properties": {
+        "encodedContent": {
+          "type": "string",
+          "description": "The content as a base64 encoded string."
+        }
+      }
+    },
+    "Ipv6CircuitConnectionConfig": {
+      "type": "object",
+      "description": "IPv6 Circuit Connection properties for global reach.",
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "/125 IP address space to carve out customer addresses for global reach."
+        },
+        "circuitConnectionStatus": {
+          "$ref": "./common.json#/definitions/CircuitConnectionStatus",
+          "description": "Express Route Circuit connection state.",
+          "readOnly": true
+        }
+      }
+    },
+    "Ipv6ExpressRouteCircuitPeeringConfig": {
+      "type": "object",
+      "description": "Contains IPv6 peering config.",
+      "properties": {
+        "primaryPeerAddressPrefix": {
+          "type": "string",
+          "description": "The primary address prefix."
+        },
+        "secondaryPeerAddressPrefix": {
+          "type": "string",
+          "description": "The secondary address prefix."
+        },
+        "microsoftPeeringConfig": {
+          "$ref": "#/definitions/ExpressRouteCircuitPeeringConfig",
+          "description": "The Microsoft peering configuration."
+        },
+        "routeFilter": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the RouteFilter resource."
+        },
+        "state": {
+          "$ref": "./common.json#/definitions/ExpressRouteCircuitPeeringState",
+          "description": "The state of peering."
+        }
+      }
+    },
+    "PatchRouteFilter": {
+      "type": "object",
+      "description": "Route Filter Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RouteFilterPropertiesFormat",
+          "description": "Properties of the route filter.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "PatchRouteFilterRule": {
+      "type": "object",
+      "description": "Route Filter Rule Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RouteFilterRulePropertiesFormat",
+          "description": "Properties of the route filter rule.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "PeerExpressRouteCircuitConnection": {
+      "type": "object",
+      "description": "Peer Express Route Circuit Connection in an ExpressRouteCircuitPeering resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PeerExpressRouteCircuitConnectionPropertiesFormat",
+          "description": "Properties of the peer express route circuit connection.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "PeerExpressRouteCircuitConnectionListResult": {
+      "type": "object",
+      "description": "The response of a PeerExpressRouteCircuitConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PeerExpressRouteCircuitConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/PeerExpressRouteCircuitConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PeerExpressRouteCircuitConnectionPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the peer express route circuit connection.",
+      "properties": {
+        "expressRouteCircuitPeering": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to Express Route Circuit Private Peering Resource of the circuit."
+        },
+        "peerExpressRouteCircuitPeering": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to Express Route Circuit Private Peering Resource of the peered circuit."
+        },
+        "addressPrefix": {
+          "type": "string",
+          "description": "/29 IP address space to carve out Customer addresses for tunnels."
+        },
+        "circuitConnectionStatus": {
+          "$ref": "./common.json#/definitions/CircuitConnectionStatus",
+          "description": "Express Route Circuit connection state.",
+          "readOnly": true
+        },
+        "connectionName": {
+          "type": "string",
+          "description": "The name of the express route circuit connection resource."
+        },
+        "authResourceGuid": {
+          "type": "string",
+          "description": "The resource guid of the authorization used for the express route circuit connection."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the peer express route circuit connection resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "RouteFilter": {
+      "type": "object",
+      "description": "Route Filter Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RouteFilterPropertiesFormat",
+          "description": "Properties of the route filter.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/TrackedResourceWithSettableIdOptionalLocation"
+        }
+      ]
+    },
+    "RouteFilterListResult": {
+      "type": "object",
+      "description": "The response of a RouteFilter list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RouteFilter items on this page",
+          "items": {
+            "$ref": "#/definitions/RouteFilter"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RouteFilterPropertiesFormat": {
+      "type": "object",
+      "description": "Route Filter Resource.",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "description": "Collection of RouteFilterRules contained within a route filter.",
+          "items": {
+            "$ref": "#/definitions/RouteFilterRule"
+          }
+        },
+        "peerings": {
+          "type": "array",
+          "description": "A collection of references to express route circuit peerings.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitPeering"
+          },
+          "readOnly": true
+        },
+        "ipv6Peerings": {
+          "type": "array",
+          "description": "A collection of references to express route circuit ipv6 peerings.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteCircuitPeering"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the route filter resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "RouteFilterRule": {
+      "type": "object",
+      "description": "Route Filter Rule Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RouteFilterRulePropertiesFormat",
+          "description": "Properties of the route filter rule.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "RouteFilterRuleListResult": {
+      "type": "object",
+      "description": "Response for the ListRouteFilterRules API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RouteFilterRule items on this page",
+          "items": {
+            "$ref": "#/definitions/RouteFilterRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RouteFilterRulePropertiesFormat": {
+      "type": "object",
+      "description": "Route Filter Rule Resource.",
+      "properties": {
+        "access": {
+          "$ref": "./common.json#/definitions/Access",
+          "description": "The access type of the rule."
+        },
+        "routeFilterRuleType": {
+          "$ref": "./common.json#/definitions/RouteFilterRuleType",
+          "description": "The rule type of the rule."
+        },
+        "communities": {
+          "type": "array",
+          "description": "The collection for bgp community values to filter on. e.g. ['12076:5010','12076:5020'].",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the route filter rule resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "access",
+        "routeFilterRuleType",
+        "communities"
+      ]
+    },
+    "ServiceEndpointPolicy": {
+      "type": "object",
+      "description": "Service End point policy resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ServiceEndpointPolicyPropertiesFormat",
+          "description": "Properties of the service end point policy.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind of service endpoint policy. This is metadata used for the Azure portal experience.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ServiceEndpointPolicyDefinition": {
+      "type": "object",
+      "description": "Service Endpoint policy definitions.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ServiceEndpointPolicyDefinitionPropertiesFormat",
+          "description": "Properties of the service endpoint policy definition.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "ServiceEndpointPolicyDefinitionListResult": {
+      "type": "object",
+      "description": "The response of a ServiceEndpointPolicyDefinition list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ServiceEndpointPolicyDefinition items on this page",
+          "items": {
+            "$ref": "#/definitions/ServiceEndpointPolicyDefinition"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ServiceEndpointPolicyDefinitionPropertiesFormat": {
+      "type": "object",
+      "description": "Service Endpoint policy definition resource.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description for this rule. Restricted to 140 chars."
+        },
+        "service": {
+          "type": "string",
+          "description": "Service endpoint name."
+        },
+        "serviceResources": {
+          "type": "array",
+          "description": "A list of service resources.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the service endpoint policy definition resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ServiceEndpointPolicyListResult": {
+      "type": "object",
+      "description": "The response of a ServiceEndpointPolicy list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ServiceEndpointPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/ServiceEndpointPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ServiceEndpointPolicyPropertiesFormat": {
+      "type": "object",
+      "description": "Service Endpoint Policy resource.",
+      "properties": {
+        "serviceEndpointPolicyDefinitions": {
+          "type": "array",
+          "description": "A collection of service endpoint policy definitions of the service endpoint policy.",
+          "items": {
+            "$ref": "#/definitions/ServiceEndpointPolicyDefinition"
+          }
+        },
+        "subnets": {
+          "type": "array",
+          "description": "A collection of references to subnets.",
+          "items": {
+            "$ref": "./virtualNetwork.json#/definitions/Subnet"
+          },
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the service endpoint policy resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the service endpoint policy resource.",
+          "readOnly": true
+        },
+        "serviceAlias": {
+          "type": "string",
+          "description": "The alias indicating if the policy belongs to a service"
+        },
+        "contextualServiceEndpointPolicies": {
+          "type": "array",
+          "description": "A collection of contextual service endpoint policy.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/firewall.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/firewall.json
@@ -1,0 +1,1461 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "AzureFirewalls"
+    },
+    {
+      "name": "AzureFirewallFqdnTags"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewallFqdnTags": {
+      "get": {
+        "operationId": "AzureFirewallFqdnTags_ListAll",
+        "tags": [
+          "AzureFirewallFqdnTags"
+        ],
+        "description": "Gets all the Azure Firewall FQDN Tags in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewallFqdnTagListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/azureFirewalls": {
+      "get": {
+        "operationId": "AzureFirewalls_ListAll",
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "description": "Gets all the Azure Firewalls in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewallListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls": {
+      "get": {
+        "operationId": "AzureFirewalls_List",
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "description": "Lists all Azure Firewalls in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewallListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}": {
+      "get": {
+        "operationId": "AzureFirewalls_Get",
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "description": "Gets the specified Azure Firewall.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "description": "The name of the Azure Firewall.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "AzureFirewalls_CreateOrUpdate",
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "description": "Creates or updates the specified Azure Firewall.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "description": "The name of the Azure Firewall.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "createAfcControlPlane",
+            "in": "query",
+            "description": "When set to true, creates an AFC control plane for the Azure Firewall.",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update Azure Firewall operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AzureFirewall' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            }
+          },
+          "201": {
+            "description": "Resource 'AzureFirewall' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/AzureFirewall"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "AzureFirewalls_UpdateTags",
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "description": "Updates tags of an Azure Firewall resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "description": "The name of the Azure Firewall.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update azure firewall tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewall"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/AzureFirewall"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AzureFirewalls_Delete",
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "description": "Deletes the specified Azure Firewall.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "description": "The name of the Azure Firewall.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}/learnedIPPrefixes": {
+      "post": {
+        "operationId": "AzureFirewalls_ListLearnedPrefixes",
+        "description": "Retrieves a list of all IP prefixes that azure firewall has learned to not SNAT.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "description": "The name of the Azure Firewall.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IPPrefixesList"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/IPPrefixesList"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}/packetCapture": {
+      "post": {
+        "operationId": "AzureFirewalls_PacketCapture",
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "description": "Runs a packet capture on AzureFirewall.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "description": "The name of the Azure Firewall.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to run packet capture on azure firewall.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FirewallPacketCaptureParameters"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/azureFirewalls/{azureFirewallName}/packetCaptureOperation": {
+      "post": {
+        "operationId": "AzureFirewalls_PacketCaptureOperation",
+        "tags": [
+          "AzureFirewalls"
+        ],
+        "description": "Runs a packet capture operation on AzureFirewall.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "azureFirewallName",
+            "in": "path",
+            "description": "The name of the Azure Firewall.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to run packet capture on azure firewall.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FirewallPacketCaptureParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AzureFirewallPacketCaptureResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/AzureFirewallPacketCaptureResponse"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "AfcConfiguration": {
+      "type": "object",
+      "description": "AFC configuration for the Azure Firewall.",
+      "properties": {
+        "serviceEndpoint": {
+          "type": "string",
+          "description": "The endpoint URL of the AFC control plane associated with this Azure Firewall.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureFirewall": {
+      "type": "object",
+      "description": "Azure Firewall resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureFirewallPropertiesFormat",
+          "description": "Properties of the azure firewall.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "./common.json#/definitions/ExtendedLocation",
+          "description": "The extended location of type local virtual network gateway."
+        },
+        "zones": {
+          "type": "array",
+          "description": "A list of availability zones denoting where the resource needs to come from.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "AzureFirewallApplicationRule": {
+      "type": "object",
+      "description": "Properties of an application rule.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the application rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the rule."
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "protocols": {
+          "type": "array",
+          "description": "Array of ApplicationRuleProtocols.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallApplicationRuleProtocol"
+          }
+        },
+        "targetFqdns": {
+          "type": "array",
+          "description": "List of FQDNs for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fqdnTags": {
+          "type": "array",
+          "description": "List of FQDN Tags for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AzureFirewallApplicationRuleCollection": {
+      "type": "object",
+      "description": "Application rule collection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureFirewallApplicationRuleCollectionPropertiesFormat",
+          "description": "Properties of the azure firewall application rule collection.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within the Azure firewall. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "AzureFirewallApplicationRuleCollectionPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the application rule collection.",
+      "properties": {
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority of the application rule collection resource.",
+          "minimum": 100,
+          "maximum": 65000
+        },
+        "action": {
+          "$ref": "#/definitions/AzureFirewallRCAction",
+          "description": "The action type of a rule collection."
+        },
+        "rules": {
+          "type": "array",
+          "description": "Collection of rules used by a application rule collection.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallApplicationRule"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the application rule collection resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureFirewallApplicationRuleProtocol": {
+      "type": "object",
+      "description": "Properties of the application rule protocol.",
+      "properties": {
+        "protocolType": {
+          "$ref": "./common.json#/definitions/AzureFirewallApplicationRuleProtocolType",
+          "description": "Protocol type."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port number for the protocol, cannot be greater than 64000. This field is optional.",
+          "minimum": 0,
+          "maximum": 64000
+        }
+      }
+    },
+    "AzureFirewallAutoscaleConfiguration": {
+      "type": "object",
+      "description": "Azure Firewall Autoscale Configuration parameters.",
+      "properties": {
+        "minCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum number of capacity units for this azure firewall. Use null to reset the value to the service default.",
+          "minimum": 2,
+          "x-nullable": true
+        },
+        "maxCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum number of capacity units for this azure firewall. Use null to reset the value to the service default.",
+          "minimum": 2,
+          "x-nullable": true
+        }
+      }
+    },
+    "AzureFirewallFqdnTag": {
+      "type": "object",
+      "description": "Azure Firewall FQDN Tag Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureFirewallFqdnTagPropertiesFormat",
+          "description": "Properties of the azure firewall FQDN tag.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "AzureFirewallFqdnTagListResult": {
+      "type": "object",
+      "description": "The response of a AzureFirewallFqdnTag list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AzureFirewallFqdnTag items on this page",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallFqdnTag"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AzureFirewallFqdnTagPropertiesFormat": {
+      "type": "object",
+      "description": "Azure Firewall FQDN Tag Properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the Azure firewall FQDN tag resource.",
+          "readOnly": true
+        },
+        "fqdnTagName": {
+          "type": "string",
+          "description": "The name of this FQDN Tag.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureFirewallIPConfiguration": {
+      "type": "object",
+      "description": "IP configuration of an Azure Firewall.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureFirewallIPConfigurationPropertiesFormat",
+          "description": "Properties of the azure firewall IP configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "AzureFirewallIPConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of IP configuration of an Azure Firewall.",
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "description": "The Firewall Internal Load Balancer IP to be used as the next hop in User Defined Routes.",
+          "readOnly": true
+        },
+        "subnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the subnet resource. This resource must be named 'AzureFirewallSubnet' or 'AzureFirewallManagementSubnet'."
+        },
+        "publicIPAddress": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the PublicIP resource. This field is a mandatory input if subnet is not null."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the Azure firewall IP configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureFirewallIpGroups": {
+      "type": "object",
+      "description": "IpGroups associated with azure firewall.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID.",
+          "readOnly": true
+        },
+        "changeNumber": {
+          "type": "string",
+          "description": "The iteration number.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureFirewallListResult": {
+      "type": "object",
+      "description": "The response of a AzureFirewall list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AzureFirewall items on this page",
+          "items": {
+            "$ref": "#/definitions/AzureFirewall"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AzureFirewallNatRCAction": {
+      "type": "object",
+      "description": "AzureFirewall NAT Rule Collection Action.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/AzureFirewallNatRCActionType",
+          "description": "The type of action."
+        }
+      }
+    },
+    "AzureFirewallNatRule": {
+      "type": "object",
+      "description": "Properties of a NAT rule.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the NAT rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the rule."
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses for this rule. Supports IP ranges, prefixes, and service tags.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of destination ports.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "protocols": {
+          "type": "array",
+          "description": "Array of AzureFirewallNetworkRuleProtocols applicable to this NAT rule.",
+          "items": {
+            "$ref": "./common.json#/definitions/AzureFirewallNetworkRuleProtocol"
+          }
+        },
+        "translatedAddress": {
+          "type": "string",
+          "description": "The translated address for this NAT rule."
+        },
+        "translatedPort": {
+          "type": "string",
+          "description": "The translated port for this NAT rule."
+        },
+        "translatedFqdn": {
+          "type": "string",
+          "description": "The translated FQDN for this NAT rule."
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AzureFirewallNatRuleCollection": {
+      "type": "object",
+      "description": "NAT rule collection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureFirewallNatRuleCollectionProperties",
+          "description": "Properties of the azure firewall NAT rule collection.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within the Azure firewall. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "AzureFirewallNatRuleCollectionProperties": {
+      "type": "object",
+      "description": "Properties of the NAT rule collection.",
+      "properties": {
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority of the NAT rule collection resource.",
+          "minimum": 100,
+          "maximum": 65000
+        },
+        "action": {
+          "$ref": "#/definitions/AzureFirewallNatRCAction",
+          "description": "The action type of a NAT rule collection."
+        },
+        "rules": {
+          "type": "array",
+          "description": "Collection of rules used by a NAT rule collection.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallNatRule"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the NAT rule collection resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureFirewallNetworkRule": {
+      "type": "object",
+      "description": "Properties of the network rule.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the network rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the rule."
+        },
+        "protocols": {
+          "type": "array",
+          "description": "Array of AzureFirewallNetworkRuleProtocols.",
+          "items": {
+            "$ref": "./common.json#/definitions/AzureFirewallNetworkRuleProtocol"
+          }
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of destination ports.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationFqdns": {
+          "type": "array",
+          "description": "List of destination FQDNs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationIpGroups": {
+          "type": "array",
+          "description": "List of destination IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AzureFirewallNetworkRuleCollection": {
+      "type": "object",
+      "description": "Network rule collection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AzureFirewallNetworkRuleCollectionPropertiesFormat",
+          "description": "Properties of the azure firewall network rule collection.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within the Azure firewall. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "AzureFirewallNetworkRuleCollectionPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the network rule collection.",
+      "properties": {
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority of the network rule collection resource.",
+          "minimum": 100,
+          "maximum": 65000
+        },
+        "action": {
+          "$ref": "#/definitions/AzureFirewallRCAction",
+          "description": "The action type of a rule collection."
+        },
+        "rules": {
+          "type": "array",
+          "description": "Collection of rules used by a network rule collection.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallNetworkRule"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the network rule collection resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureFirewallPacketCaptureFlags": {
+      "type": "object",
+      "description": "Properties of the AzureFirewallRCAction.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/AzureFirewallPacketCaptureFlagsType",
+          "description": "Flags to capture"
+        }
+      }
+    },
+    "AzureFirewallPacketCaptureResponse": {
+      "type": "object",
+      "description": "Response of an Azure Firewall Packet Capture Operation.",
+      "properties": {
+        "statusCode": {
+          "$ref": "./common.json#/definitions/AzureFirewallPacketCaptureResponseCode",
+          "description": "The response code of the performed packet capture operation"
+        },
+        "message": {
+          "type": "string",
+          "description": "Localized Message String of The Result Of The Azure Firewall Packet Capture Operation"
+        }
+      }
+    },
+    "AzureFirewallPacketCaptureRule": {
+      "type": "object",
+      "description": "Group of src/dest ips and ports to be captured.",
+      "properties": {
+        "sources": {
+          "type": "array",
+          "description": "List of source IP addresses/subnets to be captured.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinations": {
+          "type": "array",
+          "description": "List of destination IP addresses/subnets to be captured.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of ports to be captured.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AzureFirewallPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the Azure Firewall.",
+      "properties": {
+        "applicationRuleCollections": {
+          "type": "array",
+          "description": "Collection of application rule collections used by Azure Firewall.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallApplicationRuleCollection"
+          }
+        },
+        "natRuleCollections": {
+          "type": "array",
+          "description": "Collection of NAT rule collections used by Azure Firewall.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallNatRuleCollection"
+          }
+        },
+        "networkRuleCollections": {
+          "type": "array",
+          "description": "Collection of network rule collections used by Azure Firewall.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallNetworkRuleCollection"
+          }
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "IP configuration of the Azure Firewall resource.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallIPConfiguration"
+          }
+        },
+        "managementIpConfiguration": {
+          "$ref": "#/definitions/AzureFirewallIPConfiguration",
+          "description": "IP configuration of the Azure Firewall used for management traffic."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the Azure firewall resource.",
+          "readOnly": true
+        },
+        "threatIntelMode": {
+          "$ref": "./common.json#/definitions/AzureFirewallThreatIntelMode",
+          "description": "The operation mode for Threat Intelligence."
+        },
+        "virtualHub": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The virtualHub to which the firewall belongs."
+        },
+        "firewallPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The firewallPolicy associated with this azure firewall."
+        },
+        "hubIPAddresses": {
+          "$ref": "#/definitions/HubIPAddresses",
+          "description": "IP addresses associated with AzureFirewall."
+        },
+        "ipGroups": {
+          "type": "array",
+          "description": "IpGroups associated with AzureFirewall.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallIpGroups"
+          },
+          "readOnly": true
+        },
+        "sku": {
+          "$ref": "#/definitions/AzureFirewallSku",
+          "description": "The Azure Firewall Resource SKU."
+        },
+        "additionalProperties": {
+          "type": "object",
+          "description": "The additional properties used to further config this azure firewall.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "autoscaleConfiguration": {
+          "$ref": "#/definitions/AzureFirewallAutoscaleConfiguration",
+          "description": "Properties to provide a custom autoscale configuration to this azure firewall."
+        },
+        "afcConfiguration": {
+          "$ref": "#/definitions/AfcConfiguration",
+          "description": "AFC configuration for the Azure Firewall.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureFirewallPublicIPAddress": {
+      "type": "object",
+      "description": "Public IP Address associated with azure firewall.",
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "Public IP Address value."
+        }
+      }
+    },
+    "AzureFirewallRCAction": {
+      "type": "object",
+      "description": "Properties of the AzureFirewallRCAction.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/AzureFirewallRCActionType",
+          "description": "The type of action."
+        }
+      }
+    },
+    "AzureFirewallSku": {
+      "type": "object",
+      "description": "SKU of an Azure Firewall.",
+      "properties": {
+        "name": {
+          "$ref": "./common.json#/definitions/AzureFirewallSkuName",
+          "description": "Name of an Azure Firewall SKU."
+        },
+        "tier": {
+          "$ref": "./common.json#/definitions/AzureFirewallSkuTier",
+          "description": "Tier of an Azure Firewall."
+        }
+      }
+    },
+    "FirewallPacketCaptureParameters": {
+      "type": "object",
+      "description": "Azure Firewall Packet Capture Parameters.",
+      "properties": {
+        "durationInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Duration of packet capture in seconds. If the field is not provided, the default value is 60.",
+          "default": 60,
+          "minimum": 30,
+          "maximum": 1800
+        },
+        "numberOfPacketsToCapture": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of packets to be captured. If the field is not provided, the default value is 1000.",
+          "default": 1000,
+          "minimum": 100,
+          "maximum": 90000
+        },
+        "sasUrl": {
+          "type": "string",
+          "description": "Upload capture location"
+        },
+        "fileName": {
+          "type": "string",
+          "description": "Name of file to be uploaded to sasURL"
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/AzureFirewallNetworkRuleProtocol",
+          "description": "The protocol of packets to capture"
+        },
+        "flags": {
+          "type": "array",
+          "description": "The tcp-flag type to be captured. Used with protocol TCP",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallPacketCaptureFlags"
+          },
+          "x-ms-identifiers": []
+        },
+        "filters": {
+          "type": "array",
+          "description": "Rules to filter packet captures.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallPacketCaptureRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "operation": {
+          "type": "string",
+          "description": "The packet capture operation to perform. If the Start operation is selected, please provide all the fields in the firewallPacketCaptureParameters to successfully initiate the packet capture. If the Status or Stop operation is selected, only the operation field is required; all other fields in the firewallPacketCaptureParameters can be omitted to successfully retrieve the capture status or stop the capture.",
+          "default": "Start",
+          "enum": [
+            "Start",
+            "Status",
+            "Stop"
+          ],
+          "x-ms-enum": {
+            "name": "AzureFirewallPacketCaptureOperationType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Start",
+                "value": "Start",
+                "description": "Start"
+              },
+              {
+                "name": "Status",
+                "value": "Status",
+                "description": "Status"
+              },
+              {
+                "name": "Stop",
+                "value": "Stop",
+                "description": "Stop"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "HubIPAddresses": {
+      "type": "object",
+      "description": "IP addresses associated with azure firewall.",
+      "properties": {
+        "publicIPs": {
+          "$ref": "#/definitions/HubPublicIPAddresses",
+          "description": "Public IP addresses associated with azure firewall."
+        },
+        "privateIPAddress": {
+          "type": "string",
+          "description": "Private IP Address associated with azure firewall."
+        }
+      }
+    },
+    "HubPublicIPAddresses": {
+      "type": "object",
+      "description": "Public IP addresses associated with azure firewall.",
+      "properties": {
+        "addresses": {
+          "type": "array",
+          "description": "The list of Public IP addresses associated with azure firewall or IP addresses to be retained.",
+          "items": {
+            "$ref": "#/definitions/AzureFirewallPublicIPAddress"
+          }
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of Public IP addresses associated with azure firewall."
+        }
+      }
+    },
+    "IPPrefixesList": {
+      "type": "object",
+      "description": "List of SNAT IP Prefixes learnt by firewall to not SNAT",
+      "properties": {
+        "ipPrefixes": {
+          "type": "array",
+          "description": "IP Prefix value.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/firewallPolicy.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/firewallPolicy.json
@@ -1,0 +1,2697 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "FirewallPolicies"
+    },
+    {
+      "name": "FirewallPolicyRuleCollectionGroups"
+    },
+    {
+      "name": "FirewallPolicyKubeSelectorGroups"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/firewallPolicies": {
+      "get": {
+        "operationId": "FirewallPolicies_ListAll",
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "description": "Gets all the Firewall Policies in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies": {
+      "get": {
+        "operationId": "FirewallPolicies_List",
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "description": "Lists all Firewall Policies in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}": {
+      "get": {
+        "operationId": "FirewallPolicies_Get",
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "description": "Gets the specified Firewall Policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "FirewallPolicies_CreateOrUpdate",
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "description": "Creates or updates the specified Firewall Policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "afcManagedSync",
+            "in": "query",
+            "description": "Indicates that the write originates from AFC (Azure Firewall for Containers) and is permitted to modify an AFC-managed Firewall Policy.",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update Firewall Policy operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FirewallPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'FirewallPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicy"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/FirewallPolicy"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "FirewallPolicies_UpdateTags",
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "description": "Updates tags of a Azure Firewall Policy resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update Azure Firewall Policy tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "FirewallPolicies_Delete",
+        "tags": [
+          "FirewallPolicies"
+        ],
+        "description": "Deletes the specified Firewall Policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/deploy": {
+      "post": {
+        "operationId": "FirewallPolicyDeployments_Deploy",
+        "description": "Deploys the firewall policy draft and child rule collection group drafts.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/firewallPolicyDrafts/default": {
+      "get": {
+        "operationId": "FirewallPolicyDrafts_Get",
+        "description": "Get a draft Firewall Policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyDraft"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "FirewallPolicyDrafts_CreateOrUpdate",
+        "description": "Create or update a draft Firewall Policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update Firewall Policy Draft operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyDraft"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FirewallPolicyDraft' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyDraft"
+            }
+          },
+          "201": {
+            "description": "Resource 'FirewallPolicyDraft' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyDraft"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "FirewallPolicyDrafts_Delete",
+        "description": "Delete a draft policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/kubeSelectorGroups": {
+      "get": {
+        "operationId": "FirewallPolicyKubeSelectorGroups_List",
+        "tags": [
+          "FirewallPolicyKubeSelectorGroups"
+        ],
+        "description": "Lists all FirewallPolicyKubeSelectorGroups in a FirewallPolicy resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyKubeSelectorGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/kubeSelectorGroups/{kubeSelectorGroupName}": {
+      "get": {
+        "operationId": "FirewallPolicyKubeSelectorGroups_Get",
+        "tags": [
+          "FirewallPolicyKubeSelectorGroups"
+        ],
+        "description": "Gets the specified FirewallPolicyKubeSelectorGroup.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "kubeSelectorGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-._]{0,78}[a-zA-Z0-9_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyKubeSelectorGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "FirewallPolicyKubeSelectorGroups_CreateOrUpdate",
+        "tags": [
+          "FirewallPolicyKubeSelectorGroups"
+        ],
+        "description": "Creates or updates the specified FirewallPolicyKubeSelectorGroup.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "kubeSelectorGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-._]{0,78}[a-zA-Z0-9_])?$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Parameters supplied to the create or update FirewallPolicyKubeSelectorGroup operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyKubeSelectorGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FirewallPolicyKubeSelectorGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyKubeSelectorGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'FirewallPolicyKubeSelectorGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyKubeSelectorGroup"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/FirewallPolicyKubeSelectorGroup"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "FirewallPolicyKubeSelectorGroups_Delete",
+        "tags": [
+          "FirewallPolicyKubeSelectorGroups"
+        ],
+        "description": "Deletes the specified FirewallPolicyKubeSelectorGroup.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "kubeSelectorGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9-._]{0,78}[a-zA-Z0-9_])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/listIdpsFilterOptions": {
+      "post": {
+        "operationId": "FirewallPolicyIdpsSignaturesFilterValues_List",
+        "description": "Retrieves the current filter values for the signatures overrides",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SignatureOverridesFilterValuesQuery"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SignatureOverridesFilterValuesResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/listIdpsSignatures": {
+      "post": {
+        "operationId": "FirewallPolicyIdpsSignatures_List",
+        "description": "Retrieves the current status of IDPS signatures for the relevant policy. Maximal amount of returned signatures is 1000.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/IDPSQueryObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/QueryResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleCollectionGroups": {
+      "get": {
+        "operationId": "FirewallPolicyRuleCollectionGroups_List",
+        "tags": [
+          "FirewallPolicyRuleCollectionGroups"
+        ],
+        "description": "Lists all FirewallPolicyRuleCollectionGroups in a FirewallPolicy resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleCollectionGroups/{ruleCollectionGroupName}": {
+      "get": {
+        "operationId": "FirewallPolicyRuleCollectionGroups_Get",
+        "tags": [
+          "FirewallPolicyRuleCollectionGroups"
+        ],
+        "description": "Gets the specified FirewallPolicyRuleCollectionGroup.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "FirewallPolicyRuleCollectionGroups_CreateOrUpdate",
+        "tags": [
+          "FirewallPolicyRuleCollectionGroups"
+        ],
+        "description": "Creates or updates the specified FirewallPolicyRuleCollectionGroup.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update FirewallPolicyRuleCollectionGroup operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FirewallPolicyRuleCollectionGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'FirewallPolicyRuleCollectionGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroup"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/FirewallPolicyRuleCollectionGroup"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "FirewallPolicyRuleCollectionGroups_Delete",
+        "tags": [
+          "FirewallPolicyRuleCollectionGroups"
+        ],
+        "description": "Deletes the specified FirewallPolicyRuleCollectionGroup.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/ruleCollectionGroups/{ruleCollectionGroupName}/ruleCollectionGroupDrafts/default": {
+      "get": {
+        "operationId": "FirewallPolicyRuleCollectionGroupDrafts_Get",
+        "description": "Get Rule Collection Group Draft.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupDraft"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "FirewallPolicyRuleCollectionGroupDrafts_CreateOrUpdate",
+        "description": "Create or Update Rule Collection Group Draft.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update FirewallPolicyRuleCollectionGroup operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupDraft"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FirewallPolicyRuleCollectionGroupDraft' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupDraft"
+            }
+          },
+          "201": {
+            "description": "Resource 'FirewallPolicyRuleCollectionGroupDraft' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupDraft"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "FirewallPolicyRuleCollectionGroupDrafts_Delete",
+        "description": "Delete Rule Collection Group Draft.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/signatureOverrides": {
+      "get": {
+        "operationId": "FirewallPolicyIdpsSignaturesOverrides_List",
+        "description": "Returns all signatures overrides objects for a specific policy as a list containing a single value.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverridesList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firewallPolicies/{firewallPolicyName}/signatureOverrides/default": {
+      "get": {
+        "operationId": "FirewallPolicyIdpsSignaturesOverrides_Get",
+        "description": "Returns all signatures overrides for a specific policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverrides"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "FirewallPolicyIdpsSignaturesOverrides_Put",
+        "description": "Will override/create a new signature overrides for the policy's IDPS",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Will contain all properties of the object to put",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverrides"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SignaturesOverrides' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverrides"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "FirewallPolicyIdpsSignaturesOverrides_Patch",
+        "description": "Will update the status of policy's signature overrides for IDPS",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firewallPolicyName",
+            "in": "path",
+            "description": "The name of the Firewall Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Will contain all properties of the object to put",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverrides"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SignaturesOverrides"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ApplicationRule": {
+      "type": "object",
+      "description": "Rule of type application.",
+      "properties": {
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses or Service Tags.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "protocols": {
+          "type": "array",
+          "description": "Array of Application Protocols.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRuleApplicationProtocol"
+          }
+        },
+        "targetFqdns": {
+          "type": "array",
+          "description": "List of FQDNs for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "targetUrls": {
+          "type": "array",
+          "description": "List of Urls for this rule condition.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fqdnTags": {
+          "type": "array",
+          "description": "List of FQDN Tags for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceKubeSelectorGroups": {
+          "type": "array",
+          "description": "List of source Kubernetes Selector Groups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "terminateTLS": {
+          "type": "boolean",
+          "description": "Terminate TLS connections for this rule."
+        },
+        "webCategories": {
+          "type": "array",
+          "description": "List of destination azure web categories.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "httpHeadersToInsert": {
+          "type": "array",
+          "description": "List of HTTP/S headers to insert.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyHttpHeaderToInsert"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirewallPolicyRule"
+        }
+      ],
+      "x-ms-discriminator-value": "ApplicationRule"
+    },
+    "DnsSettings": {
+      "type": "object",
+      "description": "DNS Proxy Settings in Firewall Policy.",
+      "properties": {
+        "servers": {
+          "type": "array",
+          "description": "List of Custom DNS Servers.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enableProxy": {
+          "type": "boolean",
+          "description": "Enable DNS Proxy on Firewalls attached to the Firewall Policy."
+        },
+        "requireProxyForNetworkRules": {
+          "type": "boolean",
+          "description": "FQDNs in Network Rules are supported when set to true.",
+          "x-nullable": true
+        }
+      }
+    },
+    "ExplicitProxy": {
+      "type": "object",
+      "description": "Explicit Proxy Settings in Firewall Policy.",
+      "properties": {
+        "enableExplicitProxy": {
+          "type": "boolean",
+          "description": "When set to true, explicit proxy mode is enabled.",
+          "x-nullable": true
+        },
+        "httpPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port number for explicit proxy http protocol, cannot be greater than 64000.",
+          "minimum": 0,
+          "maximum": 64000
+        },
+        "httpsPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port number for explicit proxy https protocol, cannot be greater than 64000.",
+          "minimum": 0,
+          "maximum": 64000
+        },
+        "enablePacFile": {
+          "type": "boolean",
+          "description": "When set to true, pac file port and url needs to be provided.",
+          "x-nullable": true
+        },
+        "pacFilePort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port number for firewall to serve PAC file.",
+          "minimum": 0,
+          "maximum": 64000
+        },
+        "pacFile": {
+          "type": "string",
+          "description": "SAS URL for PAC file."
+        }
+      }
+    },
+    "FilterItems": {
+      "type": "object",
+      "description": "Will contain the filter name and values to operate on",
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "The name of the field we would like to filter"
+        },
+        "values": {
+          "type": "array",
+          "description": "List of values to filter the current field by",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FirewallPolicy": {
+      "type": "object",
+      "description": "FirewallPolicy Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FirewallPolicyPropertiesFormat",
+          "description": "Properties of the firewall policy.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "identity": {
+          "$ref": "./common.json#/definitions/ManagedServiceIdentity",
+          "description": "The identity of the firewall policy."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "FirewallPolicyCertificateAuthority": {
+      "type": "object",
+      "description": "Trusted Root certificates properties for tls.",
+      "properties": {
+        "keyVaultSecretId": {
+          "type": "string",
+          "description": "Secret Id of (base-64 encoded unencrypted pfx) 'Secret' or 'Certificate' object stored in KeyVault."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the CA certificate."
+        }
+      }
+    },
+    "FirewallPolicyDraft": {
+      "type": "object",
+      "description": "FirewallPolicy Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FirewallPolicyDraftProperties",
+          "description": "Properties of the firewall policy.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "FirewallPolicyDraftProperties": {
+      "type": "object",
+      "properties": {
+        "basePolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The parent firewall policy from which rules are inherited."
+        },
+        "threatIntelMode": {
+          "$ref": "./common.json#/definitions/AzureFirewallThreatIntelMode",
+          "description": "The operation mode for Threat Intelligence."
+        },
+        "threatIntelWhitelist": {
+          "$ref": "#/definitions/FirewallPolicyThreatIntelWhitelist",
+          "description": "ThreatIntel Whitelist for Firewall Policy."
+        },
+        "insights": {
+          "$ref": "#/definitions/FirewallPolicyInsights",
+          "description": "Insights on Firewall Policy."
+        },
+        "snat": {
+          "$ref": "#/definitions/FirewallPolicySNAT",
+          "description": "The private IP addresses/IP ranges to which traffic will not be SNAT."
+        },
+        "sql": {
+          "$ref": "#/definitions/FirewallPolicySQL",
+          "description": "SQL Settings definition."
+        },
+        "dnsSettings": {
+          "$ref": "#/definitions/DnsSettings",
+          "description": "DNS Proxy Settings definition."
+        },
+        "explicitProxy": {
+          "$ref": "#/definitions/ExplicitProxy",
+          "description": "Explicit Proxy Settings definition."
+        },
+        "intrusionDetection": {
+          "$ref": "#/definitions/FirewallPolicyIntrusionDetection",
+          "description": "The configuration for Intrusion detection."
+        }
+      }
+    },
+    "FirewallPolicyFilterRuleCollection": {
+      "type": "object",
+      "description": "Firewall Policy Filter Rule Collection.",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/FirewallPolicyFilterRuleCollectionAction",
+          "description": "The action type of a Filter rule collection."
+        },
+        "rules": {
+          "type": "array",
+          "description": "List of rules included in a rule collection.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRule"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirewallPolicyRuleCollection"
+        }
+      ],
+      "x-ms-discriminator-value": "FirewallPolicyFilterRuleCollection"
+    },
+    "FirewallPolicyFilterRuleCollectionAction": {
+      "type": "object",
+      "description": "Properties of the FirewallPolicyFilterRuleCollectionAction.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/FirewallPolicyFilterRuleCollectionActionType",
+          "description": "The type of action."
+        }
+      }
+    },
+    "FirewallPolicyHttpHeaderToInsert": {
+      "type": "object",
+      "description": "name and value of HTTP/S header to insert",
+      "properties": {
+        "headerName": {
+          "type": "string",
+          "description": "Contains the name of the header"
+        },
+        "headerValue": {
+          "type": "string",
+          "description": "Contains the value of the header"
+        }
+      }
+    },
+    "FirewallPolicyInsights": {
+      "type": "object",
+      "description": "Firewall Policy Insights.",
+      "properties": {
+        "isEnabled": {
+          "type": "boolean",
+          "description": "A flag to indicate if the insights are enabled on the policy."
+        },
+        "retentionDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of days the insights should be enabled on the policy."
+        },
+        "logAnalyticsResources": {
+          "$ref": "#/definitions/FirewallPolicyLogAnalyticsResources",
+          "description": "Workspaces needed to configure the Firewall Policy Insights."
+        }
+      }
+    },
+    "FirewallPolicyIntrusionDetection": {
+      "type": "object",
+      "description": "Configuration for intrusion detection mode and rules.",
+      "properties": {
+        "mode": {
+          "$ref": "./common.json#/definitions/FirewallPolicyIntrusionDetectionStateType",
+          "description": "Intrusion detection general state. When attached to a parent policy, the firewall's effective IDPS mode is the stricter mode of the two."
+        },
+        "profile": {
+          "$ref": "./common.json#/definitions/FirewallPolicyIntrusionDetectionProfileType",
+          "description": "IDPS profile name. When attached to a parent policy, the firewall's effective profile is the profile name of the parent policy."
+        },
+        "configuration": {
+          "$ref": "#/definitions/FirewallPolicyIntrusionDetectionConfiguration",
+          "description": "Intrusion detection configuration properties."
+        }
+      }
+    },
+    "FirewallPolicyIntrusionDetectionBypassTrafficSpecifications": {
+      "type": "object",
+      "description": "Intrusion detection bypass traffic specification.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the bypass traffic rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the bypass traffic rule."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/FirewallPolicyIntrusionDetectionProtocol",
+          "description": "The rule bypass protocol."
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses or ranges for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses or ranges for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of destination ports or ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationIpGroups": {
+          "type": "array",
+          "description": "List of destination IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FirewallPolicyIntrusionDetectionConfiguration": {
+      "type": "object",
+      "description": "The operation for configuring intrusion detection.",
+      "properties": {
+        "signatureOverrides": {
+          "type": "array",
+          "description": "List of specific signatures states.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyIntrusionDetectionSignatureSpecification"
+          }
+        },
+        "bypassTrafficSettings": {
+          "type": "array",
+          "description": "List of rules for traffic to bypass.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyIntrusionDetectionBypassTrafficSpecifications"
+          },
+          "x-ms-identifiers": []
+        },
+        "privateRanges": {
+          "type": "array",
+          "description": "IDPS Private IP address ranges are used to identify traffic direction (i.e. inbound, outbound, etc.). By default, only ranges defined by IANA RFC 1918 are considered private IP addresses. To modify default ranges, specify your Private IP address ranges with this property",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FirewallPolicyIntrusionDetectionSignatureSpecification": {
+      "type": "object",
+      "description": "Intrusion detection signatures specification states.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Signature id."
+        },
+        "mode": {
+          "$ref": "./common.json#/definitions/FirewallPolicyIntrusionDetectionStateType",
+          "description": "The signature state."
+        }
+      }
+    },
+    "FirewallPolicyKubeSelectorGroup": {
+      "type": "object",
+      "description": "Firewall Policy Kubernetes Selector Group resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FirewallPolicyKubeSelectorGroupProperties",
+          "description": "The properties of the firewall policy Kubernetes selector group."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "FirewallPolicyKubeSelectorGroupListResult": {
+      "type": "object",
+      "description": "The response of a FirewallPolicyKubeSelectorGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The FirewallPolicyKubeSelectorGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyKubeSelectorGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "FirewallPolicyKubeSelectorGroupProperties": {
+      "type": "object",
+      "description": "Properties of the Kubernetes Selector Group.",
+      "properties": {
+        "podSelector": {
+          "$ref": "#/definitions/KubeLabelSelector",
+          "description": "Kubernetes Pod selector for matching pods in the Kubernetes cluster."
+        },
+        "namespaceSelector": {
+          "$ref": "#/definitions/KubeLabelSelector",
+          "description": "Kubernetes Namespace selector for matching namespaces in the Kubernetes cluster."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the firewall policy Kubernetes selector group resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "FirewallPolicyListResult": {
+      "type": "object",
+      "description": "The response of a FirewallPolicy list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The FirewallPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "FirewallPolicyLogAnalyticsResources": {
+      "type": "object",
+      "description": "Log Analytics Resources for Firewall Policy Insights.",
+      "properties": {
+        "workspaces": {
+          "type": "array",
+          "description": "List of workspaces for Firewall Policy Insights.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyLogAnalyticsWorkspace"
+          },
+          "x-ms-identifiers": []
+        },
+        "defaultWorkspaceId": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The default workspace Id for Firewall Policy Insights."
+        }
+      }
+    },
+    "FirewallPolicyLogAnalyticsWorkspace": {
+      "type": "object",
+      "description": "Log Analytics Workspace for Firewall Policy Insights.",
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "Region to configure the Workspace."
+        },
+        "workspaceId": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The workspace Id for Firewall Policy Insights."
+        }
+      }
+    },
+    "FirewallPolicyNatRuleCollection": {
+      "type": "object",
+      "description": "Firewall Policy NAT Rule Collection.",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/FirewallPolicyNatRuleCollectionAction",
+          "description": "The action type of a Nat rule collection."
+        },
+        "rules": {
+          "type": "array",
+          "description": "List of rules included in a rule collection.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRule"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirewallPolicyRuleCollection"
+        }
+      ],
+      "x-ms-discriminator-value": "FirewallPolicyNatRuleCollection"
+    },
+    "FirewallPolicyNatRuleCollectionAction": {
+      "type": "object",
+      "description": "Properties of the FirewallPolicyNatRuleCollectionAction.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/FirewallPolicyNatRuleCollectionActionType",
+          "description": "The type of action."
+        }
+      }
+    },
+    "FirewallPolicyPropertiesFormat": {
+      "type": "object",
+      "description": "Firewall Policy definition.",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "A read-only string that represents the size of the FirewallPolicyPropertiesFormat in MB. (ex 0.5MB)",
+          "readOnly": true
+        },
+        "ruleCollectionGroups": {
+          "type": "array",
+          "description": "List of references to FirewallPolicyRuleCollectionGroups.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "kubeSelectorGroups": {
+          "type": "array",
+          "description": "List of references to FirewallPolicyKubeSelectorGroups.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the firewall policy resource.",
+          "readOnly": true
+        },
+        "basePolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The parent firewall policy from which rules are inherited."
+        },
+        "firewalls": {
+          "type": "array",
+          "description": "List of references to Azure Firewalls that this Firewall Policy is associated with.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "childPolicies": {
+          "type": "array",
+          "description": "List of references to Child Firewall Policies.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "threatIntelMode": {
+          "$ref": "./common.json#/definitions/AzureFirewallThreatIntelMode",
+          "description": "The operation mode for Threat Intelligence."
+        },
+        "threatIntelWhitelist": {
+          "$ref": "#/definitions/FirewallPolicyThreatIntelWhitelist",
+          "description": "ThreatIntel Whitelist for Firewall Policy."
+        },
+        "insights": {
+          "$ref": "#/definitions/FirewallPolicyInsights",
+          "description": "Insights on Firewall Policy."
+        },
+        "snat": {
+          "$ref": "#/definitions/FirewallPolicySNAT",
+          "description": "The private IP addresses/IP ranges to which traffic will not be SNAT."
+        },
+        "sql": {
+          "$ref": "#/definitions/FirewallPolicySQL",
+          "description": "SQL Settings definition."
+        },
+        "dnsSettings": {
+          "$ref": "#/definitions/DnsSettings",
+          "description": "DNS Proxy Settings definition."
+        },
+        "explicitProxy": {
+          "$ref": "#/definitions/ExplicitProxy",
+          "description": "Explicit Proxy Settings definition."
+        },
+        "intrusionDetection": {
+          "$ref": "#/definitions/FirewallPolicyIntrusionDetection",
+          "description": "The configuration for Intrusion detection."
+        },
+        "transportSecurity": {
+          "$ref": "#/definitions/FirewallPolicyTransportSecurity",
+          "description": "TLS Configuration definition."
+        },
+        "sku": {
+          "$ref": "#/definitions/FirewallPolicySku",
+          "description": "The Firewall Policy SKU."
+        },
+        "afcManaged": {
+          "type": "boolean",
+          "description": "Indicates that the Firewall Policy is managed by AFC (Azure Firewall for Containers). When set, the policy is treated as read-only for callers that do not supply the AFC-managed sync marker on write operations.",
+          "readOnly": true
+        }
+      }
+    },
+    "FirewallPolicyRule": {
+      "type": "object",
+      "description": "Properties of a rule.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the rule."
+        },
+        "ruleType": {
+          "$ref": "./common.json#/definitions/FirewallPolicyRuleType",
+          "description": "Rule Type."
+        }
+      },
+      "discriminator": "ruleType",
+      "required": [
+        "ruleType"
+      ]
+    },
+    "FirewallPolicyRuleApplicationProtocol": {
+      "type": "object",
+      "description": "Properties of the application rule protocol.",
+      "properties": {
+        "protocolType": {
+          "$ref": "./common.json#/definitions/FirewallPolicyRuleApplicationProtocolType",
+          "description": "Protocol type."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port number for the protocol, cannot be greater than 64000.",
+          "minimum": 0,
+          "maximum": 64000
+        }
+      }
+    },
+    "FirewallPolicyRuleCollection": {
+      "type": "object",
+      "description": "Properties of the rule collection.",
+      "properties": {
+        "ruleCollectionType": {
+          "$ref": "./common.json#/definitions/FirewallPolicyRuleCollectionType",
+          "description": "The type of the rule collection."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the rule collection."
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority of the Firewall Policy Rule Collection resource.",
+          "minimum": 100,
+          "maximum": 65000
+        }
+      },
+      "discriminator": "ruleCollectionType",
+      "required": [
+        "ruleCollectionType"
+      ]
+    },
+    "FirewallPolicyRuleCollectionGroup": {
+      "type": "object",
+      "description": "Rule Collection Group resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupProperties",
+          "description": "The properties of the firewall policy rule collection group.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "FirewallPolicyRuleCollectionGroupDraft": {
+      "type": "object",
+      "description": "Rule Collection Group resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FirewallPolicyRuleCollectionGroupDraftProperties",
+          "description": "The properties of the firewall policy rule collection group.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "FirewallPolicyRuleCollectionGroupDraftProperties": {
+      "type": "object",
+      "description": "Properties of the rule collection group draft.",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "A read-only string that represents the size of the FirewallPolicyRuleCollectionGroupProperties in MB. (ex 1.2MB)",
+          "readOnly": true
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority of the Firewall Policy Rule Collection Group resource.",
+          "minimum": 100,
+          "maximum": 65000
+        },
+        "ruleCollections": {
+          "type": "array",
+          "description": "Group of Firewall Policy rule collections.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRuleCollection"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "FirewallPolicyRuleCollectionGroupListResult": {
+      "type": "object",
+      "description": "The response of a FirewallPolicyRuleCollectionGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The FirewallPolicyRuleCollectionGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRuleCollectionGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "FirewallPolicyRuleCollectionGroupProperties": {
+      "type": "object",
+      "description": "Properties of the rule collection group.",
+      "properties": {
+        "size": {
+          "type": "string",
+          "description": "A read-only string that represents the size of the FirewallPolicyRuleCollectionGroupProperties in MB. (ex 1.2MB)",
+          "readOnly": true
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority of the Firewall Policy Rule Collection Group resource.",
+          "minimum": 100,
+          "maximum": 65000
+        },
+        "ruleCollections": {
+          "type": "array",
+          "description": "Group of Firewall Policy rule collections.",
+          "items": {
+            "$ref": "#/definitions/FirewallPolicyRuleCollection"
+          },
+          "x-ms-identifiers": []
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the firewall policy rule collection group resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "FirewallPolicySNAT": {
+      "type": "object",
+      "description": "The private IP addresses/IP ranges to which traffic will not be SNAT.",
+      "properties": {
+        "privateRanges": {
+          "type": "array",
+          "description": "List of private IP addresses/IP address ranges to not be SNAT.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "autoLearnPrivateRanges": {
+          "$ref": "./common.json#/definitions/AutoLearnPrivateRangesMode",
+          "description": "The operation mode for automatically learning private ranges to not be SNAT"
+        }
+      }
+    },
+    "FirewallPolicySQL": {
+      "type": "object",
+      "description": "SQL Settings in Firewall Policy.",
+      "properties": {
+        "allowSqlRedirect": {
+          "type": "boolean",
+          "description": "A flag to indicate if SQL Redirect traffic filtering is enabled. Turning on the flag requires no rule using port 11000-11999."
+        }
+      }
+    },
+    "FirewallPolicySku": {
+      "type": "object",
+      "description": "SKU of Firewall policy.",
+      "properties": {
+        "tier": {
+          "$ref": "./common.json#/definitions/FirewallPolicySkuTier",
+          "description": "Tier of Firewall Policy."
+        }
+      }
+    },
+    "FirewallPolicyThreatIntelWhitelist": {
+      "type": "object",
+      "description": "ThreatIntel Whitelist for Firewall Policy.",
+      "properties": {
+        "ipAddresses": {
+          "type": "array",
+          "description": "List of IP addresses for the ThreatIntel Whitelist.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fqdns": {
+          "type": "array",
+          "description": "List of FQDNs for the ThreatIntel Whitelist.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FirewallPolicyTransportSecurity": {
+      "type": "object",
+      "description": "Configuration needed to perform TLS termination & initiation.",
+      "properties": {
+        "certificateAuthority": {
+          "$ref": "#/definitions/FirewallPolicyCertificateAuthority",
+          "description": "The CA used for intermediate CA generation."
+        }
+      }
+    },
+    "IDPSQueryObject": {
+      "type": "object",
+      "description": "Will describe the query to run against the IDPS signatures DB",
+      "properties": {
+        "filters": {
+          "type": "array",
+          "description": "Contain all filters names and values",
+          "items": {
+            "$ref": "#/definitions/FilterItems"
+          },
+          "x-ms-identifiers": []
+        },
+        "search": {
+          "type": "string",
+          "description": "Search term in all columns"
+        },
+        "orderBy": {
+          "$ref": "#/definitions/OrderBy",
+          "description": "Column to sort response by"
+        },
+        "resultsPerPage": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of the results to return in each page",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "skip": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of records matching the filter to skip"
+        }
+      }
+    },
+    "KubeLabelSelector": {
+      "type": "object",
+      "description": "Kubernetes Label Selector for matching labels in Kubernetes Selector Groups.",
+      "properties": {
+        "matchLabels": {
+          "type": "object",
+          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "matchExpressions": {
+          "type": "array",
+          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+          "items": {
+            "$ref": "#/definitions/LabelSelectorExpression"
+          }
+        }
+      }
+    },
+    "LabelSelectorExpression": {
+      "type": "object",
+      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "key is a string of 63 characters or less, and must consist of alphanumeric characters,\n'-', '_' or '.'."
+        },
+        "operator": {
+          "$ref": "./common.json#/definitions/LabelSelectorOperator",
+          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist."
+        },
+        "values": {
+          "type": "array",
+          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NatRule": {
+      "type": "object",
+      "description": "Rule of type nat.",
+      "properties": {
+        "ipProtocols": {
+          "type": "array",
+          "description": "Array of FirewallPolicyRuleNetworkProtocols.",
+          "items": {
+            "$ref": "./common.json#/definitions/FirewallPolicyRuleNetworkProtocol"
+          }
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses or Service Tags.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of destination ports.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "translatedAddress": {
+          "type": "string",
+          "description": "The translated address for this NAT rule."
+        },
+        "translatedPort": {
+          "type": "string",
+          "description": "The translated port for this NAT rule."
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "translatedFqdn": {
+          "type": "string",
+          "description": "The translated FQDN for this NAT rule."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirewallPolicyRule"
+        }
+      ],
+      "x-ms-discriminator-value": "NatRule"
+    },
+    "NetworkRule": {
+      "type": "object",
+      "description": "Rule of type network.",
+      "properties": {
+        "ipProtocols": {
+          "type": "array",
+          "description": "Array of FirewallPolicyRuleNetworkProtocols.",
+          "items": {
+            "$ref": "./common.json#/definitions/FirewallPolicyRuleNetworkProtocol"
+          }
+        },
+        "sourceAddresses": {
+          "type": "array",
+          "description": "List of source IP addresses for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddresses": {
+          "type": "array",
+          "description": "List of destination IP addresses or Service Tags.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "List of destination ports.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceIpGroups": {
+          "type": "array",
+          "description": "List of source IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationIpGroups": {
+          "type": "array",
+          "description": "List of destination IpGroups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationFqdns": {
+          "type": "array",
+          "description": "List of destination FQDNs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceKubeSelectorGroups": {
+          "type": "array",
+          "description": "List of source Kubernetes Selector Groups for this rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FirewallPolicyRule"
+        }
+      ],
+      "x-ms-discriminator-value": "NetworkRule"
+    },
+    "OrderBy": {
+      "type": "object",
+      "description": "Describes a column to sort",
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "Describes the actual column name to sort by"
+        },
+        "order": {
+          "$ref": "./common.json#/definitions/FirewallPolicyIDPSQuerySortOrder",
+          "description": "Describes if results should be in ascending/descending order"
+        }
+      }
+    },
+    "QueryResults": {
+      "type": "object",
+      "description": "Query result",
+      "properties": {
+        "matchingRecordsCount": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of total records matching the query."
+        },
+        "signatures": {
+          "type": "array",
+          "description": "Array containing the results of the query",
+          "items": {
+            "$ref": "#/definitions/SingleQueryResult"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "SignatureOverridesFilterValuesQuery": {
+      "type": "object",
+      "description": "Describes the filter values possibles for a given column",
+      "properties": {
+        "filterName": {
+          "type": "string",
+          "description": "Describes the name of the column which values will be returned"
+        }
+      }
+    },
+    "SignatureOverridesFilterValuesResponse": {
+      "type": "object",
+      "description": "Describes the list of all possible values for a specific filter value",
+      "properties": {
+        "filterValues": {
+          "type": "array",
+          "description": "Describes the possible values",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SignaturesOverrides": {
+      "type": "object",
+      "description": "Contains all specific policy signatures overrides for the IDPS",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SignaturesOverridesProperties",
+          "description": "Will contain the properties of the resource (the actual signature overrides)"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/WritableResource"
+        }
+      ]
+    },
+    "SignaturesOverridesList": {
+      "type": "object",
+      "description": "Describes an object containing an array with a single item",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Describes a list consisting exactly one item describing the policy's signature override status",
+          "items": {
+            "$ref": "#/definitions/SignaturesOverrides"
+          }
+        }
+      }
+    },
+    "SignaturesOverridesProperties": {
+      "type": "object",
+      "description": "Will contain the properties of the resource (the actual signature overrides)",
+      "properties": {
+        "signatures": {
+          "type": "object",
+          "description": "Dictionary of <string>",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SingleQueryResult": {
+      "type": "object",
+      "properties": {
+        "signatureId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The ID of the signature"
+        },
+        "mode": {
+          "$ref": "./common.json#/definitions/FirewallPolicyIDPSSignatureMode",
+          "description": "The current mode enforced, 0 - Disabled, 1 - Alert, 2 -Deny"
+        },
+        "severity": {
+          "$ref": "./common.json#/definitions/FirewallPolicyIDPSSignatureSeverity",
+          "description": "Describes the severity of signature: 1 - High, 2 - Medium, 3 - Low"
+        },
+        "direction": {
+          "$ref": "./common.json#/definitions/FirewallPolicyIDPSSignatureDirection",
+          "description": "Describes in which direction signature is being enforced: 0 - OutBound, 1 - InBound, 2 - Any, 3 - Internal, 4 - InternalOutbound, 5 - InternalInbound"
+        },
+        "group": {
+          "type": "string",
+          "description": "Describes the groups the signature belongs to"
+        },
+        "description": {
+          "type": "string",
+          "description": "Describes what is the signature enforces"
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Describes the protocol the signatures is being enforced in"
+        },
+        "sourcePorts": {
+          "type": "array",
+          "description": "Describes the list of source ports related to this signature",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "Describes the list of destination ports related to this signature",
+          "items": {
+            "type": "string"
+          }
+        },
+        "lastUpdated": {
+          "type": "string",
+          "description": "Describes the last updated time of the signature (provided from 3rd party vendor)"
+        },
+        "inheritedFromParentPolicy": {
+          "type": "boolean",
+          "description": "Describes if this override is inherited from base policy or not"
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/firstPartyServiceTag.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/firstPartyServiceTag.json
@@ -1,0 +1,444 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "FirstPartyServiceTags"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/firstPartyServiceTags": {
+      "get": {
+        "operationId": "FirstPartyServiceTags_ListAll",
+        "tags": [
+          "FirstPartyServiceTags"
+        ],
+        "description": "Gets all the first party service tags in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirstPartyServiceTagListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firstPartyServiceTags": {
+      "get": {
+        "operationId": "FirstPartyServiceTags_List",
+        "tags": [
+          "FirstPartyServiceTags"
+        ],
+        "description": "Gets all the first party service tags in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirstPartyServiceTagListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/firstPartyServiceTags/{firstPartyServiceTagName}": {
+      "get": {
+        "operationId": "FirstPartyServiceTags_Get",
+        "tags": [
+          "FirstPartyServiceTags"
+        ],
+        "description": "Gets the specified first party service tag.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firstPartyServiceTagName",
+            "in": "path",
+            "description": "The name of the first party service tag.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,79}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirstPartyServiceTag"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "FirstPartyServiceTags_CreateOrUpdate",
+        "tags": [
+          "FirstPartyServiceTags"
+        ],
+        "description": "Creates or updates a first party service tag.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firstPartyServiceTagName",
+            "in": "path",
+            "description": "The name of the first party service tag.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,79}$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update first party service tag operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FirstPartyServiceTag"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FirstPartyServiceTag' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirstPartyServiceTag"
+            }
+          },
+          "201": {
+            "description": "Resource 'FirstPartyServiceTag' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FirstPartyServiceTag"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/FirstPartyServiceTag"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "FirstPartyServiceTags_UpdateTags",
+        "tags": [
+          "FirstPartyServiceTags"
+        ],
+        "description": "Updates a first party service tag tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firstPartyServiceTagName",
+            "in": "path",
+            "description": "The name of the first party service tag.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,79}$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update first party service tag tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FirstPartyServiceTag"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/FirstPartyServiceTag"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "FirstPartyServiceTags_Delete",
+        "tags": [
+          "FirstPartyServiceTags"
+        ],
+        "description": "Deletes the specified first party service tag.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "firstPartyServiceTagName",
+            "in": "path",
+            "description": "The name of the first party service tag.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,79}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "FirstPartyServiceTag": {
+      "type": "object",
+      "description": "First party service tag resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FirstPartyServiceTagPropertiesFormat",
+          "description": "Properties of the first party service tag."
+        },
+        "id": {
+          "type": "string",
+          "description": "The unique identifier of the resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the resource.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "FirstPartyServiceTagListResult": {
+      "type": "object",
+      "description": "The response of a FirstPartyServiceTag list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The FirstPartyServiceTag items on this page",
+          "items": {
+            "$ref": "#/definitions/FirstPartyServiceTag"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "FirstPartyServiceTagPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the first party service tag.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The value of the first party service tag."
+        },
+        "failedReason": {
+          "type": "string",
+          "description": "The reason for failure, if any.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the first party service tag resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the first party service tag resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "value"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/interconnectGroup.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/interconnectGroup.json
@@ -1,0 +1,674 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "InterconnectGroups"
+    },
+    {
+      "name": "Subgroups"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/interconnectGroups": {
+      "get": {
+        "operationId": "InterconnectGroups_ListAll",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Gets all interconnect groups in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups": {
+      "get": {
+        "operationId": "InterconnectGroups_List",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Gets all interconnect groups in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}": {
+      "get": {
+        "operationId": "InterconnectGroups_Get",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Gets information about the specified interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "InterconnectGroups_CreateOrUpdate",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Creates or updates an interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update interconnect group operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'InterconnectGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'InterconnectGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "InterconnectGroups_UpdateTags",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Updates interconnect group tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update interconnect group tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "InterconnectGroups_Delete",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Deletes the specified interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}/nodeAvailability": {
+      "post": {
+        "operationId": "InterconnectGroups_GetNodeAvailability",
+        "tags": [
+          "InterconnectGroups"
+        ],
+        "description": "Gets node availability for all subgroups in the specified interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InterconnectGroupNodeAvailability"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/InterconnectGroupNodeAvailability"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}/subgroups": {
+      "get": {
+        "operationId": "Subgroups_List",
+        "tags": [
+          "Subgroups"
+        ],
+        "description": "Gets all subgroups in an interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SubgroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/interconnectGroups/{interconnectGroupName}/subgroups/{subgroupName}": {
+      "get": {
+        "operationId": "Subgroups_Get",
+        "tags": [
+          "Subgroups"
+        ],
+        "description": "Gets the specified subgroup in an interconnect group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "interconnectGroupName",
+            "in": "path",
+            "description": "The name of the interconnect group.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[^_\\W][\\w-._]{0,79}(?<![-.])$"
+          },
+          {
+            "name": "subgroupName",
+            "in": "path",
+            "description": "The name of the subgroup.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Subgroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "InterconnectGroup": {
+      "type": "object",
+      "description": "An interconnect group resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/InterconnectGroupPropertiesFormat",
+          "description": "Properties of the interconnect group.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "InterconnectGroupListResult": {
+      "type": "object",
+      "description": "The response of a InterconnectGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The InterconnectGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/InterconnectGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "InterconnectGroupNodeAvailability": {
+      "type": "object",
+      "description": "Represents node availability information for subgroups within an interconnect group.",
+      "properties": {
+        "subgroupsNodeAvailability": {
+          "type": "array",
+          "description": "The list of subgroup node availability entries.",
+          "items": {
+            "$ref": "#/definitions/SubgroupNodeAvailabilityEntry"
+          }
+        }
+      }
+    },
+    "InterconnectGroupPropertiesFormat": {
+      "type": "object",
+      "description": "Interconnect group properties.",
+      "properties": {
+        "scope": {
+          "$ref": "./common.json#/definitions/InterconnectGroupScope",
+          "description": "Scope of interconnect group resource."
+        },
+        "subgroups": {
+          "type": "array",
+          "description": "A list of subgroups of the interconnect group.",
+          "items": {
+            "$ref": "#/definitions/Subgroup"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the interconnect group resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the interconnect group resource.",
+          "readOnly": true
+        },
+        "subgroupProfile": {
+          "$ref": "#/definitions/SubgroupProfile",
+          "description": "The subgroup profile of the interconnect group resource."
+        }
+      },
+      "required": [
+        "subgroupProfile"
+      ]
+    },
+    "Subgroup": {
+      "type": "object",
+      "description": "A subgroup in an interconnect group.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SubgroupProperties",
+          "description": "Properties of the subgroup.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "SubgroupListResult": {
+      "type": "object",
+      "description": "The response of a Subgroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Subgroup items on this page",
+          "items": {
+            "$ref": "#/definitions/Subgroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SubgroupNodeAvailabilityEntry": {
+      "type": "object",
+      "description": "Represents the node availability information for a single subgroup.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The subgroup name."
+        },
+        "internalSubgroupId": {
+          "type": "string",
+          "description": "The unique identifier of the subgroup."
+        },
+        "inServiceNodeCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of nodes that are in service."
+        },
+        "inUseNodeCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of nodes that are currently in use."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total node count for the subgroup."
+        }
+      }
+    },
+    "SubgroupProfile": {
+      "type": "object",
+      "description": "Subgroup profile of the interconnect group resource.",
+      "properties": {
+        "vmSize": {
+          "type": "string",
+          "description": "VM size of the subgroup profile."
+        },
+        "scope": {
+          "$ref": "./common.json#/definitions/SubgroupProfileScope",
+          "description": "Scope of the subgroup profile."
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Size of the subgroup profile.",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "vmSize"
+      ]
+    },
+    "SubgroupProperties": {
+      "type": "object",
+      "description": "Properties of subgroup.",
+      "properties": {
+        "internalSubgroupId": {
+          "type": "string",
+          "description": "The unique identifier of the subgroup.",
+          "readOnly": true
+        },
+        "interconnectBlock": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to an interconnect block resource.",
+          "readOnly": true
+        },
+        "virtualMachines": {
+          "type": "array",
+          "description": "A list of virtual machine references.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the subgroup.",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/loadBalancer.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/loadBalancer.json
@@ -1,0 +1,2655 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "LoadBalancers"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/loadBalancers": {
+      "get": {
+        "operationId": "LoadBalancers_ListAll",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets all the load balancers in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/setLoadBalancerFrontendPublicIpAddresses": {
+      "post": {
+        "operationId": "LoadBalancers_SwapPublicIpAddresses",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Swaps VIPs between two load balancers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerVipSwapRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers": {
+      "get": {
+        "operationId": "LoadBalancers_List",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets all the load balancers in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}": {
+      "get": {
+        "operationId": "LoadBalancers_Get",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets the specified load balancer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "detailLevel",
+            "in": "query",
+            "description": "Controls verbosity of the returned load balancer resource. When set to 'Reduced', read-only back-reference collections (e.g., rules referencing frontendIPConfigurations) are omitted from the response.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "Reduced"
+            ],
+            "x-ms-enum": {
+              "name": "LoadBalancerDetailLevel",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "Reduced",
+                  "value": "Reduced",
+                  "description": "When set to 'Reduced', read-only reference collections may be omitted."
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "LoadBalancers_CreateOrUpdate",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Creates or updates a load balancer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update load balancer operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'LoadBalancer' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          },
+          "201": {
+            "description": "Resource 'LoadBalancer' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/LoadBalancer"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "LoadBalancers_UpdateTags",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Updates a load balancer tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update load balancer tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancer"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "LoadBalancers_Delete",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Deletes the specified load balancer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools": {
+      "get": {
+        "operationId": "LoadBalancerBackendAddressPools_List",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets all the load balancer backed address pools.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerBackendAddressPoolListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendAddressPoolName}": {
+      "get": {
+        "operationId": "LoadBalancerBackendAddressPools_Get",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets load balancer backend address pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "backendAddressPoolName",
+            "in": "path",
+            "description": "The name of the backend address pool.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackendAddressPool"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "LoadBalancerBackendAddressPools_CreateOrUpdate",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Creates or updates a load balancer backend address pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "backendAddressPoolName",
+            "in": "path",
+            "description": "The name of the backend address pool.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update load balancer backend address pool operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BackendAddressPool"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BackendAddressPool' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BackendAddressPool"
+            }
+          },
+          "201": {
+            "description": "Resource 'BackendAddressPool' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BackendAddressPool"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/BackendAddressPool"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "LoadBalancerBackendAddressPools_Delete",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Deletes the specified load balancer backend address pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "backendAddressPoolName",
+            "in": "path",
+            "description": "The name of the backend address pool.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/backendAddressPools/{backendPoolName}/queryInboundNatRulePortMapping": {
+      "post": {
+        "operationId": "LoadBalancers_ListInboundNatRulePortMappings",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "List of inbound NAT rule port mappings.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "groupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "backendPoolName",
+            "in": "path",
+            "description": "The name of the backend address pool.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Query inbound NAT rule port mapping request.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueryInboundNatRulePortMappingRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackendAddressInboundNatRulePortMappings"
+            }
+          },
+          "202": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BackendAddressInboundNatRulePortMappings"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/BackendAddressInboundNatRulePortMappings"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/frontendIPConfigurations": {
+      "get": {
+        "operationId": "LoadBalancerFrontendIPConfigurations_List",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets all the load balancer frontend IP configurations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerFrontendIPConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/frontendIPConfigurations/{frontendIPConfigurationName}": {
+      "get": {
+        "operationId": "LoadBalancerFrontendIPConfigurations_Get",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets load balancer frontend IP configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "frontendIPConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within the set of frontend IP configurations used by the load balancer. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FrontendIPConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules": {
+      "get": {
+        "operationId": "InboundNatRules_List",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets all the inbound NAT rules in a load balancer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InboundNatRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/inboundNatRules/{inboundNatRuleName}": {
+      "get": {
+        "operationId": "InboundNatRules_Get",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets the specified load balancer inbound NAT rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "inboundNatRuleName",
+            "in": "path",
+            "description": "The name of the inbound NAT rule.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InboundNatRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "InboundNatRules_CreateOrUpdate",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Creates or updates a load balancer inbound NAT rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "inboundNatRuleName",
+            "in": "path",
+            "description": "The name of the inbound NAT rule.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "inboundNatRuleParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update inbound NAT rule operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InboundNatRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'InboundNatRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/InboundNatRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'InboundNatRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/InboundNatRule"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/InboundNatRule"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "InboundNatRules_Delete",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Deletes the specified load balancer inbound NAT rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "inboundNatRuleName",
+            "in": "path",
+            "description": "The name of the inbound NAT rule.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/loadBalancingRules": {
+      "get": {
+        "operationId": "LoadBalancerLoadBalancingRules_List",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets all the load balancing rules in a load balancer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerLoadBalancingRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/loadBalancingRules/{loadBalancingRuleName}": {
+      "get": {
+        "operationId": "LoadBalancerLoadBalancingRules_Get",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets the specified load balancer load balancing rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "loadBalancingRuleName",
+            "in": "path",
+            "description": "The name of the load balancing rule.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancingRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/loadBalancingRules/{loadBalancingRuleName}/health": {
+      "post": {
+        "operationId": "LoadBalancerLoadBalancingRules_Health",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Get health details of a load balancing rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "groupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "loadBalancingRuleName",
+            "in": "path",
+            "description": "The name of the load balancing rule.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerHealthPerRule"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/LoadBalancerHealthPerRule"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/migrateToIpBased": {
+      "post": {
+        "operationId": "LoadBalancers_MigrateToIpBased",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Migrate load balancer to IP Based",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "groupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9]*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the migrateToIpBased Api.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/MigrateLoadBalancerToIpBasedRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MigratedPools"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/networkInterfaces": {
+      "get": {
+        "operationId": "LoadBalancerNetworkInterfaces_List",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets associated load balancer network interfaces.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./virtualNetwork.json#/definitions/NetworkInterfaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/outboundRules": {
+      "get": {
+        "operationId": "LoadBalancerOutboundRules_List",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets all the outbound rules in a load balancer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerOutboundRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/outboundRules/{outboundRuleName}": {
+      "get": {
+        "operationId": "LoadBalancerOutboundRules_Get",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets the specified load balancer outbound rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "outboundRuleName",
+            "in": "path",
+            "description": "The name of the outbound rule.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OutboundRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes": {
+      "get": {
+        "operationId": "LoadBalancerProbes_List",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets all the load balancer probes.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/LoadBalancerProbeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/loadBalancers/{loadBalancerName}/probes/{probeName}": {
+      "get": {
+        "operationId": "LoadBalancerProbes_Get",
+        "tags": [
+          "LoadBalancers"
+        ],
+        "description": "Gets load balancer probe.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "loadBalancerName",
+            "in": "path",
+            "description": "The name of the load balancer.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "probeName",
+            "in": "path",
+            "description": "The name of the probe.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Probe"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "BackendAddressInboundNatRulePortMappings": {
+      "type": "object",
+      "description": "The response for a QueryInboundNatRulePortMapping API.",
+      "properties": {
+        "inboundNatRulePortMappings": {
+          "type": "array",
+          "description": "Collection of inbound NAT rule port mappings.",
+          "items": {
+            "$ref": "#/definitions/InboundNatRulePortMapping"
+          }
+        }
+      }
+    },
+    "BackendAddressPool": {
+      "type": "object",
+      "description": "Pool of backend IP addresses.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BackendAddressPoolPropertiesFormat",
+          "description": "Properties of load balancer backend address pool.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "BackendAddressPoolPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the backend address pool.",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "The location of the backend address pool."
+        },
+        "tunnelInterfaces": {
+          "type": "array",
+          "description": "An array of gateway load balancer tunnel interfaces.",
+          "items": {
+            "$ref": "#/definitions/GatewayLoadBalancerTunnelInterface"
+          }
+        },
+        "loadBalancerBackendAddresses": {
+          "type": "array",
+          "description": "An array of backend addresses.",
+          "items": {
+            "$ref": "#/definitions/LoadBalancerBackendAddress"
+          }
+        },
+        "backendIPConfigurations": {
+          "type": "array",
+          "description": "An array of references to IP addresses defined in network interfaces.",
+          "items": {
+            "$ref": "./virtualNetwork.json#/definitions/NetworkInterfaceIPConfiguration"
+          },
+          "readOnly": true
+        },
+        "loadBalancingRules": {
+          "type": "array",
+          "description": "An array of references to load balancing rules that use this backend address pool.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "outboundRule": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to an outbound rule that uses this backend address pool.",
+          "readOnly": true
+        },
+        "outboundRules": {
+          "type": "array",
+          "description": "An array of references to outbound rules that use this backend address pool.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "inboundNatRules": {
+          "type": "array",
+          "description": "An array of references to inbound NAT rules that use this backend address pool.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the backend address pool resource.",
+          "readOnly": true
+        },
+        "drainPeriodInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Amount of seconds Load Balancer waits for before sending RESET to client and backend address."
+        },
+        "virtualNetwork": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to a virtual network."
+        },
+        "syncMode": {
+          "$ref": "./common.json#/definitions/SyncMode",
+          "description": "Backend address synchronous mode for the backend pool"
+        }
+      }
+    },
+    "FrontendIPConfiguration": {
+      "type": "object",
+      "description": "Frontend IP address of the load balancer.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FrontendIPConfigurationPropertiesFormat",
+          "description": "Properties of the load balancer probe.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "zones": {
+          "type": "array",
+          "description": "A list of availability zones denoting the IP allocated for the resource needs to come from.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "FrontendIPConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of Frontend IP Configuration of the load balancer.",
+      "properties": {
+        "inboundNatRules": {
+          "type": "array",
+          "description": "An array of references to inbound rules that use this frontend IP.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "inboundNatPools": {
+          "type": "array",
+          "description": "An array of references to inbound pools that use this frontend IP.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "outboundRules": {
+          "type": "array",
+          "description": "An array of references to outbound rules that use this frontend IP.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "loadBalancingRules": {
+          "type": "array",
+          "description": "An array of references to load balancing rules that use this frontend IP.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "privateIPAddress": {
+          "type": "string",
+          "description": "The private IP address of the IP configuration."
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The Private IP allocation method."
+        },
+        "privateIPAddressVersion": {
+          "$ref": "./common.json#/definitions/IPVersion",
+          "description": "Whether the specific ipconfiguration is IPv4 or IPv6. Default is taken as IPv4."
+        },
+        "subnet": {
+          "$ref": "./virtualNetwork.json#/definitions/Subnet",
+          "description": "The reference to the subnet resource."
+        },
+        "publicIPAddress": {
+          "$ref": "./virtualNetwork.json#/definitions/PublicIPAddress",
+          "description": "The reference to the Public IP resource."
+        },
+        "publicIPPrefix": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the Public IP Prefix resource."
+        },
+        "gatewayLoadBalancer": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to gateway load balancer frontend IP."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the frontend IP configuration resource.",
+          "readOnly": true
+        },
+        "ddosSettings": {
+          "$ref": "./common.json#/definitions/DdosFrontendIpConfigurationSettings",
+          "description": "The DDoS protection settings associated with the frontend IP configuration."
+        },
+        "enableConnectionTracking": {
+          "type": "boolean",
+          "description": "Enables UDP flow tracking for traffic associated with the frontend IP configuration. When enabled, packets belonging to the same UDP flow are consistently directed to the same backend instance. This setting applies to all associated load balancing rules and takes precedence over rule-level enableConnectionTracking settings."
+        }
+      }
+    },
+    "GatewayLoadBalancerTunnelInterface": {
+      "type": "object",
+      "description": "Gateway load balancer tunnel interface of a load balancer backend address pool.",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port of gateway load balancer tunnel interface."
+        },
+        "identifier": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Identifier of gateway load balancer tunnel interface."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/GatewayLoadBalancerTunnelProtocol",
+          "description": "Protocol of gateway load balancer tunnel interface."
+        },
+        "type": {
+          "$ref": "./common.json#/definitions/GatewayLoadBalancerTunnelInterfaceType",
+          "description": "Traffic type of gateway load balancer tunnel interface."
+        }
+      }
+    },
+    "InboundNatPool": {
+      "type": "object",
+      "description": "Inbound NAT pool of the load balancer.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/InboundNatPoolPropertiesFormat",
+          "description": "Properties of load balancer inbound nat pool.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within the set of inbound NAT pools used by the load balancer. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "InboundNatPoolPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of Inbound NAT pool.",
+      "properties": {
+        "frontendIPConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to frontend IP addresses."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/TransportProtocol",
+          "description": "The reference to the transport protocol used by the inbound NAT pool."
+        },
+        "frontendPortRangeStart": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The first port number in the range of external ports that will be used to provide Inbound Nat to NICs associated with a load balancer. Acceptable values range between 1 and 65534."
+        },
+        "frontendPortRangeEnd": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The last port number in the range of external ports that will be used to provide Inbound Nat to NICs associated with a load balancer. Acceptable values range between 1 and 65535."
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port used for internal connections on the endpoint. Acceptable values are between 1 and 65535."
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to TCP."
+        },
+        "enableFloatingIP": {
+          "type": "boolean",
+          "description": "Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability Group. This setting is required when using the SQL AlwaysOn Availability Groups in SQL server. This setting can't be changed after you create the endpoint."
+        },
+        "enableTcpReset": {
+          "type": "boolean",
+          "description": "Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination. This element is only used when the protocol is set to TCP."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the inbound NAT pool resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "protocol",
+        "frontendPortRangeStart",
+        "frontendPortRangeEnd",
+        "backendPort"
+      ]
+    },
+    "InboundNatRule": {
+      "type": "object",
+      "description": "Inbound NAT rule of the load balancer.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/InboundNatRulePropertiesFormat",
+          "description": "Properties of load balancer inbound NAT rule.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "InboundNatRuleListResult": {
+      "type": "object",
+      "description": "The response of a InboundNatRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The InboundNatRule items on this page",
+          "items": {
+            "$ref": "#/definitions/InboundNatRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "InboundNatRulePortMapping": {
+      "type": "object",
+      "description": "Individual port mappings for inbound NAT rule created for backend pool.",
+      "properties": {
+        "inboundNatRuleName": {
+          "type": "string",
+          "description": "Name of inbound NAT rule.",
+          "readOnly": true
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/TransportProtocol",
+          "description": "The reference to the transport protocol used by the inbound NAT rule.",
+          "readOnly": true
+        },
+        "frontendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Frontend port.",
+          "readOnly": true
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Backend port.",
+          "readOnly": true
+        }
+      }
+    },
+    "InboundNatRulePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the inbound NAT rule.",
+      "properties": {
+        "frontendIPConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to frontend IP addresses."
+        },
+        "backendIPConfiguration": {
+          "$ref": "./virtualNetwork.json#/definitions/NetworkInterfaceIPConfiguration",
+          "description": "A reference to a private IP address defined on a network interface of a VM. Traffic sent to the frontend port of each of the frontend IP configurations is forwarded to the backend IP.",
+          "readOnly": true
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/TransportProtocol",
+          "description": "The reference to the transport protocol used by the load balancing rule."
+        },
+        "frontendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port for the external endpoint. Port numbers for each rule must be unique within the Load Balancer. Acceptable values range from 1 to 65534."
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port used for the internal endpoint. Acceptable values range from 1 to 65535."
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to TCP."
+        },
+        "enableFloatingIP": {
+          "type": "boolean",
+          "description": "Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability Group. This setting is required when using the SQL AlwaysOn Availability Groups in SQL server. This setting can't be changed after you create the endpoint."
+        },
+        "enableTcpReset": {
+          "type": "boolean",
+          "description": "Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination. This element is only used when the protocol is set to TCP."
+        },
+        "frontendPortRangeStart": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port range start for the external endpoint. This property is used together with BackendAddressPool and FrontendPortRangeEnd. Individual inbound NAT rule port mappings will be created for each backend address from BackendAddressPool. Acceptable values range from 1 to 65534."
+        },
+        "frontendPortRangeEnd": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port range end for the external endpoint. This property is used together with BackendAddressPool and FrontendPortRangeStart. Individual inbound NAT rule port mappings will be created for each backend address from BackendAddressPool. Acceptable values range from 1 to 65534."
+        },
+        "backendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to backendAddressPool resource."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the inbound NAT rule resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "LoadBalancer": {
+      "type": "object",
+      "description": "LoadBalancer resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/LoadBalancerPropertiesFormat",
+          "description": "Properties of load balancer.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "extendedLocation": {
+          "$ref": "./common.json#/definitions/ExtendedLocation",
+          "description": "The extended location of the load balancer."
+        },
+        "sku": {
+          "$ref": "#/definitions/LoadBalancerSku",
+          "description": "The load balancer SKU."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "LoadBalancerBackendAddress": {
+      "type": "object",
+      "description": "Load balancer backend addresses.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/LoadBalancerBackendAddressPropertiesFormat",
+          "description": "Properties of load balancer backend address pool.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the backend address."
+        }
+      }
+    },
+    "LoadBalancerBackendAddressPoolListResult": {
+      "type": "object",
+      "description": "Paged collection of BackendAddressPool items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BackendAddressPool items on this page",
+          "items": {
+            "$ref": "#/definitions/BackendAddressPool"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LoadBalancerBackendAddressPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the load balancer backend addresses.",
+      "properties": {
+        "virtualNetwork": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to an existing virtual network."
+        },
+        "subnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to an existing subnet."
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "IP Address belonging to the referenced virtual network."
+        },
+        "networkInterfaceIPConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to IP address defined in network interfaces.",
+          "readOnly": true
+        },
+        "loadBalancerFrontendIPConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the frontend ip address configuration defined in regional loadbalancer."
+        },
+        "inboundNatRulesPortMapping": {
+          "type": "array",
+          "description": "Collection of inbound NAT rule port mappings.",
+          "items": {
+            "$ref": "#/definitions/NatRulePortMapping"
+          },
+          "readOnly": true
+        },
+        "adminState": {
+          "$ref": "./common.json#/definitions/LoadBalancerBackendAddressAdminState",
+          "description": "A list of administrative states which once set can override health probe so that Load Balancer will always forward new connections to backend, or deny new connections and reset existing connections."
+        }
+      }
+    },
+    "LoadBalancerFrontendIPConfigurationListResult": {
+      "type": "object",
+      "description": "Paged collection of FrontendIPConfiguration items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The FrontendIPConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/FrontendIPConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LoadBalancerHealthPerRule": {
+      "type": "object",
+      "description": "The response for a Health API.",
+      "properties": {
+        "up": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of backend instances associated to the LB rule that are considered healthy."
+        },
+        "down": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of backend instances associated to the LB rule that are considered unhealthy."
+        },
+        "loadBalancerBackendAddresses": {
+          "type": "array",
+          "description": "Information about the health per rule of the backend addresses.",
+          "items": {
+            "$ref": "#/definitions/LoadBalancerHealthPerRulePerBackendAddress"
+          }
+        }
+      }
+    },
+    "LoadBalancerHealthPerRulePerBackendAddress": {
+      "type": "object",
+      "description": "The information about health per rule per backend address.",
+      "properties": {
+        "ipAddress": {
+          "type": "string",
+          "description": "The IP address belonging to the backend address."
+        },
+        "networkInterfaceIPConfigurationId": {
+          "type": "string",
+          "description": "Resource ID of the Network Interface IP Configuration."
+        },
+        "state": {
+          "type": "string",
+          "description": "The current health of the backend instances that is associated to the LB rule."
+        },
+        "reason": {
+          "type": "string",
+          "description": "The explanation of the State"
+        }
+      }
+    },
+    "LoadBalancerListResult": {
+      "type": "object",
+      "description": "The response of a LoadBalancer list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The LoadBalancer items on this page",
+          "items": {
+            "$ref": "#/definitions/LoadBalancer"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LoadBalancerLoadBalancingRuleListResult": {
+      "type": "object",
+      "description": "Paged collection of LoadBalancingRule items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The LoadBalancingRule items on this page",
+          "items": {
+            "$ref": "#/definitions/LoadBalancingRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LoadBalancerOutboundRuleListResult": {
+      "type": "object",
+      "description": "Paged collection of OutboundRule items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The OutboundRule items on this page",
+          "items": {
+            "$ref": "#/definitions/OutboundRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LoadBalancerProbeListResult": {
+      "type": "object",
+      "description": "Paged collection of Probe items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Probe items on this page",
+          "items": {
+            "$ref": "#/definitions/Probe"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LoadBalancerPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the load balancer.",
+      "properties": {
+        "frontendIPConfigurations": {
+          "type": "array",
+          "description": "Object representing the frontend IPs to be used for the load balancer.",
+          "items": {
+            "$ref": "#/definitions/FrontendIPConfiguration"
+          }
+        },
+        "backendAddressPools": {
+          "type": "array",
+          "description": "Collection of backend address pools used by a load balancer.",
+          "items": {
+            "$ref": "#/definitions/BackendAddressPool"
+          }
+        },
+        "loadBalancingRules": {
+          "type": "array",
+          "description": "Object collection representing the load balancing rules Gets the provisioning.",
+          "items": {
+            "$ref": "#/definitions/LoadBalancingRule"
+          }
+        },
+        "probes": {
+          "type": "array",
+          "description": "Collection of probe objects used in the load balancer.",
+          "items": {
+            "$ref": "#/definitions/Probe"
+          }
+        },
+        "inboundNatRules": {
+          "type": "array",
+          "description": "Collection of inbound NAT Rules used by a load balancer. Defining inbound NAT rules on your load balancer is mutually exclusive with defining an inbound NAT pool. Inbound NAT pools are referenced from virtual machine scale sets. NICs that are associated with individual virtual machines cannot reference an Inbound NAT pool. They have to reference individual inbound NAT rules.",
+          "items": {
+            "$ref": "#/definitions/InboundNatRule"
+          }
+        },
+        "inboundNatPools": {
+          "type": "array",
+          "description": "Defines an external port range for inbound NAT to a single backend port on NICs associated with a load balancer. Inbound NAT rules are created automatically for each NIC associated with the Load Balancer using an external port from this range. Defining an Inbound NAT pool on your Load Balancer is mutually exclusive with defining inbound NAT rules. Inbound NAT pools are referenced from virtual machine scale sets. NICs that are associated with individual virtual machines cannot reference an inbound NAT pool. They have to reference individual inbound NAT rules.",
+          "items": {
+            "$ref": "#/definitions/InboundNatPool"
+          }
+        },
+        "outboundRules": {
+          "type": "array",
+          "description": "The outbound rules.",
+          "items": {
+            "$ref": "#/definitions/OutboundRule"
+          }
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the load balancer resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the load balancer resource.",
+          "readOnly": true
+        },
+        "scope": {
+          "$ref": "./common.json#/definitions/LoadBalancerScope",
+          "description": "Indicates the scope of the load balancer: external (Public) or internal (Private)."
+        },
+        "mode": {
+          "$ref": "./common.json#/definitions/LoadBalancerMode",
+          "description": "The load balancer mode. Set to `Advanced` to enable additional capabilities on a Standard SKU load balancer. Advanced mode must be specified at creation and cannot be changed afterward.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "LoadBalancerSku": {
+      "type": "object",
+      "description": "SKU of a load balancer.",
+      "properties": {
+        "name": {
+          "$ref": "./common.json#/definitions/LoadBalancerSkuName",
+          "description": "Name of a load balancer SKU."
+        },
+        "tier": {
+          "$ref": "./common.json#/definitions/LoadBalancerSkuTier",
+          "description": "Tier of a load balancer SKU."
+        }
+      }
+    },
+    "LoadBalancerVipSwapRequest": {
+      "type": "object",
+      "description": "The request for a VIP swap.",
+      "properties": {
+        "frontendIPConfigurations": {
+          "type": "array",
+          "description": "A list of frontend IP configuration resources that should swap VIPs.",
+          "items": {
+            "$ref": "#/definitions/LoadBalancerVipSwapRequestFrontendIPConfiguration"
+          }
+        }
+      }
+    },
+    "LoadBalancerVipSwapRequestFrontendIPConfiguration": {
+      "type": "object",
+      "description": "VIP swap request's frontend IP configuration object.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of frontend IP configuration resource."
+        },
+        "properties": {
+          "$ref": "#/definitions/LoadBalancerVipSwapRequestFrontendIPConfigurationProperties",
+          "description": "The properties of VIP swap request's frontend IP configuration object.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "LoadBalancerVipSwapRequestFrontendIPConfigurationProperties": {
+      "type": "object",
+      "description": "The properties of VIP swap request's frontend IP configuration object.",
+      "properties": {
+        "publicIPAddress": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to public IP address resource."
+        }
+      }
+    },
+    "LoadBalancingRule": {
+      "type": "object",
+      "description": "A load balancing rule for a load balancer.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/LoadBalancingRulePropertiesFormat",
+          "description": "Properties of load balancer load balancing rule.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "LoadBalancingRulePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the load balancer.",
+      "properties": {
+        "frontendIPConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to frontend IP addresses."
+        },
+        "backendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to a pool of DIPs. Inbound traffic is randomly load balanced across IPs in the backend IPs."
+        },
+        "backendAddressPools": {
+          "type": "array",
+          "description": "An array of references to pool of DIPs.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "probe": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the load balancer probe used by the load balancing rule."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/TransportProtocol",
+          "description": "The reference to the transport protocol used by the load balancing rule."
+        },
+        "loadDistribution": {
+          "$ref": "./common.json#/definitions/LoadDistribution",
+          "description": "The load distribution policy for this rule."
+        },
+        "frontendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port for the external endpoint. Port numbers for each rule must be unique within the Load Balancer. Acceptable values are between 0 and 65534. Note that value 0 enables \"Any Port\"."
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port used for internal connections on the endpoint. Acceptable values are between 0 and 65535. Note that value 0 enables \"Any Port\"."
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The timeout for the TCP idle connection. The value can be set between 4 and 30 minutes. The default value is 4 minutes. This element is only used when the protocol is set to TCP."
+        },
+        "enableFloatingIP": {
+          "type": "boolean",
+          "description": "Configures a virtual machine's endpoint for the floating IP capability required to configure a SQL AlwaysOn Availability Group. This setting is required when using the SQL AlwaysOn Availability Groups in SQL server. This setting can't be changed after you create the endpoint."
+        },
+        "enableTcpReset": {
+          "type": "boolean",
+          "description": "Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination. This element is only used when the protocol is set to TCP."
+        },
+        "disableOutboundSnat": {
+          "type": "boolean",
+          "description": "Configures SNAT for the VMs in the backend pool to use the publicIP address specified in the frontend of the load balancing rule."
+        },
+        "enableConnectionTracking": {
+          "type": "boolean",
+          "description": "Enables UDP flow tracking for the load balancing rule. This property is retained for rule-level configuration compatibility. When enableConnectionTracking is specified on the associated frontend IP configuration, the frontend setting takes precedence."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the load balancing rule resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "protocol",
+        "frontendPort"
+      ]
+    },
+    "MigrateLoadBalancerToIpBasedRequest": {
+      "type": "object",
+      "description": "The request for a migrateToIpBased API.",
+      "properties": {
+        "pools": {
+          "type": "array",
+          "description": "A list of pool names that should be migrated from Nic based to IP based pool",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MigratedPools": {
+      "type": "object",
+      "description": "The response for a migrateToIpBased API.",
+      "properties": {
+        "migratedPools": {
+          "type": "array",
+          "description": "A list of pools migrated from Nic based to IP based pool",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NatRulePortMapping": {
+      "type": "object",
+      "description": "Individual port mappings for inbound NAT rule created for backend pool.",
+      "properties": {
+        "inboundNatRuleName": {
+          "type": "string",
+          "description": "Name of inbound NAT rule."
+        },
+        "frontendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Frontend port."
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Backend port."
+        }
+      }
+    },
+    "OutboundRule": {
+      "type": "object",
+      "description": "Outbound rule of the load balancer.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/OutboundRulePropertiesFormat",
+          "description": "Properties of load balancer outbound rule.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "OutboundRulePropertiesFormat": {
+      "type": "object",
+      "description": "Outbound rule of the load balancer.",
+      "properties": {
+        "allocatedOutboundPorts": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of outbound ports to be used for NAT."
+        },
+        "frontendIPConfigurations": {
+          "type": "array",
+          "description": "The Frontend IP addresses of the load balancer.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "backendAddressPool": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to a pool of DIPs. Outbound traffic is randomly load balanced across IPs in the backend IPs."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the outbound rule resource.",
+          "readOnly": true
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/LoadBalancerOutboundRuleProtocol",
+          "description": "The protocol for the outbound rule in load balancer."
+        },
+        "enableTcpReset": {
+          "type": "boolean",
+          "description": "Receive bidirectional TCP Reset on TCP flow idle timeout or unexpected connection termination. This element is only used when the protocol is set to TCP."
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The timeout for the TCP idle connection."
+        }
+      },
+      "required": [
+        "frontendIPConfigurations",
+        "backendAddressPool",
+        "protocol"
+      ]
+    },
+    "Probe": {
+      "type": "object",
+      "description": "A load balancer probe.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProbePropertiesFormat",
+          "description": "Properties of load balancer probe.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "ProbePropertiesFormat": {
+      "type": "object",
+      "description": "Load balancer probe resource.",
+      "properties": {
+        "loadBalancingRules": {
+          "type": "array",
+          "description": "The load balancer rules that use this probe.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/ProbeProtocol",
+          "description": "The protocol of the end point. If 'Tcp' is specified, a received ACK is required for the probe to be successful. If 'Http' or 'Https' is specified, a 200 OK response from the specifies URI is required for the probe to be successful."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port for communicating the probe. Possible values range from 1 to 65535, inclusive."
+        },
+        "intervalInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The interval, in seconds, for how frequently to probe the endpoint for health status. Typically, the interval is slightly less than half the allocated timeout period (in seconds) which allows two full probes before taking the instance out of rotation. The default value is 15, the minimum value is 5."
+        },
+        "noHealthyBackendsBehavior": {
+          "$ref": "./common.json#/definitions/ProbeNoHealthyBackendsBehavior",
+          "description": "Determines how new connections are handled by the load balancer when all backend instances are probed down."
+        },
+        "numberOfProbes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of probes where if no response, will result in stopping further traffic from being delivered to the endpoint. This values allows endpoints to be taken out of rotation faster or slower than the typical times used in Azure."
+        },
+        "probeThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of consecutive successful or failed probes in order to allow or deny traffic from being delivered to this endpoint. After failing the number of consecutive probes equal to this value, the endpoint will be taken out of rotation and require the same number of successful consecutive probes to be placed back in rotation."
+        },
+        "requestPath": {
+          "type": "string",
+          "description": "The URI used for requesting health status from the VM. Path is required if a protocol is set to http. Otherwise, it is not allowed. There is no default value."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the probe resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "protocol",
+        "port"
+      ]
+    },
+    "QueryInboundNatRulePortMappingRequest": {
+      "type": "object",
+      "description": "The request for a QueryInboundNatRulePortMapping API. Either IpConfiguration or IpAddress should be set",
+      "properties": {
+        "ipConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "NetworkInterfaceIPConfiguration set in load balancer backend address."
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "IP address set in load balancer backend address."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/networkGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/networkGateway.json
@@ -1,0 +1,5901 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "VirtualNetworkGateways"
+    },
+    {
+      "name": "VirtualNetworkGatewayConnections"
+    },
+    {
+      "name": "LocalNetworkGateways"
+    },
+    {
+      "name": "VirtualNetworkTap"
+    },
+    {
+      "name": "VirtualNetworkTaps"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworkTaps": {
+      "get": {
+        "operationId": "VirtualNetworkTaps_ListAll",
+        "tags": [
+          "VirtualNetworkTaps"
+        ],
+        "description": "Gets all the VirtualNetworkTaps in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkTapListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections": {
+      "get": {
+        "operationId": "VirtualNetworkGatewayConnections_List",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "The List VirtualNetworkGatewayConnections operation retrieves all the virtual network gateways connections created.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}": {
+      "get": {
+        "operationId": "VirtualNetworkGatewayConnections_Get",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "Gets the specified virtual network gateway connection by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualNetworkGatewayConnections_CreateOrUpdate",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "Creates or updates a virtual network gateway connection in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update virtual network gateway connection operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualNetworkGatewayConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualNetworkGatewayConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualNetworkGatewayConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualNetworkGatewayConnections_UpdateTags",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "Updates a virtual network gateway connection tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update virtual network gateway connection tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualNetworkGatewayConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualNetworkGatewayConnections_Delete",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "Deletes the specified virtual network Gateway connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/getikesas": {
+      "post": {
+        "operationId": "VirtualNetworkGatewayConnections_GetIkeSas",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "Lists IKE Security Associations for the virtual network gateway connection in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./networkWatcher.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/resetconnection": {
+      "post": {
+        "operationId": "VirtualNetworkGatewayConnections_ResetConnection",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "Resets the virtual network gateway connection specified.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./networkWatcher.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey": {
+      "get": {
+        "operationId": "VirtualNetworkGatewayConnections_GetSharedKey",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "The Get VirtualNetworkGatewayConnectionSharedKey operation retrieves information about the specified virtual network gateway connection shared key through Network resource provider.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKey"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualNetworkGatewayConnections_SetSharedKey",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "The Put VirtualNetworkGatewayConnectionSharedKey operation sets the virtual network gateway connection shared key for passed virtual network gateway connection in the specified resource group through Network resource provider.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the Begin Set Virtual Network Gateway connection Shared key operation throughNetwork resource provider.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKey"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKey"
+            }
+          },
+          "201": {
+            "description": "Resource 'ConnectionSharedKey' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKey"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ConnectionSharedKey"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/sharedkey/reset": {
+      "post": {
+        "operationId": "VirtualNetworkGatewayConnections_ResetSharedKey",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "The VirtualNetworkGatewayConnectionResetSharedKey operation resets the virtual network gateway connection shared key for passed virtual network gateway connection in the specified resource group through Network resource provider.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the begin reset virtual network gateway connection shared key operation through network resource provider.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionResetSharedKey"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionResetSharedKey"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ConnectionResetSharedKey"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/startPacketCapture": {
+      "post": {
+        "operationId": "VirtualNetworkGatewayConnections_StartPacketCapture",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "Starts packet capture on virtual network gateway connection in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Virtual network gateway packet capture parameters supplied to start packet capture on gateway connection.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/VpnPacketCaptureStartParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/stopPacketCapture": {
+      "post": {
+        "operationId": "VirtualNetworkGatewayConnections_StopPacketCapture",
+        "tags": [
+          "VirtualNetworkGatewayConnections"
+        ],
+        "description": "Stops packet capture on virtual network gateway connection in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Virtual network gateway packet capture parameters supplied to stop packet capture on gateway connection.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnPacketCaptureStopParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/connections/{virtualNetworkGatewayConnectionName}/vpndeviceconfigurationscript": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_VpnDeviceConfigurationScript",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Gets a xml format representation for vpn device configuration script.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayConnectionName",
+            "in": "path",
+            "description": "The name of the virtual network gateway connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the generate vpn device script operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnDeviceScriptParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways": {
+      "get": {
+        "operationId": "LocalNetworkGateways_List",
+        "tags": [
+          "LocalNetworkGateways"
+        ],
+        "description": "Gets all the local network gateways in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGatewayListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/localNetworkGateways/{localNetworkGatewayName}": {
+      "get": {
+        "operationId": "LocalNetworkGateways_Get",
+        "tags": [
+          "LocalNetworkGateways"
+        ],
+        "description": "Gets the specified local network gateway in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "localNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the local network gateway.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "LocalNetworkGateways_CreateOrUpdate",
+        "tags": [
+          "LocalNetworkGateways"
+        ],
+        "description": "Creates or updates a local network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "localNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the local network gateway.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update local network gateway operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGateway"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'LocalNetworkGateway' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGateway"
+            }
+          },
+          "201": {
+            "description": "Resource 'LocalNetworkGateway' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGateway"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/LocalNetworkGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "LocalNetworkGateways_UpdateTags",
+        "tags": [
+          "LocalNetworkGateways"
+        ],
+        "description": "Updates a local network gateway tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "localNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the local network gateway.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update local network gateway tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LocalNetworkGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "LocalNetworkGateways_Delete",
+        "tags": [
+          "LocalNetworkGateways"
+        ],
+        "description": "Deletes the specified local network gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "localNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the local network gateway.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways": {
+      "get": {
+        "operationId": "VirtualNetworkGateways_List",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Gets all virtual network gateways by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}": {
+      "get": {
+        "operationId": "VirtualNetworkGateways_Get",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Gets the specified virtual network gateway by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualNetworkGateways_CreateOrUpdate",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Creates or updates a virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update virtual network gateway operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualNetworkGateway' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualNetworkGateway' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualNetworkGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualNetworkGateways_UpdateTags",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Updates a virtual network gateway tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update virtual network gateway tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualNetworkGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualNetworkGateways_Delete",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Deletes the specified virtual network gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/abortMigration": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_InvokeAbortMigration",
+        "description": "Trigger abort migration for the virtual network gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/commitMigration": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_InvokeCommitMigration",
+        "description": "Trigger commit migration for the virtual network gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/connections": {
+      "get": {
+        "operationId": "VirtualNetworkGateways_ListConnections",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Gets all the connections in a virtual network gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayListConnectionsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/disconnectVirtualNetworkGatewayVpnConnections": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_DisconnectVirtualNetworkGatewayVpnConnections",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Disconnect vpn connections of virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "The parameters are supplied to disconnect vpn connections.",
+            "required": true,
+            "schema": {
+              "$ref": "./virtualWan.json#/definitions/P2SVpnConnectionRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/executeMigration": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_InvokeExecuteMigration",
+        "description": "Trigger execute migration for the virtual network gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnclientpackage": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_Generatevpnclientpackage",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Generates VPN client package for P2S client of the virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the generate virtual network gateway VPN client package operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnClientParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/generatevpnprofile": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GenerateVpnProfile",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Generates VPN profile for P2S client of the virtual network gateway in the specified resource group. Used for IKEV2 and radius based authentication.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the generate virtual network gateway VPN client package operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnClientParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getAdvertisedRoutes": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetAdvertisedRoutes",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "This operation retrieves a list of routes the virtual network gateway is advertising to the specified peer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peer",
+            "in": "query",
+            "description": "The IP address of the peer.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GatewayRouteListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/GatewayRouteListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getBgpPeerStatus": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetBgpPeerStatus",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "The GetBgpPeerStatus operation retrieves the status of all BGP peers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peer",
+            "in": "query",
+            "description": "The IP address of the peer to retrieve the status of.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BgpPeerStatusListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/BgpPeerStatusListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getEffectiveRoutes": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetEffectiveRoutes",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "This operation retrieves a list of effective routes for the virtual network gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GatewayEffectiveRouteListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/GatewayEffectiveRouteListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getFailoverAllTestsDetails": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetFailoverAllTestDetails",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "This operation retrieves the details of all the failover tests performed on the gateway for different peering locations",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "The type of failover test",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "fetchLatest",
+            "in": "query",
+            "description": "Fetch only the latest tests for each peering location",
+            "required": true,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExpressRouteFailoverTestDetails"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteFailoverTestDetailsArray"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getFailoverSingleTestDetails": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetFailoverSingleTestDetails",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "This operation retrieves the details of a particular failover test performed on the gateway based on the test Guid",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringLocation",
+            "in": "query",
+            "description": "Peering location of the test",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "failoverTestId",
+            "in": "query",
+            "description": "The unique Guid value which identifies the test",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/ExpressRouteFailoverSingleTestDetails"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ExpressRouteFailoverSingleTestDetailsArray"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getLearnedRoutes": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetLearnedRoutes",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "This operation retrieves a list of routes the virtual network gateway has learned, including routes learned from BGP peers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GatewayRouteListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/GatewayRouteListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getResiliencyInformation": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetResiliencyInformation",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "This operation retrieves the resiliency information for an Express Route Gateway, including the gateway's current resiliency score and recommendations to further improve the score",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "attemptRefresh",
+            "in": "query",
+            "description": "Attempt to recalculate the Resiliency Information for the gateway",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GatewayResiliencyInformation"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/GatewayResiliencyInformation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getRoutesInformation": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetRoutesInformation",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "This operation retrieves the route set information for an Express Route Gateway based on their resiliency",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "attemptRefresh",
+            "in": "query",
+            "description": "Attempt to recalculate the Route Sets Information for the gateway",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GatewayRouteSetsInformation"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/GatewayRouteSetsInformation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getVpnClientConnectionHealth": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetVpnclientConnectionHealth",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Get VPN client connection health detail per P2S client connection of the virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnClientConnectionHealthDetailListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VpnClientConnectionHealthDetailListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getvpnclientipsecparameters": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetVpnclientIpsecParameters",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "The Get VpnclientIpsecParameters operation retrieves information about the vpnclient ipsec policy for P2S client of virtual network gateway in the specified resource group through Network resource provider.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/VpnClientIPsecParameters"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VpnClientIPsecParameters"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/getvpnprofilepackageurl": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_GetVpnProfilePackageUrl",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Gets pre-generated VPN profile for P2S client of the virtual network gateway in the specified resource group. The profile needs to be generated first using generateVpnProfile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/listRadiusSecrets": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_ListRadiusSecrets",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "List all Radius servers with respective radius secrets from virtual network gateway VpnClientConfiguration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RadiusAuthServerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/natRules": {
+      "get": {
+        "operationId": "VirtualNetworkGatewayNatRules_ListByVirtualNetworkGateway",
+        "description": "Retrieves all nat rules for a particular virtual network gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVirtualNetworkGatewayNatRulesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/natRules/{natRuleName}": {
+      "get": {
+        "operationId": "VirtualNetworkGatewayNatRules_Get",
+        "description": "Retrieves the details of a nat rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "natRuleName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayNatRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualNetworkGatewayNatRules_CreateOrUpdate",
+        "description": "Creates a nat rule to a scalable virtual network gateway if it doesn't exist else updates the existing nat rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "natRuleName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "NatRuleParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or Update a Nat Rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayNatRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualNetworkGatewayNatRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayNatRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualNetworkGatewayNatRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayNatRule"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualNetworkGatewayNatRule"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualNetworkGatewayNatRules_Delete",
+        "description": "Deletes a nat rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "natRuleName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/prepareMigration": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_InvokePrepareMigration",
+        "description": "Trigger prepare migration for the virtual network gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "migrationParams",
+            "in": "body",
+            "description": "Parameters supplied to the Begin Prepare migration on basic vpn gateway through Network resource provider.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGatewayMigrationParameters"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/reset": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_Reset",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Resets the primary of the virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "gatewayVip",
+            "in": "query",
+            "description": "Virtual network gateway vip address supplied to the begin reset of the active-active feature enabled gateway.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkGateway"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VirtualNetworkGateway"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/resetvpnclientsharedkey": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_ResetVpnClientSharedKey",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Resets the VPN client shared key of the virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/setvpnclientipsecparameters": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_SetVpnclientIpsecParameters",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "The Set VpnclientIpsecParameters operation sets the vpnclient ipsec policy for P2S client of virtual network gateway in the specified resource group through Network resource provider.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vpnclientIpsecParams",
+            "in": "body",
+            "description": "Parameters supplied to the Begin Set vpnclient ipsec parameters of Virtual Network Gateway P2S client operation through Network resource provider.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnClientIPsecParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnClientIPsecParameters"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VpnClientIPsecParameters"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/startPacketCapture": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_StartPacketCapture",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Starts packet capture on virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Virtual network gateway packet capture parameters supplied to start packet capture on gateway.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/VpnPacketCaptureStartParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/startSiteFailoverTest": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_StartExpressRouteSiteFailoverSimulation",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "This operation starts failover simulation on the gateway for the specified peering location",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringLocation",
+            "in": "query",
+            "description": "Peering location of the test",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/stopPacketCapture": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_StopPacketCapture",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Stops packet capture on virtual network gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Virtual network gateway packet capture parameters supplied to stop packet capture on gateway.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnPacketCaptureStopParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/stopSiteFailoverTest": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_StopExpressRouteSiteFailoverSimulation",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "This operation stops failover simulation on the gateway for the specified peering location",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "stopParameters",
+            "in": "body",
+            "description": "Virtual network gateway stop simulation parameters supplied to stop failover simulation on gateway.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteFailoverStopApiParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkGateways/{virtualNetworkGatewayName}/supportedvpndevices": {
+      "post": {
+        "operationId": "VirtualNetworkGateways_SupportedVpnDevices",
+        "tags": [
+          "VirtualNetworkGateways"
+        ],
+        "description": "Gets a xml format representation for supported vpn devices.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkGatewayName",
+            "in": "path",
+            "description": "The name of the virtual network gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps": {
+      "get": {
+        "operationId": "VirtualNetworkTaps_ListByResourceGroup",
+        "tags": [
+          "VirtualNetworkTaps"
+        ],
+        "description": "Gets all the VirtualNetworkTaps in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkTapListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkTaps/{tapName}": {
+      "get": {
+        "operationId": "VirtualNetworkTaps_Get",
+        "tags": [
+          "VirtualNetworkTap"
+        ],
+        "description": "Get a VirtualNetworkTap",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "tapName",
+            "in": "path",
+            "description": "The name of virtual network tap.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkTap"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualNetworkTaps_CreateOrUpdate",
+        "tags": [
+          "VirtualNetworkTap"
+        ],
+        "description": "Create a VirtualNetworkTap",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "tapName",
+            "in": "path",
+            "description": "The name of virtual network tap.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update virtual network tap operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkTap"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualNetworkTap' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkTap"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualNetworkTap' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkTap"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualNetworkTap"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualNetworkTaps_UpdateTags",
+        "tags": [
+          "VirtualNetworkTap"
+        ],
+        "description": "Update a VirtualNetworkTap",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "tapName",
+            "in": "path",
+            "description": "The name of virtual network tap.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "tapParameters",
+            "in": "body",
+            "description": "Parameters supplied to update VirtualNetworkTap tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkTap"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "VirtualNetworkTaps_Delete",
+        "tags": [
+          "VirtualNetworkTap"
+        ],
+        "description": "Delete a VirtualNetworkTap",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "tapName",
+            "in": "path",
+            "description": "The name of virtual network tap.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "BgpPeerStatus": {
+      "type": "object",
+      "description": "BGP peer status details.",
+      "properties": {
+        "localAddress": {
+          "type": "string",
+          "description": "The virtual network gateway's local address.",
+          "readOnly": true
+        },
+        "neighbor": {
+          "type": "string",
+          "description": "The remote BGP peer.",
+          "readOnly": true
+        },
+        "asn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The autonomous system number of the remote BGP peer.",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "readOnly": true
+        },
+        "state": {
+          "$ref": "./common.json#/definitions/BgpPeerState",
+          "description": "The BGP peer state.",
+          "readOnly": true
+        },
+        "connectedDuration": {
+          "type": "string",
+          "description": "For how long the peering has been up.",
+          "readOnly": true
+        },
+        "routesReceived": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of routes learned from this peer.",
+          "readOnly": true
+        },
+        "messagesSent": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of BGP messages sent.",
+          "readOnly": true
+        },
+        "messagesReceived": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The number of BGP messages received.",
+          "readOnly": true
+        }
+      }
+    },
+    "BgpPeerStatusListResult": {
+      "type": "object",
+      "description": "Response for list BGP peer status API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of BGP peers.",
+          "items": {
+            "$ref": "#/definitions/BgpPeerStatus"
+          }
+        }
+      }
+    },
+    "BgpSettings": {
+      "type": "object",
+      "description": "BGP settings details.",
+      "properties": {
+        "asn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The BGP speaker's ASN.",
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "bgpPeeringAddress": {
+          "type": "string",
+          "description": "The BGP peering address and BGP identifier of this BGP speaker."
+        },
+        "peerWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The weight added to routes learned from this BGP speaker."
+        },
+        "bgpPeeringAddresses": {
+          "type": "array",
+          "description": "BGP peering address with IP configuration ID for virtual network gateway.",
+          "items": {
+            "$ref": "#/definitions/IPConfigurationBgpPeeringAddress"
+          }
+        }
+      }
+    },
+    "CertificateAuthentication": {
+      "type": "object",
+      "description": "Certificate Authentication information for a certificate based authentication connection.",
+      "properties": {
+        "outboundAuthCertificate": {
+          "type": "string",
+          "format": "uri",
+          "description": "Keyvault secret ID for outbound authentication certificate."
+        },
+        "inboundAuthCertificateSubjectName": {
+          "type": "string",
+          "description": "Inbound authentication certificate subject name."
+        },
+        "inboundAuthCertificateChain": {
+          "type": "array",
+          "description": "Inbound authentication certificate public keys.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CircuitMetadataMap": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Express Route Circuit Name"
+        },
+        "link": {
+          "type": "string",
+          "description": "Link to the Express Route circuit"
+        },
+        "location": {
+          "type": "string",
+          "description": "Peering location of the Express Route Circuit"
+        }
+      }
+    },
+    "ConnectionResetSharedKey": {
+      "type": "object",
+      "description": "The virtual network connection reset shared key.",
+      "properties": {
+        "keyLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The virtual network connection reset shared key length, should between 1 and 128.",
+          "minimum": 1,
+          "maximum": 128
+        }
+      },
+      "required": [
+        "keyLength"
+      ]
+    },
+    "ConnectionSharedKey": {
+      "type": "object",
+      "description": "Response for GetConnectionSharedKey API service call.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The virtual network connection shared key value."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ExpressRouteFailoverCircuitResourceDetails": {
+      "type": "object",
+      "properties": {
+        "nrpResourceUri": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "NRP Resource URI of the circuit"
+        },
+        "name": {
+          "type": "string",
+          "description": "Circuit Name"
+        },
+        "connectionName": {
+          "type": "string",
+          "description": "Connection name associated with the circuit"
+        }
+      }
+    },
+    "ExpressRouteFailoverConnectionResourceDetails": {
+      "type": "object",
+      "properties": {
+        "nrpResourceUri": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "NRP Resource URI of the connection"
+        },
+        "name": {
+          "type": "string",
+          "description": "Connection Name"
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/FailoverConnectionStatus",
+          "description": "The current status of the connection"
+        },
+        "lastUpdatedTime": {
+          "type": "string",
+          "description": "Time when the connection was last updated"
+        }
+      }
+    },
+    "ExpressRouteFailoverRedundantRoute": {
+      "type": "object",
+      "properties": {
+        "peeringLocations": {
+          "type": "array",
+          "description": "A list of all the peering locations for the redundant routes",
+          "items": {
+            "type": "string"
+          }
+        },
+        "routes": {
+          "type": "array",
+          "description": "A list of all the redundant routes in the peering locations",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ExpressRouteFailoverSingleTestDetails": {
+      "type": "object",
+      "description": "ExpressRoute failover single test details",
+      "properties": {
+        "peeringLocation": {
+          "type": "string",
+          "description": "Peering location of the test"
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/FailoverTestStatusForSingleTest",
+          "description": "The current status of the test"
+        },
+        "startTimeUtc": {
+          "type": "string",
+          "description": "Time when the test was started"
+        },
+        "endTimeUtc": {
+          "type": "string",
+          "description": "Time when the test was completed"
+        },
+        "redundantRoutes": {
+          "type": "array",
+          "description": "List of routes received from this peering as well as some other peering location",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteFailoverRedundantRoute"
+          }
+        },
+        "nonRedundantRoutes": {
+          "type": "array",
+          "description": "List of al the routes that were received only from this peering location",
+          "items": {
+            "type": "string"
+          }
+        },
+        "wasSimulationSuccessful": {
+          "type": "boolean",
+          "description": "Whether the failover simulation was successful or not"
+        },
+        "failoverConnectionDetails": {
+          "type": "array",
+          "description": "List of all the failover connections for this peering location",
+          "items": {
+            "$ref": "#/definitions/FailoverConnectionDetails"
+          }
+        }
+      }
+    },
+    "ExpressRouteFailoverSingleTestDetailsArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ExpressRouteFailoverSingleTestDetails"
+      }
+    },
+    "ExpressRouteFailoverStopApiParameters": {
+      "type": "object",
+      "description": "Start packet capture parameters on virtual network gateway.",
+      "properties": {
+        "peeringLocation": {
+          "type": "string",
+          "description": "Peering location of the test"
+        },
+        "wasSimulationSuccessful": {
+          "type": "boolean",
+          "description": "Whether the failover simulation was successful or not"
+        },
+        "details": {
+          "type": "array",
+          "description": "List of all the failover connections for this peering location",
+          "items": {
+            "$ref": "#/definitions/FailoverConnectionDetails"
+          }
+        }
+      }
+    },
+    "ExpressRouteFailoverTestDetails": {
+      "type": "object",
+      "description": "ExpressRoute failover test details",
+      "properties": {
+        "peeringLocation": {
+          "type": "string",
+          "description": "Peering location of the test"
+        },
+        "circuits": {
+          "type": "array",
+          "description": "All circuits in the peering location",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteFailoverCircuitResourceDetails"
+          }
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/FailoverTestStatus",
+          "description": "The current status of the test"
+        },
+        "startTime": {
+          "type": "string",
+          "description": "Time when the test was started"
+        },
+        "endTime": {
+          "type": "string",
+          "description": "Time when the test was completed"
+        },
+        "connections": {
+          "type": "array",
+          "description": "All connections to the circuits in the peering location",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteFailoverConnectionResourceDetails"
+          }
+        },
+        "testGuid": {
+          "type": "string",
+          "description": "The unique GUID associated with the test"
+        },
+        "testType": {
+          "$ref": "./common.json#/definitions/FailoverTestType",
+          "description": "The type of failover test"
+        },
+        "issues": {
+          "type": "array",
+          "description": "A list of all issues with the test",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ExpressRouteFailoverTestDetailsArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ExpressRouteFailoverTestDetails"
+      }
+    },
+    "FailoverConnectionDetails": {
+      "type": "object",
+      "properties": {
+        "failoverConnectionName": {
+          "type": "string",
+          "description": "Name of the failover connection"
+        },
+        "failoverLocation": {
+          "type": "string",
+          "description": "Location of the failover connection"
+        },
+        "isVerified": {
+          "type": "boolean",
+          "description": "Whether the customer was able to establish connectivity through this failover connection or not"
+        }
+      }
+    },
+    "GatewayCustomBgpIpAddressIpConfiguration": {
+      "type": "object",
+      "description": "GatewayCustomBgpIpAddressIpConfiguration for a virtual network gateway connection.",
+      "properties": {
+        "ipConfigurationId": {
+          "type": "string",
+          "description": "The IpconfigurationId of ipconfiguration which belongs to gateway."
+        },
+        "customBgpIpAddress": {
+          "type": "string",
+          "description": "The custom BgpPeeringAddress which belongs to IpconfigurationId."
+        }
+      },
+      "required": [
+        "ipConfigurationId",
+        "customBgpIpAddress"
+      ]
+    },
+    "GatewayEffectiveRoute": {
+      "type": "object",
+      "description": "Gateway effective routing details.",
+      "properties": {
+        "localAddress": {
+          "type": "string",
+          "description": "The gateway's local address.",
+          "readOnly": true
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "The list of address prefixes for the effective route.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "nextHopIpAddress": {
+          "type": "string",
+          "description": "The IP address of the next hop for the effective route.",
+          "readOnly": true
+        },
+        "nextHopType": {
+          "$ref": "./common.json#/definitions/GatewayEffectiveRouteNextHopType",
+          "description": "The next hop type of the effective route.",
+          "readOnly": true
+        }
+      }
+    },
+    "GatewayEffectiveRouteListResult": {
+      "type": "object",
+      "description": "List of virtual network gateway effective routes.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of gateway effective routes.",
+          "items": {
+            "$ref": "#/definitions/GatewayEffectiveRoute"
+          }
+        }
+      }
+    },
+    "GatewayResiliencyInformation": {
+      "type": "object",
+      "description": "Gateway Resiliency Information",
+      "properties": {
+        "overallScore": {
+          "type": "string",
+          "description": "Current Resiliency Score for the gateway"
+        },
+        "scoreChange": {
+          "type": "string",
+          "description": "Update in the Resiliency Score for the gateway from the last computed score"
+        },
+        "minScoreFromRecommendations": {
+          "type": "string",
+          "description": "Minimum increase expected in the score if the at least one of the recommendations is applied for the gateway"
+        },
+        "maxScoreFromRecommendations": {
+          "type": "string",
+          "description": "Maximum increase expected in the score if all of the recommendations are applied for the gateway"
+        },
+        "lastComputedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp denoting the last time when the resiliency score was computed for the gateway"
+        },
+        "nextEligibleComputeTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp denoting the next eligible time to re-compute the resiliency score for the gateway"
+        },
+        "components": {
+          "type": "array",
+          "description": "List of Resiliency based Recommendation Components for the gateway",
+          "items": {
+            "$ref": "#/definitions/ResiliencyRecommendationComponents"
+          }
+        }
+      }
+    },
+    "GatewayResiliencyRecommendation": {
+      "type": "object",
+      "description": "Resiliency Recommendation details",
+      "properties": {
+        "recommendationTitle": {
+          "type": "string",
+          "description": "Recommendation Title"
+        },
+        "recommendationId": {
+          "type": "string",
+          "description": "Recommendation Id"
+        },
+        "severity": {
+          "type": "string",
+          "description": "Impact associated with the recommendation"
+        },
+        "recommendationText": {
+          "type": "string",
+          "description": "Recommendation details"
+        },
+        "callToActionText": {
+          "type": "string",
+          "description": "Acton items to apply the recommendation"
+        },
+        "callToActionLink": {
+          "type": "string",
+          "description": "Link to the public documentation for the associated recommendation"
+        }
+      }
+    },
+    "GatewayRoute": {
+      "type": "object",
+      "description": "Gateway routing details.",
+      "properties": {
+        "localAddress": {
+          "type": "string",
+          "description": "The gateway's local address.",
+          "readOnly": true
+        },
+        "network": {
+          "type": "string",
+          "description": "The route's network prefix.",
+          "readOnly": true
+        },
+        "nextHop": {
+          "type": "string",
+          "description": "The route's next hop.",
+          "readOnly": true
+        },
+        "sourcePeer": {
+          "type": "string",
+          "description": "The peer this route was learned from.",
+          "readOnly": true
+        },
+        "origin": {
+          "type": "string",
+          "description": "The source this route was learned from.",
+          "readOnly": true
+        },
+        "asPath": {
+          "type": "string",
+          "description": "The route's AS path sequence.",
+          "readOnly": true
+        },
+        "weight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The route's weight.",
+          "readOnly": true
+        }
+      }
+    },
+    "GatewayRouteListResult": {
+      "type": "object",
+      "description": "List of virtual network gateway routes.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of gateway routes.",
+          "items": {
+            "$ref": "#/definitions/GatewayRoute"
+          }
+        }
+      }
+    },
+    "GatewayRouteSet": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Route Set name"
+        },
+        "locations": {
+          "type": "array",
+          "description": "List of different locations from where the routes are learned",
+          "items": {
+            "type": "string"
+          }
+        },
+        "details": {
+          "type": "object",
+          "description": "List of different Route Sources",
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/definitions/RouteSourceDetails"
+            },
+            "type": "array"
+          }
+        }
+      }
+    },
+    "GatewayRouteSetsInformation": {
+      "type": "object",
+      "description": "Gateway Route Sets Information",
+      "properties": {
+        "lastComputedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp denoting the last time when the route sets were computed for the gateway"
+        },
+        "nextEligibleComputeTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp denoting the next eligible time to re-compute the route sets for the gateway"
+        },
+        "routeSetVersion": {
+          "type": "string",
+          "description": "Version for the route set"
+        },
+        "routeSets": {
+          "type": "array",
+          "description": "List of Gateway Route Sets",
+          "items": {
+            "$ref": "#/definitions/GatewayRouteSet"
+          }
+        },
+        "circuitsMetadataMap": {
+          "type": "object",
+          "description": "Dictionary containing map of the circuit id and circuit details",
+          "additionalProperties": {
+            "$ref": "#/definitions/CircuitMetadataMap"
+          }
+        }
+      }
+    },
+    "IPConfigurationBgpPeeringAddress": {
+      "type": "object",
+      "description": "Properties of IPConfigurationBgpPeeringAddress.",
+      "properties": {
+        "ipconfigurationId": {
+          "type": "string",
+          "description": "The ID of IP configuration which belongs to gateway."
+        },
+        "defaultBgpIpAddresses": {
+          "type": "array",
+          "description": "The list of default BGP peering addresses which belong to IP configuration.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "customBgpIpAddresses": {
+          "type": "array",
+          "description": "The list of custom BGP peering addresses which belong to IP configuration.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tunnelIpAddresses": {
+          "type": "array",
+          "description": "The list of tunnel public IP addresses which belong to IP configuration.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "IpsecPolicy": {
+      "type": "object",
+      "description": "An IPSec Policy configuration for a virtual network gateway connection.",
+      "properties": {
+        "saLifeTimeSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The IPSec Security Association (also called Quick Mode or Phase 2 SA) lifetime in seconds for a site to site VPN tunnel."
+        },
+        "saDataSizeKilobytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The IPSec Security Association (also called Quick Mode or Phase 2 SA) payload size in KB for a site to site VPN tunnel."
+        },
+        "ipsecEncryption": {
+          "$ref": "./common.json#/definitions/IpsecEncryption",
+          "description": "The IPSec encryption algorithm (IKE phase 1)."
+        },
+        "ipsecIntegrity": {
+          "$ref": "./common.json#/definitions/IpsecIntegrity",
+          "description": "The IPSec integrity algorithm (IKE phase 1)."
+        },
+        "ikeEncryption": {
+          "$ref": "./common.json#/definitions/IkeEncryption",
+          "description": "The IKE encryption algorithm (IKE phase 2)."
+        },
+        "ikeIntegrity": {
+          "$ref": "./common.json#/definitions/IkeIntegrity",
+          "description": "The IKE integrity algorithm (IKE phase 2)."
+        },
+        "dhGroup": {
+          "$ref": "./common.json#/definitions/DhGroup",
+          "description": "The DH Group used in IKE Phase 1 for initial SA."
+        },
+        "pfsGroup": {
+          "$ref": "./common.json#/definitions/PfsGroup",
+          "description": "The Pfs Group used in IKE Phase 2 for new child SA."
+        }
+      },
+      "required": [
+        "saLifeTimeSeconds",
+        "saDataSizeKilobytes",
+        "ipsecEncryption",
+        "ipsecIntegrity",
+        "ikeEncryption",
+        "ikeIntegrity",
+        "dhGroup",
+        "pfsGroup"
+      ]
+    },
+    "ListVirtualNetworkGatewayNatRulesResult": {
+      "type": "object",
+      "description": "Result of the request to list all nat rules to a virtual network gateway. It contains a list of Nat rules and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetworkGatewayNatRule items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayNatRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LocalNetworkGateway": {
+      "type": "object",
+      "description": "A common class for general resource information.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/LocalNetworkGatewayPropertiesFormat",
+          "description": "Properties of the local network gateway.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "LocalNetworkGatewayListResult": {
+      "type": "object",
+      "description": "The response of a LocalNetworkGateway list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The LocalNetworkGateway items on this page",
+          "items": {
+            "$ref": "#/definitions/LocalNetworkGateway"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LocalNetworkGatewayPropertiesFormat": {
+      "type": "object",
+      "description": "LocalNetworkGateway properties.",
+      "properties": {
+        "localNetworkAddressSpace": {
+          "$ref": "./virtualNetwork.json#/definitions/AddressSpace",
+          "description": "Local network site address space."
+        },
+        "gatewayIpAddress": {
+          "type": "string",
+          "description": "IP address of local network gateway."
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "FQDN of local network gateway."
+        },
+        "bgpSettings": {
+          "$ref": "#/definitions/BgpSettings",
+          "description": "Local network gateway's BGP speaker settings."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the local network gateway resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the local network gateway resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "RadiusAuthServer": {
+      "type": "object",
+      "description": "Gateway or VpnServerConfiguration Radius server with radius secret details",
+      "properties": {
+        "radiusServerAddress": {
+          "type": "string",
+          "description": "Radius server IPAddress"
+        },
+        "radiusServerSecret": {
+          "type": "string",
+          "format": "password",
+          "description": "Radius server secret",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "RadiusAuthServerListResult": {
+      "type": "object",
+      "description": "List of Radius servers with respective radius secrets.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RadiusAuthServer items on this page",
+          "items": {
+            "$ref": "#/definitions/RadiusAuthServer"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RadiusServer": {
+      "type": "object",
+      "description": "Radius Server Settings.",
+      "properties": {
+        "radiusServerAddress": {
+          "type": "string",
+          "description": "The address of this radius server."
+        },
+        "radiusServerScore": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The initial score assigned to this radius server."
+        },
+        "radiusServerSecret": {
+          "type": "string",
+          "format": "password",
+          "description": "The secret used for this radius server. We will no longer return radiusServerSecret in VirtualNetworkGateway Create/Update/Get/List/UpdateTags APIs response. Please use VirtualNetworkGateway ListRadiusSecrets API to fetch radius server secrets.",
+          "x-ms-secret": true
+        }
+      },
+      "required": [
+        "radiusServerAddress"
+      ]
+    },
+    "ResiliencyRecommendationComponents": {
+      "type": "object",
+      "description": "Gateway Resiliency based Recommendations",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the Resiliency based Recommendation Component"
+        },
+        "currentScore": {
+          "type": "string",
+          "description": "Current Score of the gateway"
+        },
+        "maxScore": {
+          "type": "string",
+          "description": "Max score that the gateway can achieve if the specified recommendation is applied"
+        },
+        "recommendations": {
+          "type": "array",
+          "description": "List of Gateway Resiliency based Recommendations",
+          "items": {
+            "$ref": "#/definitions/GatewayResiliencyRecommendation"
+          }
+        }
+      }
+    },
+    "RouteSourceDetails": {
+      "type": "object",
+      "properties": {
+        "circuit": {
+          "type": "string",
+          "description": "Express Route Circuit identifier"
+        },
+        "pri": {
+          "type": "string",
+          "description": "Flag to indicate if the route learned from the primary device is active or passive"
+        },
+        "sec": {
+          "type": "string",
+          "description": "Flag to indicate if the route learned from the secondary device is active or passive"
+        }
+      }
+    },
+    "TrafficSelectorPolicy": {
+      "type": "object",
+      "description": "An traffic selector policy for a virtual network gateway connection.",
+      "properties": {
+        "localAddressRanges": {
+          "type": "array",
+          "description": "A collection of local address spaces in CIDR format.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "remoteAddressRanges": {
+          "type": "array",
+          "description": "A collection of remote address spaces in CIDR format.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "localAddressRanges",
+        "remoteAddressRanges"
+      ]
+    },
+    "TunnelConnectionHealth": {
+      "type": "object",
+      "description": "VirtualNetworkGatewayConnection properties.",
+      "properties": {
+        "tunnel": {
+          "type": "string",
+          "description": "Tunnel name.",
+          "readOnly": true
+        },
+        "connectionStatus": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionStatus",
+          "description": "Virtual Network Gateway connection status.",
+          "readOnly": true
+        },
+        "ingressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The Ingress Bytes Transferred in this connection.",
+          "readOnly": true
+        },
+        "egressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The Egress Bytes Transferred in this connection.",
+          "readOnly": true
+        },
+        "lastConnectionEstablishedUtcTime": {
+          "type": "string",
+          "description": "The time at which connection was established in Utc format.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualNetworkConnectionGatewayReference": {
+      "type": "object",
+      "description": "A reference to VirtualNetworkGateway or LocalNetworkGateway resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of VirtualNetworkGateway or LocalNetworkGateway resource."
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "VirtualNetworkGateway": {
+      "type": "object",
+      "description": "A common class for general resource information.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkGatewayPropertiesFormat",
+          "description": "Properties of the virtual network gateway.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "./common.json#/definitions/ExtendedLocation",
+          "description": "The extended location of type local virtual network gateway."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "identity": {
+          "$ref": "./common.json#/definitions/ManagedServiceIdentity",
+          "description": "The identity of the virtual network gateway, if configured."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "VirtualNetworkGatewayAutoScaleBounds": {
+      "type": "object",
+      "properties": {
+        "min": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum scale Units for Autoscale configuration"
+        },
+        "max": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum Scale Units for Autoscale configuration"
+        }
+      }
+    },
+    "VirtualNetworkGatewayAutoScaleConfiguration": {
+      "type": "object",
+      "description": "Virtual Network Gateway Autoscale Configuration details",
+      "properties": {
+        "bounds": {
+          "$ref": "#/definitions/VirtualNetworkGatewayAutoScaleBounds",
+          "description": "The bounds of the autoscale configuration"
+        }
+      }
+    },
+    "VirtualNetworkGatewayConnection": {
+      "type": "object",
+      "description": "A common class for general resource information.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkGatewayConnectionPropertiesFormat",
+          "description": "Properties of the virtual network gateway connection.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "VirtualNetworkGatewayConnectionListEntity": {
+      "type": "object",
+      "description": "A common class for general resource information.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkGatewayConnectionListEntityPropertiesFormat",
+          "description": "Properties of the virtual network gateway connection.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "VirtualNetworkGatewayConnectionListEntityPropertiesFormat": {
+      "type": "object",
+      "description": "VirtualNetworkGatewayConnection properties.",
+      "properties": {
+        "authorizationKey": {
+          "type": "string",
+          "description": "The authorizationKey."
+        },
+        "virtualNetworkGateway1": {
+          "$ref": "#/definitions/VirtualNetworkConnectionGatewayReference",
+          "description": "The reference to virtual network gateway resource."
+        },
+        "virtualNetworkGateway2": {
+          "$ref": "#/definitions/VirtualNetworkConnectionGatewayReference",
+          "description": "The reference to virtual network gateway resource."
+        },
+        "localNetworkGateway2": {
+          "$ref": "#/definitions/VirtualNetworkConnectionGatewayReference",
+          "description": "The reference to local network gateway resource."
+        },
+        "connectionType": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionType",
+          "description": "Gateway connection type."
+        },
+        "connectionProtocol": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionProtocol",
+          "description": "Connection protocol used for this connection."
+        },
+        "routingWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The routing weight."
+        },
+        "connectionMode": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionMode",
+          "description": "The connection mode for this connection."
+        },
+        "sharedKey": {
+          "type": "string",
+          "description": "The IPSec shared key. We will no longer return sharedKey in VirtualNetworkGatewayConnection Create/Update/Get/List/UpdateTags APIs response. Please use VirtualNetworkGatewayConnection GetSharedKey API to fetch connection sharedKey."
+        },
+        "connectionStatus": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionStatus",
+          "description": "Virtual Network Gateway connection status.",
+          "readOnly": true
+        },
+        "tunnelConnectionStatus": {
+          "type": "array",
+          "description": "Collection of all tunnels' connection health status.",
+          "items": {
+            "$ref": "#/definitions/TunnelConnectionHealth"
+          },
+          "readOnly": true
+        },
+        "egressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The egress bytes transferred in this connection.",
+          "readOnly": true
+        },
+        "ingressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The ingress bytes transferred in this connection.",
+          "readOnly": true
+        },
+        "peer": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to peerings resource."
+        },
+        "enableBgp": {
+          "type": "boolean",
+          "description": "EnableBgp flag."
+        },
+        "gatewayCustomBgpIpAddresses": {
+          "type": "array",
+          "description": "GatewayCustomBgpIpAddresses to be used for virtual network gateway Connection.",
+          "items": {
+            "$ref": "#/definitions/GatewayCustomBgpIpAddressIpConfiguration"
+          },
+          "x-ms-identifiers": []
+        },
+        "usePolicyBasedTrafficSelectors": {
+          "type": "boolean",
+          "description": "Enable policy-based traffic selectors."
+        },
+        "ipsecPolicies": {
+          "type": "array",
+          "description": "The IPSec Policies to be considered by this connection.",
+          "items": {
+            "$ref": "#/definitions/IpsecPolicy"
+          }
+        },
+        "trafficSelectorPolicies": {
+          "type": "array",
+          "description": "The Traffic Selector Policies to be considered by this connection.",
+          "items": {
+            "$ref": "#/definitions/TrafficSelectorPolicy"
+          }
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the virtual network gateway connection resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual network gateway connection resource.",
+          "readOnly": true
+        },
+        "expressRouteGatewayBypass": {
+          "type": "boolean",
+          "description": "Bypass ExpressRoute Gateway for data forwarding."
+        },
+        "enablePrivateLinkFastPath": {
+          "type": "boolean",
+          "description": "Bypass the ExpressRoute gateway when accessing private-links. ExpressRoute FastPath (expressRouteGatewayBypass) must be enabled."
+        },
+        "routingConfiguration": {
+          "$ref": "./virtualWan.json#/definitions/RoutingConfiguration",
+          "description": "The routing configuration indicating the associated and propagated route tables for this connection."
+        }
+      },
+      "required": [
+        "virtualNetworkGateway1",
+        "connectionType"
+      ]
+    },
+    "VirtualNetworkGatewayConnectionListResult": {
+      "type": "object",
+      "description": "The response of a VirtualNetworkGatewayConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetworkGatewayConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkGatewayConnectionPropertiesFormat": {
+      "type": "object",
+      "description": "VirtualNetworkGatewayConnection properties.",
+      "properties": {
+        "authorizationKey": {
+          "type": "string",
+          "description": "The authorizationKey."
+        },
+        "virtualNetworkGateway1": {
+          "$ref": "#/definitions/VirtualNetworkGateway",
+          "description": "The reference to virtual network gateway resource."
+        },
+        "virtualNetworkGateway2": {
+          "$ref": "#/definitions/VirtualNetworkGateway",
+          "description": "The reference to virtual network gateway resource."
+        },
+        "localNetworkGateway2": {
+          "$ref": "#/definitions/LocalNetworkGateway",
+          "description": "The reference to local network gateway resource."
+        },
+        "ingressNatRules": {
+          "type": "array",
+          "description": "List of ingress NatRules.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "egressNatRules": {
+          "type": "array",
+          "description": "List of egress NatRules.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "connectionType": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionType",
+          "description": "Gateway connection type."
+        },
+        "connectionProtocol": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionProtocol",
+          "description": "Connection protocol used for this connection."
+        },
+        "routingWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The routing weight."
+        },
+        "dpdTimeoutSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The dead peer detection timeout of this connection in seconds."
+        },
+        "connectionMode": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionMode",
+          "description": "The connection mode for this connection."
+        },
+        "tunnelProperties": {
+          "type": "array",
+          "description": "Tunnel properties for virtual network gateway connection",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayConnectionTunnelProperties"
+          }
+        },
+        "sharedKey": {
+          "type": "string",
+          "format": "password",
+          "description": "The IPSec shared key.",
+          "x-ms-secret": true
+        },
+        "connectionStatus": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionStatus",
+          "description": "Virtual Network Gateway connection status.",
+          "readOnly": true
+        },
+        "tunnelConnectionStatus": {
+          "type": "array",
+          "description": "Collection of all tunnels' connection health status.",
+          "items": {
+            "$ref": "#/definitions/TunnelConnectionHealth"
+          },
+          "readOnly": true
+        },
+        "egressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The egress bytes transferred in this connection.",
+          "readOnly": true
+        },
+        "ingressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The ingress bytes transferred in this connection.",
+          "readOnly": true
+        },
+        "peer": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to peerings resource."
+        },
+        "enableBgp": {
+          "type": "boolean",
+          "description": "EnableBgp flag."
+        },
+        "gatewayCustomBgpIpAddresses": {
+          "type": "array",
+          "description": "GatewayCustomBgpIpAddresses to be used for virtual network gateway Connection.",
+          "items": {
+            "$ref": "#/definitions/GatewayCustomBgpIpAddressIpConfiguration"
+          },
+          "x-ms-identifiers": []
+        },
+        "useLocalAzureIpAddress": {
+          "type": "boolean",
+          "description": "Use private local Azure IP for the connection."
+        },
+        "usePolicyBasedTrafficSelectors": {
+          "type": "boolean",
+          "description": "Enable policy-based traffic selectors."
+        },
+        "ipsecPolicies": {
+          "type": "array",
+          "description": "The IPSec Policies to be considered by this connection.",
+          "items": {
+            "$ref": "#/definitions/IpsecPolicy"
+          }
+        },
+        "trafficSelectorPolicies": {
+          "type": "array",
+          "description": "The Traffic Selector Policies to be considered by this connection.",
+          "items": {
+            "$ref": "#/definitions/TrafficSelectorPolicy"
+          }
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the virtual network gateway connection resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual network gateway connection resource.",
+          "readOnly": true
+        },
+        "expressRouteGatewayBypass": {
+          "type": "boolean",
+          "description": "Bypass ExpressRoute Gateway for data forwarding."
+        },
+        "enablePrivateLinkFastPath": {
+          "type": "boolean",
+          "description": "Bypass the ExpressRoute gateway when accessing private-links. ExpressRoute FastPath (expressRouteGatewayBypass) must be enabled."
+        },
+        "authenticationType": {
+          "$ref": "./common.json#/definitions/ConnectionAuthenticationType",
+          "description": "Gateway connection authentication type."
+        },
+        "certificateAuthentication": {
+          "$ref": "#/definitions/CertificateAuthentication",
+          "description": "Certificate Authentication information for a certificate based authentication connection."
+        },
+        "routingConfiguration": {
+          "$ref": "./virtualWan.json#/definitions/RoutingConfiguration",
+          "description": "The routing configuration indicating the associated and propagated route tables for this connection."
+        }
+      },
+      "required": [
+        "virtualNetworkGateway1",
+        "connectionType"
+      ]
+    },
+    "VirtualNetworkGatewayConnectionTunnelProperties": {
+      "type": "object",
+      "properties": {
+        "tunnelIpAddress": {
+          "type": "string",
+          "description": "Tunnel remote IP address"
+        },
+        "bgpPeeringAddress": {
+          "type": "string",
+          "description": "Tunnel BGP peering address"
+        }
+      }
+    },
+    "VirtualNetworkGatewayIPConfiguration": {
+      "type": "object",
+      "description": "IP configuration for virtual network gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkGatewayIPConfigurationPropertiesFormat",
+          "description": "Properties of the virtual network gateway ip configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "VirtualNetworkGatewayIPConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of VirtualNetworkGatewayIPConfiguration.",
+      "properties": {
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The private IP address allocation method."
+        },
+        "subnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the subnet resource."
+        },
+        "publicIPAddress": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the public IP resource."
+        },
+        "privateIPAddress": {
+          "type": "string",
+          "description": "Private IP Address for this gateway.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual network gateway IP configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualNetworkGatewayListConnectionsResult": {
+      "type": "object",
+      "description": "Response for the VirtualNetworkGatewayListConnections API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetworkGatewayConnectionListEntity items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayConnectionListEntity"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkGatewayListResult": {
+      "type": "object",
+      "description": "The response of a VirtualNetworkGateway list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetworkGateway items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGateway"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkGatewayMigrationParameters": {
+      "type": "object",
+      "description": "Virtual network gateway migration parameters.",
+      "properties": {
+        "migrationType": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayMigrationType",
+          "description": "MigrationType for the virtual network gateway."
+        },
+        "resourceUrl": {
+          "type": "string",
+          "description": "Resource url that needs to be passed in to migration."
+        }
+      },
+      "required": [
+        "migrationType"
+      ]
+    },
+    "VirtualNetworkGatewayMigrationStatus": {
+      "type": "object",
+      "description": "Migration status for the Virtual Network Gateway.",
+      "properties": {
+        "state": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayMigrationState",
+          "description": "Represent the current state of gateway migration."
+        },
+        "phase": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayMigrationPhase",
+          "description": "Represent the current migration phase of gateway."
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Error if any occurs during migration."
+        }
+      }
+    },
+    "VirtualNetworkGatewayNatRule": {
+      "type": "object",
+      "description": "VirtualNetworkGatewayNatRule Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkGatewayNatRuleProperties",
+          "description": "Properties of the Virtual Network Gateway NAT rule.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "VirtualNetworkGatewayNatRuleProperties": {
+      "type": "object",
+      "description": "Parameters for VirtualNetworkGatewayNatRule.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the NAT Rule resource.",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "./common.json#/definitions/VpnNatRuleType",
+          "description": "The type of NAT rule for VPN NAT."
+        },
+        "mode": {
+          "$ref": "./common.json#/definitions/VpnNatRuleMode",
+          "description": "The Source NAT direction of a VPN NAT."
+        },
+        "internalMappings": {
+          "type": "array",
+          "description": "The private IP address internal mapping for NAT.",
+          "items": {
+            "$ref": "./virtualWan.json#/definitions/VpnNatRuleMapping"
+          }
+        },
+        "externalMappings": {
+          "type": "array",
+          "description": "The private IP address external mapping for NAT.",
+          "items": {
+            "$ref": "./virtualWan.json#/definitions/VpnNatRuleMapping"
+          }
+        },
+        "ipConfigurationId": {
+          "type": "string",
+          "description": "The IP Configuration ID this NAT rule applies to."
+        }
+      }
+    },
+    "VirtualNetworkGatewayPolicyGroup": {
+      "type": "object",
+      "description": "Parameters for VirtualNetworkGatewayPolicyGroup.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkGatewayPolicyGroupProperties",
+          "description": "Properties of tVirtualNetworkGatewayPolicyGroup.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "VirtualNetworkGatewayPolicyGroupMember": {
+      "type": "object",
+      "description": "Vpn Client Connection configuration PolicyGroup member",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the VirtualNetworkGatewayPolicyGroupMember."
+        },
+        "attributeType": {
+          "$ref": "./common.json#/definitions/VpnPolicyMemberAttributeType",
+          "description": "The Vpn Policy member attribute type."
+        },
+        "attributeValue": {
+          "type": "string",
+          "description": "The value of Attribute used for this VirtualNetworkGatewayPolicyGroupMember."
+        }
+      }
+    },
+    "VirtualNetworkGatewayPolicyGroupProperties": {
+      "type": "object",
+      "description": "Properties of VirtualNetworkGatewayPolicyGroup.",
+      "properties": {
+        "isDefault": {
+          "type": "boolean",
+          "description": "Shows if this is a Default VirtualNetworkGatewayPolicyGroup or not."
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority for VirtualNetworkGatewayPolicyGroup."
+        },
+        "policyMembers": {
+          "type": "array",
+          "description": "Multiple PolicyMembers for VirtualNetworkGatewayPolicyGroup.",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayPolicyGroupMember"
+          },
+          "x-ms-identifiers": []
+        },
+        "vngClientConnectionConfigurations": {
+          "type": "array",
+          "description": "List of references to vngClientConnectionConfigurations.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the VirtualNetworkGatewayPolicyGroup resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "isDefault",
+        "priority",
+        "policyMembers"
+      ]
+    },
+    "VirtualNetworkGatewayPropertiesFormat": {
+      "type": "object",
+      "description": "VirtualNetworkGateway properties.",
+      "properties": {
+        "autoScaleConfiguration": {
+          "$ref": "#/definitions/VirtualNetworkGatewayAutoScaleConfiguration",
+          "description": "Autoscale configuration for virutal network gateway"
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "IP configurations for virtual network gateway.",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayIPConfiguration"
+          }
+        },
+        "gatewayType": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayType",
+          "description": "The type of this virtual network gateway."
+        },
+        "vpnType": {
+          "$ref": "./common.json#/definitions/VpnType",
+          "description": "The type of this virtual network gateway."
+        },
+        "vpnGatewayGeneration": {
+          "$ref": "./common.json#/definitions/VpnGatewayGeneration",
+          "description": "The generation for this VirtualNetworkGateway. Must be None if gatewayType is not VPN."
+        },
+        "enableBgp": {
+          "type": "boolean",
+          "description": "Whether BGP is enabled for this virtual network gateway or not."
+        },
+        "enablePrivateIpAddress": {
+          "type": "boolean",
+          "description": "Whether private IP needs to be enabled on this gateway for connections or not."
+        },
+        "virtualNetworkGatewayMigrationStatus": {
+          "$ref": "#/definitions/VirtualNetworkGatewayMigrationStatus",
+          "description": "The reference to the VirtualNetworkGatewayMigrationStatus which represents the status of migration."
+        },
+        "activeActive": {
+          "type": "boolean",
+          "description": "ActiveActive flag."
+        },
+        "enableHighBandwidthVpnGateway": {
+          "type": "boolean",
+          "description": "To enable Advanced Connectivity feature for VPN gateway"
+        },
+        "disableIPSecReplayProtection": {
+          "type": "boolean",
+          "description": "disableIPSecReplayProtection flag."
+        },
+        "gatewayDefaultSite": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the LocalNetworkGateway resource which represents local network site having default routes. Assign Null value in case of removing existing default site setting."
+        },
+        "sku": {
+          "$ref": "#/definitions/VirtualNetworkGatewaySku",
+          "description": "The reference to the VirtualNetworkGatewaySku resource which represents the SKU selected for Virtual network gateway."
+        },
+        "vpnClientConfiguration": {
+          "$ref": "#/definitions/VpnClientConfiguration",
+          "description": "The reference to the VpnClientConfiguration resource which represents the P2S VpnClient configurations."
+        },
+        "virtualNetworkGatewayPolicyGroups": {
+          "type": "array",
+          "description": "The reference to the VirtualNetworkGatewayPolicyGroup resource which represents the available VirtualNetworkGatewayPolicyGroup for the gateway.",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayPolicyGroup"
+          }
+        },
+        "bgpSettings": {
+          "$ref": "#/definitions/BgpSettings",
+          "description": "Virtual network gateway's BGP speaker settings."
+        },
+        "customRoutes": {
+          "$ref": "./virtualNetwork.json#/definitions/AddressSpace",
+          "description": "The reference to the address space resource which represents the custom routes address space specified by the customer for virtual network gateway and VpnClient."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the virtual network gateway resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual network gateway resource.",
+          "readOnly": true
+        },
+        "enableDnsForwarding": {
+          "type": "boolean",
+          "description": "Whether dns forwarding is enabled or not."
+        },
+        "inboundDnsForwardingEndpoint": {
+          "type": "string",
+          "description": "The IP address allocated by the gateway to which dns requests can be sent.",
+          "readOnly": true
+        },
+        "vNetExtendedLocationResourceId": {
+          "type": "string",
+          "description": "Customer vnet resource id. VirtualNetworkGateway of type local gateway is associated with the customer vnet."
+        },
+        "natRules": {
+          "type": "array",
+          "description": "NatRules for virtual network gateway.",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkGatewayNatRule"
+          }
+        },
+        "enableBgpRouteTranslationForNat": {
+          "type": "boolean",
+          "description": "EnableBgpRouteTranslationForNat flag."
+        },
+        "allowVirtualWanTraffic": {
+          "type": "boolean",
+          "description": "Configures this gateway to accept traffic from remote Virtual WAN networks."
+        },
+        "allowRemoteVnetTraffic": {
+          "type": "boolean",
+          "description": "Configure this gateway to accept traffic from other Azure Virtual Networks. This configuration does not support connectivity to Azure Virtual WAN."
+        },
+        "adminState": {
+          "$ref": "./common.json#/definitions/AdminState",
+          "description": "Property to indicate if the Express Route Gateway serves traffic when there are multiple Express Route Gateways in the vnet"
+        },
+        "resiliencyModel": {
+          "$ref": "./common.json#/definitions/ResiliencyModel",
+          "description": "Property to indicate if the Express Route Gateway has resiliency model of MultiHomed or SingleHomed"
+        }
+      }
+    },
+    "VirtualNetworkGatewaySku": {
+      "type": "object",
+      "description": "VirtualNetworkGatewaySku details.",
+      "properties": {
+        "name": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewaySkuName",
+          "description": "Gateway SKU name."
+        },
+        "tier": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewaySkuTier",
+          "description": "Gateway SKU tier."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The capacity.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualNetworkTap": {
+      "type": "object",
+      "description": "Virtual Network Tap resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkTapPropertiesFormat",
+          "description": "Virtual Network Tap Properties.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "VirtualNetworkTapListResult": {
+      "type": "object",
+      "description": "The response of a VirtualNetworkTap list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetworkTap items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkTap"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkTapPropertiesFormat": {
+      "type": "object",
+      "description": "Virtual Network Tap properties.",
+      "properties": {
+        "networkInterfaceTapConfigurations": {
+          "type": "array",
+          "description": "Specifies the list of resource IDs for the network interface IP configuration that needs to be tapped.",
+          "items": {
+            "$ref": "./virtualNetwork.json#/definitions/NetworkInterfaceTapConfiguration"
+          },
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the virtual network tap resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual network tap resource.",
+          "readOnly": true
+        },
+        "destinationNetworkInterfaceIPConfiguration": {
+          "$ref": "./virtualNetwork.json#/definitions/NetworkInterfaceIPConfiguration",
+          "description": "The reference to the private IP Address of the collector nic that will receive the tap."
+        },
+        "destinationLoadBalancerFrontEndIPConfiguration": {
+          "$ref": "./loadBalancer.json#/definitions/FrontendIPConfiguration",
+          "description": "The reference to the private IP address on the internal Load Balancer that will receive the tap."
+        },
+        "destinationPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The VXLAN destination port that will receive the tapped traffic."
+        }
+      }
+    },
+    "VngClientConnectionConfiguration": {
+      "type": "object",
+      "description": "A vpn client connection configuration for client connection configuration.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VngClientConnectionConfigurationProperties",
+          "description": "Properties of the vpn client root certificate.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "VngClientConnectionConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of VngClientConnectionConfiguration.",
+      "properties": {
+        "vpnClientAddressPool": {
+          "$ref": "./virtualNetwork.json#/definitions/AddressSpace",
+          "description": "The reference to the address space resource which represents Address space for P2S VpnClient."
+        },
+        "virtualNetworkGatewayPolicyGroups": {
+          "type": "array",
+          "description": "List of references to virtualNetworkGatewayPolicyGroups",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the VngClientConnectionConfiguration resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "vpnClientAddressPool",
+        "virtualNetworkGatewayPolicyGroups"
+      ]
+    },
+    "VpnClientConfiguration": {
+      "type": "object",
+      "description": "VpnClientConfiguration for P2S client.",
+      "properties": {
+        "vpnClientAddressPool": {
+          "$ref": "./virtualNetwork.json#/definitions/AddressSpace",
+          "description": "The reference to the address space resource which represents Address space for P2S VpnClient."
+        },
+        "vpnClientRootCertificates": {
+          "type": "array",
+          "description": "VpnClientRootCertificate for virtual network gateway.",
+          "items": {
+            "$ref": "#/definitions/VpnClientRootCertificate"
+          }
+        },
+        "vpnClientRevokedCertificates": {
+          "type": "array",
+          "description": "VpnClientRevokedCertificate for Virtual network gateway.",
+          "items": {
+            "$ref": "#/definitions/VpnClientRevokedCertificate"
+          }
+        },
+        "vpnClientProtocols": {
+          "type": "array",
+          "description": "VpnClientProtocols for Virtual network gateway.",
+          "items": {
+            "$ref": "./common.json#/definitions/VpnClientProtocol"
+          }
+        },
+        "vpnAuthenticationTypes": {
+          "type": "array",
+          "description": "VPN authentication types for the virtual network gateway..",
+          "items": {
+            "$ref": "./common.json#/definitions/VpnAuthenticationType"
+          }
+        },
+        "vpnClientIpsecPolicies": {
+          "type": "array",
+          "description": "VpnClientIpsecPolicies for virtual network gateway P2S client.",
+          "items": {
+            "$ref": "#/definitions/IpsecPolicy"
+          }
+        },
+        "radiusServerAddress": {
+          "type": "string",
+          "description": "The radius server address property of the VirtualNetworkGateway resource for vpn client connection."
+        },
+        "radiusServerSecret": {
+          "type": "string",
+          "format": "password",
+          "description": "The radius secret property of the VirtualNetworkGateway resource for vpn client connection. We will no longer return radiusServerSecret in VirtualNetworkGateway Create/Update/Get/List/UpdateTags APIs response. Please use VirtualNetworkGateway ListRadiusSecrets API to fetch radius server secrets.",
+          "x-ms-secret": true
+        },
+        "radiusServers": {
+          "type": "array",
+          "description": "The radiusServers property for multiple radius server configuration.",
+          "items": {
+            "$ref": "#/definitions/RadiusServer"
+          }
+        },
+        "aadTenant": {
+          "type": "string",
+          "description": "The AADTenant property of the VirtualNetworkGateway resource for vpn client connection used for AAD authentication."
+        },
+        "aadAudience": {
+          "type": "string",
+          "description": "The AADAudience property of the VirtualNetworkGateway resource for vpn client connection used for AAD authentication."
+        },
+        "aadIssuer": {
+          "type": "string",
+          "description": "The AADIssuer property of the VirtualNetworkGateway resource for vpn client connection used for AAD authentication."
+        },
+        "vngClientConnectionConfigurations": {
+          "type": "array",
+          "description": "per ip address pool connection policy for virtual network gateway P2S client.",
+          "items": {
+            "$ref": "#/definitions/VngClientConnectionConfiguration"
+          }
+        }
+      }
+    },
+    "VpnClientConnectionHealthDetail": {
+      "type": "object",
+      "description": "VPN client connection health detail.",
+      "properties": {
+        "vpnConnectionId": {
+          "type": "string",
+          "description": "The vpn client Id.",
+          "readOnly": true
+        },
+        "vpnConnectionDuration": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The duration time of a connected vpn client.",
+          "readOnly": true
+        },
+        "vpnConnectionTime": {
+          "type": "string",
+          "description": "The start time of a connected vpn client.",
+          "readOnly": true
+        },
+        "publicIpAddress": {
+          "type": "string",
+          "description": "The public Ip of a connected vpn client.",
+          "readOnly": true
+        },
+        "privateIpAddress": {
+          "type": "string",
+          "description": "The assigned private Ip of a connected vpn client.",
+          "readOnly": true
+        },
+        "vpnUserName": {
+          "type": "string",
+          "description": "The user name of a connected vpn client.",
+          "readOnly": true
+        },
+        "maxBandwidth": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The max band width.",
+          "readOnly": true
+        },
+        "egressPacketsTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The egress packets per second.",
+          "readOnly": true
+        },
+        "egressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The egress bytes per second.",
+          "readOnly": true
+        },
+        "ingressPacketsTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The ingress packets per second.",
+          "readOnly": true
+        },
+        "ingressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The ingress bytes per second.",
+          "readOnly": true
+        },
+        "maxPacketsPerSecond": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The max packets transferred per second.",
+          "readOnly": true
+        }
+      }
+    },
+    "VpnClientConnectionHealthDetailListResult": {
+      "type": "object",
+      "description": "List of virtual network gateway vpn client connection health.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of vpn client connection health.",
+          "items": {
+            "$ref": "#/definitions/VpnClientConnectionHealthDetail"
+          }
+        }
+      }
+    },
+    "VpnClientIPsecParameters": {
+      "type": "object",
+      "description": "An IPSec parameters for a virtual network gateway P2S connection.",
+      "properties": {
+        "saLifeTimeSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The IPSec Security Association (also called Quick Mode or Phase 2 SA) lifetime in seconds for P2S client."
+        },
+        "saDataSizeKilobytes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The IPSec Security Association (also called Quick Mode or Phase 2 SA) payload size in KB for P2S client.."
+        },
+        "ipsecEncryption": {
+          "$ref": "./common.json#/definitions/IpsecEncryption",
+          "description": "The IPSec encryption algorithm (IKE phase 1)."
+        },
+        "ipsecIntegrity": {
+          "$ref": "./common.json#/definitions/IpsecIntegrity",
+          "description": "The IPSec integrity algorithm (IKE phase 1)."
+        },
+        "ikeEncryption": {
+          "$ref": "./common.json#/definitions/IkeEncryption",
+          "description": "The IKE encryption algorithm (IKE phase 2)."
+        },
+        "ikeIntegrity": {
+          "$ref": "./common.json#/definitions/IkeIntegrity",
+          "description": "The IKE integrity algorithm (IKE phase 2)."
+        },
+        "dhGroup": {
+          "$ref": "./common.json#/definitions/DhGroup",
+          "description": "The DH Group used in IKE Phase 1 for initial SA."
+        },
+        "pfsGroup": {
+          "$ref": "./common.json#/definitions/PfsGroup",
+          "description": "The Pfs Group used in IKE Phase 2 for new child SA."
+        }
+      },
+      "required": [
+        "saLifeTimeSeconds",
+        "saDataSizeKilobytes",
+        "ipsecEncryption",
+        "ipsecIntegrity",
+        "ikeEncryption",
+        "ikeIntegrity",
+        "dhGroup",
+        "pfsGroup"
+      ]
+    },
+    "VpnClientParameters": {
+      "type": "object",
+      "description": "Vpn Client Parameters for package generation.",
+      "properties": {
+        "processorArchitecture": {
+          "$ref": "./common.json#/definitions/ProcessorArchitecture",
+          "description": "VPN client Processor Architecture."
+        },
+        "authenticationMethod": {
+          "$ref": "./common.json#/definitions/AuthenticationMethod",
+          "description": "VPN client authentication method."
+        },
+        "radiusServerAuthCertificate": {
+          "type": "string",
+          "description": "The public certificate data for the radius server authentication certificate as a Base-64 encoded string. Required only if external radius authentication has been configured with EAPTLS authentication."
+        },
+        "clientRootCertificates": {
+          "type": "array",
+          "description": "A list of client root certificates public certificate data encoded as Base-64 strings. Optional parameter for external radius based authentication with EAPTLS.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VpnClientRevokedCertificate": {
+      "type": "object",
+      "description": "VPN client revoked certificate of virtual network gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VpnClientRevokedCertificatePropertiesFormat",
+          "description": "Properties of the vpn client revoked certificate.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "VpnClientRevokedCertificatePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the revoked VPN client certificate of virtual network gateway.",
+      "properties": {
+        "thumbprint": {
+          "type": "string",
+          "description": "The revoked VPN client certificate thumbprint."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the VPN client revoked certificate resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "VpnClientRootCertificate": {
+      "type": "object",
+      "description": "VPN client root certificate of virtual network gateway.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VpnClientRootCertificatePropertiesFormat",
+          "description": "Properties of the vpn client root certificate.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "VpnClientRootCertificatePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of SSL certificates of application gateway.",
+      "properties": {
+        "publicCertData": {
+          "type": "string",
+          "description": "The certificate public data."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the VPN client root certificate resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "publicCertData"
+      ]
+    },
+    "VpnDeviceScriptParameters": {
+      "type": "object",
+      "description": "Vpn device configuration script generation parameters.",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "description": "The vendor for the vpn device."
+        },
+        "deviceFamily": {
+          "type": "string",
+          "description": "The device family for the vpn device."
+        },
+        "firmwareVersion": {
+          "type": "string",
+          "description": "The firmware version for the vpn device."
+        }
+      }
+    },
+    "VpnPacketCaptureStartParameters": {
+      "type": "object",
+      "description": "Start packet capture parameters on virtual network gateway.",
+      "properties": {
+        "filterData": {
+          "type": "string",
+          "description": "Start Packet capture parameters."
+        }
+      }
+    },
+    "VpnPacketCaptureStopParameters": {
+      "type": "object",
+      "description": "Stop packet capture parameters.",
+      "properties": {
+        "sasUrl": {
+          "type": "string",
+          "description": "SAS url for packet capture on virtual network gateway."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/networkManager.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/networkManager.json
@@ -1,0 +1,7024 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "NetworkManagers"
+    },
+    {
+      "name": "NetworkManagerActiveConnectivityConfigurations"
+    },
+    {
+      "name": "NetworkManagerActiveConfigurations"
+    },
+    {
+      "name": "NetworkManagerConnections"
+    },
+    {
+      "name": "ConnectivityConfigurations"
+    },
+    {
+      "name": "NetworkGroups"
+    },
+    {
+      "name": "StaticMembers"
+    },
+    {
+      "name": "NetworkManagerRoutingConfigurations"
+    },
+    {
+      "name": "RoutingRuleCollections"
+    },
+    {
+      "name": "RoutingRules"
+    },
+    {
+      "name": "ScopeConnections"
+    },
+    {
+      "name": "Commits"
+    },
+    {
+      "name": "SecurityAdminConfigurations"
+    },
+    {
+      "name": "AdminRuleCollections"
+    },
+    {
+      "name": "AdminRules"
+    },
+    {
+      "name": "SecurityUserConfigurations"
+    },
+    {
+      "name": "SecurityUserRuleCollections"
+    },
+    {
+      "name": "SecurityUserRules"
+    },
+    {
+      "name": "NetworkManagerEffectiveConnectivityConfiguration"
+    },
+    {
+      "name": "NetworkManagerEffectiveSecurityAdminRules"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Network/networkManagerConnections": {
+      "get": {
+        "operationId": "ManagementGroupNetworkManagerConnections_List",
+        "tags": [
+          "NetworkManagerConnections"
+        ],
+        "description": "List all network manager connections created by this management group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "managementGroupId",
+            "in": "path",
+            "description": "The management group ID.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/providers/Microsoft.Management/managementGroups/{managementGroupId}/providers/Microsoft.Network/networkManagerConnections/{networkManagerConnectionName}": {
+      "get": {
+        "operationId": "ManagementGroupNetworkManagerConnections_Get",
+        "tags": [
+          "NetworkManagerConnections"
+        ],
+        "description": "Get a specified connection created by this management group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "managementGroupId",
+            "in": "path",
+            "description": "The management group ID.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "networkManagerConnectionName",
+            "in": "path",
+            "description": "Name for the network manager connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ManagementGroupNetworkManagerConnections_CreateOrUpdate",
+        "tags": [
+          "NetworkManagerConnections"
+        ],
+        "description": "Create a network manager connection on this management group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "managementGroupId",
+            "in": "path",
+            "description": "The management group ID.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "networkManagerConnectionName",
+            "in": "path",
+            "description": "Name for the network manager connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Network manager connection to be created/updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkManagerConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkManagerConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ManagementGroupNetworkManagerConnections_Delete",
+        "tags": [
+          "NetworkManagerConnections"
+        ],
+        "description": "Delete specified pending connection created by this management group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "managementGroupId",
+            "in": "path",
+            "description": "The management group ID.",
+            "required": true,
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "name": "networkManagerConnectionName",
+            "in": "path",
+            "description": "Name for the network manager connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkManagerConnections": {
+      "get": {
+        "operationId": "SubscriptionNetworkManagerConnections_List",
+        "tags": [
+          "NetworkManagerConnections"
+        ],
+        "description": "List all network manager connections created by this subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkManagerConnections/{networkManagerConnectionName}": {
+      "get": {
+        "operationId": "SubscriptionNetworkManagerConnections_Get",
+        "tags": [
+          "NetworkManagerConnections"
+        ],
+        "description": "Get a specified connection created by this subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "networkManagerConnectionName",
+            "in": "path",
+            "description": "Name for the network manager connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "SubscriptionNetworkManagerConnections_CreateOrUpdate",
+        "tags": [
+          "NetworkManagerConnections"
+        ],
+        "description": "Create a network manager connection on this subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "networkManagerConnectionName",
+            "in": "path",
+            "description": "Name for the network manager connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Network manager connection to be created/updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkManagerConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkManagerConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SubscriptionNetworkManagerConnections_Delete",
+        "tags": [
+          "NetworkManagerConnections"
+        ],
+        "description": "Delete specified connection created by this subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "networkManagerConnectionName",
+            "in": "path",
+            "description": "Name for the network manager connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkManagers": {
+      "get": {
+        "operationId": "NetworkManagers_ListBySubscription",
+        "tags": [
+          "NetworkManagers"
+        ],
+        "description": "List all network managers in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers": {
+      "get": {
+        "operationId": "NetworkManagers_List",
+        "tags": [
+          "NetworkManagers"
+        ],
+        "description": "List network managers in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}": {
+      "get": {
+        "operationId": "NetworkManagers_Get",
+        "tags": [
+          "NetworkManagers"
+        ],
+        "description": "Gets the specified Network Manager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManager"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkManagers_CreateOrUpdate",
+        "tags": [
+          "NetworkManagers"
+        ],
+        "description": "Creates or updates a Network Manager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to specify which network manager is.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkManager"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkManager' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkManager"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkManager' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkManager"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "NetworkManagers_Patch",
+        "tags": [
+          "NetworkManagers"
+        ],
+        "description": "Patch NetworkManager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to specify which network manager is.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PatchObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManager"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkManagers_Delete",
+        "tags": [
+          "NetworkManagers"
+        ],
+        "description": "Deletes a network manager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/commit": {
+      "post": {
+        "operationId": "NetworkManagerCommits_Post",
+        "tags": [
+          "NetworkManagers"
+        ],
+        "description": "Post a Network Manager Commit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to specify which Managed Network commit is.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerCommit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerCommit"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerCommit"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/NetworkManagerCommit"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/commits": {
+      "get": {
+        "operationId": "Commits_List",
+        "tags": [
+          "Commits"
+        ],
+        "description": "Lists all commits for the specified network manager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommitListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/commits/{commitName}": {
+      "get": {
+        "operationId": "Commits_Get",
+        "tags": [
+          "Commits"
+        ],
+        "description": "Gets the specified commit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "commitName",
+            "in": "path",
+            "description": "The name of the commit.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?![.-])[a-zA-Z0-9_.-]{1,128}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Commit"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Commits_CreateOrUpdate",
+        "tags": [
+          "Commits"
+        ],
+        "description": "Creates or updates a commit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "commitName",
+            "in": "path",
+            "description": "The name of the commit.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?![.-])[a-zA-Z0-9_.-]{1,128}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Parameters supplied to specify which commit to create",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Commit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Commit' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Commit"
+            }
+          },
+          "201": {
+            "description": "Resource 'Commit' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Commit"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Commit"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Commits_Delete",
+        "tags": [
+          "Commits"
+        ],
+        "description": "Deletes a commit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "commitName",
+            "in": "path",
+            "description": "The name of the commit.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?![.-])[a-zA-Z0-9_.-]{1,128}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/connectivityConfigurations": {
+      "get": {
+        "operationId": "ConnectivityConfigurations_List",
+        "tags": [
+          "ConnectivityConfigurations"
+        ],
+        "description": "Lists all the network manager connectivity configuration in a specified network manager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectivityConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/connectivityConfigurations/{configurationName}": {
+      "get": {
+        "operationId": "ConnectivityConfigurations_Get",
+        "tags": [
+          "ConnectivityConfigurations"
+        ],
+        "description": "Gets a Network Connectivity Configuration, specified by the resource group, network manager name, and connectivity Configuration name",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager connectivity configuration.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectivityConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConnectivityConfigurations_CreateOrUpdate",
+        "tags": [
+          "ConnectivityConfigurations"
+        ],
+        "description": "Creates/Updates a new network manager connectivity configuration",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager connectivity configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectivityConfiguration",
+            "in": "body",
+            "description": "Parameters supplied to create/update a network manager connectivity configuration",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectivityConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectivityConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectivityConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'ConnectivityConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectivityConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ConnectivityConfigurations_Delete",
+        "tags": [
+          "ConnectivityConfigurations"
+        ],
+        "description": "Deletes a network manager connectivity configuration, specified by the resource group, network manager name, and connectivity configuration name",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager connectivity configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/listActiveConnectivityConfigurations": {
+      "post": {
+        "operationId": "ListActiveConnectivityConfigurations",
+        "tags": [
+          "NetworkManagerActiveConnectivityConfigurations"
+        ],
+        "description": "Lists active connectivity configurations in a network manager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Active Configuration Parameter.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ActiveConfigurationParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ActiveConnectivityConfigurationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/listActiveSecurityAdminRules": {
+      "post": {
+        "operationId": "ListActiveSecurityAdminRules",
+        "tags": [
+          "NetworkManagerActiveConfigurations"
+        ],
+        "description": "Lists active security admin rules in a network manager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Active Configuration Parameter.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ActiveConfigurationParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ActiveSecurityAdminRulesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/listDeploymentStatus": {
+      "post": {
+        "operationId": "NetworkManagerDeploymentStatus_List",
+        "tags": [
+          "NetworkManagers"
+        ],
+        "description": "Post to List of Network Manager Deployment Status.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to specify which Managed Network deployment status is.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerDeploymentStatusParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerDeploymentStatusListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/networkGroups": {
+      "get": {
+        "operationId": "NetworkGroups_List",
+        "tags": [
+          "NetworkGroups"
+        ],
+        "description": "Lists the specified network group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/networkGroups/{networkGroupName}": {
+      "get": {
+        "operationId": "NetworkGroups_Get",
+        "tags": [
+          "NetworkGroups"
+        ],
+        "description": "Gets the specified network group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "networkGroupName",
+            "in": "path",
+            "description": "The name of the network group.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkGroups_CreateOrUpdate",
+        "tags": [
+          "NetworkGroups"
+        ],
+        "description": "Creates or updates a network group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "networkGroupName",
+            "in": "path",
+            "description": "The name of the network group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The ETag of the transformation. Omit this value to always overwrite the current resource. Specify the last-seen ETag value to prevent accidentally overwriting concurrent changes.",
+            "required": false,
+            "type": "string",
+            "x-ms-client-name": "IfMatch"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the specify which network group need to create",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/NetworkGroup"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The current entity tag."
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/NetworkGroup"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The current entity tag."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkGroups_Delete",
+        "tags": [
+          "NetworkGroups"
+        ],
+        "description": "Deletes a network group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "networkGroupName",
+            "in": "path",
+            "description": "The name of the network group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/networkGroups/{networkGroupName}/staticMembers": {
+      "get": {
+        "operationId": "StaticMembers_List",
+        "tags": [
+          "StaticMembers"
+        ],
+        "description": "Lists the specified static member.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "networkGroupName",
+            "in": "path",
+            "description": "The name of the network group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StaticMemberListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/networkGroups/{networkGroupName}/staticMembers/{staticMemberName}": {
+      "get": {
+        "operationId": "StaticMembers_Get",
+        "tags": [
+          "StaticMembers"
+        ],
+        "description": "Gets the specified static member.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "networkGroupName",
+            "in": "path",
+            "description": "The name of the network group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "staticMemberName",
+            "in": "path",
+            "description": "The name of the static member.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StaticMember"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "StaticMembers_CreateOrUpdate",
+        "tags": [
+          "StaticMembers"
+        ],
+        "description": "Creates or updates a static member.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "networkGroupName",
+            "in": "path",
+            "description": "The name of the network group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "staticMemberName",
+            "in": "path",
+            "description": "The name of the static member.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the specify the static member to create",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/StaticMember"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'StaticMember' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/StaticMember"
+            }
+          },
+          "201": {
+            "description": "Resource 'StaticMember' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/StaticMember"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "StaticMembers_Delete",
+        "tags": [
+          "StaticMembers"
+        ],
+        "description": "Deletes a static member.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "networkGroupName",
+            "in": "path",
+            "description": "The name of the network group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "staticMemberName",
+            "in": "path",
+            "description": "The name of the static member.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/routingConfigurations": {
+      "get": {
+        "operationId": "NetworkManagerRoutingConfigurations_List",
+        "tags": [
+          "NetworkManagerRoutingConfigurations"
+        ],
+        "description": "Lists all the network manager routing configurations in a network manager, in a paginated format.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerRoutingConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/routingConfigurations/{configurationName}": {
+      "get": {
+        "operationId": "NetworkManagerRoutingConfigurations_Get",
+        "tags": [
+          "NetworkManagerRoutingConfigurations"
+        ],
+        "description": "Retrieves a network manager routing configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerRoutingConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkManagerRoutingConfigurations_CreateOrUpdate",
+        "tags": [
+          "NetworkManagerRoutingConfigurations"
+        ],
+        "description": "Creates or updates a network manager routing configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "routingConfiguration",
+            "in": "body",
+            "description": "The routing configuration to create or update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerRoutingConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkManagerRoutingConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerRoutingConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkManagerRoutingConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerRoutingConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkManagerRoutingConfigurations_Delete",
+        "tags": [
+          "NetworkManagerRoutingConfigurations"
+        ],
+        "description": "Deletes a network manager routing configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/routingConfigurations/{configurationName}/ruleCollections": {
+      "get": {
+        "operationId": "RoutingRuleCollections_List",
+        "tags": [
+          "RoutingRuleCollections"
+        ],
+        "description": "Lists all the rule collections in a routing configuration, in a paginated format.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RoutingRuleCollectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/routingConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}": {
+      "get": {
+        "operationId": "RoutingRuleCollections_Get",
+        "tags": [
+          "RoutingRuleCollections"
+        ],
+        "description": "Gets a network manager routing configuration rule collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager routing Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RoutingRuleCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RoutingRuleCollections_CreateOrUpdate",
+        "tags": [
+          "RoutingRuleCollections"
+        ],
+        "description": "Creates or updates a routing rule collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager routing Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollection",
+            "in": "body",
+            "description": "The Rule Collection to create or update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RoutingRuleCollection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RoutingRuleCollection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RoutingRuleCollection"
+            }
+          },
+          "201": {
+            "description": "Resource 'RoutingRuleCollection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RoutingRuleCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RoutingRuleCollections_Delete",
+        "tags": [
+          "RoutingRuleCollections"
+        ],
+        "description": "Deletes an routing rule collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager routing Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/routingConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}/rules": {
+      "get": {
+        "operationId": "RoutingRules_List",
+        "tags": [
+          "RoutingRules"
+        ],
+        "description": "List all network manager routing configuration routing rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager routing Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RoutingRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/routingConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}/rules/{ruleName}": {
+      "get": {
+        "operationId": "RoutingRules_Get",
+        "tags": [
+          "RoutingRules"
+        ],
+        "description": "Gets a network manager routing configuration routing rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager routing Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the rule.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RoutingRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RoutingRules_CreateOrUpdate",
+        "tags": [
+          "RoutingRules"
+        ],
+        "description": "Creates or updates an routing rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager routing Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the rule.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "routingRule",
+            "in": "body",
+            "description": "The routing rule to create or update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RoutingRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RoutingRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RoutingRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'RoutingRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RoutingRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RoutingRules_Delete",
+        "tags": [
+          "RoutingRules"
+        ],
+        "description": "Deletes a routing rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Routing Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager routing Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the rule.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/scopeConnections": {
+      "get": {
+        "operationId": "ScopeConnections_List",
+        "tags": [
+          "ScopeConnections"
+        ],
+        "description": "List all scope connections created by this network manager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ScopeConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/scopeConnections/{scopeConnectionName}": {
+      "get": {
+        "operationId": "ScopeConnections_Get",
+        "tags": [
+          "ScopeConnections"
+        ],
+        "description": "Get specified scope connection created by this Network Manager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "scopeConnectionName",
+            "in": "path",
+            "description": "Name for the cross-tenant connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ScopeConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ScopeConnections_CreateOrUpdate",
+        "tags": [
+          "ScopeConnections"
+        ],
+        "description": "Creates or updates scope connection from Network Manager",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "scopeConnectionName",
+            "in": "path",
+            "description": "Name for the cross-tenant connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Scope connection to be created/updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ScopeConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ScopeConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ScopeConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'ScopeConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ScopeConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ScopeConnections_Delete",
+        "tags": [
+          "ScopeConnections"
+        ],
+        "description": "Delete the pending scope connection created by this network manager.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "scopeConnectionName",
+            "in": "path",
+            "description": "Name for the cross-tenant connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations": {
+      "get": {
+        "operationId": "SecurityAdminConfigurations_List",
+        "tags": [
+          "SecurityAdminConfigurations"
+        ],
+        "description": "Lists all the network manager security admin configurations in a network manager, in a paginated format.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityAdminConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations/{configurationName}": {
+      "get": {
+        "operationId": "SecurityAdminConfigurations_Get",
+        "tags": [
+          "SecurityAdminConfigurations"
+        ],
+        "description": "Retrieves a network manager security admin configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityAdminConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "SecurityAdminConfigurations_CreateOrUpdate",
+        "tags": [
+          "SecurityAdminConfigurations"
+        ],
+        "description": "Creates or updates a network manager security admin configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "securityAdminConfiguration",
+            "in": "body",
+            "description": "The security admin configuration to create or update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SecurityAdminConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SecurityAdminConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityAdminConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'SecurityAdminConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityAdminConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SecurityAdminConfigurations_Delete",
+        "tags": [
+          "SecurityAdminConfigurations"
+        ],
+        "description": "Deletes a network manager security admin configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations/{configurationName}/ruleCollections": {
+      "get": {
+        "operationId": "AdminRuleCollections_List",
+        "tags": [
+          "AdminRuleCollections"
+        ],
+        "description": "Lists all the rule collections in a security admin configuration, in a paginated format.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AdminRuleCollectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}": {
+      "get": {
+        "operationId": "AdminRuleCollections_Get",
+        "tags": [
+          "AdminRuleCollections"
+        ],
+        "description": "Gets a network manager security admin configuration rule collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AdminRuleCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "AdminRuleCollections_CreateOrUpdate",
+        "tags": [
+          "AdminRuleCollections"
+        ],
+        "description": "Creates or updates an admin rule collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollection",
+            "in": "body",
+            "description": "The Rule Collection to create or update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AdminRuleCollection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AdminRuleCollection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AdminRuleCollection"
+            }
+          },
+          "201": {
+            "description": "Resource 'AdminRuleCollection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AdminRuleCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "AdminRuleCollections_Delete",
+        "tags": [
+          "AdminRuleCollections"
+        ],
+        "description": "Deletes an admin rule collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}/rules": {
+      "get": {
+        "operationId": "AdminRules_List",
+        "tags": [
+          "AdminRules"
+        ],
+        "description": "List all network manager security configuration admin rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AdminRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityAdminConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}/rules/{ruleName}": {
+      "get": {
+        "operationId": "AdminRules_Get",
+        "tags": [
+          "AdminRules"
+        ],
+        "description": "Gets a network manager security configuration admin rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the rule.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BaseAdminRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "AdminRules_CreateOrUpdate",
+        "tags": [
+          "AdminRules"
+        ],
+        "description": "Creates or updates an admin rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the rule.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "adminRule",
+            "in": "body",
+            "description": "The admin rule to create or update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BaseAdminRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BaseAdminRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BaseAdminRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'BaseAdminRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BaseAdminRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "AdminRules_Delete",
+        "tags": [
+          "AdminRules"
+        ],
+        "description": "Deletes an admin rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the rule.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityUserConfigurations": {
+      "get": {
+        "operationId": "SecurityUserConfigurations_List",
+        "tags": [
+          "SecurityUserConfigurations"
+        ],
+        "description": "Lists all the network manager security user configurations in a network manager, in a paginated format.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityUserConfigurations/{configurationName}": {
+      "get": {
+        "operationId": "SecurityUserConfigurations_Get",
+        "tags": [
+          "SecurityUserConfigurations"
+        ],
+        "description": "Retrieves a network manager security user configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "SecurityUserConfigurations_CreateOrUpdate",
+        "tags": [
+          "SecurityUserConfigurations"
+        ],
+        "description": "Creates or updates a network manager security user configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "securityUserConfiguration",
+            "in": "body",
+            "description": "The security user configuration to create or update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SecurityUserConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SecurityUserConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'SecurityUserConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SecurityUserConfigurations_Delete",
+        "tags": [
+          "SecurityUserConfigurations"
+        ],
+        "description": "Deletes a network manager security user configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityUserConfigurations/{configurationName}/ruleCollections": {
+      "get": {
+        "operationId": "SecurityUserRuleCollections_List",
+        "tags": [
+          "SecurityUserRuleCollections"
+        ],
+        "description": "Lists all the security user rule collections in a security configuration, in a paginated format.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserRuleCollectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityUserConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}": {
+      "get": {
+        "operationId": "SecurityUserRuleCollections_Get",
+        "tags": [
+          "SecurityUserRuleCollections"
+        ],
+        "description": "Gets a network manager security user configuration rule collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserRuleCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "SecurityUserRuleCollections_CreateOrUpdate",
+        "tags": [
+          "SecurityUserRuleCollections"
+        ],
+        "description": "Creates or updates a security user rule collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "securityUserRuleCollection",
+            "in": "body",
+            "description": "The Security User Rule Collection to create or update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SecurityUserRuleCollection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SecurityUserRuleCollection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserRuleCollection"
+            }
+          },
+          "201": {
+            "description": "Resource 'SecurityUserRuleCollection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserRuleCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SecurityUserRuleCollections_Delete",
+        "tags": [
+          "SecurityUserRuleCollections"
+        ],
+        "description": "Deletes a Security User Rule collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityUserConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}/rules": {
+      "get": {
+        "operationId": "SecurityUserRules_List",
+        "tags": [
+          "SecurityUserRules"
+        ],
+        "description": "Lists all Security User Rules in a rule collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/securityUserConfigurations/{configurationName}/ruleCollections/{ruleCollectionName}/rules/{ruleName}": {
+      "get": {
+        "operationId": "SecurityUserRules_Get",
+        "tags": [
+          "SecurityUserRules"
+        ],
+        "description": "Gets a security user rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the rule.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "SecurityUserRules_CreateOrUpdate",
+        "tags": [
+          "SecurityUserRules"
+        ],
+        "description": "Creates or updates a security user rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the rule.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "securityUserRule",
+            "in": "body",
+            "description": "The security user rule to create or update",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SecurityUserRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SecurityUserRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'SecurityUserRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityUserRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SecurityUserRules_Delete",
+        "tags": [
+          "SecurityUserRules"
+        ],
+        "description": "Deletes a security user rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "configurationName",
+            "in": "path",
+            "description": "The name of the network manager Security Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the network manager security Configuration rule collection.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "The name of the rule.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "description": "Deletes the resource even if it is part of a deployed configuration. If the configuration has been deployed, the service will do a cleanup deployment in the background, prior to the delete.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/listNetworkManagerEffectiveConnectivityConfigurations": {
+      "post": {
+        "operationId": "ListNetworkManagerEffectiveConnectivityConfigurations",
+        "tags": [
+          "NetworkManagerEffectiveConnectivityConfiguration"
+        ],
+        "description": "List all effective connectivity configurations applied on a virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to list correct page.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueryRequestOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerEffectiveConnectivityConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/listNetworkManagerEffectiveSecurityAdminRules": {
+      "post": {
+        "operationId": "ListNetworkManagerEffectiveSecurityAdminRules",
+        "tags": [
+          "NetworkManagerEffectiveSecurityAdminRules"
+        ],
+        "description": "List all effective security admin rules applied on a virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to list correct page.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueryRequestOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkManagerEffectiveSecurityAdminRulesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ActiveBaseSecurityAdminRule": {
+      "type": "object",
+      "description": "Network base admin rule.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "commitTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Deployment time string."
+        },
+        "region": {
+          "type": "string",
+          "description": "Deployment region."
+        },
+        "configurationDescription": {
+          "type": "string",
+          "description": "A description of the security admin configuration."
+        },
+        "ruleCollectionDescription": {
+          "type": "string",
+          "description": "A description of the rule collection."
+        },
+        "ruleCollectionAppliesToGroups": {
+          "type": "array",
+          "description": "Groups for rule collection",
+          "items": {
+            "$ref": "#/definitions/NetworkManagerSecurityGroupItem"
+          },
+          "x-ms-identifiers": []
+        },
+        "ruleGroups": {
+          "type": "array",
+          "description": "Effective configuration groups.",
+          "items": {
+            "$ref": "#/definitions/ConfigurationGroup"
+          }
+        },
+        "kind": {
+          "$ref": "./common.json#/definitions/EffectiveAdminRuleKind",
+          "description": "Whether the rule is custom or default."
+        }
+      },
+      "discriminator": "kind",
+      "required": [
+        "kind"
+      ]
+    },
+    "ActiveConfigurationParameter": {
+      "type": "object",
+      "description": "Effective Virtual Networks Parameter.",
+      "properties": {
+        "regions": {
+          "type": "array",
+          "description": "List of regions.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "skipToken": {
+          "type": "string",
+          "description": "When present, the value can be passed to a subsequent query call (together with the same query and scopes used in the current request) to retrieve the next page of data."
+        }
+      }
+    },
+    "ActiveConnectivityConfiguration": {
+      "type": "object",
+      "description": "Active connectivity configuration.",
+      "properties": {
+        "commitTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Deployment time string."
+        },
+        "region": {
+          "type": "string",
+          "description": "Deployment region."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EffectiveConnectivityConfiguration"
+        }
+      ]
+    },
+    "ActiveConnectivityConfigurationsListResult": {
+      "type": "object",
+      "description": "Result of the request to list active connectivity configurations. It contains a list of active connectivity configurations and a skiptoken to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Gets a page of active connectivity configurations.",
+          "items": {
+            "$ref": "#/definitions/ActiveConnectivityConfiguration"
+          }
+        },
+        "skipToken": {
+          "type": "string",
+          "description": "When present, the value can be passed to a subsequent query call (together with the same query and scopes used in the current request) to retrieve the next page of data."
+        }
+      }
+    },
+    "ActiveDefaultSecurityAdminRule": {
+      "type": "object",
+      "description": "Network default admin rule.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DefaultAdminPropertiesFormat",
+          "description": "Indicates the properties of the default security admin rule",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ActiveBaseSecurityAdminRule"
+        }
+      ],
+      "x-ms-discriminator-value": "Default"
+    },
+    "ActiveSecurityAdminRule": {
+      "type": "object",
+      "description": "Network admin rule.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AdminPropertiesFormat",
+          "description": "Indicates the properties of the security admin rule",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ActiveBaseSecurityAdminRule"
+        }
+      ],
+      "x-ms-discriminator-value": "Custom"
+    },
+    "ActiveSecurityAdminRulesListResult": {
+      "type": "object",
+      "description": "Result of the request to list active security admin rules. It contains a list of active security admin rules and a skiptoken to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Gets a page of active security admin rules.",
+          "items": {
+            "$ref": "#/definitions/ActiveBaseSecurityAdminRule"
+          }
+        },
+        "skipToken": {
+          "type": "string",
+          "description": "When present, the value can be passed to a subsequent query call (together with the same query and scopes used in the current request) to retrieve the next page of data."
+        }
+      }
+    },
+    "AddressPrefixItem": {
+      "type": "object",
+      "description": "Address prefix item.",
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "Address prefix."
+        },
+        "addressPrefixType": {
+          "$ref": "./common.json#/definitions/AddressPrefixType",
+          "description": "Address prefix type."
+        }
+      }
+    },
+    "AdminPropertiesFormat": {
+      "type": "object",
+      "description": "Security admin rule resource.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description for this rule. Restricted to 140 chars."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/SecurityConfigurationRuleProtocol",
+          "description": "Network protocol this rule applies to."
+        },
+        "sources": {
+          "type": "array",
+          "description": "The CIDR or source IP ranges.",
+          "items": {
+            "$ref": "#/definitions/AddressPrefixItem"
+          },
+          "x-ms-identifiers": [
+            "addressPrefix"
+          ]
+        },
+        "destinations": {
+          "type": "array",
+          "description": "The destination address prefixes. CIDR or destination IP ranges.",
+          "items": {
+            "$ref": "#/definitions/AddressPrefixItem"
+          },
+          "x-ms-identifiers": [
+            "addressPrefix"
+          ]
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "description": "The source port ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "description": "The destination port ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "access": {
+          "$ref": "./common.json#/definitions/SecurityConfigurationRuleAccess",
+          "description": "Indicates the access allowed for this particular rule"
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The priority of the rule. The value can be between 1 and 4096. The priority number must be unique for each rule in the collection. The lower the priority number, the higher the priority of the rule.",
+          "minimum": 1,
+          "maximum": 4096
+        },
+        "direction": {
+          "$ref": "./common.json#/definitions/SecurityConfigurationRuleDirection",
+          "description": "Indicates if the traffic matched against the rule in inbound or outbound."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "protocol",
+        "access",
+        "priority",
+        "direction"
+      ]
+    },
+    "AdminRule": {
+      "type": "object",
+      "description": "Network admin rule.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AdminPropertiesFormat",
+          "description": "Indicates the properties of the security admin rule",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseAdminRule"
+        }
+      ],
+      "x-ms-discriminator-value": "Custom"
+    },
+    "AdminRuleCollection": {
+      "type": "object",
+      "description": "Defines the admin rule collection.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AdminRuleCollectionPropertiesFormat",
+          "description": "Indicates the properties for the network manager admin rule collection.",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "AdminRuleCollectionListResult": {
+      "type": "object",
+      "description": "The response of a AdminRuleCollection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AdminRuleCollection items on this page",
+          "items": {
+            "$ref": "#/definitions/AdminRuleCollection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AdminRuleCollectionPropertiesFormat": {
+      "type": "object",
+      "description": "Defines the admin rule collection properties.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the admin rule collection."
+        },
+        "appliesToGroups": {
+          "type": "array",
+          "description": "Groups for configuration",
+          "items": {
+            "$ref": "#/definitions/NetworkManagerSecurityGroupItem"
+          },
+          "x-ms-identifiers": [
+            "networkGroupId"
+          ]
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "appliesToGroups"
+      ]
+    },
+    "AdminRuleListResult": {
+      "type": "object",
+      "description": "Paged collection of BaseAdminRule items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BaseAdminRule items on this page",
+          "items": {
+            "$ref": "#/definitions/BaseAdminRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BaseAdminRule": {
+      "type": "object",
+      "description": "Network base admin rule.",
+      "properties": {
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        },
+        "kind": {
+          "$ref": "./common.json#/definitions/AdminRuleKind",
+          "description": "Whether the rule is custom or default."
+        }
+      },
+      "discriminator": "kind",
+      "required": [
+        "kind"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "Commit": {
+      "type": "object",
+      "description": "The commit resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CommitProperties",
+          "description": "The Commit properties"
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "CommitListResult": {
+      "type": "object",
+      "description": "The response of a Commit list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Commit items on this page",
+          "items": {
+            "$ref": "#/definitions/Commit"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "CommitProperties": {
+      "type": "object",
+      "description": "Properties of commit",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the commit."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        },
+        "commitType": {
+          "$ref": "./common.json#/definitions/ConfigurationType",
+          "description": "Commit Type."
+        },
+        "configurationIds": {
+          "type": "array",
+          "description": "List of configuration IDs.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource."
+          }
+        },
+        "targetLocations": {
+          "type": "array",
+          "description": "List of target locations.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "activeLocations": {
+          "type": "array",
+          "description": "List of active locations.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "forceUpdateTag": {
+          "type": "string",
+          "description": "A value that, when changed, forces the commit to be re-evaluated and redeployed."
+        }
+      },
+      "required": [
+        "commitType",
+        "targetLocations"
+      ]
+    },
+    "ConfigurationGroup": {
+      "type": "object",
+      "description": "The network configuration group resource",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Network group ID."
+        },
+        "properties": {
+          "$ref": "#/definitions/NetworkGroupProperties",
+          "description": "The network configuration group properties",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "ConnectivityConfiguration": {
+      "type": "object",
+      "description": "The network manager connectivity configuration resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectivityConfigurationProperties",
+          "description": "Properties of a network manager connectivity configuration",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "ConnectivityConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a ConnectivityConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ConnectivityConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/ConnectivityConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ConnectivityConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of network manager connectivity configuration",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the connectivity configuration."
+        },
+        "connectivityTopology": {
+          "$ref": "./common.json#/definitions/ConnectivityTopology",
+          "description": "Connectivity topology type."
+        },
+        "hubs": {
+          "type": "array",
+          "description": "List of hubItems",
+          "items": {
+            "$ref": "#/definitions/Hub"
+          },
+          "x-ms-identifiers": [
+            "resourceId"
+          ]
+        },
+        "isGlobal": {
+          "$ref": "./common.json#/definitions/IsGlobal",
+          "description": "Flag if global mesh is supported."
+        },
+        "connectivityCapabilities": {
+          "$ref": "#/definitions/ConnectivityConfigurationPropertiesConnectivityCapabilities",
+          "description": "Collection of additional settings to enhance specific topology behaviors of the connectivity configuration resource."
+        },
+        "appliesToGroups": {
+          "type": "array",
+          "description": "Groups for configuration",
+          "items": {
+            "$ref": "#/definitions/connectivityGroupItem"
+          },
+          "x-ms-identifiers": [
+            "networkGroupId"
+          ]
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the connectivity configuration resource.",
+          "readOnly": true
+        },
+        "deleteExistingPeering": {
+          "$ref": "./common.json#/definitions/DeleteExistingPeering",
+          "description": "Flag if need to remove current existing peerings."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "connectivityTopology",
+        "appliesToGroups"
+      ]
+    },
+    "ConnectivityConfigurationPropertiesConnectivityCapabilities": {
+      "type": "object",
+      "description": "Collection of additional settings to enhance specific topology behaviors of the connectivity configuration resource.",
+      "properties": {
+        "connectedGroupPrivateEndpointsScale": {
+          "type": "string",
+          "description": "Option indicating the scale of private endpoints allowed in the connected group of the connectivity configuration.",
+          "default": "Standard",
+          "enum": [
+            "Standard",
+            "HighScale"
+          ],
+          "x-ms-enum": {
+            "name": "ConnectedGroupPrivateEndpointsScale",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Standard",
+                "value": "Standard",
+                "description": "Default. Allows for up to 2K private endpoints in the connected group."
+              },
+              {
+                "name": "HighScale",
+                "value": "HighScale",
+                "description": "Allows for up to 20K private endpoints in the connected group."
+              }
+            ]
+          }
+        },
+        "connectedGroupAddressOverlap": {
+          "type": "string",
+          "description": "Behavior to handle overlapped IP address space among members of the connected group of the connectivity configuration.",
+          "default": "Allowed",
+          "enum": [
+            "Allowed",
+            "Disallowed"
+          ],
+          "x-ms-enum": {
+            "name": "ConnectedGroupAddressOverlap",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Allowed",
+                "value": "Allowed",
+                "description": "Default. Allows connected group members to have overlapping IP address space."
+              },
+              {
+                "name": "Disallowed",
+                "value": "Disallowed",
+                "description": "Strictly disallows connected group members from having overlapping IP address space. Prevents the addition of a virtual network with overlapping address to the connected group, blocks peering between a virtual network and a connected group member if any connected group member has an overlapping range, and restricts address space modifications that would introduce overlap."
+              }
+            ]
+          }
+        },
+        "peeringEnforcement": {
+          "type": "string",
+          "description": "Option indicating enforcement of peerings created by the connectivity configuration.",
+          "default": "Unenforced",
+          "enum": [
+            "Unenforced",
+            "Enforced"
+          ],
+          "x-ms-enum": {
+            "name": "PeeringEnforcement",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Unenforced",
+                "value": "Unenforced",
+                "description": "Default. Peerings created by the connectivity configuration may be modified or deleted outside of the network manager."
+              },
+              {
+                "name": "Enforced",
+                "value": "Enforced",
+                "description": "Peerings created by the connectivity configuration will not be modifiable or deletable outside of the network manager."
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "connectedGroupPrivateEndpointsScale",
+        "connectedGroupAddressOverlap",
+        "peeringEnforcement"
+      ]
+    },
+    "CrossTenantScopes": {
+      "type": "object",
+      "description": "Cross tenant scopes.",
+      "properties": {
+        "tenantId": {
+          "type": "string",
+          "description": "Tenant ID.",
+          "readOnly": true
+        },
+        "managementGroups": {
+          "type": "array",
+          "description": "List of management groups.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "subscriptions": {
+          "type": "array",
+          "description": "List of subscriptions.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "DefaultAdminPropertiesFormat": {
+      "type": "object",
+      "description": "Security default admin rule resource.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description for this rule. Restricted to 140 chars.",
+          "readOnly": true
+        },
+        "flag": {
+          "type": "string",
+          "description": "Default rule flag."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/SecurityConfigurationRuleProtocol",
+          "description": "Network protocol this rule applies to.",
+          "readOnly": true
+        },
+        "sources": {
+          "type": "array",
+          "description": "The CIDR or source IP ranges.",
+          "items": {
+            "$ref": "#/definitions/AddressPrefixItem"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "addressPrefix"
+          ]
+        },
+        "destinations": {
+          "type": "array",
+          "description": "The destination address prefixes. CIDR or destination IP ranges.",
+          "items": {
+            "$ref": "#/definitions/AddressPrefixItem"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "addressPrefix"
+          ]
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "description": "The source port ranges.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "description": "The destination port ranges.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "access": {
+          "$ref": "./common.json#/definitions/SecurityConfigurationRuleAccess",
+          "description": "Indicates the access allowed for this particular rule",
+          "readOnly": true
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The priority of the rule. The value can be between 1 and 4096. The priority number must be unique for each rule in the collection. The lower the priority number, the higher the priority of the rule.",
+          "readOnly": true
+        },
+        "direction": {
+          "$ref": "./common.json#/definitions/SecurityConfigurationRuleDirection",
+          "description": "Indicates if the traffic matched against the rule in inbound or outbound.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "DefaultAdminRule": {
+      "type": "object",
+      "description": "Network default admin rule.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DefaultAdminPropertiesFormat",
+          "description": "Indicates the properties of the security admin rule",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseAdminRule"
+        }
+      ],
+      "x-ms-discriminator-value": "Default"
+    },
+    "EffectiveBaseSecurityAdminRule": {
+      "type": "object",
+      "description": "Network base admin rule.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "configurationDescription": {
+          "type": "string",
+          "description": "A description of the security admin configuration."
+        },
+        "ruleCollectionDescription": {
+          "type": "string",
+          "description": "A description of the rule collection."
+        },
+        "ruleCollectionAppliesToGroups": {
+          "type": "array",
+          "description": "Groups for rule collection",
+          "items": {
+            "$ref": "#/definitions/NetworkManagerSecurityGroupItem"
+          },
+          "x-ms-identifiers": [
+            "networkGroupId"
+          ]
+        },
+        "ruleGroups": {
+          "type": "array",
+          "description": "Effective configuration groups.",
+          "items": {
+            "$ref": "#/definitions/ConfigurationGroup"
+          }
+        },
+        "kind": {
+          "$ref": "./common.json#/definitions/EffectiveAdminRuleKind",
+          "description": "Whether the rule is custom or default."
+        }
+      },
+      "discriminator": "kind",
+      "required": [
+        "kind"
+      ]
+    },
+    "EffectiveConnectivityConfiguration": {
+      "type": "object",
+      "description": "The network manager effective connectivity configuration",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Connectivity configuration ID."
+        },
+        "properties": {
+          "$ref": "#/definitions/ConnectivityConfigurationProperties",
+          "description": "Properties of a network manager connectivity configuration",
+          "x-ms-client-flatten": true
+        },
+        "configurationGroups": {
+          "type": "array",
+          "description": "Effective configuration groups.",
+          "items": {
+            "$ref": "#/definitions/ConfigurationGroup"
+          }
+        }
+      }
+    },
+    "EffectiveDefaultSecurityAdminRule": {
+      "type": "object",
+      "description": "Network default admin rule.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DefaultAdminPropertiesFormat",
+          "description": "Indicates the properties of the default security admin rule",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EffectiveBaseSecurityAdminRule"
+        }
+      ],
+      "x-ms-discriminator-value": "Default"
+    },
+    "EffectiveSecurityAdminRule": {
+      "type": "object",
+      "description": "Network admin rule.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AdminPropertiesFormat",
+          "description": "Indicates the properties of the security admin rule",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/EffectiveBaseSecurityAdminRule"
+        }
+      ],
+      "x-ms-discriminator-value": "Custom"
+    },
+    "Hub": {
+      "type": "object",
+      "description": "Hub Item.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "Resource Id."
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "Resource Type."
+        }
+      }
+    },
+    "NetworkGroup": {
+      "type": "object",
+      "description": "The network group resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkGroupProperties",
+          "description": "The Network Group properties",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "NetworkGroupListResult": {
+      "type": "object",
+      "description": "The response of a NetworkGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkGroupProperties": {
+      "type": "object",
+      "description": "Properties of network group",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the network group."
+        },
+        "memberType": {
+          "$ref": "./common.json#/definitions/GroupMemberType",
+          "description": "The type of the group member."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the scope assignment resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkManager": {
+      "type": "object",
+      "description": "The Managed Network resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkManagerProperties",
+          "description": "The network manager properties",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "NetworkManagerCommit": {
+      "type": "object",
+      "description": "Network Manager Commit.",
+      "properties": {
+        "commitId": {
+          "type": "string",
+          "description": "Commit Id.",
+          "readOnly": true
+        },
+        "targetLocations": {
+          "type": "array",
+          "description": "List of target locations.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "configurationIds": {
+          "type": "array",
+          "description": "List of configuration ids.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "commitType": {
+          "$ref": "./common.json#/definitions/ConfigurationType",
+          "description": "Commit Type."
+        }
+      },
+      "required": [
+        "targetLocations",
+        "commitType"
+      ]
+    },
+    "NetworkManagerConnection": {
+      "type": "object",
+      "description": "The Network Manager Connection resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkManagerConnectionProperties",
+          "description": "The scope connection properties",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "NetworkManagerConnectionListResult": {
+      "type": "object",
+      "description": "The response of a NetworkManagerConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkManagerConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkManagerConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkManagerConnectionProperties": {
+      "type": "object",
+      "description": "Information about the network manager connection.",
+      "properties": {
+        "networkManagerId": {
+          "type": "string",
+          "description": "Network Manager Id."
+        },
+        "connectionState": {
+          "$ref": "./common.json#/definitions/ScopeConnectionState",
+          "description": "Connection state.",
+          "readOnly": true,
+          "x-ms-client-flatten": true
+        },
+        "description": {
+          "type": "string",
+          "description": "A description of the network manager connection."
+        }
+      }
+    },
+    "NetworkManagerDeploymentStatus": {
+      "type": "object",
+      "description": "Network Manager Deployment Status.",
+      "properties": {
+        "commitTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Commit Time."
+        },
+        "region": {
+          "type": "string",
+          "description": "Region Name."
+        },
+        "deploymentStatus": {
+          "$ref": "./common.json#/definitions/DeploymentStatus",
+          "description": "Deployment Status."
+        },
+        "configurationIds": {
+          "type": "array",
+          "description": "List of configuration ids.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deploymentType": {
+          "$ref": "./common.json#/definitions/ConfigurationType",
+          "description": "Configuration Deployment Type."
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "Error Message."
+        }
+      }
+    },
+    "NetworkManagerDeploymentStatusListResult": {
+      "type": "object",
+      "description": "A list of Network Manager Deployment Status",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Gets a page of Network Manager Deployment Status",
+          "items": {
+            "$ref": "#/definitions/NetworkManagerDeploymentStatus"
+          },
+          "x-ms-identifiers": []
+        },
+        "skipToken": {
+          "type": "string",
+          "description": "When present, the value can be passed to a subsequent query call (together with the same query and scopes used in the current request) to retrieve the next page of data."
+        }
+      }
+    },
+    "NetworkManagerDeploymentStatusParameter": {
+      "type": "object",
+      "description": "Network Manager Deployment Status Parameter.",
+      "properties": {
+        "regions": {
+          "type": "array",
+          "description": "List of locations.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "deploymentTypes": {
+          "type": "array",
+          "description": "List of deployment types.",
+          "items": {
+            "$ref": "./common.json#/definitions/ConfigurationType"
+          }
+        },
+        "skipToken": {
+          "type": "string",
+          "description": "Continuation token for pagination, capturing the next page size and offset, as well as the context of the query."
+        }
+      }
+    },
+    "NetworkManagerEffectiveConnectivityConfigurationListResult": {
+      "type": "object",
+      "description": "Result of the request to list networkManagerEffectiveConnectivityConfiguration. It contains a list of groups and a skiptoken to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Gets a page of NetworkManagerEffectiveConnectivityConfiguration",
+          "items": {
+            "$ref": "#/definitions/EffectiveConnectivityConfiguration"
+          }
+        },
+        "skipToken": {
+          "type": "string",
+          "description": "When present, the value can be passed to a subsequent query call (together with the same query and scopes used in the current request) to retrieve the next page of data."
+        }
+      }
+    },
+    "NetworkManagerEffectiveSecurityAdminRulesListResult": {
+      "type": "object",
+      "description": "Result of the request to list networkManagerEffectiveSecurityAdminRules. It contains a list of groups and a skiptoken to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Gets a page of NetworkManagerEffectiveSecurityAdminRules",
+          "items": {
+            "$ref": "#/definitions/EffectiveBaseSecurityAdminRule"
+          }
+        },
+        "skipToken": {
+          "type": "string",
+          "description": "When present, the value can be passed to a subsequent query call (together with the same query and scopes used in the current request) to retrieve the next page of data."
+        }
+      }
+    },
+    "NetworkManagerListResult": {
+      "type": "object",
+      "description": "The response of a NetworkManager list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkManager items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkManager"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkManagerProperties": {
+      "type": "object",
+      "description": "Properties of Managed Network",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the network manager."
+        },
+        "networkManagerScopes": {
+          "$ref": "#/definitions/NetworkManagerPropertiesNetworkManagerScopes",
+          "description": "Scope of Network Manager."
+        },
+        "networkManagerScopeAccesses": {
+          "type": "array",
+          "description": "Scope Access.",
+          "items": {
+            "$ref": "./common.json#/definitions/ConfigurationType"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the network manager resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "networkManagerScopes"
+      ]
+    },
+    "NetworkManagerPropertiesNetworkManagerScopes": {
+      "type": "object",
+      "description": "Scope of Network Manager.",
+      "properties": {
+        "managementGroups": {
+          "type": "array",
+          "description": "List of management groups.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subscriptions": {
+          "type": "array",
+          "description": "List of subscriptions.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "crossTenantScopes": {
+          "type": "array",
+          "description": "List of cross tenant scopes.",
+          "items": {
+            "$ref": "#/definitions/CrossTenantScopes"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "NetworkManagerRoutingConfiguration": {
+      "type": "object",
+      "description": "Defines the routing configuration",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkManagerRoutingConfigurationPropertiesFormat",
+          "description": "Indicates the properties for the network manager routing configuration.",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "NetworkManagerRoutingConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a NetworkManagerRoutingConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkManagerRoutingConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkManagerRoutingConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkManagerRoutingConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Defines the routing configuration properties.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the routing configuration."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        },
+        "routeTableUsageMode": {
+          "type": "string",
+          "description": "Route table usage mode defines which route table will be used by the configuration. If not defined, this will default to 'ManagedOnly'.",
+          "default": "ManagedOnly",
+          "enum": [
+            "ManagedOnly",
+            "UseExisting"
+          ],
+          "x-ms-enum": {
+            "name": "RouteTableUsageMode",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "ManagedOnly",
+                "value": "ManagedOnly",
+                "description": "Only route tables managed by the routing configuration will be used."
+              },
+              {
+                "name": "UseExisting",
+                "value": "UseExisting",
+                "description": "Use existing user-defined route tables already associated with resources."
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NetworkManagerRoutingGroupItem": {
+      "type": "object",
+      "description": "Network manager routing group item.",
+      "properties": {
+        "networkGroupId": {
+          "type": "string",
+          "description": "Network manager group Id."
+        }
+      },
+      "required": [
+        "networkGroupId"
+      ]
+    },
+    "NetworkManagerSecurityGroupItem": {
+      "type": "object",
+      "description": "Network manager security group item.",
+      "properties": {
+        "networkGroupId": {
+          "type": "string",
+          "description": "Network manager group Id."
+        }
+      },
+      "required": [
+        "networkGroupId"
+      ]
+    },
+    "PatchObject": {
+      "type": "object",
+      "description": "Object for patch operations.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "QueryRequestOptions": {
+      "type": "object",
+      "description": "Query Request Options",
+      "properties": {
+        "skipToken": {
+          "type": "string",
+          "description": "When present, the value can be passed to a subsequent query call (together with the same query and scopes used in the current request) to retrieve the next page of data."
+        }
+      }
+    },
+    "RoutingRule": {
+      "type": "object",
+      "description": "Network routing rule.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RoutingRulePropertiesFormat",
+          "description": "Indicates the properties of the routing rule",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "RoutingRuleCollection": {
+      "type": "object",
+      "description": "Defines the routing rule collection.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RoutingRuleCollectionPropertiesFormat",
+          "description": "Indicates the properties for the network manager routing rule collection.",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "RoutingRuleCollectionListResult": {
+      "type": "object",
+      "description": "The response of a RoutingRuleCollection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RoutingRuleCollection items on this page",
+          "items": {
+            "$ref": "#/definitions/RoutingRuleCollection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RoutingRuleCollectionPropertiesFormat": {
+      "type": "object",
+      "description": "Defines the routing rule collection properties.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the routing rule collection."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        },
+        "appliesTo": {
+          "type": "array",
+          "description": "Groups for configuration",
+          "items": {
+            "$ref": "#/definitions/NetworkManagerRoutingGroupItem"
+          },
+          "x-ms-identifiers": [
+            "networkGroupId"
+          ]
+        },
+        "disableBgpRoutePropagation": {
+          "$ref": "./common.json#/definitions/DisableBgpRoutePropagation",
+          "description": "Determines whether BGP route propagation is enabled. Defaults to true."
+        }
+      },
+      "required": [
+        "appliesTo"
+      ]
+    },
+    "RoutingRuleListResult": {
+      "type": "object",
+      "description": "The response of a RoutingRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RoutingRule items on this page",
+          "items": {
+            "$ref": "#/definitions/RoutingRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RoutingRuleNextHop": {
+      "type": "object",
+      "description": "Next hop.",
+      "properties": {
+        "nextHopType": {
+          "$ref": "./common.json#/definitions/RoutingRuleNextHopType",
+          "description": "Next hop type."
+        },
+        "nextHopAddress": {
+          "type": "string",
+          "description": "Next hop address. Only required if the next hop type is VirtualAppliance."
+        }
+      },
+      "required": [
+        "nextHopType"
+      ]
+    },
+    "RoutingRulePropertiesFormat": {
+      "type": "object",
+      "description": "Routing rule resource.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description for this rule."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        },
+        "destination": {
+          "$ref": "#/definitions/RoutingRuleRouteDestination",
+          "description": "Indicates the destination for this particular rule."
+        },
+        "nextHop": {
+          "$ref": "#/definitions/RoutingRuleNextHop",
+          "description": "Indicates the next hop for this particular rule."
+        }
+      },
+      "required": [
+        "destination",
+        "nextHop"
+      ]
+    },
+    "RoutingRuleRouteDestination": {
+      "type": "object",
+      "description": "Route destination.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/RoutingRuleDestinationType",
+          "description": "Destination type."
+        },
+        "destinationAddress": {
+          "type": "string",
+          "description": "Destination address."
+        }
+      },
+      "required": [
+        "type",
+        "destinationAddress"
+      ]
+    },
+    "ScopeConnection": {
+      "type": "object",
+      "description": "The Scope Connections resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ScopeConnectionProperties",
+          "description": "The scope connection properties",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "ScopeConnectionListResult": {
+      "type": "object",
+      "description": "The response of a ScopeConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ScopeConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/ScopeConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ScopeConnectionProperties": {
+      "type": "object",
+      "description": "Scope connection.",
+      "properties": {
+        "tenantId": {
+          "type": "string",
+          "description": "Tenant ID."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "Resource ID."
+        },
+        "connectionState": {
+          "$ref": "./common.json#/definitions/ScopeConnectionState",
+          "description": "Connection State",
+          "readOnly": true,
+          "x-ms-client-flatten": true
+        },
+        "description": {
+          "type": "string",
+          "description": "A description of the scope connection."
+        }
+      }
+    },
+    "SecurityAdminConfiguration": {
+      "type": "object",
+      "description": "Defines the security admin configuration",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SecurityAdminConfigurationPropertiesFormat",
+          "description": "Indicates the properties for the network manager security admin configuration.",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "SecurityAdminConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a SecurityAdminConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SecurityAdminConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/SecurityAdminConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SecurityAdminConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Defines the security admin configuration properties.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the security configuration."
+        },
+        "applyOnNetworkIntentPolicyBasedServices": {
+          "type": "array",
+          "description": "Enum list of network intent policy based services.",
+          "items": {
+            "$ref": "./common.json#/definitions/NetworkIntentPolicyBasedService"
+          }
+        },
+        "networkGroupAddressSpaceAggregationOption": {
+          "$ref": "./common.json#/definitions/AddressSpaceAggregationOption",
+          "description": "Determine update behavior for changes to network groups referenced within the rules in this configuration."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "SecurityUserConfiguration": {
+      "type": "object",
+      "description": "Defines the security user configuration",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SecurityUserConfigurationPropertiesFormat",
+          "description": "Indicates the properties for the network manager security user configuration.",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "SecurityUserConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a SecurityUserConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SecurityUserConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/SecurityUserConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SecurityUserConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Defines the security user configuration properties.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the security user configuration."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "SecurityUserGroupItem": {
+      "type": "object",
+      "description": "Network manager security user group item.",
+      "properties": {
+        "networkGroupId": {
+          "type": "string",
+          "description": "Network manager group Id."
+        }
+      },
+      "required": [
+        "networkGroupId"
+      ]
+    },
+    "SecurityUserRule": {
+      "type": "object",
+      "description": "Network security user rule.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SecurityUserRulePropertiesFormat",
+          "description": "Indicates the properties of the security user rule",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "SecurityUserRuleCollection": {
+      "type": "object",
+      "description": "Defines the security user rule collection.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SecurityUserRuleCollectionPropertiesFormat",
+          "description": "Indicates the properties for the network manager security user rule collection.",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "SecurityUserRuleCollectionListResult": {
+      "type": "object",
+      "description": "The response of a SecurityUserRuleCollection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SecurityUserRuleCollection items on this page",
+          "items": {
+            "$ref": "#/definitions/SecurityUserRuleCollection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SecurityUserRuleCollectionPropertiesFormat": {
+      "type": "object",
+      "description": "Defines the security user rule collection properties.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description of the security user rule collection."
+        },
+        "appliesToGroups": {
+          "type": "array",
+          "description": "Groups for configuration",
+          "items": {
+            "$ref": "#/definitions/SecurityUserGroupItem"
+          },
+          "x-ms-identifiers": [
+            "networkGroupId"
+          ]
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "appliesToGroups"
+      ]
+    },
+    "SecurityUserRuleListResult": {
+      "type": "object",
+      "description": "The response of a SecurityUserRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SecurityUserRule items on this page",
+          "items": {
+            "$ref": "#/definitions/SecurityUserRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SecurityUserRulePropertiesFormat": {
+      "type": "object",
+      "description": "Security rule resource.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description for this rule."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/SecurityConfigurationRuleProtocol",
+          "description": "Network protocol this rule applies to."
+        },
+        "sources": {
+          "type": "array",
+          "description": "The CIDR or source IP ranges.",
+          "items": {
+            "$ref": "#/definitions/AddressPrefixItem"
+          },
+          "x-ms-identifiers": [
+            "addressPrefix"
+          ]
+        },
+        "destinations": {
+          "type": "array",
+          "description": "The destination address prefixes. CIDR or destination IP ranges.",
+          "items": {
+            "$ref": "#/definitions/AddressPrefixItem"
+          },
+          "x-ms-identifiers": [
+            "addressPrefix"
+          ]
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "description": "The source port ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "description": "The destination port ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "direction": {
+          "$ref": "./common.json#/definitions/SecurityConfigurationRuleDirection",
+          "description": "Indicates if the traffic matched against the rule in inbound or outbound."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the security configuration user rule resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "Unique identifier for this resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "protocol",
+        "direction"
+      ]
+    },
+    "StaticMember": {
+      "type": "object",
+      "description": "StaticMember Item.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StaticMemberProperties",
+          "description": "The Static Member properties",
+          "x-ms-client-flatten": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ChildResource"
+        }
+      ]
+    },
+    "StaticMemberListResult": {
+      "type": "object",
+      "description": "The response of a StaticMember list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The StaticMember items on this page",
+          "items": {
+            "$ref": "#/definitions/StaticMember"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "StaticMemberProperties": {
+      "type": "object",
+      "description": "Properties of static member.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "Resource Id."
+        },
+        "region": {
+          "type": "string",
+          "description": "Resource region.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the scope assignment resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "connectivityGroupItem": {
+      "type": "object",
+      "description": "Connectivity group item.",
+      "properties": {
+        "networkGroupId": {
+          "type": "string",
+          "description": "Network group Id."
+        },
+        "useHubGateway": {
+          "$ref": "./common.json#/definitions/UseHubGateway",
+          "description": "Flag if need to use hub gateway."
+        },
+        "isGlobal": {
+          "$ref": "./common.json#/definitions/IsGlobal",
+          "description": "Flag if global is supported."
+        },
+        "groupConnectivity": {
+          "$ref": "./common.json#/definitions/GroupConnectivity",
+          "description": "Group connectivity type."
+        }
+      },
+      "required": [
+        "networkGroupId",
+        "groupConnectivity"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/networkSecurityPerimeter.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/networkSecurityPerimeter.json
@@ -1,0 +1,3006 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "NetworkSecurityPerimeters"
+    },
+    {
+      "name": "NetworkSecurityPerimeterProfiles"
+    },
+    {
+      "name": "NetworkSecurityPerimeterAccessRules"
+    },
+    {
+      "name": "NetworkSecurityPerimeterAssociations"
+    },
+    {
+      "name": "NetworkSecurityPerimeterLinks"
+    },
+    {
+      "name": "NetworkSecurityPerimeterLinkReferences"
+    },
+    {
+      "name": "NetworkSecurityPerimeterLoggingConfigurations"
+    },
+    {
+      "name": "NetworkSecurityPerimeterAssociableResourceTypes"
+    },
+    {
+      "name": "NetworkSecurityPerimeterOperationStatuses"
+    },
+    {
+      "name": "NetworkSecurityPerimeterServiceTags"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/networkSecurityPerimeterOperationStatuses/{operationId}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterOperationStatuses_Get",
+        "tags": [
+          "NetworkSecurityPerimeterOperationStatuses"
+        ],
+        "description": "Gets the operation status for the given operation id.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "operationId",
+            "in": "path",
+            "description": "The operation id of the async operation.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/OperationStatusResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspOperationStatusGet": {
+            "$ref": "./examples/NspOperationStatusGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/nspServiceTags": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterServiceTags_List",
+        "tags": [
+          "NetworkSecurityPerimeterServiceTags"
+        ],
+        "description": "Gets the list of service tags supported by NSP. These service tags can be used to create access rules in NSP.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/NspServiceTagsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NSPServiceTagsList": {
+            "$ref": "./examples/NspServiceTagsList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/perimeterAssociableResourceTypes": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterAssociableResourceTypes_List",
+        "tags": [
+          "NetworkSecurityPerimeterAssociableResourceTypes"
+        ],
+        "description": "Gets the list of resources that are onboarded with NSP. These resources can be associated with a network security perimeter",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PerimeterAssociableResourcesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterAssociableResourceTypes": {
+            "$ref": "./examples/PerimeterAssociableResourcesList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkSecurityPerimeters": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeters_ListBySubscription",
+        "tags": [
+          "NetworkSecurityPerimeters"
+        ],
+        "description": "List all network security perimeters in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimetersList": {
+            "$ref": "./examples/NetworkSecurityPerimeterListAll.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeters_List",
+        "tags": [
+          "NetworkSecurityPerimeters"
+        ],
+        "description": "List network security perimeters in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Network Security Perimeter": {
+            "$ref": "./examples/NetworkSecurityPerimeterList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeters_Get",
+        "tags": [
+          "NetworkSecurityPerimeters"
+        ],
+        "description": "Gets the specified network security perimeter by the name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeter"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterGet": {
+            "$ref": "./examples/NetworkSecurityPerimeterGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkSecurityPerimeters_CreateOrUpdate",
+        "tags": [
+          "NetworkSecurityPerimeters"
+        ],
+        "description": "Creates or updates a Network Security Perimeter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameter supplied to create or update the network security perimeter.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkSecurityPerimeter' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeter"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkSecurityPerimeter' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeter"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create a geo-linked Network Security Perimeter": {
+            "$ref": "./examples/NetworkSecurityPerimeterPutGeoLinked.json"
+          },
+          "Put Network Security Perimeter": {
+            "$ref": "./examples/NetworkSecurityPerimeterPut.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "NetworkSecurityPerimeters_Patch",
+        "tags": [
+          "NetworkSecurityPerimeters"
+        ],
+        "description": "Patch Tags for a Network Security Perimeter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameter supplied to the network security perimeter.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateTagsRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeter"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Network Security Perimeter": {
+            "$ref": "./examples/NetworkSecurityPerimeterPatch.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkSecurityPerimeters_Delete",
+        "tags": [
+          "NetworkSecurityPerimeters"
+        ],
+        "description": "Deletes a network security perimeter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "forceDeletion",
+            "in": "query",
+            "description": "Deletes the resource even if it contains any child associations.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NetworkSecurityPerimeterDelete": {
+            "$ref": "./examples/NetworkSecurityPerimeterDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/linkReferences": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterLinkReferences_List",
+        "tags": [
+          "NetworkSecurityPerimeterLinkReferences"
+        ],
+        "description": "Lists the NSP LinkReference resources in the specified network security perimeter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspLinkReferenceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLinkReferenceList": {
+            "$ref": "./examples/NspLinkReferenceList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/linkReferences/{linkReferenceName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterLinkReferences_Get",
+        "tags": [
+          "NetworkSecurityPerimeterLinkReferences"
+        ],
+        "description": "Gets the specified NSP linkReference resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "linkReferenceName",
+            "in": "path",
+            "description": "The name of the NSP linkReference.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspLinkReference"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLinkReferencesGet": {
+            "$ref": "./examples/NspLinkReferenceGet.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkSecurityPerimeterLinkReferences_Delete",
+        "tags": [
+          "NetworkSecurityPerimeterLinkReferences"
+        ],
+        "description": "Deletes an NSP LinkReference resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "linkReferenceName",
+            "in": "path",
+            "description": "The name of the NSP linkReference.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLinkReferenceDelete": {
+            "$ref": "./examples/NspLinkReferenceDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/links": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterLinks_List",
+        "tags": [
+          "NetworkSecurityPerimeterLinks"
+        ],
+        "description": "Lists the NSP Link resources in the specified network security perimeter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspLinkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLinkList": {
+            "$ref": "./examples/NspLinkList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/links/{linkName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterLinks_Get",
+        "tags": [
+          "NetworkSecurityPerimeterLinks"
+        ],
+        "description": "Gets the specified NSP link resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "linkName",
+            "in": "path",
+            "description": "The name of the NSP link.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspLink"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLinksGet": {
+            "$ref": "./examples/NspLinkGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkSecurityPerimeterLinks_CreateOrUpdate",
+        "tags": [
+          "NetworkSecurityPerimeterLinks"
+        ],
+        "description": "Creates or updates NSP link resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "linkName",
+            "in": "path",
+            "description": "The name of the NSP link.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that hold the NspLink resource to be created/updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NspLink"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NspLink' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NspLink"
+            }
+          },
+          "201": {
+            "description": "Resource 'NspLink' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NspLink"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLinksPut": {
+            "$ref": "./examples/NspLinkPut.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkSecurityPerimeterLinks_Delete",
+        "tags": [
+          "NetworkSecurityPerimeterLinks"
+        ],
+        "description": "Deletes an NSP Link resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "linkName",
+            "in": "path",
+            "description": "The name of the NSP link.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLinkDelete": {
+            "$ref": "./examples/NspLinkDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/loggingConfigurations": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterLoggingConfigurations_List",
+        "tags": [
+          "NetworkSecurityPerimeterLoggingConfigurations"
+        ],
+        "description": "Lists the NSP logging configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspLoggingConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLoggingConfigurationList": {
+            "$ref": "./examples/NspLoggingConfigurationList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/loggingConfigurations/{loggingConfigurationName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterLoggingConfigurations_Get",
+        "tags": [
+          "NetworkSecurityPerimeterLoggingConfigurations"
+        ],
+        "description": "Gets the NSP logging configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "loggingConfigurationName",
+            "in": "path",
+            "description": "The name of the NSP logging configuration. Accepts 'instance' as name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspLoggingConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLoggingConfigurationGet": {
+            "$ref": "./examples/NspLoggingConfigurationGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkSecurityPerimeterLoggingConfigurations_CreateOrUpdate",
+        "tags": [
+          "NetworkSecurityPerimeterLoggingConfigurations"
+        ],
+        "description": "Creates or updates NSP logging configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "loggingConfigurationName",
+            "in": "path",
+            "description": "The name of the NSP logging configuration. Accepts 'instance' as name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that hold the NspLoggingConfiguration to be created/updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NspLoggingConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NspLoggingConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NspLoggingConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'NspLoggingConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NspLoggingConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLoggingConfigurationPut": {
+            "$ref": "./examples/NspLoggingConfigurationPut.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkSecurityPerimeterLoggingConfigurations_Delete",
+        "tags": [
+          "NetworkSecurityPerimeterLoggingConfigurations"
+        ],
+        "description": "Deletes an NSP Logging configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "loggingConfigurationName",
+            "in": "path",
+            "description": "The name of the NSP logging configuration. Accepts 'instance' as name.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspLoggingConfigurationDelete": {
+            "$ref": "./examples/NspLoggingConfigurationDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/profiles": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterProfiles_List",
+        "tags": [
+          "NetworkSecurityPerimeterProfiles"
+        ],
+        "description": "Lists the NSP profiles in the specified network security perimeter.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspProfileListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspProfilesList": {
+            "$ref": "./examples/NspProfileList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/profiles/{profileName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterProfiles_Get",
+        "tags": [
+          "NetworkSecurityPerimeterProfiles"
+        ],
+        "description": "Gets the specified NSP profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "The name of the NSP profile.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspProfilesGet": {
+            "$ref": "./examples/NspProfileGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkSecurityPerimeterProfiles_CreateOrUpdate",
+        "tags": [
+          "NetworkSecurityPerimeterProfiles"
+        ],
+        "description": "Creates or updates a network profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "The name of the NSP profile.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that hold the NspProfile resource to be created/updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NspProfile"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NspProfile' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NspProfile"
+            }
+          },
+          "201": {
+            "description": "Resource 'NspProfile' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NspProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspProfilesPut": {
+            "$ref": "./examples/NspProfilePut.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkSecurityPerimeterProfiles_Delete",
+        "tags": [
+          "NetworkSecurityPerimeterProfiles"
+        ],
+        "description": "Deletes an NSP profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "The name of the NSP profile.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspProfilesDelete": {
+            "$ref": "./examples/NspProfileDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/profiles/{profileName}/accessRules": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterAccessRules_List",
+        "tags": [
+          "NetworkSecurityPerimeterAccessRules"
+        ],
+        "description": "Lists the NSP access rules in the specified NSP profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "The name of the NSP profile.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspAccessRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspAccessRulesList": {
+            "$ref": "./examples/NspAccessRuleList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/profiles/{profileName}/accessRules/{accessRuleName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterAccessRules_Get",
+        "tags": [
+          "NetworkSecurityPerimeterAccessRules"
+        ],
+        "description": "Gets the specified NSP access rule by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "The name of the NSP profile.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "accessRuleName",
+            "in": "path",
+            "description": "The name of the NSP access rule.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspAccessRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspAccessRuleGet": {
+            "$ref": "./examples/NspAccessRuleGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkSecurityPerimeterAccessRules_CreateOrUpdate",
+        "tags": [
+          "NetworkSecurityPerimeterAccessRules"
+        ],
+        "description": "Creates or updates a network access rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "The name of the NSP profile.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "accessRuleName",
+            "in": "path",
+            "description": "The name of the NSP access rule.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that hold the NspAccessRule resource to be created/updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NspAccessRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NspAccessRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NspAccessRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'NspAccessRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NspAccessRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspAccessRulePut": {
+            "$ref": "./examples/NspAccessRulePut.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkSecurityPerimeterAccessRules_Delete",
+        "tags": [
+          "NetworkSecurityPerimeterAccessRules"
+        ],
+        "description": "Deletes an NSP access rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "The name of the NSP profile.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "accessRuleName",
+            "in": "path",
+            "description": "The name of the NSP access rule.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspAccessRulesDelete": {
+            "$ref": "./examples/NspAccessRuleDelete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/profiles/{profileName}/accessRules/{accessRuleName}/reconcile": {
+      "post": {
+        "operationId": "NetworkSecurityPerimeterAccessRules_Reconcile",
+        "tags": [
+          "NetworkSecurityPerimeterAccessRules"
+        ],
+        "description": "Reconcile NSP access rules",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "profileName",
+            "in": "path",
+            "description": "The name of the NSP profile.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "accessRuleName",
+            "in": "path",
+            "description": "The name of the NSP access rule.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for NSP access rule reconcile",
+            "required": true,
+            "schema": {}
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {}
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspAccessRuleReconcile": {
+            "$ref": "./examples/NspAccessRuleReconcile.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/resourceAssociations": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterAssociations_List",
+        "tags": [
+          "NetworkSecurityPerimeterAssociations"
+        ],
+        "description": "Lists the NSP resource associations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "An optional query parameter which specifies the maximum number of records to be returned by the server.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "SkipToken is only used if a previous operation returned a partial result. If a previous response contains a nextLink element, the value of the nextLink element will include a skipToken parameter that specifies a starting point to use for subsequent calls.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/NspAssociationsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspAssociationList": {
+            "$ref": "./examples/NspAssociationList.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/resourceAssociations/{associationName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterAssociations_Get",
+        "tags": [
+          "NetworkSecurityPerimeterAssociations"
+        ],
+        "description": "Gets the specified NSP association by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "associationName",
+            "in": "path",
+            "description": "The name of the NSP association.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NspAssociation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspAssociationGet": {
+            "$ref": "./examples/NspAssociationGet.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkSecurityPerimeterAssociations_CreateOrUpdate",
+        "tags": [
+          "NetworkSecurityPerimeterAssociations"
+        ],
+        "description": "Creates or updates a NSP resource association.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "associationName",
+            "in": "path",
+            "description": "The name of the NSP association.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that hold the NspAssociation resource to be created/updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NspAssociation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NspAssociation' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NspAssociation"
+            }
+          },
+          "201": {
+            "description": "Resource 'NspAssociation' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NspAssociation"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/NspAssociation"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspAssociationPut": {
+            "$ref": "./examples/NspAssociationPut.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/NspAssociation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "NetworkSecurityPerimeterAssociations_Delete",
+        "tags": [
+          "NetworkSecurityPerimeterAssociations"
+        ],
+        "description": "Deletes an NSP association resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "associationName",
+            "in": "path",
+            "description": "The name of the NSP association.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspAssociationDelete": {
+            "$ref": "./examples/NspAssociationDelete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityPerimeters/{networkSecurityPerimeterName}/resourceAssociations/{associationName}/reconcile": {
+      "post": {
+        "operationId": "NetworkSecurityPerimeterAssociations_Reconcile",
+        "tags": [
+          "NetworkSecurityPerimeterAssociations"
+        ],
+        "description": "Reconcile NSP association",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityPerimeterName",
+            "in": "path",
+            "description": "The name of the network security perimeter.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "associationName",
+            "in": "path",
+            "description": "The name of the NSP association.",
+            "required": true,
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "(^[a-zA-Z0-9]+[a-zA-Z0-9_.-]*[a-zA-Z0-9_]+$)|(^[a-zA-Z0-9]$)"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for NSP association reconcile",
+            "required": true,
+            "schema": {}
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {}
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "NspAssociationReconcile": {
+            "$ref": "./examples/NspAssociationReconcile.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "NetworkSecurityPerimeter": {
+      "type": "object",
+      "description": "The Network Security Perimeter resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterProperties",
+          "description": "The network security perimeter properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SecurityPerimeterTrackedResource"
+        }
+      ]
+    },
+    "NetworkSecurityPerimeterListResult": {
+      "type": "object",
+      "description": "The response of a NetworkSecurityPerimeter list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkSecurityPerimeter items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeter"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkSecurityPerimeterProperties": {
+      "type": "object",
+      "description": "Properties of network security perimeter.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/NspProvisioningState",
+          "description": "The provisioning state of the scope assignment resource.",
+          "readOnly": true
+        },
+        "perimeterGuid": {
+          "type": "string",
+          "description": "perimeter guid of the network security perimeter.",
+          "readOnly": true
+        },
+        "createMode": {
+          "$ref": "./common.json#/definitions/NspCreateMode",
+          "description": "The creation mode of the network security perimeter. This property is immutable after creation.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "remotePerimeterId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the source network security perimeter. This property is required when createMode is GeoLinkedPerimeter and is immutable after creation.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/networkSecurityPerimeters"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NspAccessRule": {
+      "type": "object",
+      "description": "The NSP access rule resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NspAccessRuleProperties",
+          "description": "Properties of the NSP access rule.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SecurityPerimeterProxyResource"
+        }
+      ]
+    },
+    "NspAccessRuleListResult": {
+      "type": "object",
+      "description": "The response of a NspAccessRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NspAccessRule items on this page",
+          "items": {
+            "$ref": "#/definitions/NspAccessRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NspAccessRuleProperties": {
+      "type": "object",
+      "description": "Properties of NSP access rule.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/NspProvisioningState",
+          "description": "The provisioning state of the scope assignment resource.",
+          "readOnly": true
+        },
+        "direction": {
+          "$ref": "./common.json#/definitions/AccessRuleDirection",
+          "description": "Direction that specifies whether the access rules is inbound/outbound."
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "Inbound address prefixes (IPv4/IPv6)",
+          "items": {
+            "type": "string"
+          }
+        },
+        "fullyQualifiedDomainNames": {
+          "type": "array",
+          "description": "Outbound rules in fully qualified domain name format.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subscriptions": {
+          "type": "array",
+          "description": "List of subscription ids",
+          "items": {
+            "$ref": "#/definitions/SubscriptionId"
+          },
+          "x-ms-client-flatten": true
+        },
+        "networkSecurityPerimeters": {
+          "type": "array",
+          "description": "Rule specified by the perimeter id.",
+          "items": {
+            "$ref": "#/definitions/PerimeterBasedAccessRule"
+          },
+          "readOnly": true,
+          "x-ms-client-flatten": true
+        },
+        "emailAddresses": {
+          "type": "array",
+          "description": "Outbound rules in email address format. This access rule type is currently unavailable for use.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "phoneNumbers": {
+          "type": "array",
+          "description": "Outbound rules in phone number format. This access rule type is currently unavailable for use.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "serviceTags": {
+          "type": "array",
+          "description": "Inbound rules of type service tag. This access rule type is currently unavailable for use.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NspAssociation": {
+      "type": "object",
+      "description": "The NSP resource association resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NspAssociationProperties",
+          "description": "Properties of the NSP resource association.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SecurityPerimeterProxyResource"
+        }
+      ]
+    },
+    "NspAssociationProperties": {
+      "type": "object",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/NspProvisioningState",
+          "description": "The provisioning state of the resource  association resource.",
+          "readOnly": true
+        },
+        "privateLinkResource": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The PaaS resource to be associated."
+        },
+        "profile": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Profile id to which the PaaS resource is associated."
+        },
+        "accessMode": {
+          "$ref": "./common.json#/definitions/AssociationAccessMode",
+          "description": "Access mode on the association."
+        },
+        "hasProvisioningIssues": {
+          "type": "string",
+          "description": "Specifies if there are provisioning issues",
+          "readOnly": true
+        }
+      }
+    },
+    "NspAssociationsListResult": {
+      "type": "object",
+      "description": "Paged collection of NspAssociation items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NspAssociation items on this page",
+          "items": {
+            "$ref": "#/definitions/NspAssociation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NspLink": {
+      "type": "object",
+      "description": "The network security perimeter link resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NspLinkProperties",
+          "description": "Properties of the network security perimeter link resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SecurityPerimeterProxyResource"
+        }
+      ]
+    },
+    "NspLinkListResult": {
+      "type": "object",
+      "description": "The response of a NspLink list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NspLink items on this page",
+          "items": {
+            "$ref": "#/definitions/NspLink"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NspLinkProperties": {
+      "type": "object",
+      "description": "Properties of NSP Link resource.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/NspLinkProvisioningState",
+          "description": "The provisioning state of the NSP Link resource.",
+          "readOnly": true
+        },
+        "autoApprovedRemotePerimeterResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Perimeter ARM Id for the remote NSP with which the link gets created in Auto-approval mode. It should be used when the NSP admin have Microsoft.Network/networkSecurityPerimeters/linkPerimeter/action permission on the remote NSP resource.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/networkSecurityPerimeters"
+              }
+            ]
+          }
+        },
+        "remotePerimeterGuid": {
+          "type": "string",
+          "description": "Remote NSP Guid with which the link gets created.",
+          "readOnly": true
+        },
+        "remotePerimeterLocation": {
+          "type": "string",
+          "description": "Remote NSP location with which the link gets created.",
+          "readOnly": true
+        },
+        "localInboundProfiles": {
+          "type": "array",
+          "description": "Local Inbound profile names to which Inbound is allowed. Use ['*'] to allow inbound to all profiles.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "localOutboundProfiles": {
+          "type": "array",
+          "description": "Local Outbound profile names from which Outbound is allowed. In current version, it is readonly property and it's value is set to ['*'] to allow outbound from all profiles. In later version, user will be able to modify it.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "remoteInboundProfiles": {
+          "type": "array",
+          "description": "Remote Inbound profile names to which Inbound is allowed. Use ['*'] to allow inbound to all profiles. This property can only be updated in auto-approval mode.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "remoteOutboundProfiles": {
+          "type": "array",
+          "description": "Remote Outbound profile names from which Outbound is allowed. In current version, it is readonly property and it's value is set to ['*'] to allow outbound from all profiles. In later version, user will be able to modify it.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "A message passed to the owner of the remote NSP link resource with this connection request. In case of Auto-approved flow, it is default to 'Auto Approved'. Restricted to 140 chars."
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/NspLinkStatus",
+          "description": "The NSP link state.",
+          "readOnly": true
+        }
+      }
+    },
+    "NspLinkReference": {
+      "type": "object",
+      "description": "The network security perimeter linkReference resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NspLinkReferenceProperties",
+          "description": "Properties of the network security perimeter linkReference resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SecurityPerimeterProxyResource"
+        }
+      ]
+    },
+    "NspLinkReferenceListResult": {
+      "type": "object",
+      "description": "The response of a NspLinkReference list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NspLinkReference items on this page",
+          "items": {
+            "$ref": "#/definitions/NspLinkReference"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NspLinkReferenceProperties": {
+      "type": "object",
+      "description": "Properties of NSP LinkReference resource.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/NspLinkProvisioningState",
+          "description": "The provisioning state of the NSP LinkReference resource.",
+          "readOnly": true
+        },
+        "remotePerimeterResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Perimeter ARM Id for the remote NSP with which the link is created.",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/networkSecurityPerimeters"
+              }
+            ]
+          }
+        },
+        "remotePerimeterGuid": {
+          "type": "string",
+          "description": "Remote NSP Guid with which the link is created.",
+          "readOnly": true
+        },
+        "remotePerimeterLocation": {
+          "type": "string",
+          "description": "Remote NSP location with which the link gets created.",
+          "readOnly": true
+        },
+        "localInboundProfiles": {
+          "type": "array",
+          "description": "Local Inbound profile names to which Inbound is allowed. Use ['*'] to allow inbound to all profiles.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "localOutboundProfiles": {
+          "type": "array",
+          "description": "Local Outbound profile names from which Outbound is allowed. In current version, it is readonly property and it's value is set to ['*'] to allow outbound from all profiles. In later version, user will be able to modify it.",
+          "uniqueItems": true,
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "remoteInboundProfiles": {
+          "type": "array",
+          "description": "Remote Inbound profile names to which Inbound is allowed. ['*'] value implies inbound is allowed to all profiles at remote perimeter. This property can only be updated from corresponding link resource present in remote perimeter.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "remoteOutboundProfiles": {
+          "type": "array",
+          "description": "Remote Outbound profile names from which Outbound is allowed. ['*'] value implies outbound is allowed from all profiles at remote perimeter. This property can only be updated from corresponding link resource present in remote perimeter.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "A message sent by the remote NSP link admin for connection request. In case of Auto-approved flow, it is default to 'Auto Approved'.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/NspLinkStatus",
+          "description": "The NSP linkReference state. It cannot be changed if link is created in auto-approval mode."
+        }
+      }
+    },
+    "NspLoggingConfiguration": {
+      "type": "object",
+      "description": "The NSP logging configuration",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NspLoggingConfigurationProperties",
+          "description": "Properties of the NSP logging configuration.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SecurityPerimeterProxyResource"
+        }
+      ]
+    },
+    "NspLoggingConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a NspLoggingConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NspLoggingConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/NspLoggingConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NspLoggingConfigurationProperties": {
+      "type": "object",
+      "description": "The NSP logging configuration properties.",
+      "properties": {
+        "enabledLogCategories": {
+          "type": "array",
+          "description": "The log categories to enable in the NSP logging configuration.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the NSP logging configuration."
+        }
+      }
+    },
+    "NspProfile": {
+      "type": "object",
+      "description": "The network security perimeter profile resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NspProfileProperties",
+          "description": "Properties of the network security perimeter profile",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SecurityPerimeterProxyResource"
+        }
+      ]
+    },
+    "NspProfileListResult": {
+      "type": "object",
+      "description": "The response of a NspProfile list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NspProfile items on this page",
+          "items": {
+            "$ref": "#/definitions/NspProfile"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NspProfileProperties": {
+      "type": "object",
+      "description": "Properties of NSP profile.",
+      "properties": {
+        "accessRulesVersion": {
+          "type": "string",
+          "description": "Version number that increases with every update to access rules within the profile.",
+          "readOnly": true
+        },
+        "diagnosticSettingsVersion": {
+          "type": "string",
+          "description": "Version number that increases with every update to diagnostic settings within the profile.",
+          "readOnly": true
+        }
+      }
+    },
+    "NspServiceTagsListResult": {
+      "type": "object",
+      "description": "Result of the request to list NSP service tags.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NspServiceTagsResource items on this page",
+          "items": {
+            "$ref": "#/definitions/NspServiceTagsResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NspServiceTagsResource": {
+      "type": "object",
+      "description": "Resource containing list of NSP service tags.",
+      "properties": {
+        "serviceTags": {
+          "type": "array",
+          "description": "NSP service tags.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PerimeterAssociableResource": {
+      "type": "object",
+      "description": "Resource that is onboarded to use network security perimeter. Also referred as perimeter associable resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PerimeterAssociableResourceProperties",
+          "description": "Properties of the perimeter associable resource.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "id": {
+          "type": "string",
+          "description": "Identifier of the perimeter associable resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        }
+      }
+    },
+    "PerimeterAssociableResourceProperties": {
+      "type": "object",
+      "description": "Properties of the perimeter associable resources.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "A friendly name for the properties of perimeter associable resources.",
+          "readOnly": true
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "Resource type/provider name.",
+          "readOnly": true
+        },
+        "publicDnsZones": {
+          "type": "array",
+          "description": "Public DNS zone names of the resources.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "serviceTags": {
+          "type": "array",
+          "description": "Service tags associated with the resource provider.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "readinessState": {
+          "$ref": "./common.json#/definitions/NspReadinessState",
+          "description": "The readiness state of the resource type for NSP support.",
+          "readOnly": true
+        },
+        "outboundSupported": {
+          "type": "boolean",
+          "description": "Indicates whether the resource type supports outbound scenario.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the PaaS resource type.",
+          "readOnly": true
+        }
+      }
+    },
+    "PerimeterAssociableResourcesListResult": {
+      "type": "object",
+      "description": "Paged collection of PerimeterAssociableResource items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PerimeterAssociableResource items on this page",
+          "items": {
+            "$ref": "#/definitions/PerimeterAssociableResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PerimeterBasedAccessRule": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "NSP id in the ARM id format.",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/networkSecurityPerimeters"
+              }
+            ]
+          }
+        },
+        "perimeterGuid": {
+          "type": "string",
+          "description": "Resource guid of the NSP supplied.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the NSP supplied.",
+          "readOnly": true
+        }
+      }
+    },
+    "SubscriptionId": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Subscription id in the ARM id format.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Resources/subscriptions"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "UpdateTagsRequest": {
+      "type": "object",
+      "description": "Update tags request.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Network security perimeter identifier.",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/networkSecurityPerimeters"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "type": "object",
+          "description": "List of tags for Network Security Perimeter",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/networkWatcher.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/networkWatcher.json
@@ -1,0 +1,5136 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "NetworkWatchers"
+    },
+    {
+      "name": "TrafficAnalytics"
+    },
+    {
+      "name": "PacketCaptures"
+    },
+    {
+      "name": "ConnectionAnalyzers"
+    },
+    {
+      "name": "ConnectionMonitors"
+    },
+    {
+      "name": "FlowLogs"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkWatchers": {
+      "get": {
+        "operationId": "NetworkWatchers_ListAll",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Gets all network watchers by subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcherListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers": {
+      "get": {
+        "operationId": "NetworkWatchers_List",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Gets all network watchers by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcherListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}": {
+      "get": {
+        "operationId": "NetworkWatchers_Get",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Gets the specified network watcher by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcher"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkWatchers_CreateOrUpdate",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Creates or updates a network watcher in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the network watcher resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcher"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkWatcher' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcher"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkWatcher' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcher"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "NetworkWatchers_UpdateTags",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Updates a network watcher tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update network watcher tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkWatcher"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkWatchers_Delete",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Deletes the specified network watcher resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/availableProvidersList": {
+      "post": {
+        "operationId": "NetworkWatchers_ListAvailableProviders",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "NOTE: This feature is currently in preview and still being tested for stability. Lists all available internet service providers for a specified Azure region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that scope the list of available providers.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AvailableProvidersListParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AvailableProvidersList"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/AvailableProvidersList"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/AvailableProvidersList"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/azureReachabilityReport": {
+      "post": {
+        "operationId": "NetworkWatchers_GetAzureReachabilityReport",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "NOTE: This feature is currently in preview and still being tested for stability. Gets the relative latency score for internet service providers from a specified location to Azure regions.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that determine Azure reachability report configuration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AzureReachabilityReportParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AzureReachabilityReport"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/AzureReachabilityReport"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/AzureReachabilityReport"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/configureFlowLog": {
+      "post": {
+        "operationId": "NetworkWatchers_SetFlowLogConfiguration",
+        "tags": [
+          "NetworkWatchers",
+          "TrafficAnalytics"
+        ],
+        "description": "Configures flow log and traffic analytics (optional) on a specified resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the configuration of flow log.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FlowLogInformation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FlowLogInformation"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/FlowLogInformation"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/FlowLogInformation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionAnalyzers": {
+      "get": {
+        "operationId": "NetworkWatchers_ConnectionAnalyzersList",
+        "tags": [
+          "ConnectionAnalyzers"
+        ],
+        "description": "Lists all connection analyzers in the specified network watcher.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionAnalyzerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionAnalyzers/{connectionAnalyzerName}": {
+      "get": {
+        "operationId": "NetworkWatchers_ConnectionAnalyzersGet",
+        "tags": [
+          "ConnectionAnalyzers"
+        ],
+        "description": "Gets the specified connection analyzer by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "connectionAnalyzerName",
+            "in": "path",
+            "description": "The name of the connection analyzer.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionAnalyzer"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkWatchers_ConnectionAnalyzersCreate",
+        "tags": [
+          "ConnectionAnalyzers"
+        ],
+        "description": "Creates or updates a connection analyzer in the specified network watcher.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "connectionAnalyzerName",
+            "in": "path",
+            "description": "The name of the connection analyzer.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters that define the operation to create a connection analyzer.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionAnalyzer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectionAnalyzer' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionAnalyzer"
+            }
+          },
+          "201": {
+            "description": "Resource 'ConnectionAnalyzer' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionAnalyzer"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ConnectionAnalyzer"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "NetworkWatchers_ConnectionAnalyzersUpdateTags",
+        "tags": [
+          "ConnectionAnalyzers"
+        ],
+        "description": "Updates the tags of the specified connection analyzer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "connectionAnalyzerName",
+            "in": "path",
+            "description": "The name of the connection analyzer.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters supplied to update connection analyzer tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionAnalyzer"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkWatchers_ConnectionAnalyzersDelete",
+        "tags": [
+          "ConnectionAnalyzers"
+        ],
+        "description": "Deletes the specified connection analyzer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "connectionAnalyzerName",
+            "in": "path",
+            "description": "The name of the connection analyzer.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionAnalyzers/{connectionAnalyzerName}/query": {
+      "post": {
+        "operationId": "NetworkWatchers_ConnectionAnalyzersQuery",
+        "tags": [
+          "ConnectionAnalyzers"
+        ],
+        "description": "Queries the specified connection analyzer for diagnostic results.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "connectionAnalyzerName",
+            "in": "path",
+            "description": "The name of the connection analyzer.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionAnalyzerQueryStatusResult"
+            }
+          },
+          "202": {
+            "description": "Operation succeeded.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ConnectionAnalyzerQueryStatusResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors": {
+      "get": {
+        "operationId": "ConnectionMonitors_List",
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "description": "Lists all connection monitors for the specified Network Watcher.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}": {
+      "get": {
+        "operationId": "ConnectionMonitors_Get",
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "description": "Gets a connection monitor by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "description": "The name of the connection monitor.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConnectionMonitors_CreateOrUpdate",
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "description": "Create or update a connection monitor.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "description": "The name of the connection monitor.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "migrate",
+            "in": "query",
+            "description": "Value indicating whether connection monitor V1 should be migrated to V2 format.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the operation to create a connection monitor.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectionMonitorResult' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorResult"
+            }
+          },
+          "201": {
+            "description": "Resource 'ConnectionMonitorResult' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorResult"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ConnectionMonitorResult"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ConnectionMonitors_UpdateTags",
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "description": "Update tags of the specified connection monitor.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "description": "The name of the connection monitor.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update connection monitor tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionMonitorResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ConnectionMonitors_Delete",
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "description": "Deletes the specified connection monitor.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "description": "The name of the connection monitor.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectionMonitors/{connectionMonitorName}/stop": {
+      "post": {
+        "operationId": "ConnectionMonitors_Stop",
+        "tags": [
+          "ConnectionMonitors"
+        ],
+        "description": "Stops the specified connection monitor.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionMonitorName",
+            "in": "path",
+            "description": "The name of the connection monitor.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/connectivityCheck": {
+      "post": {
+        "operationId": "NetworkWatchers_CheckConnectivity",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Verifies the possibility of establishing a direct TCP connection from a virtual machine to a given endpoint including another VM or an arbitrary remote server.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that determine how the connectivity check will be performed.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectivityParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectivityInformation"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/ConnectivityInformation"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ConnectivityInformation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs": {
+      "get": {
+        "operationId": "FlowLogs_List",
+        "tags": [
+          "FlowLogs"
+        ],
+        "description": "Lists all flow log resources for the specified Network Watcher.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FlowLogListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/flowLogs/{flowLogName}": {
+      "get": {
+        "operationId": "FlowLogs_Get",
+        "tags": [
+          "FlowLogs"
+        ],
+        "description": "Gets a flow log resource by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "flowLogName",
+            "in": "path",
+            "description": "The name of the flow log resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FlowLog"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "FlowLogs_CreateOrUpdate",
+        "tags": [
+          "FlowLogs"
+        ],
+        "description": "Create or update a flow log for the specified network security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "flowLogName",
+            "in": "path",
+            "description": "The name of the flow log resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the create or update flow log resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FlowLog"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'FlowLog' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FlowLog"
+            }
+          },
+          "201": {
+            "description": "Resource 'FlowLog' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/FlowLog"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/FlowLog"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "FlowLogs_UpdateTags",
+        "tags": [
+          "FlowLogs"
+        ],
+        "description": "Update tags of the specified flow log.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "flowLogName",
+            "in": "path",
+            "description": "The name of the flow log resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update flow log tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FlowLog"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "FlowLogs_Delete",
+        "tags": [
+          "FlowLogs"
+        ],
+        "description": "Deletes the specified flow log resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "flowLogName",
+            "in": "path",
+            "description": "The name of the flow log resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/ipFlowVerify": {
+      "post": {
+        "operationId": "NetworkWatchers_VerifyIPFlow",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Verify IP flow from the specified VM to a location given the currently configured NSG rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the IP flow to be verified.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VerificationIPFlowParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VerificationIPFlowResult"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/VerificationIPFlowResult"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VerificationIPFlowResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/networkConfigurationDiagnostic": {
+      "post": {
+        "operationId": "NetworkWatchers_GetNetworkConfigurationDiagnostic",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Gets Network Configuration Diagnostic data to help customers understand and debug network behavior. It provides detailed information on what security rules were applied to a specified traffic flow and the result of evaluating these rules. Customers must provide details of a flow like source, destination, protocol, etc. The API returns whether traffic was allowed or denied, the rules evaluated for the specified flow and the evaluation results.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters to get network configuration diagnostic.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkConfigurationDiagnosticParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkConfigurationDiagnosticResponse"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/NetworkConfigurationDiagnosticResponse"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/NetworkConfigurationDiagnosticResponse"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/nextHop": {
+      "post": {
+        "operationId": "NetworkWatchers_GetNextHop",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Gets the next hop from the specified VM.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the source and destination endpoint.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NextHopParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NextHopResult"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/NextHopResult"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/NextHopResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures": {
+      "get": {
+        "operationId": "PacketCaptures_List",
+        "tags": [
+          "PacketCaptures"
+        ],
+        "description": "Lists all packet capture sessions within the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PacketCaptureListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}": {
+      "get": {
+        "operationId": "PacketCaptures_Get",
+        "tags": [
+          "PacketCaptures"
+        ],
+        "description": "Gets a packet capture session by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "packetCaptureName",
+            "in": "path",
+            "description": "The name of the packet capture session.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PacketCaptureResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "PacketCaptures_Create",
+        "tags": [
+          "PacketCaptures"
+        ],
+        "description": "Create and start a packet capture on the specified VM.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "packetCaptureName",
+            "in": "path",
+            "description": "The name of the packet capture session.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the create packet capture operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PacketCapture"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Resource 'PacketCaptureResult' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PacketCaptureResult"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/PacketCaptureResult"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PacketCaptures_Delete",
+        "tags": [
+          "PacketCaptures"
+        ],
+        "description": "Deletes the specified packet capture session.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "packetCaptureName",
+            "in": "path",
+            "description": "The name of the packet capture session.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}/queryStatus": {
+      "post": {
+        "operationId": "PacketCaptures_GetStatus",
+        "tags": [
+          "PacketCaptures"
+        ],
+        "description": "Query the status of a running packet capture session.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "packetCaptureName",
+            "in": "path",
+            "description": "The name of the packet capture session.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PacketCaptureQueryStatusResult"
+            }
+          },
+          "202": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PacketCaptureQueryStatusResult"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PacketCaptureQueryStatusResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/packetCaptures/{packetCaptureName}/stop": {
+      "post": {
+        "operationId": "PacketCaptures_Stop",
+        "tags": [
+          "PacketCaptures"
+        ],
+        "description": "Stops a specified packet capture session.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "packetCaptureName",
+            "in": "path",
+            "description": "The name of the packet capture session.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryFlowLogStatus": {
+      "post": {
+        "operationId": "NetworkWatchers_GetFlowLogStatus",
+        "tags": [
+          "NetworkWatchers",
+          "TrafficAnalytics"
+        ],
+        "description": "Queries status of flow log and traffic analytics (optional) on a specified resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define a resource to query flow log and traffic analytics (optional) status.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/FlowLogStatusParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/FlowLogInformation"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/FlowLogInformation"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/FlowLogInformation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/queryTroubleshootResult": {
+      "post": {
+        "operationId": "NetworkWatchers_GetTroubleshootingResult",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Get the last completed troubleshooting result on a specified resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the resource to query the troubleshooting result.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QueryTroubleshootingParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TroubleshootingResult"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/TroubleshootingResult"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/TroubleshootingResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/securityGroupView": {
+      "post": {
+        "operationId": "NetworkWatchers_GetVMSecurityRules",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Gets the configured and effective security group rules on the specified VM.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the VM to check security groups for.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SecurityGroupViewParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityGroupViewResult"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/SecurityGroupViewResult"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/SecurityGroupViewResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/topology": {
+      "post": {
+        "operationId": "NetworkWatchers_GetTopology",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Gets the current network topology by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the representation of topology.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TopologyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Topology"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkWatchers/{networkWatcherName}/troubleshoot": {
+      "post": {
+        "operationId": "NetworkWatchers_GetTroubleshooting",
+        "tags": [
+          "NetworkWatchers"
+        ],
+        "description": "Initiate troubleshooting on a specified resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkWatcherName",
+            "in": "path",
+            "description": "The name of the network watcher.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters that define the resource to troubleshoot.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/TroubleshootingParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/TroubleshootingResult"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/TroubleshootingResult"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/TroubleshootingResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "AvailableProvidersList": {
+      "type": "object",
+      "description": "List of available countries with details.",
+      "properties": {
+        "countries": {
+          "type": "array",
+          "description": "List of available countries.",
+          "items": {
+            "$ref": "#/definitions/AvailableProvidersListCountry"
+          }
+        }
+      },
+      "required": [
+        "countries"
+      ]
+    },
+    "AvailableProvidersListCity": {
+      "type": "object",
+      "description": "City or town details.",
+      "properties": {
+        "cityName": {
+          "type": "string",
+          "description": "The city or town name."
+        },
+        "providers": {
+          "type": "array",
+          "description": "A list of Internet service providers.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AvailableProvidersListCountry": {
+      "type": "object",
+      "description": "Country details.",
+      "properties": {
+        "countryName": {
+          "type": "string",
+          "description": "The country name."
+        },
+        "providers": {
+          "type": "array",
+          "description": "A list of Internet service providers.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "states": {
+          "type": "array",
+          "description": "List of available states in the country.",
+          "items": {
+            "$ref": "#/definitions/AvailableProvidersListState"
+          }
+        }
+      }
+    },
+    "AvailableProvidersListParameters": {
+      "type": "object",
+      "description": "Constraints that determine the list of available Internet service providers.",
+      "properties": {
+        "azureLocations": {
+          "type": "array",
+          "description": "A list of Azure regions.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "country": {
+          "type": "string",
+          "description": "The country for available providers list."
+        },
+        "state": {
+          "type": "string",
+          "description": "The state for available providers list."
+        },
+        "city": {
+          "type": "string",
+          "description": "The city or town for available providers list."
+        }
+      }
+    },
+    "AvailableProvidersListState": {
+      "type": "object",
+      "description": "State details.",
+      "properties": {
+        "stateName": {
+          "type": "string",
+          "description": "The state name."
+        },
+        "providers": {
+          "type": "array",
+          "description": "A list of Internet service providers.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cities": {
+          "type": "array",
+          "description": "List of available cities or towns in the state.",
+          "items": {
+            "$ref": "#/definitions/AvailableProvidersListCity"
+          }
+        }
+      }
+    },
+    "AzureReachabilityReport": {
+      "type": "object",
+      "description": "Azure reachability report details.",
+      "properties": {
+        "aggregationLevel": {
+          "type": "string",
+          "description": "The aggregation level of Azure reachability report. Can be Country, State or City."
+        },
+        "providerLocation": {
+          "$ref": "#/definitions/AzureReachabilityReportLocation",
+          "description": "Parameters that define a geographic location."
+        },
+        "reachabilityReport": {
+          "type": "array",
+          "description": "List of Azure reachability report items.",
+          "items": {
+            "$ref": "#/definitions/AzureReachabilityReportItem"
+          }
+        }
+      },
+      "required": [
+        "aggregationLevel",
+        "providerLocation",
+        "reachabilityReport"
+      ]
+    },
+    "AzureReachabilityReportItem": {
+      "type": "object",
+      "description": "Azure reachability report details for a given provider location.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "The Internet service provider."
+        },
+        "azureLocation": {
+          "type": "string",
+          "description": "The Azure region."
+        },
+        "latencies": {
+          "type": "array",
+          "description": "List of latency details for each of the time series.",
+          "items": {
+            "$ref": "#/definitions/AzureReachabilityReportLatencyInfo"
+          }
+        }
+      }
+    },
+    "AzureReachabilityReportLatencyInfo": {
+      "type": "object",
+      "description": "Details on latency for a time series.",
+      "properties": {
+        "timeStamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The time stamp."
+        },
+        "score": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The relative latency score between 1 and 100, higher values indicating a faster connection.",
+          "minimum": 1,
+          "maximum": 100
+        }
+      }
+    },
+    "AzureReachabilityReportLocation": {
+      "type": "object",
+      "description": "Parameters that define a geographic location.",
+      "properties": {
+        "country": {
+          "type": "string",
+          "description": "The name of the country."
+        },
+        "state": {
+          "type": "string",
+          "description": "The name of the state."
+        },
+        "city": {
+          "type": "string",
+          "description": "The name of the city or town."
+        }
+      },
+      "required": [
+        "country"
+      ]
+    },
+    "AzureReachabilityReportParameters": {
+      "type": "object",
+      "description": "Geographic and time constraints for Azure reachability report.",
+      "properties": {
+        "providerLocation": {
+          "$ref": "#/definitions/AzureReachabilityReportLocation",
+          "description": "Parameters that define a geographic location."
+        },
+        "providers": {
+          "type": "array",
+          "description": "List of Internet service providers.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "azureLocations": {
+          "type": "array",
+          "description": "Optional Azure regions to scope the query to.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time for the Azure reachability report."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time for the Azure reachability report."
+        }
+      },
+      "required": [
+        "providerLocation",
+        "startTime",
+        "endTime"
+      ]
+    },
+    "ConnectionAnalyzer": {
+      "type": "object",
+      "description": "Defines a connection analyzer resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the connection analyzer.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "description": "Resource ID of the connection analyzer.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "Azure Resource Manager metadata containing createdBy and modifiedBy information.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/ConnectionAnalyzerProperties",
+          "description": "Properties of the connection analyzer."
+        }
+      },
+      "required": [
+        "location",
+        "properties"
+      ],
+      "x-ms-azure-resource": true
+    },
+    "ConnectionAnalyzerEndpoint": {
+      "type": "object",
+      "description": "Describes a source or destination endpoint of a connection analyzer.\n\nThe schema is intentionally permissive (a flat object) because the set of\nvalid fields is determined by `type` and is enforced server-side by the\nNetwork Resource Provider. The required and allowed fields per `type` are:\n\n- `VM`, `VMSS`, `BastionHost`, `ApplicationGateway`: `resourceId` is\n  required and must be the ARM resource ID of the corresponding resource\n  (a virtual machine, virtual machine scale set or VMSS instance, Azure\n  Bastion host, or Application Gateway, respectively); `address` is not\n  used; `port` is optional.\n- `ExternalAddress`: `address` is required and must be an IP address or\n  FQDN reachable from outside Azure; `resourceId` is not used; `port` is\n  optional.\n\nRequests that supply fields not allowed for the chosen `type`, or omit a\nrequired field, are rejected by the service with a validation error. This\nfollows the same convention used by `ConnectivitySource` and\n`ConnectivityDestination` on Network Watcher.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/ConnectionAnalyzerEndpointType",
+          "description": "The type of the endpoint. Determines which of `resourceId` and `address`\nare required; see the model-level documentation for the per-type contract."
+        },
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "ARM resource ID of the endpoint resource. Required when `type` is `VM`,\n`VMSS`, `BastionHost`, or `ApplicationGateway`. Not used when `type` is\n`ExternalAddress`."
+        },
+        "address": {
+          "type": "string",
+          "description": "IP address or FQDN of the endpoint. Required when `type` is\n`ExternalAddress`. Not used for the resource-typed endpoint kinds (`VM`,\n`VMSS`, `BastionHost`, `ApplicationGateway`)."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port to use for the endpoint (0-65535).",
+          "minimum": 0,
+          "maximum": 65535
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "ConnectionAnalyzerListResult": {
+      "type": "object",
+      "description": "List of connection analyzers.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Information about connection analyzers.",
+          "items": {
+            "$ref": "#/definitions/ConnectionAnalyzer"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
+        }
+      }
+    },
+    "ConnectionAnalyzerProperties": {
+      "type": "object",
+      "description": "Properties of a connection analyzer.",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/ConnectionAnalyzerEndpoint",
+          "description": "Source endpoint of the connection analyzer."
+        },
+        "destination": {
+          "$ref": "#/definitions/ConnectionAnalyzerEndpoint",
+          "description": "Destination endpoint of the connection analyzer."
+        },
+        "diagnosticOperations": {
+          "type": "array",
+          "description": "List of diagnostic operations to run.",
+          "minItems": 1,
+          "items": {
+            "$ref": "./common.json#/definitions/DiagnosticOperation"
+          }
+        },
+        "protocolSettings": {
+          "$ref": "#/definitions/ProtocolSettings",
+          "description": "Protocol-level settings."
+        },
+        "diagnosticOperationsSettings": {
+          "$ref": "#/definitions/DiagnosticOperationsSettings",
+          "description": "Per-operation diagnostic settings."
+        },
+        "expiryInDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Time-to-live (days) before the analyzer expires.",
+          "minimum": 1
+        },
+        "outputSettings": {
+          "$ref": "#/definitions/OutputSettings",
+          "description": "Output settings (e.g. storage account)."
+        },
+        "requestTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "UTC time when the connection analyzer request was received.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the connection analyzer resource.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "./common.json#/definitions/ConnectionAnalyzerStatus",
+          "description": "Current execution status of the connection analyzer.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "source",
+        "destination",
+        "diagnosticOperations"
+      ]
+    },
+    "ConnectionAnalyzerQueryStatusResult": {
+      "type": "object",
+      "description": "Status result returned when querying a connection analyzer for its diagnostic results.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource ID of the connection analyzer.",
+          "readOnly": true
+        },
+        "connectionAnalyzerStatus": {
+          "$ref": "./common.json#/definitions/ConnectionAnalyzerStatus",
+          "description": "Current execution status of the connection analyzer."
+        },
+        "error": {
+          "type": "string",
+          "description": "Error message if the connection analyzer operation failed."
+        },
+        "outputStoragePath": {
+          "type": "string",
+          "description": "Storage path where the connection analyzer output is written."
+        },
+        "expiryInUtc": {
+          "type": "string",
+          "format": "date-time",
+          "description": "UTC time when the connection analyzer expires."
+        },
+        "diagnosticOperationResults": {
+          "type": "array",
+          "description": "Results of the individual diagnostic operations.",
+          "items": {
+            "$ref": "#/definitions/DiagnosticOperationResult"
+          },
+          "x-ms-identifiers": [
+            "diagnosticOperation"
+          ]
+        }
+      }
+    },
+    "ConnectionMonitor": {
+      "type": "object",
+      "description": "Parameters that define the operation to create a connection monitor.",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Connection monitor location."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Connection monitor tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/ConnectionMonitorParameters",
+          "description": "Properties of the connection monitor.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ]
+    },
+    "ConnectionMonitorDestination": {
+      "type": "object",
+      "description": "Describes the destination of connection monitor.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "The ID of the resource used as the destination by connection monitor."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address of the connection monitor destination (IP or domain name)."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The destination port used by connection monitor.",
+          "minimum": 0,
+          "maximum": 65535
+        }
+      }
+    },
+    "ConnectionMonitorEndpoint": {
+      "type": "object",
+      "description": "Describes the connection monitor endpoint.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the connection monitor endpoint."
+        },
+        "type": {
+          "$ref": "./common.json#/definitions/EndpointType",
+          "description": "The endpoint type."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "Resource ID of the connection monitor endpoint are supported for AzureVM, AzureVMSS, AzureVNet, AzureSubnet, MMAWorkspaceMachine, MMAWorkspaceNetwork, AzureArcVM endpoint type."
+        },
+        "address": {
+          "type": "string",
+          "description": "Address of the connection monitor endpoint. Supported for AzureVM, ExternalAddress, ArcMachine, MMAWorkspaceMachine endpoint type."
+        },
+        "filter": {
+          "$ref": "#/definitions/ConnectionMonitorEndpointFilter",
+          "description": "Filter field is getting deprecated and should not be used. Instead use Include/Exclude scope fields for it."
+        },
+        "scope": {
+          "$ref": "#/definitions/ConnectionMonitorEndpointScope",
+          "description": "Endpoint scope defines which target resource to monitor in case of compound resource endpoints like VMSS, AzureSubnet, AzureVNet, MMAWorkspaceNetwork, AzureArcNetwork."
+        },
+        "coverageLevel": {
+          "$ref": "./common.json#/definitions/CoverageLevel",
+          "description": "Test coverage for the endpoint."
+        },
+        "locationDetails": {
+          "$ref": "#/definitions/ConnectionMonitorEndpointLocationDetails",
+          "description": "Location details is optional and only being used for 'AzureArcNetwork' type endpoints, which contains region details."
+        },
+        "subscriptionId": {
+          "type": "string",
+          "description": "Subscription ID for connection monitor endpoint. It's an optional parameter which is being used for 'AzureArcNetwork' type endpoint."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "ConnectionMonitorEndpointFilter": {
+      "type": "object",
+      "description": "Describes the connection monitor endpoint filter.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/ConnectionMonitorEndpointFilterType",
+          "description": "The behavior of the endpoint filter. Currently only 'Include' is supported."
+        },
+        "items": {
+          "type": "array",
+          "description": "List of items in the filter.",
+          "items": {
+            "$ref": "#/definitions/ConnectionMonitorEndpointFilterItem"
+          }
+        }
+      }
+    },
+    "ConnectionMonitorEndpointFilterItem": {
+      "type": "object",
+      "description": "Describes the connection monitor endpoint filter item.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/ConnectionMonitorEndpointFilterItemType",
+          "description": "The type of item included in the filter. Currently only 'AgentAddress' is supported."
+        },
+        "address": {
+          "type": "string",
+          "description": "The address of the filter item."
+        }
+      }
+    },
+    "ConnectionMonitorEndpointLocationDetails": {
+      "type": "object",
+      "description": "Connection monitor endpoint location details only being used for 'AzureArcNetwork' type endpoints, which contains the region details.",
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "Region for connection monitor endpoint."
+        }
+      }
+    },
+    "ConnectionMonitorEndpointScope": {
+      "type": "object",
+      "description": "Describes the connection monitor endpoint scope.",
+      "properties": {
+        "include": {
+          "type": "array",
+          "description": "List of items which needs to be included to the endpoint scope.",
+          "items": {
+            "$ref": "#/definitions/ConnectionMonitorEndpointScopeItem"
+          }
+        },
+        "exclude": {
+          "type": "array",
+          "description": "List of items which needs to be excluded from the endpoint scope.",
+          "items": {
+            "$ref": "#/definitions/ConnectionMonitorEndpointScopeItem"
+          }
+        }
+      }
+    },
+    "ConnectionMonitorEndpointScopeItem": {
+      "type": "object",
+      "description": "Describes the connection monitor endpoint scope item.",
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "The address of the endpoint item. Supported types are IPv4/IPv6 subnet mask or IPv4/IPv6 IP address."
+        }
+      }
+    },
+    "ConnectionMonitorHttpConfiguration": {
+      "type": "object",
+      "description": "Describes the HTTP configuration.",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port to connect to.",
+          "minimum": 0,
+          "maximum": 65535
+        },
+        "method": {
+          "$ref": "./common.json#/definitions/HTTPConfigurationMethod",
+          "description": "The HTTP method to use."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path component of the URI. For instance, \"/dir1/dir2\"."
+        },
+        "requestHeaders": {
+          "type": "array",
+          "description": "The HTTP headers to transmit with the request.",
+          "items": {
+            "$ref": "#/definitions/HTTPHeader"
+          }
+        },
+        "validStatusCodeRanges": {
+          "type": "array",
+          "description": "HTTP status codes to consider successful. For instance, \"2xx,301-304,418\".",
+          "items": {
+            "type": "string"
+          }
+        },
+        "preferHTTPS": {
+          "type": "boolean",
+          "description": "Value indicating whether HTTPS is preferred over HTTP in cases where the choice is not explicit."
+        }
+      }
+    },
+    "ConnectionMonitorIcmpConfiguration": {
+      "type": "object",
+      "description": "Describes the ICMP configuration.",
+      "properties": {
+        "disableTraceRoute": {
+          "type": "boolean",
+          "description": "Value indicating whether path evaluation with trace route should be disabled."
+        }
+      }
+    },
+    "ConnectionMonitorListResult": {
+      "type": "object",
+      "description": "List of connection monitors.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Information about connection monitors.",
+          "items": {
+            "$ref": "#/definitions/ConnectionMonitorResult"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
+        }
+      }
+    },
+    "ConnectionMonitorOutput": {
+      "type": "object",
+      "description": "Describes a connection monitor output destination.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/OutputType",
+          "description": "Connection monitor output destination type. Currently, only \"Workspace\" is supported."
+        },
+        "workspaceSettings": {
+          "$ref": "#/definitions/ConnectionMonitorWorkspaceSettings",
+          "description": "Describes the settings for producing output into a log analytics workspace."
+        }
+      }
+    },
+    "ConnectionMonitorParameters": {
+      "type": "object",
+      "description": "Parameters that define the operation to create a connection monitor.",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/ConnectionMonitorSource",
+          "description": "Describes the source of connection monitor."
+        },
+        "destination": {
+          "$ref": "#/definitions/ConnectionMonitorDestination",
+          "description": "Describes the destination of connection monitor."
+        },
+        "autoStart": {
+          "type": "boolean",
+          "description": "Determines if the connection monitor will start automatically once created.",
+          "default": true
+        },
+        "monitoringIntervalInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Monitoring interval in seconds.",
+          "default": 60,
+          "minimum": 30,
+          "maximum": 1800
+        },
+        "endpoints": {
+          "type": "array",
+          "description": "List of connection monitor endpoints.",
+          "items": {
+            "$ref": "#/definitions/ConnectionMonitorEndpoint"
+          }
+        },
+        "testConfigurations": {
+          "type": "array",
+          "description": "List of connection monitor test configurations.",
+          "items": {
+            "$ref": "#/definitions/ConnectionMonitorTestConfiguration"
+          }
+        },
+        "testGroups": {
+          "type": "array",
+          "description": "List of connection monitor test groups.",
+          "items": {
+            "$ref": "#/definitions/ConnectionMonitorTestGroup"
+          }
+        },
+        "outputs": {
+          "type": "array",
+          "description": "List of connection monitor outputs.",
+          "items": {
+            "$ref": "#/definitions/ConnectionMonitorOutput"
+          }
+        },
+        "notes": {
+          "type": "string",
+          "description": "Optional notes to be associated with the connection monitor."
+        }
+      }
+    },
+    "ConnectionMonitorResult": {
+      "type": "object",
+      "description": "Information about the connection monitor.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectionMonitorResultProperties",
+          "description": "Properties of the connection monitor result.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/TrackedResourceWithEtag"
+        }
+      ]
+    },
+    "ConnectionMonitorResultProperties": {
+      "type": "object",
+      "description": "Describes the properties of a connection monitor.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the connection monitor.",
+          "readOnly": true
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date and time when the connection monitor was started.",
+          "readOnly": true
+        },
+        "monitoringStatus": {
+          "type": "string",
+          "description": "The monitoring status of the connection monitor.",
+          "readOnly": true
+        },
+        "connectionMonitorType": {
+          "$ref": "./common.json#/definitions/ConnectionMonitorType",
+          "description": "Type of connection monitor.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionMonitorParameters"
+        }
+      ]
+    },
+    "ConnectionMonitorSource": {
+      "type": "object",
+      "description": "Describes the source of connection monitor.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "The ID of the resource used as the source by connection monitor."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The source port used by connection monitor.",
+          "minimum": 0,
+          "maximum": 65535
+        }
+      },
+      "required": [
+        "resourceId"
+      ]
+    },
+    "ConnectionMonitorSuccessThreshold": {
+      "type": "object",
+      "description": "Describes the threshold for declaring a test successful.",
+      "properties": {
+        "checksFailedPercent": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum percentage of failed checks permitted for a test to evaluate as successful."
+        },
+        "roundTripTimeMs": {
+          "type": "number",
+          "format": "float",
+          "description": "The maximum round-trip time in milliseconds permitted for a test to evaluate as successful."
+        }
+      }
+    },
+    "ConnectionMonitorTcpConfiguration": {
+      "type": "object",
+      "description": "Describes the TCP configuration.",
+      "properties": {
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port to connect to.",
+          "minimum": 0,
+          "maximum": 65535
+        },
+        "disableTraceRoute": {
+          "type": "boolean",
+          "description": "Value indicating whether path evaluation with trace route should be disabled."
+        },
+        "destinationPortBehavior": {
+          "$ref": "./common.json#/definitions/DestinationPortBehavior",
+          "description": "Destination port behavior."
+        }
+      }
+    },
+    "ConnectionMonitorTestConfiguration": {
+      "type": "object",
+      "description": "Describes a connection monitor test configuration.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the connection monitor test configuration."
+        },
+        "testFrequencySec": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The frequency of test evaluation, in seconds."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/ConnectionMonitorTestConfigurationProtocol",
+          "description": "The protocol to use in test evaluation."
+        },
+        "preferredIPVersion": {
+          "$ref": "./common.json#/definitions/PreferredIPVersion",
+          "description": "The preferred IP version to use in test evaluation. The connection monitor may choose to use a different version depending on other parameters."
+        },
+        "httpConfiguration": {
+          "$ref": "#/definitions/ConnectionMonitorHttpConfiguration",
+          "description": "The parameters used to perform test evaluation over HTTP."
+        },
+        "tcpConfiguration": {
+          "$ref": "#/definitions/ConnectionMonitorTcpConfiguration",
+          "description": "The parameters used to perform test evaluation over TCP."
+        },
+        "icmpConfiguration": {
+          "$ref": "#/definitions/ConnectionMonitorIcmpConfiguration",
+          "description": "The parameters used to perform test evaluation over ICMP."
+        },
+        "successThreshold": {
+          "$ref": "#/definitions/ConnectionMonitorSuccessThreshold",
+          "description": "The threshold for declaring a test successful."
+        }
+      },
+      "required": [
+        "name",
+        "protocol"
+      ]
+    },
+    "ConnectionMonitorTestGroup": {
+      "type": "object",
+      "description": "Describes the connection monitor test group.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the connection monitor test group."
+        },
+        "disable": {
+          "type": "boolean",
+          "description": "Value indicating whether test group is disabled."
+        },
+        "testConfigurations": {
+          "type": "array",
+          "description": "List of test configuration names.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sources": {
+          "type": "array",
+          "description": "List of source endpoint names.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinations": {
+          "type": "array",
+          "description": "List of destination endpoint names.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "testConfigurations",
+        "sources",
+        "destinations"
+      ]
+    },
+    "ConnectionMonitorWorkspaceSettings": {
+      "type": "object",
+      "description": "Describes the settings for producing output into a log analytics workspace.",
+      "properties": {
+        "workspaceResourceId": {
+          "type": "string",
+          "description": "Log analytics workspace resource ID."
+        }
+      }
+    },
+    "ConnectivityCheckSettings": {
+      "type": "object",
+      "description": "Settings that control how connectivity checks are performed by the connection analyzer.",
+      "properties": {
+        "generatePath": {
+          "type": "boolean",
+          "description": "Whether to generate a hop-by-hop path during the connectivity check. Default value is true.",
+          "default": true
+        },
+        "preferredIPVersion": {
+          "$ref": "./common.json#/definitions/PreferredIPVersion",
+          "description": "Preferred IP version for the connectivity check."
+        }
+      }
+    },
+    "ConnectivityDestination": {
+      "type": "object",
+      "description": "Parameters that define destination of connection.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "The ID of the resource to which a connection attempt will be made."
+        },
+        "address": {
+          "type": "string",
+          "description": "The IP address or URI the resource to which a connection attempt will be made."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Port on which check connectivity will be performed.",
+          "minimum": 0,
+          "maximum": 65535
+        }
+      }
+    },
+    "ConnectivityHop": {
+      "type": "object",
+      "description": "Information about a hop between the source and the destination.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the hop.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the hop.",
+          "readOnly": true
+        },
+        "address": {
+          "type": "string",
+          "description": "The IP address of the hop.",
+          "readOnly": true
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "The ID of the resource corresponding to this hop.",
+          "readOnly": true
+        },
+        "nextHopIds": {
+          "type": "array",
+          "description": "List of next hop identifiers.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "previousHopIds": {
+          "type": "array",
+          "description": "List of previous hop identifiers.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "links": {
+          "type": "array",
+          "description": "List of hop links.",
+          "items": {
+            "$ref": "#/definitions/HopLink"
+          },
+          "readOnly": true
+        },
+        "previousLinks": {
+          "type": "array",
+          "description": "List of previous hop links.",
+          "items": {
+            "$ref": "#/definitions/HopLink"
+          },
+          "readOnly": true
+        },
+        "issues": {
+          "type": "array",
+          "description": "List of issues.",
+          "items": {
+            "$ref": "#/definitions/ConnectivityIssue"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ConnectivityInformation": {
+      "type": "object",
+      "description": "Information on the connectivity status.",
+      "properties": {
+        "hops": {
+          "type": "array",
+          "description": "List of hops between the source and the destination.",
+          "items": {
+            "$ref": "#/definitions/ConnectivityHop"
+          },
+          "readOnly": true
+        },
+        "connectionStatus": {
+          "$ref": "./common.json#/definitions/ConnectionStatus",
+          "description": "The connection status.",
+          "readOnly": true
+        },
+        "avgLatencyInMs": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Average latency in milliseconds.",
+          "readOnly": true
+        },
+        "minLatencyInMs": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum latency in milliseconds.",
+          "readOnly": true
+        },
+        "maxLatencyInMs": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum latency in milliseconds.",
+          "readOnly": true
+        },
+        "probesSent": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of probes sent.",
+          "readOnly": true
+        },
+        "probesFailed": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of failed probes.",
+          "readOnly": true
+        }
+      }
+    },
+    "ConnectivityIssue": {
+      "type": "object",
+      "description": "Information about an issue encountered in the process of checking for connectivity.",
+      "properties": {
+        "origin": {
+          "$ref": "./common.json#/definitions/Origin",
+          "description": "The origin of the issue.",
+          "readOnly": true
+        },
+        "severity": {
+          "$ref": "./common.json#/definitions/Severity",
+          "description": "The severity of the issue.",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "./common.json#/definitions/IssueType",
+          "description": "The type of issue.",
+          "readOnly": true
+        },
+        "context": {
+          "type": "array",
+          "description": "Provides additional context on the issue.",
+          "items": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ConnectivityParameters": {
+      "type": "object",
+      "description": "Parameters that determine how the connectivity check will be performed.",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/ConnectivitySource",
+          "description": "The source of the connection."
+        },
+        "destination": {
+          "$ref": "#/definitions/ConnectivityDestination",
+          "description": "The destination of connection."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/Protocol",
+          "description": "Network protocol."
+        },
+        "protocolConfiguration": {
+          "$ref": "#/definitions/ProtocolConfiguration",
+          "description": "Configuration of the protocol."
+        },
+        "preferredIPVersion": {
+          "$ref": "./common.json#/definitions/IPVersion",
+          "description": "Preferred IP version of the connection."
+        }
+      },
+      "required": [
+        "source",
+        "destination"
+      ]
+    },
+    "ConnectivitySource": {
+      "type": "object",
+      "description": "Parameters that define the source of the connection.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "The ID of the resource from which a connectivity check will be initiated."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The source port from which a connectivity check will be performed.",
+          "minimum": 0,
+          "maximum": 65535
+        }
+      },
+      "required": [
+        "resourceId"
+      ]
+    },
+    "DiagnosticOperationResult": {
+      "type": "object",
+      "description": "Result of an individual diagnostic operation run by a connection analyzer.",
+      "properties": {
+        "diagnosticOperation": {
+          "$ref": "./common.json#/definitions/DiagnosticOperation",
+          "description": "The diagnostic operation that was run."
+        },
+        "error": {
+          "type": "string",
+          "description": "Error encountered while running the diagnostic operation, if any."
+        },
+        "result": {
+          "type": "string",
+          "description": "The result of the diagnostic operation, serialized as a JSON string.\n\nThe payload shape varies by `diagnosticOperation`. For example, a\n`ConnectivityCheck` operation returns a JSON object such as\n`{ \"ConnectivityStatus\": \"Reachable\" }`. Consumers should parse this\nstring as JSON according to the corresponding diagnostic operation."
+        }
+      },
+      "required": [
+        "diagnosticOperation"
+      ]
+    },
+    "DiagnosticOperationsSettings": {
+      "type": "object",
+      "description": "Diagnostic settings to provide for the ConnectionAnalyzer operation.",
+      "properties": {
+        "connectivityCheckSettings": {
+          "$ref": "#/definitions/ConnectivityCheckSettings",
+          "description": "Settings for the ConnectivityCheck diagnostic operation."
+        },
+        "expressRouteDiagnosticsSettings": {
+          "$ref": "#/definitions/ExpressRouteDiagnosticsSettings",
+          "description": "Settings for the ExpressRouteDiagnostic diagnostic operation."
+        }
+      }
+    },
+    "ErrorResponse": {
+      "type": "object",
+      "description": "The error object.",
+      "properties": {
+        "error": {
+          "$ref": "./common.json#/definitions/ErrorDetails",
+          "title": "Error",
+          "description": "The error details object."
+        }
+      }
+    },
+    "EvaluatedNetworkSecurityGroup": {
+      "type": "object",
+      "description": "Results of network security group evaluation.",
+      "properties": {
+        "networkSecurityGroupId": {
+          "type": "string",
+          "description": "Network security group ID."
+        },
+        "appliedTo": {
+          "type": "string",
+          "description": "Resource ID of nic or subnet to which network security group is applied."
+        },
+        "matchedRule": {
+          "$ref": "#/definitions/MatchedRule",
+          "description": "Matched network security rule."
+        },
+        "rulesEvaluationResult": {
+          "type": "array",
+          "description": "List of network security rules evaluation results.",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityRulesEvaluationResult"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ExpressRouteDiagnosticsSettings": {
+      "type": "object",
+      "description": "Settings that control how Express Route diagnostics are performed by the connection analyzer.",
+      "properties": {
+        "erCircuitResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the Express Route circuit.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/expressRouteCircuits"
+              }
+            ]
+          }
+        },
+        "bandwidth": {
+          "type": "number",
+          "format": "float",
+          "description": "Bandwidth (in Mbps) to use for the Express Route diagnostic."
+        }
+      }
+    },
+    "FlowLog": {
+      "type": "object",
+      "description": "A flow log resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/FlowLogPropertiesFormat",
+          "description": "Properties of the flow log.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "identity": {
+          "$ref": "./common.json#/definitions/ManagedServiceIdentity",
+          "description": "FlowLog resource Managed Identity"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "FlowLogFormatParameters": {
+      "type": "object",
+      "description": "Parameters that define the flow log format.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/FlowLogFormatType",
+          "description": "The file type of flow log."
+        },
+        "version": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The version (revision) of the flow log.",
+          "default": 0
+        }
+      }
+    },
+    "FlowLogInformation": {
+      "type": "object",
+      "description": "Information on the configuration of flow log and traffic analytics (optional) .",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "The ID of the resource to configure for flow log and traffic analytics (optional) ."
+        },
+        "properties": {
+          "$ref": "#/definitions/FlowLogProperties",
+          "description": "Properties of the flow log.",
+          "x-ms-client-flatten": true
+        },
+        "flowAnalyticsConfiguration": {
+          "$ref": "#/definitions/TrafficAnalyticsProperties",
+          "description": "Parameters that define the configuration of traffic analytics."
+        },
+        "identity": {
+          "$ref": "./common.json#/definitions/ManagedServiceIdentity",
+          "description": "FlowLog resource Managed Identity"
+        }
+      },
+      "required": [
+        "targetResourceId",
+        "properties"
+      ]
+    },
+    "FlowLogListResult": {
+      "type": "object",
+      "description": "The response of a FlowLog list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The FlowLog items on this page",
+          "items": {
+            "$ref": "#/definitions/FlowLog"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "FlowLogProperties": {
+      "type": "object",
+      "description": "Parameters that define the configuration of flow log.",
+      "properties": {
+        "storageId": {
+          "type": "string",
+          "description": "ID of the storage account which is used to store the flow log."
+        },
+        "enabledFilteringCriteria": {
+          "type": "string",
+          "description": "Optional field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged."
+        },
+        "recordTypes": {
+          "type": "string",
+          "description": "Optional field to filter network traffic logs based on flow states. Value of this field could be any comma separated combination string of letters B,C,E or D. B represents Begin, when a flow is created. C represents Continue for an ongoing flow generated at every five-minute interval. E represents End, when a flow is terminated. D represents Deny, when a flow is denied. If not specified, all network traffic will be logged."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Flag to enable/disable flow logging."
+        },
+        "retentionPolicy": {
+          "$ref": "#/definitions/RetentionPolicyParameters",
+          "description": "Parameters that define the retention policy for flow log."
+        },
+        "format": {
+          "$ref": "#/definitions/FlowLogFormatParameters",
+          "description": "Parameters that define the flow log format."
+        }
+      },
+      "required": [
+        "storageId",
+        "enabled"
+      ]
+    },
+    "FlowLogPropertiesFormat": {
+      "type": "object",
+      "description": "Parameters that define the configuration of flow log.",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "ID of network security group to which flow log will be applied."
+        },
+        "targetResourceGuid": {
+          "type": "string",
+          "description": "Guid of network security group to which flow log will be applied.",
+          "readOnly": true
+        },
+        "storageId": {
+          "type": "string",
+          "description": "ID of the storage account which is used to store the flow log."
+        },
+        "enabledFilteringCriteria": {
+          "type": "string",
+          "description": "Optional field to filter network traffic logs based on SrcIP, SrcPort, DstIP, DstPort, Protocol, Encryption, Direction and Action. If not specified, all network traffic will be logged."
+        },
+        "recordTypes": {
+          "type": "string",
+          "description": "Optional field to filter network traffic logs based on flow states. Value of this field could be any comma separated combination string of letters B,C,E or D. B represents Begin, when a flow is created. C represents Continue for an ongoing flow generated at every five-minute interval. E represents End, when a flow is terminated. D represents Deny, when a flow is denied. If not specified, all network traffic will be logged."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Flag to enable/disable flow logging."
+        },
+        "retentionPolicy": {
+          "$ref": "#/definitions/RetentionPolicyParameters",
+          "description": "Parameters that define the retention policy for flow log."
+        },
+        "format": {
+          "$ref": "#/definitions/FlowLogFormatParameters",
+          "description": "Parameters that define the flow log format."
+        },
+        "flowAnalyticsConfiguration": {
+          "$ref": "#/definitions/TrafficAnalyticsProperties",
+          "description": "Parameters that define the configuration of traffic analytics."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the flow log.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "targetResourceId",
+        "storageId"
+      ]
+    },
+    "FlowLogStatusParameters": {
+      "type": "object",
+      "description": "Parameters that define a resource to query flow log and traffic analytics (optional) status.",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "The target resource where getting the flow log and traffic analytics (optional) status."
+        }
+      },
+      "required": [
+        "targetResourceId"
+      ]
+    },
+    "HTTPConfiguration": {
+      "type": "object",
+      "description": "HTTP configuration of the connectivity check.",
+      "properties": {
+        "method": {
+          "$ref": "./common.json#/definitions/HTTPMethod",
+          "description": "HTTP method."
+        },
+        "headers": {
+          "type": "array",
+          "description": "List of HTTP headers.",
+          "items": {
+            "$ref": "#/definitions/HTTPHeader"
+          }
+        },
+        "validStatusCodes": {
+          "type": "array",
+          "description": "Valid status codes.",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    },
+    "HTTPHeader": {
+      "type": "object",
+      "description": "The HTTP header.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name in HTTP header."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value in HTTP header."
+        }
+      }
+    },
+    "HopLink": {
+      "type": "object",
+      "description": "Hop link.",
+      "properties": {
+        "nextHopId": {
+          "type": "string",
+          "description": "The ID of the next hop.",
+          "readOnly": true
+        },
+        "linkType": {
+          "type": "string",
+          "description": "Link type.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/HopLinkProperties",
+          "description": "Hop link properties.",
+          "x-ms-client-flatten": true
+        },
+        "issues": {
+          "type": "array",
+          "description": "List of issues.",
+          "items": {
+            "$ref": "#/definitions/ConnectivityIssue"
+          },
+          "readOnly": true
+        },
+        "context": {
+          "type": "object",
+          "description": "Provides additional context on links.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "Resource ID.",
+          "readOnly": true
+        }
+      }
+    },
+    "HopLinkProperties": {
+      "type": "object",
+      "description": "Hop link properties.",
+      "properties": {
+        "roundTripTimeMin": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Minimum roundtrip time in milliseconds.",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "readOnly": true
+        },
+        "roundTripTimeAvg": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Average roundtrip time in milliseconds.",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "readOnly": true
+        },
+        "roundTripTimeMax": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Maximum roundtrip time in milliseconds.",
+          "minimum": 0,
+          "maximum": 4294967295,
+          "readOnly": true
+        }
+      }
+    },
+    "MatchedRule": {
+      "type": "object",
+      "description": "Matched rule.",
+      "properties": {
+        "ruleName": {
+          "type": "string",
+          "description": "Name of the matched network security rule."
+        },
+        "action": {
+          "type": "string",
+          "description": "The network traffic is allowed or denied. Possible values are 'Allow' and 'Deny'."
+        }
+      }
+    },
+    "NetworkConfigurationDiagnosticParameters": {
+      "type": "object",
+      "description": "Parameters to get network configuration diagnostic.",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "The ID of the target resource to perform network configuration diagnostic. Valid options are VM, NetworkInterface, VMSS/NetworkInterface and Application Gateway."
+        },
+        "verbosityLevel": {
+          "$ref": "./common.json#/definitions/VerbosityLevel",
+          "description": "Verbosity level."
+        },
+        "profiles": {
+          "type": "array",
+          "description": "List of network configuration diagnostic profiles.",
+          "items": {
+            "$ref": "#/definitions/NetworkConfigurationDiagnosticProfile"
+          }
+        }
+      },
+      "required": [
+        "targetResourceId",
+        "profiles"
+      ]
+    },
+    "NetworkConfigurationDiagnosticProfile": {
+      "type": "object",
+      "description": "Parameters to compare with network configuration.",
+      "properties": {
+        "direction": {
+          "$ref": "./common.json#/definitions/Direction",
+          "description": "The direction of the traffic."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Protocol to be verified on. Accepted values are '*', TCP, UDP."
+        },
+        "source": {
+          "type": "string",
+          "description": "Traffic source. Accepted values are '*', IP Address/CIDR, Service Tag."
+        },
+        "destination": {
+          "type": "string",
+          "description": "Traffic destination. Accepted values are: '*', IP Address/CIDR, Service Tag."
+        },
+        "destinationPort": {
+          "type": "string",
+          "description": "Traffic destination port. Accepted values are '*' and a single port in the range (0 - 65535)."
+        }
+      },
+      "required": [
+        "direction",
+        "protocol",
+        "source",
+        "destination",
+        "destinationPort"
+      ]
+    },
+    "NetworkConfigurationDiagnosticResponse": {
+      "type": "object",
+      "description": "Results of network configuration diagnostic on the target resource.",
+      "properties": {
+        "results": {
+          "type": "array",
+          "description": "List of network configuration diagnostic results.",
+          "items": {
+            "$ref": "#/definitions/NetworkConfigurationDiagnosticResult"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkConfigurationDiagnosticResult": {
+      "type": "object",
+      "description": "Network configuration diagnostic result corresponded to provided traffic query.",
+      "properties": {
+        "profile": {
+          "$ref": "#/definitions/NetworkConfigurationDiagnosticProfile",
+          "description": "Network configuration diagnostic profile."
+        },
+        "networkSecurityGroupResult": {
+          "$ref": "#/definitions/NetworkSecurityGroupResult",
+          "description": "Network security group result."
+        }
+      }
+    },
+    "NetworkInterfaceAssociation": {
+      "type": "object",
+      "description": "Network interface and its custom security rules.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Network interface ID.",
+          "readOnly": true
+        },
+        "securityRules": {
+          "type": "array",
+          "description": "Collection of custom security rules.",
+          "items": {
+            "$ref": "./virtualNetwork.json#/definitions/SecurityRule"
+          }
+        }
+      }
+    },
+    "NetworkSecurityGroupResult": {
+      "type": "object",
+      "description": "Network configuration diagnostic result corresponded provided traffic query.",
+      "properties": {
+        "securityRuleAccessResult": {
+          "$ref": "./common.json#/definitions/SecurityRuleAccess",
+          "description": "The network traffic is allowed or denied."
+        },
+        "evaluatedNetworkSecurityGroups": {
+          "type": "array",
+          "description": "List of results network security groups diagnostic.",
+          "items": {
+            "$ref": "#/definitions/EvaluatedNetworkSecurityGroup"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkSecurityRulesEvaluationResult": {
+      "type": "object",
+      "description": "Network security rules evaluation result.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the network security rule."
+        },
+        "protocolMatched": {
+          "type": "boolean",
+          "description": "Value indicating whether protocol is matched."
+        },
+        "sourceMatched": {
+          "type": "boolean",
+          "description": "Value indicating whether source is matched."
+        },
+        "sourcePortMatched": {
+          "type": "boolean",
+          "description": "Value indicating whether source port is matched."
+        },
+        "destinationMatched": {
+          "type": "boolean",
+          "description": "Value indicating whether destination is matched."
+        },
+        "destinationPortMatched": {
+          "type": "boolean",
+          "description": "Value indicating whether destination port is matched."
+        }
+      }
+    },
+    "NetworkWatcher": {
+      "type": "object",
+      "description": "Network watcher in a resource group.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkWatcherPropertiesFormat",
+          "description": "Properties of the network watcher.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "NetworkWatcherListResult": {
+      "type": "object",
+      "description": "Response for ListNetworkWatchers API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of network watcher resources.",
+          "items": {
+            "$ref": "#/definitions/NetworkWatcher"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
+        }
+      }
+    },
+    "NetworkWatcherPropertiesFormat": {
+      "type": "object",
+      "description": "The network watcher properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the network watcher resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "NextHopParameters": {
+      "type": "object",
+      "description": "Parameters that define the source and destination endpoint.",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "The resource identifier of the target resource against which the action is to be performed."
+        },
+        "sourceIPAddress": {
+          "type": "string",
+          "description": "The source IP address."
+        },
+        "destinationIPAddress": {
+          "type": "string",
+          "description": "The destination IP address."
+        },
+        "targetNicResourceId": {
+          "type": "string",
+          "description": "The NIC ID. (If VM has multiple NICs and IP forwarding is enabled on any of the nics, then this parameter must be specified. Otherwise optional)."
+        }
+      },
+      "required": [
+        "targetResourceId",
+        "sourceIPAddress",
+        "destinationIPAddress"
+      ]
+    },
+    "NextHopResult": {
+      "type": "object",
+      "description": "The information about next hop from the specified VM.",
+      "properties": {
+        "nextHopType": {
+          "$ref": "./common.json#/definitions/NextHopType",
+          "description": "Next hop type."
+        },
+        "nextHopIpAddress": {
+          "type": "string",
+          "description": "Next hop IP Address."
+        },
+        "routeTableId": {
+          "type": "string",
+          "description": "The resource identifier for the route table associated with the route being returned. If the route being returned does not correspond to any user created routes then this field will be the string 'System Route'."
+        }
+      }
+    },
+    "OutputSettings": {
+      "type": "object",
+      "description": "Settings that control where the connection analyzer writes its results.",
+      "properties": {
+        "storageAccountSettings": {
+          "$ref": "#/definitions/StorageAccountSettings",
+          "description": "Storage account where output is written."
+        }
+      }
+    },
+    "PacketCapture": {
+      "type": "object",
+      "description": "Parameters that define the create packet capture operation.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PacketCaptureParameters",
+          "description": "Properties of the packet capture.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "properties"
+      ]
+    },
+    "PacketCaptureFilter": {
+      "type": "object",
+      "description": "Filter that is applied to packet capture request. Multiple filters can be applied.",
+      "properties": {
+        "protocol": {
+          "type": "string",
+          "description": "Protocol to be filtered on.",
+          "default": "Any",
+          "enum": [
+            "TCP",
+            "UDP",
+            "Any"
+          ],
+          "x-ms-enum": {
+            "name": "PcProtocol",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "TCP",
+                "value": "TCP",
+                "description": "TCP"
+              },
+              {
+                "name": "UDP",
+                "value": "UDP",
+                "description": "UDP"
+              },
+              {
+                "name": "Any",
+                "value": "Any",
+                "description": "Any"
+              }
+            ]
+          }
+        },
+        "localIPAddress": {
+          "type": "string",
+          "description": "Local IP Address to be filtered on. Notation: \"127.0.0.1\" for single address entry. \"127.0.0.1-127.0.0.255\" for range. \"127.0.0.1;127.0.0.5\"? for multiple entries. Multiple ranges not currently supported. Mixing ranges with multiple entries not currently supported. Default = null."
+        },
+        "remoteIPAddress": {
+          "type": "string",
+          "description": "Local IP Address to be filtered on. Notation: \"127.0.0.1\" for single address entry. \"127.0.0.1-127.0.0.255\" for range. \"127.0.0.1;127.0.0.5;\" for multiple entries. Multiple ranges not currently supported. Mixing ranges with multiple entries not currently supported. Default = null."
+        },
+        "localPort": {
+          "type": "string",
+          "description": "Local port to be filtered on. Notation: \"80\" for single port entry.\"80-85\" for range. \"80;443;\" for multiple entries. Multiple ranges not currently supported. Mixing ranges with multiple entries not currently supported. Default = null."
+        },
+        "remotePort": {
+          "type": "string",
+          "description": "Remote port to be filtered on. Notation: \"80\" for single port entry.\"80-85\" for range. \"80;443;\" for multiple entries. Multiple ranges not currently supported. Mixing ranges with multiple entries not currently supported. Default = null."
+        }
+      }
+    },
+    "PacketCaptureListResult": {
+      "type": "object",
+      "description": "List of packet capture sessions.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Information about packet capture sessions.",
+          "items": {
+            "$ref": "#/definitions/PacketCaptureResult"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of results."
+        }
+      }
+    },
+    "PacketCaptureMachineScope": {
+      "type": "object",
+      "description": "A list of AzureVMSS instances which can be included or excluded to run packet capture. If both included and excluded are empty, then the packet capture will run on all instances of AzureVMSS.",
+      "properties": {
+        "include": {
+          "type": "array",
+          "description": "List of AzureVMSS instances to run packet capture on.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "exclude": {
+          "type": "array",
+          "description": "List of AzureVMSS instances which has to be excluded from the AzureVMSS from running packet capture.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PacketCaptureParameters": {
+      "type": "object",
+      "description": "Parameters that define the create packet capture operation.",
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "The ID of the targeted resource, only AzureVM and AzureVMSS as target type are currently supported."
+        },
+        "scope": {
+          "$ref": "#/definitions/PacketCaptureMachineScope",
+          "description": "A list of AzureVMSS instances which can be included or excluded to run packet capture. If both included and excluded are empty, then the packet capture will run on all instances of AzureVMSS."
+        },
+        "targetType": {
+          "$ref": "./common.json#/definitions/PacketCaptureTargetType",
+          "description": "Target type of the resource provided."
+        },
+        "bytesToCapturePerPacket": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of bytes captured per packet, the remaining bytes are truncated.",
+          "default": 0,
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "totalBytesPerSession": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Maximum size of the capture output.",
+          "default": 1073741824,
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "timeLimitInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum duration of the capture session in seconds.",
+          "default": 18000,
+          "minimum": 0,
+          "maximum": 18000
+        },
+        "storageLocation": {
+          "$ref": "#/definitions/PacketCaptureStorageLocation",
+          "description": "The storage location for a packet capture session."
+        },
+        "filters": {
+          "type": "array",
+          "description": "A list of packet capture filters.",
+          "items": {
+            "$ref": "#/definitions/PacketCaptureFilter"
+          }
+        },
+        "continuousCapture": {
+          "type": "boolean",
+          "description": "This continuous capture is a nullable boolean, which can hold 'null', 'true' or 'false' value. If we do not pass this parameter, it would be consider as 'null', default value is 'null'."
+        },
+        "captureSettings": {
+          "$ref": "#/definitions/PacketCaptureSettings",
+          "description": "The capture setting holds the 'FileCount', 'FileSizeInBytes', 'SessionTimeLimitInSeconds' values."
+        }
+      },
+      "required": [
+        "target",
+        "storageLocation"
+      ]
+    },
+    "PacketCaptureQueryStatusResult": {
+      "type": "object",
+      "description": "Status of packet capture session.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the packet capture resource."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the packet capture resource."
+        },
+        "captureStartTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time of the packet capture session."
+        },
+        "packetCaptureStatus": {
+          "$ref": "./common.json#/definitions/PcStatus",
+          "description": "The status of the packet capture session."
+        },
+        "stopReason": {
+          "type": "string",
+          "description": "The reason the current packet capture session was stopped."
+        },
+        "packetCaptureError": {
+          "type": "array",
+          "description": "List of errors of packet capture session.",
+          "items": {
+            "$ref": "./common.json#/definitions/PcError"
+          }
+        }
+      }
+    },
+    "PacketCaptureResult": {
+      "type": "object",
+      "description": "Information about packet capture session.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the packet capture session.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "description": "ID of the packet capture operation.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/PacketCaptureResultProperties",
+          "description": "Properties of the packet capture result.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "PacketCaptureResultProperties": {
+      "type": "object",
+      "description": "The properties of a packet capture session.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the packet capture session.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PacketCaptureParameters"
+        }
+      ]
+    },
+    "PacketCaptureSettings": {
+      "type": "object",
+      "description": "The storage location for a packet capture session.",
+      "properties": {
+        "fileCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of file count. Default value of count is 10 and maximum number is 10000.",
+          "default": 10,
+          "minimum": 0,
+          "maximum": 10000
+        },
+        "fileSizeInBytes": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Number of bytes captured per packet. Default value in bytes 104857600 (100MB) and maximum in bytes 4294967295 (4GB).",
+          "default": 104857600,
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "sessionTimeLimitInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum duration of the capture session in seconds is 604800s (7 days) for a file. Default value in second 86400s (1 day).",
+          "default": 86400,
+          "minimum": 0,
+          "maximum": 604800
+        }
+      }
+    },
+    "PacketCaptureStorageLocation": {
+      "type": "object",
+      "description": "The storage location for a packet capture session.",
+      "properties": {
+        "storageId": {
+          "type": "string",
+          "description": "The ID of the storage account to save the packet capture session. Required if no localPath or filePath is provided."
+        },
+        "storagePath": {
+          "type": "string",
+          "description": "The URI of the storage path to save the packet capture. Must be a well-formed URI describing the location to save the packet capture."
+        },
+        "filePath": {
+          "type": "string",
+          "description": "This path is invalid if 'Continuous Capture' is provided with 'true' or 'false'. A valid local path on the targeting VM. Must include the name of the capture file (*.cap). For linux virtual machine it must start with /var/captures. Required if no storage ID is provided, otherwise optional."
+        },
+        "localPath": {
+          "type": "string",
+          "description": "This path is valid if 'Continuous Capture' is provided with 'true' or 'false' and required if no storage ID is provided, otherwise optional. Must include the name of the capture file (*.cap). For linux virtual machine it must start with /var/captures."
+        }
+      }
+    },
+    "ProtocolConfiguration": {
+      "type": "object",
+      "description": "Configuration of the protocol.",
+      "properties": {
+        "HTTPConfiguration": {
+          "$ref": "#/definitions/HTTPConfiguration",
+          "description": "HTTP configuration of the connectivity check."
+        }
+      }
+    },
+    "ProtocolSettings": {
+      "type": "object",
+      "description": "Protocol-level settings for the connection analyzer.",
+      "properties": {
+        "protocol": {
+          "$ref": "./common.json#/definitions/Protocol",
+          "description": "Network protocol."
+        },
+        "httpConfiguration": {
+          "$ref": "#/definitions/HTTPConfiguration",
+          "description": "HTTP configuration (used when protocol is Http or Https)."
+        }
+      }
+    },
+    "QueryTroubleshootingParameters": {
+      "type": "object",
+      "description": "Parameters that define the resource to query the troubleshooting result.",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "The target resource ID to query the troubleshooting result."
+        }
+      },
+      "required": [
+        "targetResourceId"
+      ]
+    },
+    "RetentionPolicyParameters": {
+      "type": "object",
+      "description": "Parameters that define the retention policy for flow log.",
+      "properties": {
+        "days": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of days to retain flow log records.",
+          "default": 0
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Flag to enable/disable retention.",
+          "default": false
+        }
+      }
+    },
+    "SecurityGroupNetworkInterface": {
+      "type": "object",
+      "description": "Network interface and all its associated security rules.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "ID of the network interface."
+        },
+        "securityRuleAssociations": {
+          "$ref": "#/definitions/SecurityRuleAssociations",
+          "description": "All security rules associated with the network interface."
+        }
+      }
+    },
+    "SecurityGroupViewParameters": {
+      "type": "object",
+      "description": "Parameters that define the VM to check security groups for.",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "ID of the target VM."
+        }
+      },
+      "required": [
+        "targetResourceId"
+      ]
+    },
+    "SecurityGroupViewResult": {
+      "type": "object",
+      "description": "The information about security rules applied to the specified VM.",
+      "properties": {
+        "networkInterfaces": {
+          "type": "array",
+          "description": "List of network interfaces on the specified VM.",
+          "items": {
+            "$ref": "#/definitions/SecurityGroupNetworkInterface"
+          }
+        }
+      }
+    },
+    "SecurityRuleAssociations": {
+      "type": "object",
+      "description": "All security rules associated with the network interface.",
+      "properties": {
+        "networkInterfaceAssociation": {
+          "$ref": "#/definitions/NetworkInterfaceAssociation",
+          "description": "Network interface and it's custom security rules."
+        },
+        "subnetAssociation": {
+          "$ref": "#/definitions/SubnetAssociation",
+          "description": "Subnet and it's custom security rules."
+        },
+        "defaultSecurityRules": {
+          "type": "array",
+          "description": "Collection of default security rules of the network security group.",
+          "items": {
+            "$ref": "./virtualNetwork.json#/definitions/SecurityRule"
+          }
+        },
+        "effectiveSecurityRules": {
+          "type": "array",
+          "description": "Collection of effective security rules.",
+          "items": {
+            "$ref": "./virtualNetwork.json#/definitions/EffectiveNetworkSecurityRule"
+          }
+        }
+      }
+    },
+    "StorageAccountSettings": {
+      "type": "object",
+      "description": "Storage account where the connection analyzer writes its output.",
+      "properties": {
+        "storageAccountId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the storage account.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Storage/storageAccounts"
+              }
+            ]
+          }
+        },
+        "path": {
+          "type": "string",
+          "description": "Sub-path within the storage account where results are written."
+        }
+      },
+      "required": [
+        "storageAccountId"
+      ]
+    },
+    "SubnetAssociation": {
+      "type": "object",
+      "description": "Subnet and it's custom security rules.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Subnet ID.",
+          "readOnly": true
+        },
+        "securityRules": {
+          "type": "array",
+          "description": "Collection of custom security rules.",
+          "items": {
+            "$ref": "./virtualNetwork.json#/definitions/SecurityRule"
+          }
+        }
+      }
+    },
+    "Topology": {
+      "type": "object",
+      "description": "Topology of the specified resource group.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "GUID representing the operation id.",
+          "readOnly": true
+        },
+        "createdDateTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The datetime when the topology was initially created for the resource group.",
+          "readOnly": true
+        },
+        "lastModified": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The datetime when the topology was last modified.",
+          "readOnly": true
+        },
+        "resources": {
+          "type": "array",
+          "description": "A list of topology resources.",
+          "items": {
+            "$ref": "#/definitions/TopologyResource"
+          }
+        }
+      }
+    },
+    "TopologyAssociation": {
+      "type": "object",
+      "description": "Resources that have an association with the parent resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is associated with the parent resource."
+        },
+        "resourceId": {
+          "type": "string",
+          "description": "The ID of the resource that is associated with the parent resource."
+        },
+        "associationType": {
+          "$ref": "./common.json#/definitions/AssociationType",
+          "description": "The association type of the child resource to the parent resource."
+        }
+      }
+    },
+    "TopologyParameters": {
+      "type": "object",
+      "description": "Parameters that define the representation of topology.",
+      "properties": {
+        "targetResourceGroupName": {
+          "type": "string",
+          "description": "The name of the target resource group to perform topology on."
+        },
+        "targetVirtualNetwork": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the Virtual Network resource."
+        },
+        "targetSubnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the Subnet resource."
+        }
+      }
+    },
+    "TopologyResource": {
+      "type": "object",
+      "description": "The network resource topology information for the given resource group.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource."
+        },
+        "id": {
+          "type": "string",
+          "description": "ID of the resource."
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location."
+        },
+        "associations": {
+          "type": "array",
+          "description": "Holds the associations the resource has with other resources in the resource group.",
+          "items": {
+            "$ref": "#/definitions/TopologyAssociation"
+          }
+        }
+      }
+    },
+    "TrafficAnalyticsConfigurationProperties": {
+      "type": "object",
+      "description": "Parameters that define the configuration of traffic analytics.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Flag to enable/disable traffic analytics."
+        },
+        "workspaceId": {
+          "type": "string",
+          "description": "The resource guid of the attached workspace."
+        },
+        "workspaceRegion": {
+          "type": "string",
+          "description": "The location of the attached workspace."
+        },
+        "workspaceResourceId": {
+          "type": "string",
+          "description": "Resource Id of the attached workspace."
+        },
+        "trafficAnalyticsInterval": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The interval in minutes which would decide how frequently TA service should do flow analytics."
+        }
+      }
+    },
+    "TrafficAnalyticsProperties": {
+      "type": "object",
+      "description": "Parameters that define the configuration of traffic analytics.",
+      "properties": {
+        "networkWatcherFlowAnalyticsConfiguration": {
+          "$ref": "#/definitions/TrafficAnalyticsConfigurationProperties",
+          "description": "Parameters that define the configuration of traffic analytics."
+        }
+      }
+    },
+    "TroubleshootingDetails": {
+      "type": "object",
+      "description": "Information gained from troubleshooting of specified resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The id of the get troubleshoot operation."
+        },
+        "reasonType": {
+          "type": "string",
+          "description": "Reason type of failure."
+        },
+        "summary": {
+          "type": "string",
+          "description": "A summary of troubleshooting."
+        },
+        "detail": {
+          "type": "string",
+          "description": "Details on troubleshooting results."
+        },
+        "recommendedActions": {
+          "type": "array",
+          "description": "List of recommended actions.",
+          "items": {
+            "$ref": "#/definitions/TroubleshootingRecommendedActions"
+          }
+        }
+      }
+    },
+    "TroubleshootingParameters": {
+      "type": "object",
+      "description": "Parameters that define the resource to troubleshoot.",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "The target resource to troubleshoot."
+        },
+        "properties": {
+          "$ref": "#/definitions/TroubleshootingProperties",
+          "description": "Properties of the troubleshooting resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "required": [
+        "targetResourceId",
+        "properties"
+      ]
+    },
+    "TroubleshootingProperties": {
+      "type": "object",
+      "description": "Storage location provided for troubleshoot.",
+      "properties": {
+        "storageId": {
+          "type": "string",
+          "description": "The ID for the storage account to save the troubleshoot result."
+        },
+        "storagePath": {
+          "type": "string",
+          "description": "The path to the blob to save the troubleshoot result in."
+        }
+      },
+      "required": [
+        "storageId",
+        "storagePath"
+      ]
+    },
+    "TroubleshootingRecommendedActions": {
+      "type": "object",
+      "description": "Recommended actions based on discovered issues.",
+      "properties": {
+        "actionId": {
+          "type": "string",
+          "description": "ID of the recommended action."
+        },
+        "actionText": {
+          "type": "string",
+          "description": "Description of recommended actions."
+        },
+        "actionUri": {
+          "type": "string",
+          "description": "The uri linking to a documentation for the recommended troubleshooting actions."
+        },
+        "actionUriText": {
+          "type": "string",
+          "description": "The information from the URI for the recommended troubleshooting actions."
+        }
+      }
+    },
+    "TroubleshootingResult": {
+      "type": "object",
+      "description": "Troubleshooting information gained from specified resource.",
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The start time of the troubleshooting."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The end time of the troubleshooting."
+        },
+        "code": {
+          "type": "string",
+          "description": "The result code of the troubleshooting."
+        },
+        "results": {
+          "type": "array",
+          "description": "Information from troubleshooting.",
+          "items": {
+            "$ref": "#/definitions/TroubleshootingDetails"
+          }
+        }
+      }
+    },
+    "VerificationIPFlowParameters": {
+      "type": "object",
+      "description": "Parameters that define the IP flow to be verified.",
+      "properties": {
+        "targetResourceId": {
+          "type": "string",
+          "description": "The ID of the target resource to perform next-hop on."
+        },
+        "direction": {
+          "$ref": "./common.json#/definitions/Direction",
+          "description": "The direction of the packet represented as a 5-tuple."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/IpFlowProtocol",
+          "description": "Protocol to be verified on."
+        },
+        "localPort": {
+          "type": "string",
+          "description": "The local port. Acceptable values are a single integer in the range (0-65535). Support for * for the source port, which depends on the direction."
+        },
+        "remotePort": {
+          "type": "string",
+          "description": "The remote port. Acceptable values are a single integer in the range (0-65535). Support for * for the source port, which depends on the direction."
+        },
+        "localIPAddress": {
+          "type": "string",
+          "description": "The local IP address. Acceptable values are valid IPv4 addresses."
+        },
+        "remoteIPAddress": {
+          "type": "string",
+          "description": "The remote IP address. Acceptable values are valid IPv4 addresses."
+        },
+        "targetNicResourceId": {
+          "type": "string",
+          "description": "The NIC ID. (If VM has multiple NICs and IP forwarding is enabled on any of them, then this parameter must be specified. Otherwise optional)."
+        }
+      },
+      "required": [
+        "targetResourceId",
+        "direction",
+        "protocol",
+        "localPort",
+        "remotePort",
+        "localIPAddress",
+        "remoteIPAddress"
+      ]
+    },
+    "VerificationIPFlowResult": {
+      "type": "object",
+      "description": "Results of IP flow verification on the target resource.",
+      "properties": {
+        "access": {
+          "$ref": "./common.json#/definitions/Access",
+          "description": "Indicates whether the traffic is allowed or denied."
+        },
+        "ruleName": {
+          "type": "string",
+          "description": "Name of the rule. If input is not matched against any security rule, it is not displayed."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/networkingOperations.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/networkingOperations.json
@@ -1,0 +1,300 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Network/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "Lists all of the available Network Rest API operations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Availability": {
+      "type": "object",
+      "description": "Availability of the metric.",
+      "properties": {
+        "timeGrain": {
+          "type": "string",
+          "description": "The time grain of the availability."
+        },
+        "retention": {
+          "type": "string",
+          "description": "The retention of the availability."
+        },
+        "blobDuration": {
+          "type": "string",
+          "description": "Duration of the availability blob."
+        }
+      }
+    },
+    "Dimension": {
+      "type": "object",
+      "description": "Dimension of the metric.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the dimension."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the dimension."
+        },
+        "internalName": {
+          "type": "string",
+          "description": "The internal name of the dimension."
+        }
+      }
+    },
+    "LogSpecification": {
+      "type": "object",
+      "description": "Description of logging specification.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the specification."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the specification."
+        },
+        "blobDuration": {
+          "type": "string",
+          "description": "Duration of the blob."
+        }
+      }
+    },
+    "MetricSpecification": {
+      "type": "object",
+      "description": "Description of metrics specification.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the metric."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the metric."
+        },
+        "displayDescription": {
+          "type": "string",
+          "description": "The description of the metric."
+        },
+        "unit": {
+          "type": "string",
+          "description": "Units the metric to be displayed in."
+        },
+        "aggregationType": {
+          "type": "string",
+          "description": "The aggregation type."
+        },
+        "availabilities": {
+          "type": "array",
+          "description": "List of availability.",
+          "items": {
+            "$ref": "#/definitions/Availability"
+          }
+        },
+        "enableRegionalMdmAccount": {
+          "type": "boolean",
+          "description": "Whether regional MDM account enabled."
+        },
+        "fillGapWithZero": {
+          "type": "boolean",
+          "description": "Whether gaps would be filled with zeros."
+        },
+        "metricFilterPattern": {
+          "type": "string",
+          "description": "Pattern for the filter of the metric."
+        },
+        "dimensions": {
+          "type": "array",
+          "description": "List of dimensions.",
+          "items": {
+            "$ref": "#/definitions/Dimension"
+          }
+        },
+        "isInternal": {
+          "type": "boolean",
+          "description": "Whether the metric is internal."
+        },
+        "sourceMdmAccount": {
+          "type": "string",
+          "description": "The source MDM account."
+        },
+        "sourceMdmNamespace": {
+          "type": "string",
+          "description": "The source MDM namespace."
+        },
+        "resourceIdDimensionNameOverride": {
+          "type": "string",
+          "description": "The resource Id dimension name override."
+        }
+      }
+    },
+    "Operation": {
+      "type": "object",
+      "description": "Network REST API operation definition.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Operation name: {provider}/{resource}/{operation}."
+        },
+        "display": {
+          "$ref": "#/definitions/OperationDisplay",
+          "description": "Display metadata associated with the operation."
+        },
+        "origin": {
+          "type": "string",
+          "description": "Origin of the operation."
+        },
+        "properties": {
+          "$ref": "#/definitions/OperationPropertiesFormat",
+          "description": "Operation properties format.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "OperationDisplay": {
+      "type": "object",
+      "description": "Display metadata associated with the operation.",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Service provider: Microsoft Network."
+        },
+        "resource": {
+          "type": "string",
+          "description": "Resource on which the operation is performed."
+        },
+        "operation": {
+          "type": "string",
+          "description": "Type of the operation: get, read, delete, etc."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the operation."
+        }
+      }
+    },
+    "OperationListResult": {
+      "type": "object",
+      "description": "Paged collection of Operation items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Operation items on this page",
+          "items": {
+            "$ref": "#/definitions/Operation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "OperationPropertiesFormat": {
+      "type": "object",
+      "description": "Description of operation properties format.",
+      "properties": {
+        "serviceSpecification": {
+          "$ref": "#/definitions/OperationPropertiesFormatServiceSpecification",
+          "description": "Specification of the service."
+        }
+      }
+    },
+    "OperationPropertiesFormatServiceSpecification": {
+      "type": "object",
+      "description": "Specification of the service.",
+      "properties": {
+        "metricSpecifications": {
+          "type": "array",
+          "description": "Operation service specification.",
+          "items": {
+            "$ref": "#/definitions/MetricSpecification"
+          }
+        },
+        "logSpecifications": {
+          "type": "array",
+          "description": "Operation log specification.",
+          "items": {
+            "$ref": "#/definitions/LogSpecification"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/serviceGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/serviceGateway.json
@@ -1,0 +1,847 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "ServiceGateways"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/serviceGateways": {
+      "get": {
+        "operationId": "ServiceGateways_ListAll",
+        "tags": [
+          "ServiceGateways"
+        ],
+        "description": "Gets all the service gateways in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceGatewayListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceGateways": {
+      "get": {
+        "operationId": "ServiceGateways_List",
+        "tags": [
+          "ServiceGateways"
+        ],
+        "description": "Gets all the service gateways in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceGatewayListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceGateways/{serviceGatewayName}": {
+      "get": {
+        "operationId": "ServiceGateways_Get",
+        "tags": [
+          "ServiceGateways"
+        ],
+        "description": "Gets the specified service gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceGatewayName",
+            "in": "path",
+            "description": "The name of the service gateway.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ServiceGateways_CreateOrUpdate",
+        "tags": [
+          "ServiceGateways"
+        ],
+        "description": "Creates or updates a service gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceGatewayName",
+            "in": "path",
+            "description": "The name of the service gateway.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update service gateway operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServiceGateway"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ServiceGateway' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ServiceGateway"
+            }
+          },
+          "201": {
+            "description": "Resource 'ServiceGateway' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ServiceGateway"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ServiceGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ServiceGateways_UpdateTags",
+        "tags": [
+          "ServiceGateways"
+        ],
+        "description": "Updates a service gateway tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceGatewayName",
+            "in": "path",
+            "description": "The name of the service gateway.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update service gateway tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ServiceGateways_Delete",
+        "tags": [
+          "ServiceGateways"
+        ],
+        "description": "Deletes the specified service gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceGatewayName",
+            "in": "path",
+            "description": "The name of the service gateway.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceGateways/{serviceGatewayName}/addressLocations": {
+      "get": {
+        "operationId": "ServiceGateways_GetAddressLocations",
+        "tags": [
+          "ServiceGateways"
+        ],
+        "description": "Get address locations in service gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceGatewayName",
+            "in": "path",
+            "description": "The name of the service gateway.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GetServiceGatewayAddressLocationsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceGateways/{serviceGatewayName}/services": {
+      "get": {
+        "operationId": "ServiceGateways_GetServices",
+        "tags": [
+          "ServiceGateways"
+        ],
+        "description": "Get Services in service gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceGatewayName",
+            "in": "path",
+            "description": "The name of the service gateway.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GetServiceGatewayServicesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceGateways/{serviceGatewayName}/updateAddressLocations": {
+      "post": {
+        "operationId": "ServiceGateways_UpdateAddressLocations",
+        "tags": [
+          "ServiceGateways"
+        ],
+        "description": "Creates or updates address locations within the service gateway.\n\nThe request supports both full and partial update modes at two levels: location and address.\n\nFull update replaces all existing data.\n\nPartial update modifies only the specified entries:\n\nFor location-level partial updates, if no address is provided, the existing address will be deleted.\n\nFor address-level partial updates, if no services are provided, the existing services will be considered for deletion.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceGatewayName",
+            "in": "path",
+            "description": "The name of the service gateway.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update address locations in service gateway operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServiceGatewayUpdateAddressLocationsRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status-only success response for synchronous service gateway update actions.",
+            "schema": {
+              "$ref": "./common.json#/definitions/ServiceGatewayActionOkResponseBody"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/serviceGateways/{serviceGatewayName}/updateServices": {
+      "post": {
+        "operationId": "ServiceGateways_UpdateServices",
+        "tags": [
+          "ServiceGateways"
+        ],
+        "description": "Creates, updates, or deletes services within the service gateway.\nThe request supports both full and partial update modes at the service level.\n\nFull update replaces all existing services with the new list provided in the request.\nPartial update modifies only the specified services.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceGatewayName",
+            "in": "path",
+            "description": "The name of the service gateway.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update services in service gateway operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServiceGatewayUpdateServicesRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Status-only success response for synchronous service gateway update actions.",
+            "schema": {
+              "$ref": "./common.json#/definitions/ServiceGatewayActionOkResponseBody"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "GetServiceGatewayAddressLocationsResult": {
+      "type": "object",
+      "description": "Response for get service gateway address locations.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ServiceGatewayAddressLocationResponse items on this page",
+          "items": {
+            "$ref": "#/definitions/ServiceGatewayAddressLocationResponse"
+          },
+          "x-ms-identifiers": [
+            "addressLocation"
+          ]
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "GetServiceGatewayServicesResult": {
+      "type": "object",
+      "description": "Response for get service gateway services.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ServiceGatewayService items on this page",
+          "items": {
+            "$ref": "#/definitions/ServiceGatewayService"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RouteTargetAddressPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of route target address",
+      "properties": {
+        "subnet": {
+          "$ref": "./virtualNetwork.json#/definitions/Subnet",
+          "description": "The reference to the subnet resource."
+        },
+        "privateIPAddress": {
+          "type": "string",
+          "description": "The private IPv4 or IPv6 address of the service gateway route target address."
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The Private IP allocation method."
+        }
+      }
+    },
+    "ServiceGateway": {
+      "type": "object",
+      "description": "ServiceGateway resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ServiceGatewayPropertiesFormat",
+          "description": "Properties of service gateway.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "sku": {
+          "$ref": "#/definitions/ServiceGatewaySku",
+          "description": "The service gateway SKU."
+        },
+        "zones": {
+          "type": "array",
+          "description": "A list of availability zones denoting the zone in which service gateway should be deployed.\n\n- The zone values must be provided as strings representing numeric identifiers like \"1\", \"2\", \"3\" etc.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SecurityPerimeterTrackedResource"
+        }
+      ]
+    },
+    "ServiceGatewayAddress": {
+      "type": "object",
+      "description": "Properties of the service gateway address.",
+      "properties": {
+        "address": {
+          "type": "string",
+          "description": "Address to update"
+        },
+        "services": {
+          "type": "array",
+          "description": "Collection of services in address.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ServiceGatewayAddressLocation": {
+      "type": "object",
+      "description": "Properties of the service gateway address location.",
+      "properties": {
+        "addressLocation": {
+          "type": "string",
+          "description": "Location to update"
+        },
+        "addressUpdateAction": {
+          "$ref": "./common.json#/definitions/AddressUpdateAction",
+          "description": "Specifies the type of update operation to perform on addresses within the address location of service gateway.\n\n- FullUpdate: Replaces all existing address data with the new list provided in the request. Any previously defined addresses not included will be removed.\n- PartialUpdate: Updates only the specified addresses."
+        },
+        "addresses": {
+          "type": "array",
+          "description": "An array of addresses to create or update in locations.",
+          "items": {
+            "$ref": "#/definitions/ServiceGatewayAddress"
+          },
+          "x-ms-identifiers": [
+            "address"
+          ]
+        }
+      }
+    },
+    "ServiceGatewayAddressLocationResponse": {
+      "type": "object",
+      "description": "Properties of the service gateway address location.",
+      "properties": {
+        "addressLocation": {
+          "type": "string",
+          "description": "Location to update"
+        },
+        "addresses": {
+          "type": "array",
+          "description": "An array of addresses to create or update in locations.",
+          "items": {
+            "$ref": "#/definitions/ServiceGatewayAddress"
+          },
+          "x-ms-identifiers": [
+            "address"
+          ]
+        }
+      }
+    },
+    "ServiceGatewayListResult": {
+      "type": "object",
+      "description": "The response of a ServiceGateway list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ServiceGateway items on this page",
+          "items": {
+            "$ref": "#/definitions/ServiceGateway"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ServiceGatewayPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the service gateway.",
+      "properties": {
+        "virtualNetwork": {
+          "$ref": "./virtualNetwork.json#/definitions/VirtualNetwork",
+          "description": "Reference to an existing virtual network."
+        },
+        "routeTargetAddress": {
+          "$ref": "#/definitions/RouteTargetAddressPropertiesFormat",
+          "description": "Route Target address of Service gateway"
+        },
+        "routeTargetAddressV6": {
+          "$ref": "#/definitions/RouteTargetAddressPropertiesFormat",
+          "description": "Route Target address V6 of Service gateway"
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the service gateway resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the service gateway resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ServiceGatewayService": {
+      "type": "object",
+      "description": "Properties of the service gateway service.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the service"
+        },
+        "properties": {
+          "$ref": "#/definitions/ServiceGatewayServicePropertiesFormat",
+          "description": "Properties of service gateway service.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "ServiceGatewayServicePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the service gateway service.",
+      "properties": {
+        "serviceType": {
+          "$ref": "./common.json#/definitions/ServiceType",
+          "description": "Name of the service."
+        },
+        "isDefault": {
+          "type": "boolean",
+          "description": "Set to true to mark default service for inbound or outbound."
+        },
+        "loadBalancerBackendPools": {
+          "type": "array",
+          "description": "An array of load balancer backend address pools.",
+          "items": {
+            "$ref": "./loadBalancer.json#/definitions/BackendAddressPool"
+          }
+        },
+        "publicNatGatewayId": {
+          "type": "string",
+          "description": "Azure Resource Id of public natgateway."
+        }
+      }
+    },
+    "ServiceGatewayServiceRequest": {
+      "type": "object",
+      "description": "Properties of the service gateway services request.",
+      "properties": {
+        "isDelete": {
+          "type": "boolean",
+          "description": "Set to true to mark the service for deletion."
+        },
+        "service": {
+          "$ref": "#/definitions/ServiceGatewayService",
+          "description": "Service of service gateway."
+        }
+      }
+    },
+    "ServiceGatewaySku": {
+      "type": "object",
+      "description": "SKU of a service gateway.",
+      "properties": {
+        "name": {
+          "$ref": "./common.json#/definitions/ServiceGatewaySkuName",
+          "description": "Name of a service gateway SKU."
+        },
+        "tier": {
+          "$ref": "./common.json#/definitions/ServiceGatewaySkuTier",
+          "description": "Tier of a service gateway SKU."
+        }
+      }
+    },
+    "ServiceGatewayUpdateAddressLocationsRequest": {
+      "type": "object",
+      "description": "Properties of the service gateway update address locations request.",
+      "properties": {
+        "action": {
+          "$ref": "./common.json#/definitions/UpdateAction",
+          "description": "Specifies the type of update operation to perform on address locations within the service gateway.\n\n- FullUpdate: Replaces all existing address location data with the new list provided in the request. Any previously defined locations not included will be removed.\n- PartialUpdate: Updates only the specified address locations."
+        },
+        "addressLocations": {
+          "type": "array",
+          "description": "An array of address locations to create or update.",
+          "items": {
+            "$ref": "#/definitions/ServiceGatewayAddressLocation"
+          },
+          "x-ms-identifiers": [
+            "addressLocation"
+          ]
+        }
+      }
+    },
+    "ServiceGatewayUpdateServicesRequest": {
+      "type": "object",
+      "description": "Properties of the service gateway update services request.",
+      "properties": {
+        "action": {
+          "$ref": "./common.json#/definitions/ServiceUpdateAction",
+          "description": "Specifies the type of update operation to perform on services within the service gateway.\n\n- FullUpdate: Replaces all existing services with the new list provided in the request. Any previously defined services not included will be removed.\n- PartialUpdate: Updates only the specified services."
+        },
+        "serviceRequests": {
+          "type": "array",
+          "description": "Collection of service updates.",
+          "items": {
+            "$ref": "#/definitions/ServiceGatewayServiceRequest"
+          },
+          "x-ms-identifiers": [
+            "service/name"
+          ]
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/virtualNetwork.json
@@ -1,0 +1,20528 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "ApplicationSecurityGroups"
+    },
+    {
+      "name": "applicationSecurityGroups"
+    },
+    {
+      "name": "BastionHosts"
+    },
+    {
+      "name": "BastionShareableLink"
+    },
+    {
+      "name": "NetworkInterfaces"
+    },
+    {
+      "name": "PublicIPAddresses"
+    },
+    {
+      "name": "VipSwap"
+    },
+    {
+      "name": "CustomIpPrefixes"
+    },
+    {
+      "name": "ddosCustomPolicies"
+    },
+    {
+      "name": "DdosProtectionPlans"
+    },
+    {
+      "name": "DscpConfiguration"
+    },
+    {
+      "name": "DscpConfigurations"
+    },
+    {
+      "name": "IpamPools"
+    },
+    {
+      "name": "StaticCidrs"
+    },
+    {
+      "name": "IpAllocations"
+    },
+    {
+      "name": "IpGroups"
+    },
+    {
+      "name": "NatGateways"
+    },
+    {
+      "name": "Network Interfaces"
+    },
+    {
+      "name": "NetworkProfiles"
+    },
+    {
+      "name": "NetworkSecurityGroups"
+    },
+    {
+      "name": "SecurityRules"
+    },
+    {
+      "name": "ReachabilityAnalysisIntents"
+    },
+    {
+      "name": "ReachabilityAnalysisIntent"
+    },
+    {
+      "name": "VerifierWorkspaces"
+    },
+    {
+      "name": "ReachabilityAnalysisRuns"
+    },
+    {
+      "name": "NetworkVirtualAppliances"
+    },
+    {
+      "name": "VirtualApplianceSites"
+    },
+    {
+      "name": "VirtualApplianceSkus"
+    },
+    {
+      "name": "PrivateEndpoints"
+    },
+    {
+      "name": "PrivateDnsZoneGroups"
+    },
+    {
+      "name": "PrivateLinkServices"
+    },
+    {
+      "name": "PrivateLinkService"
+    },
+    {
+      "name": "PublicIPPrefixes"
+    },
+    {
+      "name": "RouteTables"
+    },
+    {
+      "name": "Routes"
+    },
+    {
+      "name": "SecurityPartnerProviders"
+    },
+    {
+      "name": "VirtualNetworks"
+    },
+    {
+      "name": "Subnets"
+    },
+    {
+      "name": "VirtualNetworkPeerings"
+    },
+    {
+      "name": "VirtualRouters"
+    },
+    {
+      "name": "VirtualRouterPeerings"
+    },
+    {
+      "name": "Usages"
+    },
+    {
+      "name": "AddressPrefixSets"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/IpAllocations": {
+      "get": {
+        "operationId": "IpAllocations_List",
+        "tags": [
+          "IpAllocations"
+        ],
+        "description": "Gets all IpAllocations in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpAllocationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/applicationSecurityGroups": {
+      "get": {
+        "operationId": "ApplicationSecurityGroups_ListAll",
+        "tags": [
+          "ApplicationSecurityGroups"
+        ],
+        "description": "Gets all application security groups in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/bastionHosts": {
+      "get": {
+        "operationId": "BastionHosts_List",
+        "tags": [
+          "BastionHosts"
+        ],
+        "description": "Lists all Bastion Hosts in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BastionHostListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/customIpPrefixes": {
+      "get": {
+        "operationId": "CustomIPPrefixes_ListAll",
+        "tags": [
+          "CustomIpPrefixes"
+        ],
+        "description": "Gets all the custom IP prefixes in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CustomIpPrefixListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ddosCustomPolicies": {
+      "get": {
+        "operationId": "DdosCustomPolicies_ListAll",
+        "tags": [
+          "ddosCustomPolicies"
+        ],
+        "description": "Gets all the DDoS custom policies in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DdosCustomPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ddosProtectionPlans": {
+      "get": {
+        "operationId": "DdosProtectionPlans_List",
+        "tags": [
+          "DdosProtectionPlans"
+        ],
+        "description": "Gets all DDoS protection plans in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DdosProtectionPlanListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/dscpConfigurations": {
+      "get": {
+        "operationId": "DscpConfiguration_ListAll",
+        "tags": [
+          "DscpConfigurations"
+        ],
+        "description": "Gets all dscp configurations in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DscpConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/ipGroups": {
+      "get": {
+        "operationId": "IpGroups_List",
+        "tags": [
+          "IpGroups"
+        ],
+        "description": "Gets all IpGroups in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/autoApprovedPrivateLinkServices": {
+      "get": {
+        "operationId": "PrivateLinkServices_ListAutoApprovedPrivateLinkServices",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Returns all of the private link service ids that can be linked to a Private Endpoint with auto approved in this subscription in this region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AutoApprovedPrivateLinkServicesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availableDelegations": {
+      "get": {
+        "operationId": "AvailableDelegations_List",
+        "description": "Gets all of the available subnet delegations for this subscription in this region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AvailableDelegationsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availablePrivateEndpointTypes": {
+      "get": {
+        "operationId": "AvailablePrivateEndpointTypes_List",
+        "description": "Returns all of the resource types that can be linked to a Private Endpoint in this subscription in this region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AvailablePrivateEndpointTypesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/availableServiceAliases": {
+      "get": {
+        "operationId": "AvailableServiceAliases_List",
+        "description": "Gets all available service aliases for this subscription in this region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AvailableServiceAliasesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/checkDnsNameAvailability": {
+      "get": {
+        "operationId": "CheckDnsNameAvailability",
+        "description": "Checks whether a domain name in the cloudapp.azure.com zone is available for use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "domainNameLabel",
+            "in": "query",
+            "description": "The domain name to be verified. It must conform to the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DnsNameAvailabilityResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/checkPrivateLinkServiceVisibility": {
+      "post": {
+        "operationId": "PrivateLinkServices_CheckPrivateLinkServiceVisibility",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Checks whether the subscription is visible to private link service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckPrivateLinkServiceVisibilityRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkServiceVisibility"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PrivateLinkServiceVisibility"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/serviceTagDetails": {
+      "get": {
+        "operationId": "ServiceTagInformation_List",
+        "description": "Gets a list of service tag information resources with pagination.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "noAddressPrefixes",
+            "in": "query",
+            "description": "Do not return address prefixes for the tag(s).",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "tagName",
+            "in": "query",
+            "description": "Return tag information for a particular tag.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ServiceTagInformationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/serviceTags": {
+      "get": {
+        "operationId": "ServiceTags_List",
+        "description": "Gets a list of service tag information resources.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ServiceTagsListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/usages": {
+      "get": {
+        "operationId": "Usages_List",
+        "tags": [
+          "Usages"
+        ],
+        "description": "List network usages for a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/UsagesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/locations/{location}/virtualNetworkAvailableEndpointServices": {
+      "get": {
+        "operationId": "AvailableEndpointServices_List",
+        "description": "List what values of endpoint services are available for use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/EndpointServicesListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/natGateways": {
+      "get": {
+        "operationId": "NatGateways_ListAll",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "Gets all the Nat Gateways in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NatGatewayListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkInterfaces": {
+      "get": {
+        "operationId": "NetworkInterfaces_ListAll",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Gets all network interfaces in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkProfiles": {
+      "get": {
+        "operationId": "NetworkProfiles_ListAll",
+        "tags": [
+          "NetworkProfiles"
+        ],
+        "description": "Gets all the network profiles in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkProfileListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkSecurityGroups": {
+      "get": {
+        "operationId": "NetworkSecurityGroups_ListAll",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Gets all network security groups in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkVirtualApplianceSkus": {
+      "get": {
+        "operationId": "VirtualApplianceSkus_List",
+        "tags": [
+          "VirtualApplianceSkus"
+        ],
+        "description": "List all SKUs available for a virtual appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceSkuListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkVirtualApplianceSkus/{skuName}": {
+      "get": {
+        "operationId": "VirtualApplianceSkus_Get",
+        "tags": [
+          "VirtualApplianceSkus"
+        ],
+        "description": "Retrieves a single available sku for network virtual appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "skuName",
+            "in": "path",
+            "description": "Name of the Sku.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceSku"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/networkVirtualAppliances": {
+      "get": {
+        "operationId": "NetworkVirtualAppliances_List",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Gets all Network Virtual Appliances in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/privateEndpoints": {
+      "get": {
+        "operationId": "PrivateEndpoints_ListBySubscription",
+        "tags": [
+          "PrivateEndpoints"
+        ],
+        "description": "Gets all private endpoints in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/privateLinkServices": {
+      "get": {
+        "operationId": "PrivateLinkServices_ListBySubscription",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Gets all private link service in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkServiceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPAddresses": {
+      "get": {
+        "operationId": "PublicIPAddresses_ListAll",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Gets all the public IP addresses in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddressListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/publicIPPrefixes": {
+      "get": {
+        "operationId": "PublicIPPrefixes_ListAll",
+        "tags": [
+          "PublicIPPrefixes"
+        ],
+        "description": "Gets all the public IP prefixes in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPPrefixListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/routeTables": {
+      "get": {
+        "operationId": "RouteTables_ListAll",
+        "tags": [
+          "RouteTables"
+        ],
+        "description": "Gets all route tables in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteTableListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/securityPartnerProviders": {
+      "get": {
+        "operationId": "SecurityPartnerProviders_List",
+        "tags": [
+          "SecurityPartnerProviders"
+        ],
+        "description": "Gets all the Security Partner Providers in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityPartnerProviderListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworks": {
+      "get": {
+        "operationId": "VirtualNetworks_ListAll",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Gets all virtual networks in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualRouters": {
+      "get": {
+        "operationId": "VirtualRouters_List",
+        "tags": [
+          "VirtualRouters"
+        ],
+        "description": "Gets all the Virtual Routers in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualRouterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations": {
+      "get": {
+        "operationId": "IpAllocations_ListByResourceGroup",
+        "tags": [
+          "IpAllocations"
+        ],
+        "description": "Gets all IpAllocations in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpAllocationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/IpAllocations/{ipAllocationName}": {
+      "get": {
+        "operationId": "IpAllocations_Get",
+        "tags": [
+          "IpAllocations"
+        ],
+        "description": "Gets the specified IpAllocation by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ipAllocationName",
+            "in": "path",
+            "description": "The name of the IpAllocation.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpAllocation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "IpAllocations_CreateOrUpdate",
+        "tags": [
+          "IpAllocations"
+        ],
+        "description": "Creates or updates an IpAllocation in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ipAllocationName",
+            "in": "path",
+            "description": "The name of the IpAllocation.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update virtual network operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/IpAllocation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'IpAllocation' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/IpAllocation"
+            }
+          },
+          "201": {
+            "description": "Resource 'IpAllocation' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/IpAllocation"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/IpAllocation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "IpAllocations_UpdateTags",
+        "tags": [
+          "IpAllocations"
+        ],
+        "description": "Updates a IpAllocation tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ipAllocationName",
+            "in": "path",
+            "description": "The name of the IpAllocation.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update IpAllocation tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpAllocation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "IpAllocations_Delete",
+        "tags": [
+          "IpAllocations"
+        ],
+        "description": "Deletes the specified IpAllocation.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ipAllocationName",
+            "in": "path",
+            "description": "The name of the IpAllocation.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups": {
+      "get": {
+        "operationId": "ApplicationSecurityGroups_List",
+        "tags": [
+          "ApplicationSecurityGroups"
+        ],
+        "description": "Gets all the application security groups in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}": {
+      "get": {
+        "operationId": "ApplicationSecurityGroups_Get",
+        "tags": [
+          "ApplicationSecurityGroups"
+        ],
+        "description": "Gets information about the specified application security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "description": "The name of the application security group.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ApplicationSecurityGroups_CreateOrUpdate",
+        "tags": [
+          "ApplicationSecurityGroups"
+        ],
+        "description": "Creates or updates an application security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "description": "The name of the application security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update ApplicationSecurityGroup operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ApplicationSecurityGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'ApplicationSecurityGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroup"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ApplicationSecurityGroup"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ApplicationSecurityGroups_UpdateTags",
+        "tags": [
+          "applicationSecurityGroups"
+        ],
+        "description": "Updates an application security group's tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "description": "The name of the application security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update application security group tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationSecurityGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ApplicationSecurityGroups_Delete",
+        "tags": [
+          "ApplicationSecurityGroups"
+        ],
+        "description": "Deletes the specified application security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "description": "The name of the application security group.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}/addressPrefixSets": {
+      "get": {
+        "operationId": "AddressPrefixSets_List",
+        "tags": [
+          "AddressPrefixSets"
+        ],
+        "description": "Gets all address prefix sets in an application security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "description": "The name of the application security group.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AddressPrefixSetListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationSecurityGroups/{applicationSecurityGroupName}/addressPrefixSets/{addressPrefixSetName}": {
+      "get": {
+        "operationId": "AddressPrefixSets_Get",
+        "tags": [
+          "AddressPrefixSets"
+        ],
+        "description": "Gets the specified address prefix set.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "description": "The name of the application security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "addressPrefixSetName",
+            "in": "path",
+            "description": "The name of the address prefix set.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,78}[a-zA-Z0-9_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AddressPrefixSet"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "AddressPrefixSets_CreateOrUpdate",
+        "tags": [
+          "AddressPrefixSets"
+        ],
+        "description": "Creates or updates an address prefix set.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "description": "The name of the application security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "addressPrefixSetName",
+            "in": "path",
+            "description": "The name of the address prefix set.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,78}[a-zA-Z0-9_])?$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Parameters supplied to the create or update address prefix set operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddressPrefixSet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AddressPrefixSet' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AddressPrefixSet"
+            }
+          },
+          "201": {
+            "description": "Resource 'AddressPrefixSet' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AddressPrefixSet"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/AddressPrefixSet"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AddressPrefixSets_Delete",
+        "tags": [
+          "AddressPrefixSets"
+        ],
+        "description": "Deletes the specified address prefix set.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "applicationSecurityGroupName",
+            "in": "path",
+            "description": "The name of the application security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "addressPrefixSetName",
+            "in": "path",
+            "description": "The name of the address prefix set.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9]([a-zA-Z0-9_.-]{0,78}[a-zA-Z0-9_])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts": {
+      "get": {
+        "operationId": "BastionHosts_ListByResourceGroup",
+        "tags": [
+          "BastionHosts"
+        ],
+        "description": "Lists all Bastion Hosts in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BastionHostListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}": {
+      "get": {
+        "operationId": "BastionHosts_Get",
+        "tags": [
+          "BastionHosts"
+        ],
+        "description": "Gets the specified Bastion Host.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "bastionHostName",
+            "in": "path",
+            "description": "The name of the Bastion Host.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BastionHost"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "BastionHosts_CreateOrUpdate",
+        "tags": [
+          "BastionHosts"
+        ],
+        "description": "Creates or updates the specified Bastion Host.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "bastionHostName",
+            "in": "path",
+            "description": "The name of the Bastion Host.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update Bastion Host operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BastionHost"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BastionHost' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BastionHost"
+            }
+          },
+          "201": {
+            "description": "Resource 'BastionHost' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BastionHost"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/BastionHost"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "BastionHosts_UpdateTags",
+        "tags": [
+          "BastionHosts"
+        ],
+        "description": "Updates Tags for BastionHost resource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "bastionHostName",
+            "in": "path",
+            "description": "The name of the Bastion Host.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update BastionHost tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BastionHost"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/BastionHost"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "BastionHosts_Delete",
+        "tags": [
+          "BastionHosts"
+        ],
+        "description": "Deletes the specified Bastion Host.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "bastionHostName",
+            "in": "path",
+            "description": "The name of the Bastion Host.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/createShareableLinks": {
+      "post": {
+        "operationId": "PutBastionShareableLink",
+        "tags": [
+          "BastionHosts",
+          "BastionShareableLink"
+        ],
+        "description": "Creates a Bastion Shareable Links for all the VMs specified in the request.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "bastionHostName",
+            "in": "path",
+            "description": "The name of the Bastion Host.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "bslRequest",
+            "in": "body",
+            "description": "Post request for Create/Delete/Get Bastion Shareable Link endpoints.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BastionShareableLinkListRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BastionShareableLinkListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/BastionShareableLinkListResult"
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/deleteShareableLinks": {
+      "post": {
+        "operationId": "DeleteBastionShareableLink",
+        "tags": [
+          "BastionHosts",
+          "BastionShareableLink"
+        ],
+        "description": "Deletes the Bastion Shareable Links for all the VMs specified in the request.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "bastionHostName",
+            "in": "path",
+            "description": "The name of the Bastion Host.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "bslRequest",
+            "in": "body",
+            "description": "Post request for Create/Delete/Get Bastion Shareable Link endpoints.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BastionShareableLinkListRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/deleteShareableLinksByToken": {
+      "post": {
+        "operationId": "DeleteBastionShareableLinkByToken",
+        "tags": [
+          "BastionHosts",
+          "BastionShareableLink"
+        ],
+        "description": "Deletes the Bastion Shareable Links for all the tokens specified in the request.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "bastionHostName",
+            "in": "path",
+            "description": "The name of the Bastion Host.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "bslTokenRequest",
+            "in": "body",
+            "description": "Post request for Delete Bastion Shareable Link By Token endpoint.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BastionShareableLinkTokenListRequest"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/disconnectActiveSessions": {
+      "post": {
+        "operationId": "DisconnectActiveSessions",
+        "tags": [
+          "BastionHosts"
+        ],
+        "description": "Returns the list of currently active sessions on the Bastion.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "bastionHostName",
+            "in": "path",
+            "description": "The name of the Bastion Host.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "sessionIds",
+            "in": "body",
+            "description": "The list of sessionids to disconnect.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SessionIds"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BastionSessionDeleteResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/getActiveSessions": {
+      "post": {
+        "operationId": "GetActiveSessions",
+        "tags": [
+          "BastionHosts"
+        ],
+        "description": "Returns the list of currently active sessions on the Bastion.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "bastionHostName",
+            "in": "path",
+            "description": "The name of the Bastion Host.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BastionActiveSessionListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/BastionActiveSessionListResult"
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/bastionHosts/{bastionHostName}/getShareableLinks": {
+      "post": {
+        "operationId": "GetBastionShareableLink",
+        "tags": [
+          "BastionHosts",
+          "BastionShareableLink"
+        ],
+        "description": "Return the Bastion Shareable Links for all the VMs specified in the request.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "bastionHostName",
+            "in": "path",
+            "description": "The name of the Bastion Host.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "bslRequest",
+            "in": "body",
+            "description": "Post request for Create/Delete/Get Bastion Shareable Link endpoints.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BastionShareableLinkListRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BastionShareableLinkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/customIpPrefixes": {
+      "get": {
+        "operationId": "CustomIPPrefixes_List",
+        "tags": [
+          "CustomIpPrefixes"
+        ],
+        "description": "Gets all custom IP prefixes in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CustomIpPrefixListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/customIpPrefixes/{customIpPrefixName}": {
+      "get": {
+        "operationId": "CustomIPPrefixes_Get",
+        "tags": [
+          "CustomIpPrefixes"
+        ],
+        "description": "Gets the specified custom IP prefix in a specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "customIpPrefixName",
+            "in": "path",
+            "description": "The name of the custom IP prefix.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CustomIpPrefix"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "CustomIPPrefixes_CreateOrUpdate",
+        "tags": [
+          "CustomIpPrefixes"
+        ],
+        "description": "Creates or updates a custom IP prefix.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "customIpPrefixName",
+            "in": "path",
+            "description": "The name of the custom IP prefix.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update custom IP prefix operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CustomIpPrefix"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CustomIpPrefix' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CustomIpPrefix"
+            }
+          },
+          "201": {
+            "description": "Resource 'CustomIpPrefix' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CustomIpPrefix"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/CustomIpPrefix"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "CustomIPPrefixes_UpdateTags",
+        "tags": [
+          "CustomIpPrefixes"
+        ],
+        "description": "Updates custom IP prefix tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "customIpPrefixName",
+            "in": "path",
+            "description": "The name of the custom IP prefix.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update custom IP prefix tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CustomIpPrefix"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "CustomIPPrefixes_Delete",
+        "tags": [
+          "CustomIpPrefixes"
+        ],
+        "description": "Deletes the specified custom IP prefix.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "customIpPrefixName",
+            "in": "path",
+            "description": "The name of the custom IP prefix.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies": {
+      "get": {
+        "operationId": "DdosCustomPolicies_List",
+        "tags": [
+          "ddosCustomPolicies"
+        ],
+        "description": "Gets all the DDoS custom policies in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DdosCustomPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosCustomPolicies/{ddosCustomPolicyName}": {
+      "get": {
+        "operationId": "DdosCustomPolicies_Get",
+        "tags": [
+          "ddosCustomPolicies"
+        ],
+        "description": "Gets information about the specified DDoS custom policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ddosCustomPolicyName",
+            "in": "path",
+            "description": "The name of the DDoS custom policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DdosCustomPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "DdosCustomPolicies_CreateOrUpdate",
+        "tags": [
+          "ddosCustomPolicies"
+        ],
+        "description": "Creates or updates a DDoS custom policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ddosCustomPolicyName",
+            "in": "path",
+            "description": "The name of the DDoS custom policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DdosCustomPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DdosCustomPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DdosCustomPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'DdosCustomPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DdosCustomPolicy"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/DdosCustomPolicy"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "DdosCustomPolicies_UpdateTags",
+        "tags": [
+          "ddosCustomPolicies"
+        ],
+        "description": "Update a DDoS custom policy tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ddosCustomPolicyName",
+            "in": "path",
+            "description": "The name of the DDoS custom policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update DDoS custom policy resource tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DdosCustomPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DdosCustomPolicies_Delete",
+        "tags": [
+          "ddosCustomPolicies"
+        ],
+        "description": "Deletes the specified DDoS custom policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ddosCustomPolicyName",
+            "in": "path",
+            "description": "The name of the DDoS custom policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans": {
+      "get": {
+        "operationId": "DdosProtectionPlans_ListByResourceGroup",
+        "tags": [
+          "DdosProtectionPlans"
+        ],
+        "description": "Gets all the DDoS protection plans in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DdosProtectionPlanListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ddosProtectionPlans/{ddosProtectionPlanName}": {
+      "get": {
+        "operationId": "DdosProtectionPlans_Get",
+        "tags": [
+          "DdosProtectionPlans"
+        ],
+        "description": "Gets information about the specified DDoS protection plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ddosProtectionPlanName",
+            "in": "path",
+            "description": "The name of the DDoS protection plan.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DdosProtectionPlan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "DdosProtectionPlans_CreateOrUpdate",
+        "tags": [
+          "DdosProtectionPlans"
+        ],
+        "description": "Creates or updates a DDoS protection plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ddosProtectionPlanName",
+            "in": "path",
+            "description": "The name of the DDoS protection plan.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DdosProtectionPlan"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DdosProtectionPlan' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DdosProtectionPlan"
+            }
+          },
+          "201": {
+            "description": "Resource 'DdosProtectionPlan' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DdosProtectionPlan"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/DdosProtectionPlan"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "DdosProtectionPlans_UpdateTags",
+        "tags": [
+          "DdosProtectionPlans"
+        ],
+        "description": "Update a DDoS protection plan tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ddosProtectionPlanName",
+            "in": "path",
+            "description": "The name of the DDoS protection plan.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the update DDoS protection plan resource tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DdosProtectionPlan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DdosProtectionPlans_Delete",
+        "tags": [
+          "DdosProtectionPlans"
+        ],
+        "description": "Deletes the specified DDoS protection plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ddosProtectionPlanName",
+            "in": "path",
+            "description": "The name of the DDoS protection plan.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dscpConfigurations": {
+      "get": {
+        "operationId": "DscpConfiguration_List",
+        "tags": [
+          "DscpConfigurations"
+        ],
+        "description": "Gets a DSCP Configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DscpConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dscpConfigurations/{dscpConfigurationName}": {
+      "get": {
+        "operationId": "DscpConfiguration_Get",
+        "tags": [
+          "DscpConfiguration"
+        ],
+        "description": "Gets a DSCP Configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "dscpConfigurationName",
+            "in": "path",
+            "description": "The name of the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DscpConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "DscpConfiguration_CreateOrUpdate",
+        "tags": [
+          "DscpConfiguration"
+        ],
+        "description": "Creates or updates a DSCP Configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "dscpConfigurationName",
+            "in": "path",
+            "description": "The name of the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update DscpConfiguration operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DscpConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DscpConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DscpConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'DscpConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DscpConfiguration"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/DscpConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "DscpConfiguration_Delete",
+        "tags": [
+          "DscpConfiguration"
+        ],
+        "description": "Deletes a DSCP Configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "dscpConfigurationName",
+            "in": "path",
+            "description": "The name of the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups": {
+      "get": {
+        "operationId": "IpGroups_ListByResourceGroup",
+        "tags": [
+          "IpGroups"
+        ],
+        "description": "Gets all IpGroups in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/ipGroups/{ipGroupsName}": {
+      "get": {
+        "operationId": "IpGroups_Get",
+        "tags": [
+          "IpGroups"
+        ],
+        "description": "Gets the specified ipGroups.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ipGroupsName",
+            "in": "path",
+            "description": "The name of the ipGroups.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands resourceIds (of Firewalls/Network Security Groups etc.) back referenced by the IpGroups resource.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "IpGroups_CreateOrUpdate",
+        "tags": [
+          "IpGroups"
+        ],
+        "description": "Creates or updates an ipGroups in a specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ipGroupsName",
+            "in": "path",
+            "description": "The name of the ipGroups.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update IpGroups operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/IpGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'IpGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/IpGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'IpGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/IpGroup"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/IpGroup"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "IpGroups_UpdateGroups",
+        "tags": [
+          "IpGroups"
+        ],
+        "description": "Updates tags of an IpGroups resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ipGroupsName",
+            "in": "path",
+            "description": "The name of the ipGroups.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the update ipGroups operation.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "IpGroups_Delete",
+        "tags": [
+          "IpGroups"
+        ],
+        "description": "Deletes the specified ipGroups.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "ipGroupsName",
+            "in": "path",
+            "description": "The name of the ipGroups.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/autoApprovedPrivateLinkServices": {
+      "get": {
+        "operationId": "PrivateLinkServices_ListAutoApprovedPrivateLinkServicesByResourceGroup",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Returns all of the private link service ids that can be linked to a Private Endpoint with auto approved in this subscription in this region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AutoApprovedPrivateLinkServicesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/availableDelegations": {
+      "get": {
+        "operationId": "AvailableResourceGroupDelegations_List",
+        "description": "Gets all of the available subnet delegations for this resource group in this region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AvailableDelegationsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/availablePrivateEndpointTypes": {
+      "get": {
+        "operationId": "AvailablePrivateEndpointTypes_ListByResourceGroup",
+        "description": "Returns all of the resource types that can be linked to a Private Endpoint in this subscription in this region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AvailablePrivateEndpointTypesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/availableServiceAliases": {
+      "get": {
+        "operationId": "AvailableServiceAliases_ListByResourceGroup",
+        "description": "Gets all available service aliases for this resource group in this region.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AvailableServiceAliasesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/locations/{location}/checkPrivateLinkServiceVisibility": {
+      "post": {
+        "operationId": "PrivateLinkServices_CheckPrivateLinkServiceVisibilityByResourceGroup",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Checks whether the subscription is visible to private link service in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckPrivateLinkServiceVisibilityRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkServiceVisibility"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PrivateLinkServiceVisibility"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways": {
+      "get": {
+        "operationId": "NatGateways_List",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "Gets all nat gateways in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NatGatewayListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/natGateways/{natGatewayName}": {
+      "get": {
+        "operationId": "NatGateways_Get",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "Gets the specified nat gateway in a specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "The name of the nat gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NatGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NatGateways_CreateOrUpdate",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "Creates or updates a nat gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "The name of the nat gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update nat gateway operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NatGateway"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NatGateway' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NatGateway"
+            }
+          },
+          "201": {
+            "description": "Resource 'NatGateway' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NatGateway"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/NatGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "NatGateways_UpdateTags",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "Updates nat gateway tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "The name of the nat gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update nat gateway tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NatGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NatGateways_Delete",
+        "tags": [
+          "NatGateways"
+        ],
+        "description": "Deletes the specified nat gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "natGatewayName",
+            "in": "path",
+            "description": "The name of the nat gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces": {
+      "get": {
+        "operationId": "NetworkInterfaces_List",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Gets all network interfaces in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}": {
+      "get": {
+        "operationId": "NetworkInterfaces_Get",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Gets information about the specified network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkInterfaces_CreateOrUpdate",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Creates or updates a network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update network interface operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkInterface' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkInterface' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/NetworkInterface"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "NetworkInterfaces_UpdateTags",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Updates a network interface tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update network interface tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkInterfaces_Delete",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Deletes the specified network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveNetworkSecurityGroups": {
+      "post": {
+        "operationId": "NetworkInterfaces_ListEffectiveNetworkSecurityGroups",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Gets all network security groups applied to a network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EffectiveNetworkSecurityGroupListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EffectiveNetworkSecurityGroupListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/effectiveRouteTable": {
+      "post": {
+        "operationId": "NetworkInterfaces_GetEffectiveRouteTable",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Gets all route tables applied to a network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EffectiveRouteListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EffectiveRouteListResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/ipConfigurations": {
+      "get": {
+        "operationId": "NetworkInterfaceIPConfigurations_List",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Get all ip configurations in a network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceIPConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/ipConfigurations/{ipConfigurationName}": {
+      "get": {
+        "operationId": "NetworkInterfaceIPConfigurations_Get",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Gets the specified network interface ip configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ipConfigurationName",
+            "in": "path",
+            "description": "The name of the ip configuration name.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceIPConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/loadBalancers": {
+      "get": {
+        "operationId": "NetworkInterfaceLoadBalancers_List",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "List all load balancers in a network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceLoadBalancerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations": {
+      "get": {
+        "operationId": "NetworkInterfaceTapConfigurations_List",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Get all Tap configurations in a network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceTapConfigurationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkInterfaces/{networkInterfaceName}/tapConfigurations/{tapConfigurationName}": {
+      "get": {
+        "operationId": "NetworkInterfaceTapConfigurations_Get",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Get the specified tap configuration on a network interface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "tapConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceTapConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkInterfaceTapConfigurations_CreateOrUpdate",
+        "tags": [
+          "Network Interfaces"
+        ],
+        "description": "Creates or updates a Tap configuration in the specified NetworkInterface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "tapConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "tapConfigurationParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update tap configuration operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceTapConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkInterfaceTapConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceTapConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkInterfaceTapConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceTapConfiguration"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/NetworkInterfaceTapConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "NetworkInterfaceTapConfigurations_Delete",
+        "tags": [
+          "Network Interfaces"
+        ],
+        "description": "Deletes the specified tap configuration from the NetworkInterface.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "tapConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/ipamPools": {
+      "get": {
+        "operationId": "IpamPools_List",
+        "tags": [
+          "IpamPools"
+        ],
+        "summary": "Gets list of Pool resources at Network Manager level.",
+        "description": "Gets list of Pool resources at Network Manager level.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "skipToken",
+            "in": "query",
+            "description": "Optional skip token.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "Optional num entries to skip.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 0
+          },
+          {
+            "name": "top",
+            "in": "query",
+            "description": "Optional num entries to show.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 50
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "description": "Optional key by which to sort.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "sortValue",
+            "in": "query",
+            "description": "Optional sort value for pagination.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpamPoolList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/ipamPools/{poolName}": {
+      "get": {
+        "operationId": "IpamPools_Get",
+        "tags": [
+          "IpamPools"
+        ],
+        "summary": "Gets the specific Pool resource.",
+        "description": "Gets the specific Pool resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "poolName",
+            "in": "path",
+            "description": "Pool resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpamPool"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "IpamPools_Create",
+        "tags": [
+          "IpamPools"
+        ],
+        "summary": "Creates/Updates the Pool resource.",
+        "description": "Creates/Updates the Pool resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "poolName",
+            "in": "path",
+            "description": "Pool resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the pool to update. This value can be omitted or set to \"*\" to apply the operation unconditionally.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Pool resource object to create/update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/IpamPool"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'IpamPool' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/IpamPool"
+            }
+          },
+          "201": {
+            "description": "Resource 'IpamPool' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/IpamPool"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/IpamPool"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "IpamPools_Update",
+        "tags": [
+          "IpamPools"
+        ],
+        "summary": "Updates the specific Pool resource.",
+        "description": "Updates the specific Pool resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "poolName",
+            "in": "path",
+            "description": "Pool resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the pool to update. This value can be omitted or set to \"*\" to apply the operation unconditionally.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Pool resource object to update partially.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/IpamPoolUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IpamPool"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "IpamPools_Delete",
+        "tags": [
+          "IpamPools"
+        ],
+        "summary": "Delete the Pool resource.",
+        "description": "Delete the Pool resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "poolName",
+            "in": "path",
+            "description": "Pool resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the pool to update. This value can be omitted or set to \"*\" to apply the operation unconditionally.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/ipamPools/{poolName}/getPoolUsage": {
+      "post": {
+        "operationId": "IpamPools_GetPoolUsage",
+        "tags": [
+          "IpamPools"
+        ],
+        "summary": "Get the Pool Usage.",
+        "description": "Get the Pool Usage.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "poolName",
+            "in": "path",
+            "description": "Pool resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PoolUsage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/ipamPools/{poolName}/listAssociatedResources": {
+      "post": {
+        "operationId": "IpamPools_ListAssociatedResources",
+        "tags": [
+          "IpamPools"
+        ],
+        "summary": "List Associated Resource in the Pool.",
+        "description": "List Associated Resource in the Pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "poolName",
+            "in": "path",
+            "description": "Pool resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PoolAssociationList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/ipamPools/{poolName}/staticCidrs": {
+      "get": {
+        "operationId": "StaticCidrs_List",
+        "tags": [
+          "StaticCidrs"
+        ],
+        "summary": "Gets list of Static CIDR resources at Network Manager level.",
+        "description": "Gets list of Static CIDR resources at Network Manager level.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "poolName",
+            "in": "path",
+            "description": "Pool resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "skipToken",
+            "in": "query",
+            "description": "Optional skip token.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "Optional num entries to skip.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 0
+          },
+          {
+            "name": "top",
+            "in": "query",
+            "description": "Optional num entries to show.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 50
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "description": "Optional key by which to sort.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "sortValue",
+            "in": "query",
+            "description": "Optional sort value for pagination.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StaticCidrList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/ipamPools/{poolName}/staticCidrs/{staticCidrName}": {
+      "get": {
+        "operationId": "StaticCidrs_Get",
+        "tags": [
+          "StaticCidrs"
+        ],
+        "summary": "Gets the specific Static CIDR resource.",
+        "description": "Gets the specific Static CIDR resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "poolName",
+            "in": "path",
+            "description": "Pool resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "staticCidrName",
+            "in": "path",
+            "description": "StaticCidr resource name to retrieve.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/StaticCidr"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "StaticCidrs_Create",
+        "tags": [
+          "StaticCidrs"
+        ],
+        "summary": "Creates/Updates the Static CIDR resource.",
+        "description": "Creates/Updates the Static CIDR resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "poolName",
+            "in": "path",
+            "description": "The name of the IPAM pool.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "staticCidrName",
+            "in": "path",
+            "description": "Name for the static CIDR.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "StaticCidr resource object to create/update.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/StaticCidr"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'StaticCidr' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/StaticCidr"
+            }
+          },
+          "201": {
+            "description": "Resource 'StaticCidr' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/StaticCidr"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "StaticCidrs_Delete",
+        "tags": [
+          "StaticCidrs"
+        ],
+        "summary": "Delete the Static CIDR resource.",
+        "description": "Delete the Static CIDR resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "poolName",
+            "in": "path",
+            "description": "Pool resource name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "staticCidrName",
+            "in": "path",
+            "description": "StaticCidr resource name to retrieve.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/verifierWorkspaces": {
+      "get": {
+        "operationId": "VerifierWorkspaces_List",
+        "tags": [
+          "VerifierWorkspaces"
+        ],
+        "summary": "Gets list of Verifier Workspaces.",
+        "description": "Gets list of Verifier Workspaces.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "skipToken",
+            "in": "query",
+            "description": "Optional skip token.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "Optional num entries to skip.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 0
+          },
+          {
+            "name": "top",
+            "in": "query",
+            "description": "Optional num entries to show.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 50
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "description": "Optional key by which to sort.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "sortValue",
+            "in": "query",
+            "description": "Optional sort value for pagination.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VerifierWorkspaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/verifierWorkspaces/{workspaceName}": {
+      "get": {
+        "operationId": "VerifierWorkspaces_Get",
+        "tags": [
+          "VerifierWorkspaces"
+        ],
+        "summary": "Gets Verifier Workspace.",
+        "description": "Gets Verifier Workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VerifierWorkspace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VerifierWorkspaces_Create",
+        "tags": [
+          "VerifierWorkspaces"
+        ],
+        "summary": "Creates Verifier Workspace.",
+        "description": "Creates Verifier Workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the pool to update. This value can be omitted or set to \"*\" to apply the operation unconditionally.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Verifier Workspace object to create/update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VerifierWorkspace"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VerifierWorkspace' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VerifierWorkspace"
+            }
+          },
+          "201": {
+            "description": "Resource 'VerifierWorkspace' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VerifierWorkspace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "VerifierWorkspaces_Update",
+        "tags": [
+          "VerifierWorkspaces"
+        ],
+        "summary": "Updates Verifier Workspace.",
+        "description": "Updates Verifier Workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the pool to update. This value can be omitted or set to \"*\" to apply the operation unconditionally.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Verifier Workspace object to create/update.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/VerifierWorkspaceUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VerifierWorkspace"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "VerifierWorkspaces_Delete",
+        "tags": [
+          "VerifierWorkspaces"
+        ],
+        "summary": "Deletes Verifier Workspace.",
+        "description": "Deletes Verifier Workspace.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "If-Match",
+            "in": "header",
+            "description": "The entity state (ETag) version of the pool to update. This value can be omitted or set to \"*\" to apply the operation unconditionally.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/verifierWorkspaces/{workspaceName}/reachabilityAnalysisIntents": {
+      "get": {
+        "operationId": "ReachabilityAnalysisIntents_List",
+        "tags": [
+          "ReachabilityAnalysisIntents"
+        ],
+        "summary": "Gets list of Reachability Analysis Intents .",
+        "description": "Gets list of Reachability Analysis Intents .",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "skipToken",
+            "in": "query",
+            "description": "Optional skip token.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "Optional num entries to skip.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 0
+          },
+          {
+            "name": "top",
+            "in": "query",
+            "description": "Optional num entries to show.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 50
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "description": "Optional key by which to sort.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "sortValue",
+            "in": "query",
+            "description": "Optional sort value for pagination.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ReachabilityAnalysisIntentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/verifierWorkspaces/{workspaceName}/reachabilityAnalysisIntents/{reachabilityAnalysisIntentName}": {
+      "get": {
+        "operationId": "ReachabilityAnalysisIntents_Get",
+        "tags": [
+          "ReachabilityAnalysisIntents"
+        ],
+        "summary": "Get the Reachability Analysis Intent.",
+        "description": "Get the Reachability Analysis Intent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "reachabilityAnalysisIntentName",
+            "in": "path",
+            "description": "Reachability Analysis Intent name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ReachabilityAnalysisIntent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ReachabilityAnalysisIntents_Create",
+        "tags": [
+          "ReachabilityAnalysisIntents"
+        ],
+        "summary": "Creates Reachability Analysis Intent.",
+        "description": "Creates Reachability Analysis Intent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "reachabilityAnalysisIntentName",
+            "in": "path",
+            "description": "Reachability Analysis Intent name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Reachability Analysis Intent object to create/update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReachabilityAnalysisIntent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ReachabilityAnalysisIntent' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ReachabilityAnalysisIntent"
+            }
+          },
+          "201": {
+            "description": "Resource 'ReachabilityAnalysisIntent' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ReachabilityAnalysisIntent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ReachabilityAnalysisIntents_Delete",
+        "tags": [
+          "ReachabilityAnalysisIntent"
+        ],
+        "summary": "Deletes Reachability Analysis Intent.",
+        "description": "Deletes Reachability Analysis Intent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "reachabilityAnalysisIntentName",
+            "in": "path",
+            "description": "Reachability Analysis Intent name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/verifierWorkspaces/{workspaceName}/reachabilityAnalysisRuns": {
+      "get": {
+        "operationId": "ReachabilityAnalysisRuns_List",
+        "tags": [
+          "ReachabilityAnalysisRuns"
+        ],
+        "summary": "Gets list of Reachability Analysis Runs.",
+        "description": "Gets list of Reachability Analysis Runs.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "skipToken",
+            "in": "query",
+            "description": "Optional skip token.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "Optional num entries to skip.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 0
+          },
+          {
+            "name": "top",
+            "in": "query",
+            "description": "Optional num entries to show.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 50
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "description": "Optional key by which to sort.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "sortValue",
+            "in": "query",
+            "description": "Optional sort value for pagination.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ReachabilityAnalysisRunListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkManagers/{networkManagerName}/verifierWorkspaces/{workspaceName}/reachabilityAnalysisRuns/{reachabilityAnalysisRunName}": {
+      "get": {
+        "operationId": "ReachabilityAnalysisRuns_Get",
+        "tags": [
+          "ReachabilityAnalysisRuns"
+        ],
+        "summary": "Gets Reachability Analysis Run.",
+        "description": "Gets Reachability Analysis Run.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "reachabilityAnalysisRunName",
+            "in": "path",
+            "description": "Reachability Analysis Run name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ReachabilityAnalysisRun"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ReachabilityAnalysisRuns_Create",
+        "tags": [
+          "ReachabilityAnalysisRuns"
+        ],
+        "summary": "Creates Reachability Analysis Runs.",
+        "description": "Creates Reachability Analysis Runs.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "reachabilityAnalysisRunName",
+            "in": "path",
+            "description": "Reachability Analysis Run name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Analysis Run resource object to create/update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReachabilityAnalysisRun"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ReachabilityAnalysisRun' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ReachabilityAnalysisRun"
+            }
+          },
+          "201": {
+            "description": "Resource 'ReachabilityAnalysisRun' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ReachabilityAnalysisRun"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ReachabilityAnalysisRuns_Delete",
+        "tags": [
+          "ReachabilityAnalysisRuns"
+        ],
+        "summary": "Deletes Reachability Analysis Run.",
+        "description": "Deletes Reachability Analysis Run.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkManagerName",
+            "in": "path",
+            "description": "The name of the network manager.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "workspaceName",
+            "in": "path",
+            "description": "The name of the resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "reachabilityAnalysisRunName",
+            "in": "path",
+            "description": "Reachability Analysis Run name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CommonErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles": {
+      "get": {
+        "operationId": "NetworkProfiles_List",
+        "tags": [
+          "NetworkProfiles"
+        ],
+        "description": "Gets all network profiles in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkProfileListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkProfiles/{networkProfileName}": {
+      "get": {
+        "operationId": "NetworkProfiles_Get",
+        "tags": [
+          "NetworkProfiles"
+        ],
+        "description": "Gets the specified network profile in a specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkProfileName",
+            "in": "path",
+            "description": "The name of the public IP prefix.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkProfiles_CreateOrUpdate",
+        "tags": [
+          "NetworkProfiles"
+        ],
+        "description": "Creates or updates a network profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkProfileName",
+            "in": "path",
+            "description": "The name of the public IP prefix.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update network profile operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkProfile"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkProfile' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkProfile"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkProfile' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "patch": {
+        "operationId": "NetworkProfiles_UpdateTags",
+        "tags": [
+          "NetworkProfiles"
+        ],
+        "description": "Updates network profile tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkProfileName",
+            "in": "path",
+            "description": "The name of the public IP prefix.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update network profile tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkProfile"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkProfiles_Delete",
+        "tags": [
+          "NetworkProfiles"
+        ],
+        "description": "Deletes the specified network profile.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkProfileName",
+            "in": "path",
+            "description": "The name of the public IP prefix.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups": {
+      "get": {
+        "operationId": "NetworkSecurityGroups_List",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Gets all network security groups in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}": {
+      "get": {
+        "operationId": "NetworkSecurityGroups_Get",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Gets the specified network security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "The name of the network security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkSecurityGroups_CreateOrUpdate",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Creates or updates a network security group in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "The name of the network security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update network security group operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkSecurityGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkSecurityGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/NetworkSecurityGroup"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "NetworkSecurityGroups_UpdateTags",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Updates a network security group tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "The name of the network security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update network security group tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkSecurityGroups_Delete",
+        "tags": [
+          "NetworkSecurityGroups"
+        ],
+        "description": "Deletes the specified network security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "The name of the network security group.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/defaultSecurityRules": {
+      "get": {
+        "operationId": "DefaultSecurityRules_List",
+        "tags": [
+          "SecurityRules"
+        ],
+        "description": "Gets all default security rules in a network security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "The name of the network security group.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/defaultSecurityRules/{defaultSecurityRuleName}": {
+      "get": {
+        "operationId": "DefaultSecurityRules_Get",
+        "tags": [
+          "SecurityRules"
+        ],
+        "description": "Get the specified default network security rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "The name of the network security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "defaultSecurityRuleName",
+            "in": "path",
+            "description": "The name of the default security rule.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules": {
+      "get": {
+        "operationId": "SecurityRules_List",
+        "tags": [
+          "SecurityRules"
+        ],
+        "description": "Gets all security rules in a network security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "The name of the network security group.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkSecurityGroups/{networkSecurityGroupName}/securityRules/{securityRuleName}": {
+      "get": {
+        "operationId": "SecurityRules_Get",
+        "tags": [
+          "SecurityRules"
+        ],
+        "description": "Get the specified network security rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "The name of the network security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "securityRuleName",
+            "in": "path",
+            "description": "The name of the security rule.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "SecurityRules_CreateOrUpdate",
+        "tags": [
+          "SecurityRules"
+        ],
+        "description": "Creates or updates a security rule in the specified network security group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "The name of the network security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "securityRuleName",
+            "in": "path",
+            "description": "The name of the security rule.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "securityRuleParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update network security rule operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SecurityRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'SecurityRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityRule"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/SecurityRule"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "SecurityRules_Delete",
+        "tags": [
+          "SecurityRules"
+        ],
+        "description": "Deletes the specified network security rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkSecurityGroupName",
+            "in": "path",
+            "description": "The name of the network security group.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "securityRuleName",
+            "in": "path",
+            "description": "The name of the security rule.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances": {
+      "get": {
+        "operationId": "NetworkVirtualAppliances_ListByResourceGroup",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Lists all Network Virtual Appliances in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}": {
+      "get": {
+        "operationId": "NetworkVirtualAppliances_Get",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Gets the specified Network Virtual Appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualAppliance"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkVirtualAppliances_CreateOrUpdate",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Creates or updates the specified Network Virtual Appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update Network Virtual Appliance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualAppliance"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'NetworkVirtualAppliance' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualAppliance"
+            }
+          },
+          "201": {
+            "description": "Resource 'NetworkVirtualAppliance' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualAppliance"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/NetworkVirtualAppliance"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "NetworkVirtualAppliances_UpdateTags",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Updates a Network Virtual Appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to Update Network Virtual Appliance Tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualAppliance"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "NetworkVirtualAppliances_Delete",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Deletes the specified Network Virtual Appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/abortMigration": {
+      "post": {
+        "operationId": "NetworkVirtualAppliances_AbortMigration",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Aborts an in-progress migration of the specified Network Virtual Appliance and rolls back to the previous state.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Action completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/commitMigration": {
+      "post": {
+        "operationId": "NetworkVirtualAppliances_CommitMigration",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Commits the migration of the specified Network Virtual Appliance. This finalizes a previously executed migration workflow.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters supplied to commit the migration of the Network Virtual Appliance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceCommitMigrationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Action completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/executeMigration": {
+      "post": {
+        "operationId": "NetworkVirtualAppliances_ExecuteMigration",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Executes the migration of the specified Network Virtual Appliance. This step performs the migration workflow that was previously prepared.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters supplied to execute the migration of the Network Virtual Appliance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceExecuteMigrationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Action completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/getBootDiagnosticLogs": {
+      "post": {
+        "operationId": "NetworkVirtualAppliances_GetBootDiagnosticLogs",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Retrieves the boot diagnostic logs for a VM instance belonging to the specified Network Virtual Appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "Parameters supplied to retrieve boot diagnostic logs for a NVA VM instance",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceBootDiagnosticParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceInstanceId"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/NetworkVirtualApplianceInstanceId"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/inboundSecurityRules/{ruleCollectionName}": {
+      "get": {
+        "operationId": "InboundSecurityRule_Get",
+        "description": "Retrieves the available specified Network Virtual Appliance Inbound Security Rules Collection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/InboundSecurityRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "InboundSecurityRule_CreateOrUpdate",
+        "description": "Creates or updates the specified Network Virtual Appliance Inbound Security Rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ruleCollectionName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update Network Virtual Appliance Inbound Security Rules operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/InboundSecurityRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'InboundSecurityRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/InboundSecurityRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'InboundSecurityRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/InboundSecurityRule"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/InboundSecurityRule"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/prepareMigration": {
+      "post": {
+        "operationId": "NetworkVirtualAppliances_PrepareMigration",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Prepares the migration of the specified Network Virtual Appliance. This is the first step of a migration workflow, such as migrating to a new OS version or to the new internal load balancer architecture.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters supplied to prepare the migration of the Network Virtual Appliance.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualAppliancePrepareMigrationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Action completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/reimage": {
+      "post": {
+        "operationId": "NetworkVirtualAppliances_Reimage",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Reimages one VM belonging to the specified Network Virtual Appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "NetworkVirtualApplianceInstanceIds",
+            "in": "body",
+            "description": "Specifies a list of virtual machine instance IDs from the Network Virtual Appliance VM instances.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceInstanceIds"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceInstanceIds"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/NetworkVirtualApplianceInstanceIds"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/restart": {
+      "post": {
+        "operationId": "NetworkVirtualAppliances_Restart",
+        "tags": [
+          "NetworkVirtualAppliances"
+        ],
+        "description": "Restarts one or more VMs belonging to the specified Network Virtual Appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "NetworkVirtualApplianceInstanceIds",
+            "in": "body",
+            "description": "Specifies a list of virtual machine instance IDs from the Network Virtual Appliance VM instances.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceInstanceIds"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceInstanceIds"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/NetworkVirtualApplianceInstanceIds"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/virtualApplianceSites": {
+      "get": {
+        "operationId": "VirtualApplianceSites_List",
+        "tags": [
+          "VirtualApplianceSites"
+        ],
+        "description": "Lists all Network Virtual Appliance Sites in a Network Virtual Appliance resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceSiteListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/virtualApplianceSites/{siteName}": {
+      "get": {
+        "operationId": "VirtualApplianceSites_Get",
+        "tags": [
+          "VirtualApplianceSites"
+        ],
+        "description": "Gets the specified Virtual Appliance Site.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "siteName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualApplianceSite"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualApplianceSites_CreateOrUpdate",
+        "tags": [
+          "VirtualApplianceSites"
+        ],
+        "description": "Creates or updates the specified Network Virtual Appliance Site.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "siteName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update Network Virtual Appliance Site operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualApplianceSite"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualApplianceSite' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualApplianceSite"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualApplianceSite' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualApplianceSite"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualApplianceSite"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualApplianceSites_Delete",
+        "tags": [
+          "VirtualApplianceSites"
+        ],
+        "description": "Deletes the specified site from a Virtual Appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "siteName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints": {
+      "get": {
+        "operationId": "PrivateEndpoints_List",
+        "tags": [
+          "PrivateEndpoints"
+        ],
+        "description": "Gets all private endpoints in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}": {
+      "get": {
+        "operationId": "PrivateEndpoints_Get",
+        "tags": [
+          "PrivateEndpoints"
+        ],
+        "description": "Gets the specified private endpoint by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateEndpointName",
+            "in": "path",
+            "description": "The name of the private endpoint.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpoint"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpoints_CreateOrUpdate",
+        "tags": [
+          "PrivateEndpoints"
+        ],
+        "description": "Creates or updates an private endpoint in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateEndpointName",
+            "in": "path",
+            "description": "The name of the private endpoint.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update private endpoint operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpoint"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpoint' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpoint"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpoint' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpoint"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/PrivateEndpoint"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PrivateEndpoints_Delete",
+        "tags": [
+          "PrivateEndpoints"
+        ],
+        "description": "Deletes the specified private endpoint.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateEndpointName",
+            "in": "path",
+            "description": "The name of the private endpoint.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups": {
+      "get": {
+        "operationId": "PrivateDnsZoneGroups_List",
+        "tags": [
+          "PrivateDnsZoneGroups"
+        ],
+        "description": "Gets all private dns zone groups in a private endpoint.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateEndpointName",
+            "in": "path",
+            "description": "The name of the private endpoint.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateDnsZoneGroupListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateEndpoints/{privateEndpointName}/privateDnsZoneGroups/{privateDnsZoneGroupName}": {
+      "get": {
+        "operationId": "PrivateDnsZoneGroups_Get",
+        "tags": [
+          "PrivateDnsZoneGroups"
+        ],
+        "description": "Gets the private dns zone group resource by specified private dns zone group name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateEndpointName",
+            "in": "path",
+            "description": "The name of the private endpoint.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateDnsZoneGroupName",
+            "in": "path",
+            "description": "The name of the private endpoint.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateDnsZoneGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateDnsZoneGroups_CreateOrUpdate",
+        "tags": [
+          "PrivateDnsZoneGroups"
+        ],
+        "description": "Creates or updates a private dns zone group in the specified private endpoint.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateEndpointName",
+            "in": "path",
+            "description": "The name of the private endpoint.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateDnsZoneGroupName",
+            "in": "path",
+            "description": "The name of the private endpoint.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update private dns zone group operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateDnsZoneGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateDnsZoneGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateDnsZoneGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateDnsZoneGroup"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/PrivateDnsZoneGroup"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PrivateDnsZoneGroups_Delete",
+        "tags": [
+          "PrivateDnsZoneGroups"
+        ],
+        "description": "Deletes the specified private dns zone group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "privateEndpointName",
+            "in": "path",
+            "description": "The name of the private endpoint.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateDnsZoneGroupName",
+            "in": "path",
+            "description": "The name of the private endpoint.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices": {
+      "get": {
+        "operationId": "PrivateLinkServices_List",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Gets all private link services in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkServiceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}": {
+      "get": {
+        "operationId": "PrivateLinkServices_Get",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Gets the specified private link service by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "description": "The name of the private link service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkService"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateLinkServices_CreateOrUpdate",
+        "tags": [
+          "PrivateLinkService"
+        ],
+        "description": "Creates or updates an private link service in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "description": "The name of the private link service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update private link service operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkService"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateLinkService' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkService"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateLinkService' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkService"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/PrivateLinkService"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PrivateLinkServices_Delete",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Deletes the specified private link service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "description": "The name of the private link service.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateLinkServices_ListPrivateEndpointConnections",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Gets all private end point connections for a specific private link service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "description": "The name of the private link service.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/privateLinkServices/{serviceName}/privateEndpointConnections/{peConnectionName}": {
+      "get": {
+        "operationId": "PrivateLinkServices_GetPrivateEndpointConnection",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Get the specific private end point connection by specific private link service in the resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "description": "The name of the private link service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peConnectionName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateLinkServices_UpdatePrivateEndpointConnection",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Approve or reject private end point connection for a private link service in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "description": "The name of the private link service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peConnectionName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to approve or reject the private end point connection.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PrivateLinkServices_DeletePrivateEndpointConnection",
+        "tags": [
+          "PrivateLinkServices"
+        ],
+        "description": "Delete private end point connection for a private link service in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "serviceName",
+            "in": "path",
+            "description": "The name of the private link service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peConnectionName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses": {
+      "get": {
+        "operationId": "PublicIPAddresses_List",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Gets all public IP addresses in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddressListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}": {
+      "get": {
+        "operationId": "PublicIPAddresses_Get",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Gets the specified public IP address in a specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "description": "The name of the public IP address.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "PublicIPAddresses_CreateOrUpdate",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Creates or updates a static or dynamic public IP address.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "description": "The name of the public IP address.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update public IP address operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PublicIPAddress' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          },
+          "201": {
+            "description": "Resource 'PublicIPAddress' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/PublicIPAddress"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PublicIPAddresses_UpdateTags",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Updates public IP address tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "description": "The name of the public IP address.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update public IP address tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PublicIPAddresses_Delete",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Deletes the specified public IP address.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "description": "The name of the public IP address.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}/ddosProtectionStatus": {
+      "post": {
+        "operationId": "PublicIPAddresses_DdosProtectionStatus",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Gets the Ddos Protection Status of a Public IP Address",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "description": "The name of the public IP address.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIpDdosProtectionStatusResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PublicIpDdosProtectionStatusResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}/disassociateCloudServiceReservedPublicIp": {
+      "post": {
+        "operationId": "PublicIPAddresses_DisassociateCloudServiceReservedPublicIp",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Disassociates the Cloud Service reserved Public IP and associates the specified Standalone Public IP to the same Cloud Service frontend.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "description": "The name of the public IP address.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameter that define which Public IP Address should be associated in place of given Public IP Address.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DisassociateCloudServicePublicIpRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PublicIPAddress"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}/reserveCloudServicePublicIpAddress": {
+      "post": {
+        "operationId": "PublicIPAddresses_ReserveCloudServicePublicIpAddress",
+        "tags": [
+          "PublicIPAddresses"
+        ],
+        "description": "Reserves the specified Cloud Service Public IP by switching its allocation method to Static. If rollback is requested, reverts the allocation method to Dynamic.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "description": "The name of the public IP address.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameter that define which Public IP Address should be associated in place of given Public IP Address.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ReserveCloudServicePublicIpAddressRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "format": "uri",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PublicIPAddress"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes": {
+      "get": {
+        "operationId": "PublicIPPrefixes_List",
+        "tags": [
+          "PublicIPPrefixes"
+        ],
+        "description": "Gets all public IP prefixes in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPPrefixListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/publicIPPrefixes/{publicIpPrefixName}": {
+      "get": {
+        "operationId": "PublicIPPrefixes_Get",
+        "tags": [
+          "PublicIPPrefixes"
+        ],
+        "description": "Gets the specified public IP prefix in a specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpPrefixName",
+            "in": "path",
+            "description": "The name of the public IP prefix.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPPrefix"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "PublicIPPrefixes_CreateOrUpdate",
+        "tags": [
+          "PublicIPPrefixes"
+        ],
+        "description": "Creates or updates a static or dynamic public IP prefix.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpPrefixName",
+            "in": "path",
+            "description": "The name of the public IP prefix.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update public IP prefix operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PublicIPPrefix"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PublicIPPrefix' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PublicIPPrefix"
+            }
+          },
+          "201": {
+            "description": "Resource 'PublicIPPrefix' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PublicIPPrefix"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PublicIPPrefix"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "PublicIPPrefixes_UpdateTags",
+        "tags": [
+          "PublicIPPrefixes"
+        ],
+        "description": "Updates public IP prefix tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpPrefixName",
+            "in": "path",
+            "description": "The name of the public IP prefix.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update public IP prefix tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPPrefix"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "PublicIPPrefixes_Delete",
+        "tags": [
+          "PublicIPPrefixes"
+        ],
+        "description": "Deletes the specified public IP prefix.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "publicIpPrefixName",
+            "in": "path",
+            "description": "The name of the public IP prefix.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables": {
+      "get": {
+        "operationId": "RouteTables_List",
+        "tags": [
+          "RouteTables"
+        ],
+        "description": "Gets all route tables in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteTableListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}": {
+      "get": {
+        "operationId": "RouteTables_Get",
+        "tags": [
+          "RouteTables"
+        ],
+        "description": "Gets the specified route table.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the route table.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteTable"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RouteTables_CreateOrUpdate",
+        "tags": [
+          "RouteTables"
+        ],
+        "description": "Create or updates a route table in a specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the route table.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update route table operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RouteTable"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RouteTable' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RouteTable"
+            }
+          },
+          "201": {
+            "description": "Resource 'RouteTable' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RouteTable"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/RouteTable"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "RouteTables_UpdateTags",
+        "tags": [
+          "RouteTables"
+        ],
+        "description": "Updates a route table tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the route table.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update route table tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteTable"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RouteTables_Delete",
+        "tags": [
+          "RouteTables"
+        ],
+        "description": "Deletes the specified route table.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the route table.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes": {
+      "get": {
+        "operationId": "Routes_List",
+        "tags": [
+          "Routes"
+        ],
+        "description": "Gets all routes in a route table.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the route table.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/routeTables/{routeTableName}/routes/{routeName}": {
+      "get": {
+        "operationId": "Routes_Get",
+        "tags": [
+          "Routes"
+        ],
+        "description": "Gets the specified route from a route table.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the route table.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeName",
+            "in": "path",
+            "description": "The name of the route.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Route"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Routes_CreateOrUpdate",
+        "tags": [
+          "Routes"
+        ],
+        "description": "Creates or updates a route in the specified route table.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the route table.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeName",
+            "in": "path",
+            "description": "The name of the route.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update route operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Route"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Route' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Route"
+            }
+          },
+          "201": {
+            "description": "Resource 'Route' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Route"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Route"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Routes_Delete",
+        "tags": [
+          "Routes"
+        ],
+        "description": "Deletes the specified route from a route table.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the route table.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeName",
+            "in": "path",
+            "description": "The name of the route.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders": {
+      "get": {
+        "operationId": "SecurityPartnerProviders_ListByResourceGroup",
+        "tags": [
+          "SecurityPartnerProviders"
+        ],
+        "description": "Lists all Security Partner Providers in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityPartnerProviderListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/securityPartnerProviders/{securityPartnerProviderName}": {
+      "get": {
+        "operationId": "SecurityPartnerProviders_Get",
+        "tags": [
+          "SecurityPartnerProviders"
+        ],
+        "description": "Gets the specified Security Partner Provider.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "securityPartnerProviderName",
+            "in": "path",
+            "description": "The name of the Security Partner Provider.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityPartnerProvider"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "SecurityPartnerProviders_CreateOrUpdate",
+        "tags": [
+          "SecurityPartnerProviders"
+        ],
+        "description": "Creates or updates the specified Security Partner Provider.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "securityPartnerProviderName",
+            "in": "path",
+            "description": "The name of the Security Partner Provider.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update Security Partner Provider operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SecurityPartnerProvider"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SecurityPartnerProvider' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityPartnerProvider"
+            }
+          },
+          "201": {
+            "description": "Resource 'SecurityPartnerProvider' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SecurityPartnerProvider"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/SecurityPartnerProvider"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "SecurityPartnerProviders_UpdateTags",
+        "tags": [
+          "SecurityPartnerProviders"
+        ],
+        "description": "Updates tags of a Security Partner Provider resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "securityPartnerProviderName",
+            "in": "path",
+            "description": "The name of the Security Partner Provider.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update Security Partner Provider tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecurityPartnerProvider"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SecurityPartnerProviders_Delete",
+        "tags": [
+          "SecurityPartnerProviders"
+        ],
+        "description": "Deletes the specified Security Partner Provider.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "securityPartnerProviderName",
+            "in": "path",
+            "description": "The name of the Security Partner Provider.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks": {
+      "get": {
+        "operationId": "VirtualNetworks_List",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Gets all virtual networks in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}": {
+      "get": {
+        "operationId": "VirtualNetworks_Get",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Gets the specified virtual network by resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualNetworks_CreateOrUpdate",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Creates or updates a virtual network in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update virtual network operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualNetwork' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualNetwork' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualNetwork"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualNetworks_UpdateTags",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Updates a virtual network tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update virtual network tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetwork"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "VirtualNetworks_Delete",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Deletes the specified virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/checkIPAddressAvailability": {
+      "get": {
+        "operationId": "VirtualNetworks_CheckIPAddressAvailability",
+        "description": "Checks whether a private IP address is available for use.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ipAddress",
+            "in": "query",
+            "description": "The private IP address to be verified.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/IPAddressAvailabilityResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/ddosProtectionStatus": {
+      "post": {
+        "operationId": "VirtualNetworks_ListDdosProtectionStatus",
+        "description": "Gets the Ddos Protection Status of all IP Addresses under the Virtual Network",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "top",
+            "in": "query",
+            "description": "The max number of ip addresses to return.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "skipToken",
+            "in": "query",
+            "description": "The skipToken that is given with nextLink.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkDdosProtectionStatusResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VirtualNetworkDdosProtectionStatusResult"
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/moveIpConfigurations": {
+      "post": {
+        "operationId": "VirtualNetworks_MoveIpConfigurations",
+        "tags": [
+          "VirtualNetworks"
+        ],
+        "description": "Move IP configurations from one virtual network to another.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Parameters supplied to move IP configurations from one virtual network to another.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MoveIpConfigurationsRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets": {
+      "get": {
+        "operationId": "Subnets_List",
+        "tags": [
+          "Subnets"
+        ],
+        "description": "Gets all subnets in a virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SubnetListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}": {
+      "get": {
+        "operationId": "Subnets_Get",
+        "tags": [
+          "Subnets"
+        ],
+        "description": "Gets the specified subnet by virtual network and resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "The name of the subnet.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Subnet"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Subnets_CreateOrUpdate",
+        "tags": [
+          "Subnets"
+        ],
+        "description": "Creates or updates a subnet in the specified virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "The name of the subnet.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subnetParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update subnet operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Subnet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Subnet' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Subnet"
+            }
+          },
+          "201": {
+            "description": "Resource 'Subnet' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Subnet"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Subnet"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Subnets_Delete",
+        "tags": [
+          "Subnets"
+        ],
+        "description": "Deletes the specified subnet.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "The name of the subnet.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/prepareNetworkPolicies": {
+      "post": {
+        "operationId": "Subnets_PrepareNetworkPolicies",
+        "description": "Prepares a subnet by applying network intent policies.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "The name of the subnet.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "prepareNetworkPoliciesRequestParameters",
+            "in": "body",
+            "description": "Parameters supplied to prepare subnet by applying network intent policies.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrepareNetworkPoliciesRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/resourceNavigationLinks": {
+      "get": {
+        "operationId": "ResourceNavigationLinks_List",
+        "description": "Gets a list of resource navigation links for a subnet.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "The name of the subnet.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ResourceNavigationLinksListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/serviceAssociationLinks": {
+      "get": {
+        "operationId": "ServiceAssociationLinks_List",
+        "description": "Gets a list of service association links for a subnet.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "The name of the subnet.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceAssociationLinksListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/subnets/{subnetName}/unprepareNetworkPolicies": {
+      "post": {
+        "operationId": "Subnets_UnprepareNetworkPolicies",
+        "description": "Unprepares a subnet by removing network intent policies.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "subnetName",
+            "in": "path",
+            "description": "The name of the subnet.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "unprepareNetworkPoliciesRequestParameters",
+            "in": "body",
+            "description": "Parameters supplied to unprepare subnet to remove network intent policies.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UnprepareNetworkPoliciesRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/usages": {
+      "get": {
+        "operationId": "VirtualNetworks_ListUsage",
+        "description": "Lists usage stats.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkListUsageResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings": {
+      "get": {
+        "operationId": "VirtualNetworkPeerings_List",
+        "tags": [
+          "VirtualNetworkPeerings"
+        ],
+        "description": "Gets all virtual network peerings in a virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkPeeringListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworks/{virtualNetworkName}/virtualNetworkPeerings/{virtualNetworkPeeringName}": {
+      "get": {
+        "operationId": "VirtualNetworkPeerings_Get",
+        "tags": [
+          "VirtualNetworkPeerings"
+        ],
+        "description": "Gets the specified virtual network peering.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "virtualNetworkPeeringName",
+            "in": "path",
+            "description": "The name of the virtual network peering.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkPeering"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualNetworkPeerings_CreateOrUpdate",
+        "tags": [
+          "VirtualNetworkPeerings"
+        ],
+        "description": "Creates or updates a peering in the specified virtual network.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "virtualNetworkPeeringName",
+            "in": "path",
+            "description": "The name of the virtual network peering.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "syncRemoteAddressSpace",
+            "in": "query",
+            "description": "Parameter indicates the intention to sync the peering with the current address space on the remote vNet after it's updated.",
+            "required": false,
+            "type": "string",
+            "enum": [
+              "true"
+            ],
+            "x-ms-enum": {
+              "name": "SyncRemoteAddressSpace",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "true",
+                  "value": "true",
+                  "description": "true"
+                }
+              ]
+            }
+          },
+          {
+            "name": "VirtualNetworkPeeringParameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update virtual network peering operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkPeering"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualNetworkPeering' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkPeering"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualNetworkPeering' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkPeering"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualNetworkPeering"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualNetworkPeerings_Delete",
+        "tags": [
+          "VirtualNetworkPeerings"
+        ],
+        "description": "Deletes the specified virtual network peering.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkName",
+            "in": "path",
+            "description": "The name of the virtual network.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "virtualNetworkPeeringName",
+            "in": "path",
+            "description": "The name of the virtual network peering.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters": {
+      "get": {
+        "operationId": "VirtualRouters_ListByResourceGroup",
+        "tags": [
+          "VirtualRouters"
+        ],
+        "description": "Lists all Virtual Routers in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualRouterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}": {
+      "get": {
+        "operationId": "VirtualRouters_Get",
+        "tags": [
+          "VirtualRouters"
+        ],
+        "description": "Gets the specified Virtual Router.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualRouterName",
+            "in": "path",
+            "description": "The name of the Virtual Router.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualRouter"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualRouters_CreateOrUpdate",
+        "tags": [
+          "VirtualRouters"
+        ],
+        "description": "Creates or updates the specified Virtual Router.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualRouterName",
+            "in": "path",
+            "description": "The name of the Virtual Router.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update Virtual Router.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualRouter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualRouter' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualRouter"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualRouter' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualRouter"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualRouter"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualRouters_Delete",
+        "tags": [
+          "VirtualRouters"
+        ],
+        "description": "Deletes the specified Virtual Router.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualRouterName",
+            "in": "path",
+            "description": "The name of the Virtual Router.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings": {
+      "get": {
+        "operationId": "VirtualRouterPeerings_List",
+        "tags": [
+          "VirtualRouterPeerings"
+        ],
+        "description": "Lists all Virtual Router Peerings in a Virtual Router resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualRouterName",
+            "in": "path",
+            "description": "The name of the Virtual Router.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualRouterPeeringListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualRouters/{virtualRouterName}/peerings/{peeringName}": {
+      "get": {
+        "operationId": "VirtualRouterPeerings_Get",
+        "tags": [
+          "VirtualRouterPeerings"
+        ],
+        "description": "Gets the specified Virtual Router Peering.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualRouterName",
+            "in": "path",
+            "description": "The name of the Virtual Router.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualRouterPeering"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualRouterPeerings_CreateOrUpdate",
+        "tags": [
+          "VirtualRouterPeerings"
+        ],
+        "description": "Creates or updates the specified Virtual Router Peering.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualRouterName",
+            "in": "path",
+            "description": "The name of the Virtual Router.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update Virtual Router Peering operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualRouterPeering"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualRouterPeering' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualRouterPeering"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualRouterPeering' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualRouterPeering"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualRouterPeering"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualRouterPeerings_Delete",
+        "tags": [
+          "VirtualRouterPeerings"
+        ],
+        "description": "Deletes the specified peering from a Virtual Router.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualRouterName",
+            "in": "path",
+            "description": "The name of the Virtual Router.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/cloudServices/{cloudServiceName}/networkInterfaces": {
+      "get": {
+        "operationId": "NetworkInterfaces_ListCloudServiceNetworkInterfaces",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Gets all network interfaces in a cloud service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "cloudServiceName",
+            "in": "path",
+            "description": "The name of the cloud service.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/microsoft.Compute/cloudServices/{resourceName}/providers/Microsoft.Network/cloudServiceSlots": {
+      "get": {
+        "operationId": "VipSwap_List",
+        "tags": [
+          "VipSwap"
+        ],
+        "description": "Gets the list of SwapResource which identifies the slot type for the specified cloud service. The slot type on a cloud service can either be Staging or Production",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "groupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the cloud service.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SwapResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{groupName}/providers/microsoft.Compute/cloudServices/{resourceName}/providers/Microsoft.Network/cloudServiceSlots/{singletonResource}": {
+      "get": {
+        "operationId": "VipSwap_Get",
+        "tags": [
+          "VipSwap"
+        ],
+        "description": "Gets the SwapResource which identifies the slot type for the specified cloud service. The slot type on a cloud service can either be Staging or Production",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "groupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the cloud service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "singletonResource",
+            "in": "path",
+            "description": "The name of the singleton resource.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "swap"
+            ],
+            "x-ms-enum": {
+              "name": "SingletonResource",
+              "modelAsString": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SwapResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VipSwap_Create",
+        "tags": [
+          "VipSwap"
+        ],
+        "description": "Performs vip swap operation on swappable cloud services.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "groupName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the cloud service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "singletonResource",
+            "in": "path",
+            "description": "The name of the singleton resource.",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "swap"
+            ],
+            "x-ms-enum": {
+              "name": "SingletonResource",
+              "modelAsString": false
+            }
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "SwapResource object where slot type should be the target slot after vip swap for the specified cloud service.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SwapResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/cloudServices/{cloudServiceName}/publicipaddresses": {
+      "get": {
+        "operationId": "PublicIPAddresses_ListCloudServicePublicIPAddresses",
+        "description": "Gets information about all public IP addresses on a cloud service level.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "cloudServiceName",
+            "in": "path",
+            "description": "The name of the cloud service.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddressListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/cloudServices/{cloudServiceName}/roleInstances/{roleInstanceName}/networkInterfaces": {
+      "get": {
+        "operationId": "NetworkInterfaces_ListCloudServiceRoleInstanceNetworkInterfaces",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Gets information about all network interfaces in a role instance in a cloud service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "cloudServiceName",
+            "in": "path",
+            "description": "The name of the cloud service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "roleInstanceName",
+            "in": "path",
+            "description": "The name of role instance.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterfaceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/cloudServices/{cloudServiceName}/roleInstances/{roleInstanceName}/networkInterfaces/{networkInterfaceName}": {
+      "get": {
+        "operationId": "NetworkInterfaces_GetCloudServiceNetworkInterface",
+        "tags": [
+          "NetworkInterfaces"
+        ],
+        "description": "Get the specified network interface in a cloud service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "cloudServiceName",
+            "in": "path",
+            "description": "The name of the cloud service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "roleInstanceName",
+            "in": "path",
+            "description": "The name of role instance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkInterface"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/cloudServices/{cloudServiceName}/roleInstances/{roleInstanceName}/networkInterfaces/{networkInterfaceName}/ipconfigurations/{ipConfigurationName}/publicipaddresses": {
+      "get": {
+        "operationId": "PublicIPAddresses_ListCloudServiceRoleInstancePublicIPAddresses",
+        "description": "Gets information about all public IP addresses in a role instance IP configuration in a cloud service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "cloudServiceName",
+            "in": "path",
+            "description": "The name of the cloud service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "roleInstanceName",
+            "in": "path",
+            "description": "The role instance name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ipConfigurationName",
+            "in": "path",
+            "description": "The name of the IP configuration.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddressListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/microsoft.Compute/cloudServices/{cloudServiceName}/roleInstances/{roleInstanceName}/networkInterfaces/{networkInterfaceName}/ipconfigurations/{ipConfigurationName}/publicipaddresses/{publicIpAddressName}": {
+      "get": {
+        "operationId": "PublicIPAddresses_GetCloudServicePublicIPAddress",
+        "description": "Get the specified public IP address in a cloud service.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "cloudServiceName",
+            "in": "path",
+            "description": "The name of the cloud service.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "roleInstanceName",
+            "in": "path",
+            "description": "The role instance name.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "networkInterfaceName",
+            "in": "path",
+            "description": "The name of the network interface.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ipConfigurationName",
+            "in": "path",
+            "description": "The name of the IP configuration.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "publicIpAddressName",
+            "in": "path",
+            "description": "The name of the public IP Address.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$expand",
+            "in": "query",
+            "description": "Expands referenced resources.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PublicIPAddress"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AddressPrefixSet": {
+      "type": "object",
+      "description": "Address prefix set child resource of an application security group.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AddressPrefixSetPropertiesFormat",
+          "description": "Properties of the address prefix set."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AddressPrefixSetListResult": {
+      "type": "object",
+      "description": "The response of a AddressPrefixSet list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AddressPrefixSet items on this page",
+          "items": {
+            "$ref": "#/definitions/AddressPrefixSet"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AddressPrefixSetPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of address prefix set.",
+      "properties": {
+        "addressPrefixes": {
+          "type": "array",
+          "description": "The list of address prefixes in CIDR notation. Supports both IPv4 and IPv6 CIDR notation (e.g. '10.0.0.0/16', '2001:db8::/32').",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the address prefix set resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "addressPrefixes"
+      ]
+    },
+    "AddressSpace": {
+      "type": "object",
+      "description": "AddressSpace contains an array of IP address ranges that can be used by subnets of the virtual network.",
+      "properties": {
+        "addressPrefixes": {
+          "type": "array",
+          "description": "A list of address blocks reserved for this virtual network in CIDR notation.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ipamPoolPrefixAllocations": {
+          "type": "array",
+          "description": "A list of IPAM Pools allocating IP address prefixes.",
+          "items": {
+            "$ref": "#/definitions/IpamPoolPrefixAllocation"
+          }
+        }
+      }
+    },
+    "ApplicationSecurityGroup": {
+      "type": "object",
+      "description": "An application security group in a resource group.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ApplicationSecurityGroupPropertiesFormat",
+          "description": "Properties of the application security group.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ApplicationSecurityGroupListResult": {
+      "type": "object",
+      "description": "The response of a ApplicationSecurityGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ApplicationSecurityGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/ApplicationSecurityGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ApplicationSecurityGroupPropertiesFormat": {
+      "type": "object",
+      "description": "Application security group properties.",
+      "properties": {
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the application security group resource. It uniquely identifies a resource, even if the user changes its name or migrate the resource across subscriptions or resource groups.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the application security group resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "AutoApprovedPrivateLinkService": {
+      "type": "object",
+      "description": "The information of an AutoApprovedPrivateLinkService.",
+      "properties": {
+        "privateLinkService": {
+          "type": "string",
+          "description": "The id of the private link service resource."
+        }
+      }
+    },
+    "AutoApprovedPrivateLinkServicesResult": {
+      "type": "object",
+      "description": "An array of private link service id that can be linked to a private end point with auto approved.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AutoApprovedPrivateLinkService items on this page",
+          "items": {
+            "$ref": "#/definitions/AutoApprovedPrivateLinkService"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AvailableDelegation": {
+      "type": "object",
+      "description": "The serviceName of an AvailableDelegation indicates a possible delegation for a subnet.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the AvailableDelegation resource."
+        },
+        "id": {
+          "type": "string",
+          "description": "A unique identifier of the AvailableDelegation resource."
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type."
+        },
+        "serviceName": {
+          "type": "string",
+          "description": "The name of the service and resource."
+        },
+        "actions": {
+          "type": "array",
+          "description": "The actions permitted to the service upon delegation.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AvailableDelegationsResult": {
+      "type": "object",
+      "description": "An array of available delegations.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AvailableDelegation items on this page",
+          "items": {
+            "$ref": "#/definitions/AvailableDelegation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AvailablePrivateEndpointType": {
+      "type": "object",
+      "description": "The information of an AvailablePrivateEndpointType.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the service and resource."
+        },
+        "id": {
+          "type": "string",
+          "description": "A unique identifier of the AvailablePrivateEndpoint Type resource."
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type."
+        },
+        "resourceName": {
+          "type": "string",
+          "description": "The name of the service and resource."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name of the resource."
+        }
+      }
+    },
+    "AvailablePrivateEndpointTypesResult": {
+      "type": "object",
+      "description": "An array of available PrivateEndpoint types.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AvailablePrivateEndpointType items on this page",
+          "items": {
+            "$ref": "#/definitions/AvailablePrivateEndpointType"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AvailableServiceAlias": {
+      "type": "object",
+      "description": "The available service alias.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the service alias."
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the service alias."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the resource."
+        },
+        "resourceName": {
+          "type": "string",
+          "description": "The resource name of the service alias."
+        }
+      }
+    },
+    "AvailableServiceAliasesResult": {
+      "type": "object",
+      "description": "An array of available service aliases.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AvailableServiceAlias items on this page",
+          "items": {
+            "$ref": "#/definitions/AvailableServiceAlias"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BastionActiveSession": {
+      "type": "object",
+      "description": "The session detail for a target.",
+      "properties": {
+        "sessionId": {
+          "type": "string",
+          "description": "A unique id for the session.",
+          "readOnly": true
+        },
+        "startTime": {
+          "description": "The time when the session started.",
+          "readOnly": true
+        },
+        "targetSubscriptionId": {
+          "type": "string",
+          "description": "The subscription id for the target virtual machine.",
+          "readOnly": true
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "The type of the resource.",
+          "readOnly": true
+        },
+        "targetHostName": {
+          "type": "string",
+          "description": "The host name of the target.",
+          "readOnly": true
+        },
+        "targetResourceGroup": {
+          "type": "string",
+          "description": "The resource group of the target.",
+          "readOnly": true
+        },
+        "userName": {
+          "type": "string",
+          "description": "The user name who is active on this session.",
+          "readOnly": true
+        },
+        "targetIpAddress": {
+          "type": "string",
+          "description": "The IP Address of the target.",
+          "readOnly": true
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/BastionConnectProtocol",
+          "description": "The protocol used to connect to the target.",
+          "readOnly": true
+        },
+        "targetResourceId": {
+          "type": "string",
+          "description": "The resource id of the target.",
+          "readOnly": true
+        },
+        "sessionDurationInMins": {
+          "type": "number",
+          "format": "float",
+          "description": "Duration in mins the session has been active.",
+          "readOnly": true
+        }
+      }
+    },
+    "BastionActiveSessionListResult": {
+      "type": "object",
+      "description": "Response for GetActiveSessions.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BastionActiveSession items on this page",
+          "items": {
+            "$ref": "#/definitions/BastionActiveSession"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BastionHost": {
+      "type": "object",
+      "description": "Bastion Host resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BastionHostPropertiesFormat",
+          "description": "Represents the bastion host resource.",
+          "x-ms-client-flatten": true
+        },
+        "zones": {
+          "type": "array",
+          "description": "A list of availability zones denoting where the resource needs to come from.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The sku of this Bastion Host."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "BastionHostIPConfiguration": {
+      "type": "object",
+      "description": "IP configuration of an Bastion Host.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BastionHostIPConfigurationPropertiesFormat",
+          "description": "Represents the ip configuration associated with the resource.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Ip configuration type.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "BastionHostIPConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of IP configuration of an Bastion Host.",
+      "properties": {
+        "subnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference of the subnet resource."
+        },
+        "publicIPAddress": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference of the PublicIP resource. Null for private only bastion"
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the bastion host IP configuration resource.",
+          "readOnly": true
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "Private IP allocation method."
+        }
+      },
+      "required": [
+        "subnet"
+      ]
+    },
+    "BastionHostListResult": {
+      "type": "object",
+      "description": "The response of a BastionHost list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BastionHost items on this page",
+          "items": {
+            "$ref": "#/definitions/BastionHost"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BastionHostPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the Bastion Host.",
+      "properties": {
+        "ipConfigurations": {
+          "type": "array",
+          "description": "IP configuration of the Bastion Host resource.",
+          "items": {
+            "$ref": "#/definitions/BastionHostIPConfiguration"
+          }
+        },
+        "dnsName": {
+          "type": "string",
+          "description": "FQDN for the endpoint on which bastion host is accessible."
+        },
+        "virtualNetwork": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to an existing virtual network required for Developer Bastion Host only."
+        },
+        "networkAcls": {
+          "$ref": "#/definitions/BastionHostPropertiesFormatNetworkAcls"
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the bastion host resource.",
+          "readOnly": true
+        },
+        "scaleUnits": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The scale units for the Bastion Host resource.",
+          "minimum": 2,
+          "maximum": 50
+        },
+        "disableCopyPaste": {
+          "type": "boolean",
+          "description": "Enable/Disable Copy/Paste feature of the Bastion Host resource.",
+          "default": false
+        },
+        "enableFileCopy": {
+          "type": "boolean",
+          "description": "Enable/Disable File Copy feature of the Bastion Host resource.",
+          "default": false
+        },
+        "enableIpConnect": {
+          "type": "boolean",
+          "description": "Enable/Disable IP Connect feature of the Bastion Host resource.",
+          "default": false
+        },
+        "enableShareableLink": {
+          "type": "boolean",
+          "description": "Enable/Disable Shareable Link of the Bastion Host resource.",
+          "default": false
+        },
+        "enableTunneling": {
+          "type": "boolean",
+          "description": "Enable/Disable Tunneling feature of the Bastion Host resource.",
+          "default": false
+        },
+        "enableKerberos": {
+          "type": "boolean",
+          "description": "Enable/Disable Kerberos feature of the Bastion Host resource.",
+          "default": false
+        },
+        "enableSessionRecording": {
+          "type": "boolean",
+          "description": "Enable/Disable Session Recording feature of the Bastion Host resource.",
+          "default": false
+        },
+        "enablePrivateOnlyBastion": {
+          "type": "boolean",
+          "description": "Enable/Disable Private Only feature of the Bastion Host resource.",
+          "default": false
+        }
+      }
+    },
+    "BastionHostPropertiesFormatNetworkAcls": {
+      "type": "object",
+      "properties": {
+        "ipRules": {
+          "type": "array",
+          "description": "Sets the IP ACL rules for Developer Bastion Host.",
+          "items": {
+            "$ref": "#/definitions/IPRule"
+          }
+        }
+      }
+    },
+    "BastionSessionDeleteResult": {
+      "type": "object",
+      "description": "Response for DisconnectActiveSessions.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BastionSessionState items on this page",
+          "items": {
+            "$ref": "#/definitions/BastionSessionState"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BastionSessionState": {
+      "type": "object",
+      "description": "The session state detail for a target.",
+      "properties": {
+        "sessionId": {
+          "type": "string",
+          "description": "A unique id for the session.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Used for extra information.",
+          "readOnly": true
+        },
+        "state": {
+          "type": "string",
+          "description": "The state of the session. Disconnected/Failed/NotFound.",
+          "readOnly": true
+        }
+      }
+    },
+    "BastionShareableLink": {
+      "type": "object",
+      "description": "Bastion Shareable Link.",
+      "properties": {
+        "vm": {
+          "$ref": "#/definitions/VM",
+          "description": "Reference of the virtual machine resource."
+        },
+        "bsl": {
+          "type": "string",
+          "description": "The unique Bastion Shareable Link to the virtual machine.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "description": "The time when the link was created.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Optional field indicating the warning or error message related to the vm in case of partial failure.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "vm"
+      ]
+    },
+    "BastionShareableLinkListRequest": {
+      "type": "object",
+      "description": "Post request for Create/Delete/Get Bastion Shareable Link endpoints.",
+      "properties": {
+        "vms": {
+          "type": "array",
+          "description": "List of VM references.",
+          "items": {
+            "$ref": "#/definitions/BastionShareableLink"
+          }
+        }
+      }
+    },
+    "BastionShareableLinkListResult": {
+      "type": "object",
+      "description": "Response for all the Bastion Shareable Link endpoints.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BastionShareableLink items on this page",
+          "items": {
+            "$ref": "#/definitions/BastionShareableLink"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BastionShareableLinkTokenListRequest": {
+      "type": "object",
+      "description": "Post request for Delete Bastion Shareable Link By Token endpoint.",
+      "properties": {
+        "tokens": {
+          "type": "array",
+          "description": "List of Bastion Shareable Link Token.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "BreakOutCategoryPolicies": {
+      "type": "object",
+      "description": "Network Virtual Appliance Sku Properties.",
+      "properties": {
+        "allow": {
+          "type": "boolean",
+          "description": "Flag to control breakout of o365 allow category."
+        },
+        "optimize": {
+          "type": "boolean",
+          "description": "Flag to control breakout of o365 optimize category."
+        },
+        "default": {
+          "type": "boolean",
+          "description": "Flag to control breakout of o365 default category."
+        }
+      }
+    },
+    "CheckPrivateLinkServiceVisibilityRequest": {
+      "type": "object",
+      "description": "Request body of the CheckPrivateLinkServiceVisibility API service call.",
+      "properties": {
+        "privateLinkServiceAlias": {
+          "type": "string",
+          "description": "The alias of the private link service."
+        }
+      }
+    },
+    "Container": {
+      "type": "object",
+      "description": "Reference to container resource in remote resource provider.",
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ContainerNetworkInterface": {
+      "type": "object",
+      "description": "Container network interface child resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContainerNetworkInterfacePropertiesFormat",
+          "description": "Container network interface properties.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource. This name can be used to access the resource."
+        },
+        "type": {
+          "type": "string",
+          "description": "Sub Resource type.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ContainerNetworkInterfaceConfiguration": {
+      "type": "object",
+      "description": "Container network interface configuration child resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContainerNetworkInterfaceConfigurationPropertiesFormat",
+          "description": "Container network interface configuration properties.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource. This name can be used to access the resource."
+        },
+        "type": {
+          "type": "string",
+          "description": "Sub Resource type.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ContainerNetworkInterfaceConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Container network interface configuration properties.",
+      "properties": {
+        "ipConfigurations": {
+          "type": "array",
+          "description": "A list of ip configurations of the container network interface configuration.",
+          "items": {
+            "$ref": "#/definitions/IPConfigurationProfile"
+          }
+        },
+        "containerNetworkInterfaces": {
+          "type": "array",
+          "description": "A list of container network interfaces created from this container network interface configuration.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the container network interface configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ContainerNetworkInterfaceIpConfiguration": {
+      "type": "object",
+      "description": "The ip configuration for a container network interface.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContainerNetworkInterfaceIpConfigurationPropertiesFormat",
+          "description": "Properties of the container network interface IP configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource. This name can be used to access the resource."
+        },
+        "type": {
+          "type": "string",
+          "description": "Sub Resource type.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      }
+    },
+    "ContainerNetworkInterfaceIpConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the container network interface IP configuration.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the container network interface IP configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ContainerNetworkInterfacePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of container network interface.",
+      "properties": {
+        "containerNetworkInterfaceConfiguration": {
+          "$ref": "#/definitions/ContainerNetworkInterfaceConfiguration",
+          "description": "Container network interface configuration from which this container network interface is created.",
+          "readOnly": true
+        },
+        "container": {
+          "$ref": "#/definitions/Container",
+          "description": "Reference to the container to which this container network interface is attached."
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "Reference to the ip configuration on this container nic.",
+          "items": {
+            "$ref": "#/definitions/ContainerNetworkInterfaceIpConfiguration"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the container network interface resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "CustomDnsConfigPropertiesFormat": {
+      "type": "object",
+      "description": "Contains custom Dns resolution configuration from customer.",
+      "properties": {
+        "fqdn": {
+          "type": "string",
+          "description": "Fqdn that resolves to private endpoint ip address."
+        },
+        "ipAddresses": {
+          "type": "array",
+          "description": "A list of private ip addresses of the private endpoint.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CustomIpPrefix": {
+      "type": "object",
+      "description": "Custom IP prefix resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CustomIpPrefixPropertiesFormat",
+          "description": "Custom IP prefix properties.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "./common.json#/definitions/ExtendedLocation",
+          "description": "The extended location of the custom IP prefix."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "zones": {
+          "type": "array",
+          "description": "A list of availability zones denoting where the resource needs to come from.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "CustomIpPrefixListResult": {
+      "type": "object",
+      "description": "The response of a CustomIpPrefix list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The CustomIpPrefix items on this page",
+          "items": {
+            "$ref": "#/definitions/CustomIpPrefix"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "CustomIpPrefixPropertiesFormat": {
+      "type": "object",
+      "description": "Custom IP prefix properties.",
+      "properties": {
+        "asn": {
+          "type": "string",
+          "description": "The ASN for CIDR advertising. Should be an integer as string."
+        },
+        "cidr": {
+          "type": "string",
+          "description": "The prefix range in CIDR notation. Should include the start address and the prefix length."
+        },
+        "signedMessage": {
+          "type": "string",
+          "description": "Signed message for WAN validation."
+        },
+        "authorizationMessage": {
+          "type": "string",
+          "description": "Authorization message for WAN validation."
+        },
+        "customIpPrefixParent": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The Parent CustomIpPrefix for IPv6 /64 CustomIpPrefix."
+        },
+        "childCustomIpPrefixes": {
+          "type": "array",
+          "description": "The list of all Children for IPv6 /48 CustomIpPrefix.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "commissionedState": {
+          "$ref": "./common.json#/definitions/CommissionedState",
+          "description": "The commissioned state of the Custom IP Prefix."
+        },
+        "expressRouteAdvertise": {
+          "type": "boolean",
+          "description": "Whether to do express route advertise."
+        },
+        "geo": {
+          "$ref": "./common.json#/definitions/Geo",
+          "description": "The Geo for CIDR advertising. Should be an Geo code."
+        },
+        "noInternetAdvertise": {
+          "type": "boolean",
+          "description": "Whether to Advertise the range to Internet."
+        },
+        "prefixType": {
+          "$ref": "./common.json#/definitions/CustomIpPrefixType",
+          "description": "Type of custom IP prefix. Should be Singular, Parent, or Child."
+        },
+        "publicIpPrefixes": {
+          "type": "array",
+          "description": "The list of all referenced PublicIpPrefixes.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the custom IP prefix resource.",
+          "readOnly": true
+        },
+        "failedReason": {
+          "type": "string",
+          "description": "The reason why resource is in failed state.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the custom IP prefix resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "DdosCustomPolicy": {
+      "type": "object",
+      "description": "A DDoS custom policy in a resource group.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DdosCustomPolicyPropertiesFormat",
+          "description": "Properties of the DDoS custom policy.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "DdosCustomPolicyListResult": {
+      "type": "object",
+      "description": "The response of a DdosCustomPolicy list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DdosCustomPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/DdosCustomPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DdosCustomPolicyPropertiesFormat": {
+      "type": "object",
+      "description": "DDoS custom policy properties.",
+      "properties": {
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the DDoS custom policy resource. It uniquely identifies the resource, even if the user changes its name or migrate the resource across subscriptions or resource groups.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the DDoS custom policy resource.",
+          "readOnly": true
+        },
+        "detectionRules": {
+          "type": "array",
+          "description": "The list of DDoS detection rules associated with the custom policy.",
+          "items": {
+            "$ref": "#/definitions/DdosDetectionRule"
+          }
+        },
+        "frontEndIpConfiguration": {
+          "type": "array",
+          "description": "The list of frontend IP configurations associated with the custom policy.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "publicIPAddresses": {
+          "type": "array",
+          "description": "The list of public IP addresses associated with the custom policy. This list is read-only.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "DdosDetectionRule": {
+      "type": "object",
+      "description": "A DDoS detection rule resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the DDoS detection rule."
+        },
+        "id": {
+          "type": "string",
+          "description": "The resource ID of the DDoS detection rule.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/DdosDetectionRulePropertiesFormat",
+          "description": "Properties of the DDoS detection rule.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "DdosDetectionRulePropertiesFormat": {
+      "type": "object",
+      "description": "DDoS detection rule properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the DDoS detection rule.",
+          "readOnly": true
+        },
+        "detectionMode": {
+          "$ref": "./common.json#/definitions/DdosDetectionMode",
+          "description": "The detection mode for the DDoS detection rule."
+        },
+        "trafficDetectionRule": {
+          "$ref": "#/definitions/TrafficDetectionRule",
+          "description": "The traffic detection rule details."
+        }
+      }
+    },
+    "DdosProtectionPlan": {
+      "type": "object",
+      "description": "A DDoS protection plan in a resource group.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DdosProtectionPlanPropertiesFormat",
+          "description": "Properties of the DDoS protection plan.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/TrackedResourceWithOptionalLocation"
+        }
+      ]
+    },
+    "DdosProtectionPlanListResult": {
+      "type": "object",
+      "description": "The response of a DdosProtectionPlan list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DdosProtectionPlan items on this page",
+          "items": {
+            "$ref": "#/definitions/DdosProtectionPlan"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DdosProtectionPlanPropertiesFormat": {
+      "type": "object",
+      "description": "DDoS protection plan properties.",
+      "properties": {
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the DDoS protection plan resource. It uniquely identifies the resource, even if the user changes its name or migrate the resource across subscriptions or resource groups.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the DDoS protection plan resource.",
+          "readOnly": true
+        },
+        "publicIPAddresses": {
+          "type": "array",
+          "description": "The list of public IPs associated with the DDoS protection plan resource. This list is read-only.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "virtualNetworks": {
+          "type": "array",
+          "description": "The list of virtual networks associated with the DDoS protection plan resource. This list is read-only.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "DdosSettings": {
+      "type": "object",
+      "description": "Contains the DDoS protection settings of the public IP.",
+      "properties": {
+        "protectionMode": {
+          "$ref": "./common.json#/definitions/DdosSettingsProtectionMode",
+          "description": "The DDoS protection mode of the public IP"
+        },
+        "ddosCustomPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The DDoS custom policy associated with the public IP."
+        },
+        "ddosProtectionPlan": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The DDoS protection plan associated with the public IP. Can only be set if ProtectionMode is Enabled"
+        }
+      }
+    },
+    "Delegation": {
+      "type": "object",
+      "description": "Details the service to which the subnet is delegated.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ServiceDelegationPropertiesFormat",
+          "description": "Properties of the subnet.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a subnet. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "DelegationProperties": {
+      "type": "object",
+      "description": "Properties of the delegation.",
+      "properties": {
+        "serviceName": {
+          "type": "string",
+          "description": "The service name to which the NVA is delegated."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "Provisioning states of a resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "DhcpOptions": {
+      "type": "object",
+      "description": "DhcpOptions contains an array of DNS servers available to VMs deployed in the virtual network. Standard DHCP option for a subnet overrides VNET DHCP options.",
+      "properties": {
+        "dnsServers": {
+          "type": "array",
+          "description": "The list of DNS servers IP addresses.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DisassociateCloudServicePublicIpRequest": {
+      "type": "object",
+      "description": "The request for DisassociateCloudServicePublicIpOperation.",
+      "properties": {
+        "publicIpArmId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "ARM ID of the Standalone Public IP to associate. This is of the form : /subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.Network/publicIPAddresses/{publicIpAddressName}",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/publicIPAddresses"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "publicIpArmId"
+      ]
+    },
+    "DnsNameAvailabilityResult": {
+      "type": "object",
+      "description": "Response for the CheckDnsNameAvailability API service call.",
+      "properties": {
+        "available": {
+          "type": "boolean",
+          "description": "Domain availability (True/False)."
+        }
+      }
+    },
+    "DscpConfiguration": {
+      "type": "object",
+      "description": "Differentiated Services Code Point configuration for any given network interface",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DscpConfigurationPropertiesFormat",
+          "description": "Properties of the network interface.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "DscpConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a DscpConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DscpConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/DscpConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DscpConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Differentiated Services Code Point configuration properties.",
+      "properties": {
+        "markings": {
+          "type": "array",
+          "description": "List of markings to be used in the configuration.",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "sourceIpRanges": {
+          "type": "array",
+          "description": "Source IP ranges.",
+          "items": {
+            "$ref": "#/definitions/QosIpRange"
+          }
+        },
+        "destinationIpRanges": {
+          "type": "array",
+          "description": "Destination IP ranges.",
+          "items": {
+            "$ref": "#/definitions/QosIpRange"
+          }
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "description": "Sources port ranges.",
+          "items": {
+            "$ref": "#/definitions/QosPortRange"
+          }
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "description": "Destination port ranges.",
+          "items": {
+            "$ref": "#/definitions/QosPortRange"
+          }
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/ProtocolType",
+          "description": "RNM supported protocol types."
+        },
+        "qosDefinitionCollection": {
+          "type": "array",
+          "description": "QoS object definitions",
+          "items": {
+            "$ref": "#/definitions/QosDefinition"
+          }
+        },
+        "qosCollectionId": {
+          "type": "string",
+          "description": "Qos Collection ID generated by RNM.",
+          "readOnly": true
+        },
+        "associatedNetworkInterfaces": {
+          "type": "array",
+          "description": "Associated Network Interfaces to the DSCP Configuration.",
+          "items": {
+            "$ref": "#/definitions/NetworkInterface"
+          },
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the DSCP Configuration resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the DSCP Configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "EffectiveNetworkSecurityGroup": {
+      "type": "object",
+      "description": "Effective network security group.",
+      "properties": {
+        "networkSecurityGroup": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The ID of network security group that is applied."
+        },
+        "association": {
+          "$ref": "#/definitions/EffectiveNetworkSecurityGroupAssociation",
+          "description": "Associated resources."
+        },
+        "effectiveSecurityRules": {
+          "type": "array",
+          "description": "A collection of effective security rules.",
+          "items": {
+            "$ref": "#/definitions/EffectiveNetworkSecurityRule"
+          }
+        },
+        "tagMap": {
+          "type": "object",
+          "description": "Mapping of tags to list of IP Addresses included within the tag.",
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        }
+      }
+    },
+    "EffectiveNetworkSecurityGroupAssociation": {
+      "type": "object",
+      "description": "The effective network security group association.",
+      "properties": {
+        "networkManager": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The ID of the Azure network manager if assigned."
+        },
+        "subnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The ID of the subnet if assigned."
+        },
+        "networkInterface": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The ID of the network interface if assigned."
+        }
+      }
+    },
+    "EffectiveNetworkSecurityGroupListResult": {
+      "type": "object",
+      "description": "Response for list effective network security groups API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The EffectiveNetworkSecurityGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/EffectiveNetworkSecurityGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EffectiveNetworkSecurityRule": {
+      "type": "object",
+      "description": "Effective network security rules.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the security rule specified by the user (if created by the user)."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/EffectiveSecurityRuleProtocol",
+          "description": "The network protocol this rule applies to."
+        },
+        "sourcePortRange": {
+          "type": "string",
+          "description": "The source port or range."
+        },
+        "destinationPortRange": {
+          "type": "string",
+          "description": "The destination port or range."
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "description": "The source port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "description": "The destination port ranges. Expected values include a single integer between 0 and 65535, a range using '-' as separator (e.g. 100-400), or an asterisk (*).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceAddressPrefix": {
+          "type": "string",
+          "description": "The source address prefix."
+        },
+        "destinationAddressPrefix": {
+          "type": "string",
+          "description": "The destination address prefix."
+        },
+        "sourceAddressPrefixes": {
+          "type": "array",
+          "description": "The source address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationAddressPrefixes": {
+          "type": "array",
+          "description": "The destination address prefixes. Expected values include CIDR IP ranges, Default Tags (VirtualNetwork, AzureLoadBalancer, Internet), System Tags, and the asterisk (*).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "expandedSourceAddressPrefix": {
+          "type": "array",
+          "description": "The expanded source address prefix.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "expandedDestinationAddressPrefix": {
+          "type": "array",
+          "description": "Expanded destination address prefix.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "access": {
+          "$ref": "./common.json#/definitions/SecurityRuleAccess",
+          "description": "Whether network traffic is allowed or denied."
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The priority of the rule."
+        },
+        "direction": {
+          "$ref": "./common.json#/definitions/SecurityRuleDirection",
+          "description": "The direction of the rule."
+        }
+      }
+    },
+    "EffectiveRoute": {
+      "type": "object",
+      "description": "Effective Route.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the user defined route. This is optional."
+        },
+        "disableBgpRoutePropagation": {
+          "type": "boolean",
+          "description": "If true, on-premises routes are not propagated to the network interfaces in the subnet."
+        },
+        "source": {
+          "$ref": "./common.json#/definitions/EffectiveRouteSource",
+          "description": "Who created the route."
+        },
+        "state": {
+          "$ref": "./common.json#/definitions/EffectiveRouteState",
+          "description": "The value of effective route."
+        },
+        "addressPrefix": {
+          "type": "array",
+          "description": "The address prefixes of the effective routes in CIDR notation.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nextHopIpAddress": {
+          "type": "array",
+          "description": "The IP address of the next hop of the effective route.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nextHopType": {
+          "$ref": "./common.json#/definitions/RouteNextHopType",
+          "description": "The type of Azure hop the packet should be sent to."
+        }
+      }
+    },
+    "EffectiveRouteListResult": {
+      "type": "object",
+      "description": "Response for list effective route API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The EffectiveRoute items on this page",
+          "items": {
+            "$ref": "#/definitions/EffectiveRoute"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EndpointServiceResult": {
+      "type": "object",
+      "description": "Endpoint service.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the endpoint service.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the endpoint service.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "EndpointServicesListResult": {
+      "type": "object",
+      "description": "Paged collection of EndpointServiceResult items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The EndpointServiceResult items on this page",
+          "items": {
+            "$ref": "#/definitions/EndpointServiceResult"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "IPAddressAvailabilityResult": {
+      "type": "object",
+      "description": "Response for CheckIPAddressAvailability API service call.",
+      "properties": {
+        "available": {
+          "type": "boolean",
+          "description": "Private IP address availability."
+        },
+        "availableIPAddresses": {
+          "type": "array",
+          "description": "Contains other available private IP addresses if the asked for address is taken.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "isPlatformReserved": {
+          "type": "boolean",
+          "description": "Private IP address platform reserved."
+        }
+      }
+    },
+    "IPConfiguration": {
+      "type": "object",
+      "description": "IP configuration.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/IPConfigurationPropertiesFormat",
+          "description": "Properties of the IP configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "IPConfigurationProfile": {
+      "type": "object",
+      "description": "IP configuration profile child resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/IPConfigurationProfilePropertiesFormat",
+          "description": "Properties of the IP configuration profile.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource. This name can be used to access the resource."
+        },
+        "type": {
+          "type": "string",
+          "description": "Sub Resource type.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "IPConfigurationProfilePropertiesFormat": {
+      "type": "object",
+      "description": "IP configuration profile properties.",
+      "properties": {
+        "subnet": {
+          "$ref": "#/definitions/Subnet",
+          "description": "The reference to the subnet resource to create a container network interface ip configuration."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the IP configuration profile resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "IPConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of IP configuration.",
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "description": "The private IP address of the IP configuration."
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The private IP address allocation method."
+        },
+        "subnet": {
+          "$ref": "#/definitions/Subnet",
+          "description": "The reference to the subnet resource."
+        },
+        "publicIPAddress": {
+          "$ref": "#/definitions/PublicIPAddress",
+          "description": "The reference to the public IP resource."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the IP configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "IPRule": {
+      "type": "object",
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "Specifies the IP or IP range in CIDR format. Only IPV4 address is allowed."
+        }
+      }
+    },
+    "IPTraffic": {
+      "type": "object",
+      "description": "IP traffic information.",
+      "properties": {
+        "sourceIps": {
+          "type": "array",
+          "description": "List of source IP addresses of the traffic..",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationIps": {
+          "type": "array",
+          "description": "List of destination IP addresses of the traffic..",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourcePorts": {
+          "type": "array",
+          "description": "The source ports of the traffic.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPorts": {
+          "type": "array",
+          "description": "The destination ports of the traffic.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "protocols": {
+          "type": "array",
+          "items": {
+            "$ref": "./common.json#/definitions/NetworkProtocol"
+          }
+        }
+      },
+      "required": [
+        "sourceIps",
+        "destinationIps",
+        "sourcePorts",
+        "destinationPorts",
+        "protocols"
+      ]
+    },
+    "InboundSecurityRule": {
+      "type": "object",
+      "description": "NVA Inbound Security Rule resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/InboundSecurityRuleProperties",
+          "description": "The properties of the Inbound Security Rules.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "InboundSecurityRuleProperties": {
+      "type": "object",
+      "description": "Properties of the Inbound Security Rules resource.",
+      "properties": {
+        "ruleType": {
+          "$ref": "./common.json#/definitions/InboundSecurityRuleType",
+          "description": "Rule Type. This should be either AutoExpire or Permanent. Auto Expire Rule only creates NSG rules. Permanent Rule creates NSG rule and SLB LB Rule."
+        },
+        "rules": {
+          "type": "array",
+          "description": "List of allowed rules.",
+          "items": {
+            "$ref": "#/definitions/InboundSecurityRules"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "InboundSecurityRules": {
+      "type": "object",
+      "description": "Properties of the Inbound Security Rules resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the rule."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/InboundSecurityRulesProtocol",
+          "description": "Protocol. This should be either TCP or UDP."
+        },
+        "sourceAddressPrefix": {
+          "type": "string",
+          "description": "The CIDR or source IP range."
+        },
+        "destinationPortRange": {
+          "type": "integer",
+          "format": "int32",
+          "description": "NVA port ranges to be opened up. One needs to provide specific ports.",
+          "minimum": 0,
+          "maximum": 65535
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "description": "NVA port ranges to be opened up. One can provide a range of ports. Allowed port value between 0 and 65535.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appliesOn": {
+          "type": "array",
+          "description": "Public IP name in case of Permanent Rule type & Interface Name in case of Auto Expire Rule type",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "IntentContent": {
+      "type": "object",
+      "description": "Intent information.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Source resource id of the intent."
+        },
+        "destinationResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Destination resource id of the intent."
+        },
+        "ipTraffic": {
+          "$ref": "#/definitions/IPTraffic",
+          "description": "IP traffic information."
+        }
+      },
+      "required": [
+        "sourceResourceId",
+        "destinationResourceId",
+        "ipTraffic"
+      ]
+    },
+    "InternetIngressPublicIpsProperties": {
+      "type": "object",
+      "title": "Internet Ingress Public Ip Properties",
+      "description": "Resource Uri of Public Ip for Standard Load Balancer Frontend End.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource Uri of Public Ip",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/publicIPAddresses"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "IpAllocation": {
+      "type": "object",
+      "description": "IpAllocation resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/IpAllocationPropertiesFormat",
+          "description": "Properties of the IpAllocation.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "IpAllocationListResult": {
+      "type": "object",
+      "description": "The response of a IpAllocation list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The IpAllocation items on this page",
+          "items": {
+            "$ref": "#/definitions/IpAllocation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "IpAllocationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the IpAllocation.",
+      "properties": {
+        "subnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The Subnet that using the prefix of this IpAllocation resource.",
+          "readOnly": true
+        },
+        "virtualNetwork": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The VirtualNetwork that using the prefix of this IpAllocation resource.",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "./common.json#/definitions/IpAllocationType",
+          "description": "The type for the IpAllocation."
+        },
+        "prefix": {
+          "type": "string",
+          "description": "The address prefix for the IpAllocation."
+        },
+        "prefixLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The address prefix length for the IpAllocation.",
+          "default": 0,
+          "x-nullable": true
+        },
+        "prefixType": {
+          "$ref": "./common.json#/definitions/IPVersion",
+          "description": "The address prefix Type for the IpAllocation."
+        },
+        "ipamAllocationId": {
+          "type": "string",
+          "description": "The IPAM allocation ID."
+        },
+        "allocationTags": {
+          "type": "object",
+          "description": "IpAllocation tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "IpGroup": {
+      "type": "object",
+      "description": "The IpGroups resource information.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/IpGroupPropertiesFormat",
+          "description": "Properties of the IpGroups.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "IpGroupListResult": {
+      "type": "object",
+      "description": "The response of a IpGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The IpGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/IpGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "IpGroupPropertiesFormat": {
+      "type": "object",
+      "description": "The IpGroups property information.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the IpGroups resource.",
+          "readOnly": true
+        },
+        "ipAddresses": {
+          "type": "array",
+          "description": "IpAddresses/IpAddressPrefixes in the IpGroups resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "firewalls": {
+          "type": "array",
+          "description": "List of references to Firewall resources that this IpGroups is associated with.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "firewallPolicies": {
+          "type": "array",
+          "description": "List of references to Firewall Policies resources that this IpGroups is associated with.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "IpTag": {
+      "type": "object",
+      "description": "Contains the IpTag associated with the object.",
+      "properties": {
+        "ipTagType": {
+          "type": "string",
+          "description": "The IP tag type. Example: FirstPartyUsage."
+        },
+        "tag": {
+          "type": "string",
+          "description": "The value of the IP tag associated with the public IP. Example: SQL."
+        },
+        "firstPartyServiceTagId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the first party service tag associated with the IP tag.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/firstPartyServiceTags"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "IpamPool": {
+      "type": "object",
+      "description": "Instance of Pool resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/IpamPoolProperties",
+          "description": "Properties of IpamPool resource properties which are specific to the Pool resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/CommonTrackedResource"
+        }
+      ]
+    },
+    "IpamPoolList": {
+      "type": "object",
+      "description": "List of IpamPool",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The IpamPool items on this page",
+          "items": {
+            "$ref": "#/definitions/IpamPool"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "IpamPoolPrefixAllocation": {
+      "type": "object",
+      "description": "IpamPool prefix allocation reference.",
+      "properties": {
+        "pool": {
+          "$ref": "#/definitions/IpamPoolPrefixAllocationPool",
+          "x-ms-client-flatten": true
+        },
+        "numberOfIpAddresses": {
+          "type": "string",
+          "description": "Number of IP addresses to allocate."
+        },
+        "allocatedAddressPrefixes": {
+          "type": "array",
+          "description": "List of assigned IP address prefixes in the IpamPool of the associated resource.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "IpamPoolPrefixAllocationPool": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource id of the associated Azure IpamPool resource."
+        }
+      }
+    },
+    "IpamPoolProperties": {
+      "type": "object",
+      "description": "Properties of IpamPool resource properties which are specific to the Pool resource.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "String representing a friendly name for the resource."
+        },
+        "ipAddressType": {
+          "type": "array",
+          "description": "List of IP address type for the IpamPool.",
+          "items": {
+            "$ref": "./common.json#/definitions/IpType"
+          },
+          "readOnly": true
+        },
+        "parentPoolName": {
+          "type": "string",
+          "description": "String representing parent IpamPool resource name. If empty the IpamPool will be a root pool."
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "List of IP address prefixes of the resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "Provisioning states of a resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "addressPrefixes"
+      ]
+    },
+    "IpamPoolUpdate": {
+      "type": "object",
+      "description": "Represents the IpamPool update API request interface.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Dictionary of <string>",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/IpamPoolUpdateProperties",
+          "description": "Represents the IpamPool update properties."
+        }
+      }
+    },
+    "IpamPoolUpdateProperties": {
+      "type": "object",
+      "description": "Represents the IpamPool update properties.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "String representing a friendly name for the resource."
+        }
+      }
+    },
+    "MoveIpConfigurationItem": {
+      "type": "object",
+      "description": "An item representing a source and target IP configuration for a move operation.",
+      "properties": {
+        "sourceIpConfiguration": {
+          "$ref": "#/definitions/MoveIpConfigurationResourceReference",
+          "description": "The source IP configuration to move from."
+        },
+        "targetIpConfiguration": {
+          "$ref": "#/definitions/MoveIpConfigurationResourceReference",
+          "description": "The target IP configuration to move to."
+        }
+      },
+      "required": [
+        "sourceIpConfiguration",
+        "targetIpConfiguration"
+      ]
+    },
+    "MoveIpConfigurationResourceReference": {
+      "type": "object",
+      "description": "Reference to an IP configuration resource by ARM resource ID.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ARM resource ID of the IP configuration.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/networkInterfaces/ipConfigurations"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "id"
+      ]
+    },
+    "MoveIpConfigurationsRequest": {
+      "type": "object",
+      "description": "Request body for the MoveIpConfigurations operation.",
+      "properties": {
+        "moveIpConfigurationItems": {
+          "type": "array",
+          "description": "A list of IP configuration move items.",
+          "items": {
+            "$ref": "#/definitions/MoveIpConfigurationItem"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "moveIpConfigurationItems"
+      ]
+    },
+    "NatGateway": {
+      "type": "object",
+      "description": "Nat Gateway resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NatGatewayPropertiesFormat",
+          "description": "Nat Gateway properties.",
+          "x-ms-client-flatten": true
+        },
+        "sku": {
+          "$ref": "#/definitions/NatGatewaySku",
+          "description": "The nat gateway SKU."
+        },
+        "zones": {
+          "type": "array",
+          "description": "A list of availability zones denoting the zone in which Nat Gateway should be deployed.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "NatGatewayListResult": {
+      "type": "object",
+      "description": "The response of a NatGateway list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NatGateway items on this page",
+          "items": {
+            "$ref": "#/definitions/NatGateway"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NatGatewayPropertiesFormat": {
+      "type": "object",
+      "description": "Nat Gateway properties.",
+      "properties": {
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The idle timeout of the nat gateway."
+        },
+        "publicIpAddresses": {
+          "type": "array",
+          "description": "An array of public ip addresses V4 associated with the nat gateway resource.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "publicIpAddressesV6": {
+          "type": "array",
+          "description": "An array of public ip addresses V6 associated with the nat gateway resource.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "publicIpPrefixes": {
+          "type": "array",
+          "description": "An array of public ip prefixes V4 associated with the nat gateway resource.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "publicIpPrefixesV6": {
+          "type": "array",
+          "description": "An array of public ip prefixes V6 associated with the nat gateway resource.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "subnets": {
+          "type": "array",
+          "description": "An array of references to the subnets using this nat gateway resource.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "sourceVirtualNetwork": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to the source virtual network using this nat gateway resource."
+        },
+        "serviceGateway": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to an existing service gateway."
+        },
+        "nat64": {
+          "$ref": "./common.json#/definitions/Nat64State",
+          "description": "Whether Nat64 is enabled for the NAT gateway resource."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the NAT gateway resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the NAT gateway resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "NatGatewaySku": {
+      "type": "object",
+      "description": "SKU of nat gateway.",
+      "properties": {
+        "name": {
+          "$ref": "./common.json#/definitions/NatGatewaySkuName",
+          "description": "Name of Nat Gateway SKU."
+        }
+      }
+    },
+    "NetworkIntentPolicy": {
+      "type": "object",
+      "description": "Network Intent Policy resource.",
+      "properties": {
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "NetworkIntentPolicyConfiguration": {
+      "type": "object",
+      "description": "Details of NetworkIntentPolicyConfiguration for PrepareNetworkPoliciesRequest.",
+      "properties": {
+        "networkIntentPolicyName": {
+          "type": "string",
+          "description": "The name of the Network Intent Policy for storing in target subscription."
+        },
+        "sourceNetworkIntentPolicy": {
+          "$ref": "#/definitions/NetworkIntentPolicy",
+          "description": "Source network intent policy."
+        }
+      }
+    },
+    "NetworkInterface": {
+      "type": "object",
+      "description": "A network interface in a resource group.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkInterfacePropertiesFormat",
+          "description": "Properties of the network interface.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "./common.json#/definitions/ExtendedLocation",
+          "description": "The extended location of the network interface."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "NetworkInterfaceDnsSettings": {
+      "type": "object",
+      "description": "DNS settings of a network interface.",
+      "properties": {
+        "dnsServers": {
+          "type": "array",
+          "description": "List of DNS servers IP addresses. Use 'AzureProvidedDNS' to switch to azure provided DNS resolution. 'AzureProvidedDNS' value cannot be combined with other IPs, it must be the only value in dnsServers collection.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "appliedDnsServers": {
+          "type": "array",
+          "description": "If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers from all NICs that are part of the Availability Set. This property is what is configured on each of those VMs.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "internalDnsNameLabel": {
+          "type": "string",
+          "description": "Relative DNS name for this NIC used for internal communications between VMs in the same virtual network."
+        },
+        "internalFqdn": {
+          "type": "string",
+          "description": "Fully qualified DNS name supporting internal communications between VMs in the same virtual network.",
+          "readOnly": true
+        },
+        "internalDomainNameSuffix": {
+          "type": "string",
+          "description": "Even if internalDnsNameLabel is not specified, a DNS entry is created for the primary NIC of the VM. This DNS name can be constructed by concatenating the VM name with the value of internalDomainNameSuffix.",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkInterfaceIPConfiguration": {
+      "type": "object",
+      "description": "IPConfiguration in a network interface.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkInterfaceIPConfigurationPropertiesFormat",
+          "description": "Network interface IP configuration properties.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "NetworkInterfaceIPConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a NetworkInterfaceIPConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkInterfaceIPConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfaceIPConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties": {
+      "type": "object",
+      "description": "PrivateLinkConnection properties for the network interface.",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The group ID for current private link connection.",
+          "readOnly": true
+        },
+        "requiredMemberName": {
+          "type": "string",
+          "description": "The required member name for current private link connection.",
+          "readOnly": true
+        },
+        "fqdns": {
+          "type": "array",
+          "description": "List of FQDNs for current private link connection.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkInterfaceIPConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of IP configuration.",
+      "properties": {
+        "gatewayLoadBalancer": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to gateway load balancer frontend IP."
+        },
+        "virtualNetworkTaps": {
+          "type": "array",
+          "description": "The reference to Virtual Network Taps.",
+          "items": {
+            "$ref": "./networkGateway.json#/definitions/VirtualNetworkTap"
+          }
+        },
+        "applicationGatewayBackendAddressPools": {
+          "type": "array",
+          "description": "The reference to ApplicationGatewayBackendAddressPool resource.",
+          "items": {
+            "$ref": "./applicationGateway.json#/definitions/ApplicationGatewayBackendAddressPool"
+          }
+        },
+        "loadBalancerBackendAddressPools": {
+          "type": "array",
+          "description": "The reference to LoadBalancerBackendAddressPool resource.",
+          "items": {
+            "$ref": "./loadBalancer.json#/definitions/BackendAddressPool"
+          }
+        },
+        "loadBalancerInboundNatRules": {
+          "type": "array",
+          "description": "A list of references of LoadBalancerInboundNatRules.",
+          "items": {
+            "$ref": "./loadBalancer.json#/definitions/InboundNatRule"
+          }
+        },
+        "privateIPAddress": {
+          "type": "string",
+          "description": "Private IP address of the IP configuration. It can be a single IP address or a CIDR block in the format <address>/<prefix-length>."
+        },
+        "privateIPAddressPrefixLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The private IP address prefix length. If specified and the allocation method is dynamic, the service will allocate a CIDR block instead of a single IP address.",
+          "minimum": 1,
+          "maximum": 128,
+          "x-nullable": true
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The private IP address allocation method."
+        },
+        "privateIPAddressVersion": {
+          "$ref": "./common.json#/definitions/IPVersion",
+          "description": "Whether the specific IP configuration is IPv4 or IPv6. Default is IPv4."
+        },
+        "subnet": {
+          "$ref": "#/definitions/Subnet",
+          "description": "Subnet bound to the IP configuration."
+        },
+        "primary": {
+          "type": "boolean",
+          "description": "Whether this is a primary customer address on the network interface."
+        },
+        "publicIPAddress": {
+          "$ref": "#/definitions/PublicIPAddress",
+          "description": "Public IP address bound to the IP configuration."
+        },
+        "applicationSecurityGroups": {
+          "type": "array",
+          "description": "Application security groups in which the IP configuration is included.",
+          "items": {
+            "$ref": "#/definitions/ApplicationSecurityGroup"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the network interface IP configuration.",
+          "readOnly": true
+        },
+        "privateLinkConnectionProperties": {
+          "$ref": "#/definitions/NetworkInterfaceIPConfigurationPrivateLinkConnectionProperties",
+          "description": "PrivateLinkConnection properties for the network interface.",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkInterfaceListResult": {
+      "type": "object",
+      "description": "The response of a NetworkInterface list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkInterface items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkInterface"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkInterfaceLoadBalancerListResult": {
+      "type": "object",
+      "description": "Paged collection of LoadBalancer items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The LoadBalancer items on this page",
+          "items": {
+            "$ref": "./loadBalancer.json#/definitions/LoadBalancer"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkInterfacePropertiesFormat": {
+      "type": "object",
+      "description": "NetworkInterface properties.",
+      "properties": {
+        "virtualMachine": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to a virtual machine.",
+          "readOnly": true
+        },
+        "networkSecurityGroup": {
+          "$ref": "#/definitions/NetworkSecurityGroup",
+          "description": "The reference to the NetworkSecurityGroup resource."
+        },
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "A reference to the private endpoint to which the network interface is linked.",
+          "readOnly": true
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "A list of IPConfigurations of the network interface.",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfaceIPConfiguration"
+          }
+        },
+        "tapConfigurations": {
+          "type": "array",
+          "description": "A list of TapConfigurations of the network interface.",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfaceTapConfiguration"
+          },
+          "readOnly": true
+        },
+        "dnsSettings": {
+          "$ref": "#/definitions/NetworkInterfaceDnsSettings",
+          "description": "The DNS settings in network interface."
+        },
+        "macAddress": {
+          "type": "string",
+          "description": "The MAC address of the network interface.",
+          "readOnly": true
+        },
+        "primary": {
+          "type": "boolean",
+          "description": "Whether this is a primary network interface on a virtual machine.",
+          "readOnly": true
+        },
+        "vnetEncryptionSupported": {
+          "type": "boolean",
+          "description": "Whether the virtual machine this nic is attached to supports encryption.",
+          "readOnly": true
+        },
+        "defaultOutboundConnectivityEnabled": {
+          "type": "boolean",
+          "description": "Whether default outbound connectivity for nic was configured or not.",
+          "readOnly": true
+        },
+        "enableAcceleratedNetworking": {
+          "type": "boolean",
+          "description": "If the network interface is configured for accelerated networking. Not applicable to VM sizes which require accelerated networking."
+        },
+        "disableTcpStateTracking": {
+          "type": "boolean",
+          "description": "Indicates whether to disable tcp state tracking."
+        },
+        "enableIPForwarding": {
+          "type": "boolean",
+          "description": "Indicates whether IP forwarding is enabled on this network interface."
+        },
+        "hostedWorkloads": {
+          "type": "array",
+          "description": "A list of references to linked BareMetal resources.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "dscpConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to the dscp configuration to which the network interface is linked.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the network interface resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the network interface resource.",
+          "readOnly": true
+        },
+        "workloadType": {
+          "type": "string",
+          "description": "WorkloadType of the NetworkInterface for BareMetal resources"
+        },
+        "nicType": {
+          "$ref": "./common.json#/definitions/NetworkInterfaceNicType",
+          "description": "Type of Network Interface resource."
+        },
+        "privateLinkService": {
+          "$ref": "#/definitions/PrivateLinkService",
+          "description": "Privatelinkservice of the network interface resource."
+        },
+        "migrationPhase": {
+          "$ref": "./common.json#/definitions/NetworkInterfaceMigrationPhase",
+          "description": "Migration phase of Network Interface resource."
+        },
+        "auxiliaryMode": {
+          "$ref": "./common.json#/definitions/NetworkInterfaceAuxiliaryMode",
+          "description": "Auxiliary mode of Network Interface resource."
+        },
+        "auxiliarySku": {
+          "$ref": "./common.json#/definitions/NetworkInterfaceAuxiliarySku",
+          "description": "Auxiliary sku of Network Interface resource."
+        }
+      }
+    },
+    "NetworkInterfaceTapConfiguration": {
+      "type": "object",
+      "description": "Tap configuration in a Network Interface.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkInterfaceTapConfigurationPropertiesFormat",
+          "description": "Properties of the Virtual Network Tap configuration.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "NetworkInterfaceTapConfigurationListResult": {
+      "type": "object",
+      "description": "The response of a NetworkInterfaceTapConfiguration list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkInterfaceTapConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkInterfaceTapConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkInterfaceTapConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of Virtual Network Tap configuration.",
+      "properties": {
+        "virtualNetworkTap": {
+          "$ref": "./networkGateway.json#/definitions/VirtualNetworkTap",
+          "description": "The reference to the Virtual Network Tap resource."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the network interface tap configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkProfile": {
+      "type": "object",
+      "description": "Network profile resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkProfilePropertiesFormat",
+          "description": "Network profile properties.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "NetworkProfileListResult": {
+      "type": "object",
+      "description": "The response of a NetworkProfile list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkProfile items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkProfile"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkProfilePropertiesFormat": {
+      "type": "object",
+      "description": "Network profile properties.",
+      "properties": {
+        "containerNetworkInterfaces": {
+          "type": "array",
+          "description": "List of child container network interfaces.",
+          "items": {
+            "$ref": "#/definitions/ContainerNetworkInterface"
+          },
+          "readOnly": true
+        },
+        "containerNetworkInterfaceConfigurations": {
+          "type": "array",
+          "description": "List of chid container network interface configurations.",
+          "items": {
+            "$ref": "#/definitions/ContainerNetworkInterfaceConfiguration"
+          }
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the network profile resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the network profile resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkSecurityGroup": {
+      "type": "object",
+      "description": "NetworkSecurityGroup resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityGroupPropertiesFormat",
+          "description": "Properties of the network security group.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "NetworkSecurityGroupListResult": {
+      "type": "object",
+      "description": "The response of a NetworkSecurityGroup list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkSecurityGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkSecurityGroupPropertiesFormat": {
+      "type": "object",
+      "description": "Network Security Group resource.",
+      "properties": {
+        "flushConnection": {
+          "type": "boolean",
+          "description": "When enabled, flows created from Network Security Group connections will be re-evaluated when rules are updates. Initial enablement will trigger re-evaluation."
+        },
+        "securityRules": {
+          "type": "array",
+          "description": "A collection of security rules of the network security group.",
+          "items": {
+            "$ref": "#/definitions/SecurityRule"
+          }
+        },
+        "defaultSecurityRules": {
+          "type": "array",
+          "description": "The default security rules of network security group.",
+          "items": {
+            "$ref": "#/definitions/SecurityRule"
+          },
+          "readOnly": true
+        },
+        "networkInterfaces": {
+          "type": "array",
+          "description": "A collection of references to network interfaces.",
+          "items": {
+            "$ref": "#/definitions/NetworkInterface"
+          },
+          "readOnly": true
+        },
+        "subnets": {
+          "type": "array",
+          "description": "A collection of references to subnets.",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          },
+          "readOnly": true
+        },
+        "flowLogs": {
+          "type": "array",
+          "description": "A collection of references to flow log resources.",
+          "items": {
+            "$ref": "./networkWatcher.json#/definitions/FlowLog"
+          },
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the network security group resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the network security group resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkVirtualAppliance": {
+      "type": "object",
+      "description": "NetworkVirtualAppliance Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkVirtualAppliancePropertiesFormat",
+          "description": "Properties of the Network Virtual Appliance.",
+          "x-ms-client-flatten": true
+        },
+        "identity": {
+          "$ref": "./common.json#/definitions/ManagedServiceIdentity",
+          "description": "The service principal that has read access to cloud-init and config blob."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "NetworkVirtualApplianceBootDiagnosticParameters": {
+      "type": "object",
+      "description": "Specifies input parameters required to retrieve the boot diagnostic logs for an NVA instance",
+      "properties": {
+        "instanceId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The network virtual appliance instance id for which boot diagnostic logs is being requested"
+        },
+        "serialConsoleStorageSasUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Specifies the sas-url to the storage blob into which serial console logs for the requested instance will be written"
+        },
+        "consoleScreenshotStorageSasUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Specifies the sas-url to the storage blob into which console screen shot for the requested instance will be written"
+        }
+      }
+    },
+    "NetworkVirtualApplianceCommitMigrationProperties": {
+      "type": "object",
+      "description": "Properties supplied to commit the migration of a Network Virtual Appliance.",
+      "properties": {
+        "migrationType": {
+          "$ref": "./common.json#/definitions/MigrationType",
+          "description": "The type of migration workflow to commit."
+        }
+      },
+      "required": [
+        "migrationType"
+      ]
+    },
+    "NetworkVirtualApplianceCommitMigrationRequest": {
+      "type": "object",
+      "description": "Parameters supplied to commit the migration of a Network Virtual Appliance.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkVirtualApplianceCommitMigrationProperties",
+          "description": "Properties of the commit migration request."
+        }
+      }
+    },
+    "NetworkVirtualApplianceExecuteMigrationProperties": {
+      "type": "object",
+      "description": "Properties supplied to execute the migration of a Network Virtual Appliance.",
+      "properties": {
+        "migrationType": {
+          "$ref": "./common.json#/definitions/MigrationType",
+          "description": "The type of migration workflow to execute."
+        }
+      },
+      "required": [
+        "migrationType"
+      ]
+    },
+    "NetworkVirtualApplianceExecuteMigrationRequest": {
+      "type": "object",
+      "description": "Parameters supplied to execute the migration of a Network Virtual Appliance.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkVirtualApplianceExecuteMigrationProperties",
+          "description": "Properties of the execute migration request."
+        }
+      }
+    },
+    "NetworkVirtualApplianceInstanceId": {
+      "type": "object",
+      "properties": {
+        "instanceId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The network virtual appliance instance id for which boot diagnostic logs is being requested"
+        }
+      }
+    },
+    "NetworkVirtualApplianceInstanceIds": {
+      "type": "object",
+      "description": "Specifies a list of virtual machine instance IDs from the Network Virtual Appliance VM instances.",
+      "properties": {
+        "instanceIds": {
+          "type": "array",
+          "description": "The network virtual appliance instance ids. Omitting the network virtual appliance instance ids will result in the operation being performed on all virtual machines belonging to the network virtual appliance.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NetworkVirtualApplianceListResult": {
+      "type": "object",
+      "description": "The response of a NetworkVirtualAppliance list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkVirtualAppliance items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkVirtualAppliance"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkVirtualApplianceMigrationStatus": {
+      "type": "object",
+      "description": "The migration status of a Network Virtual Appliance.",
+      "properties": {
+        "migrationType": {
+          "$ref": "./common.json#/definitions/MigrationType",
+          "description": "The type of migration workflow currently in progress or last performed."
+        },
+        "migrationPhase": {
+          "type": "string",
+          "description": "The current phase of the migration workflow (for example, Prepare, Execute, Commit, or Abort)."
+        },
+        "migrationPhaseStatus": {
+          "type": "string",
+          "description": "The detailed status of the current migration phase."
+        }
+      }
+    },
+    "NetworkVirtualAppliancePrepareMigrationProperties": {
+      "type": "object",
+      "description": "Properties supplied to prepare the migration of a Network Virtual Appliance.",
+      "properties": {
+        "migrationType": {
+          "$ref": "./common.json#/definitions/MigrationType",
+          "description": "The type of migration workflow to prepare."
+        },
+        "marketPlaceVersion": {
+          "type": "string",
+          "description": "The marketplace version to migrate to. Applicable when migrationType is MigrateToNewOSVersion."
+        }
+      },
+      "required": [
+        "migrationType"
+      ]
+    },
+    "NetworkVirtualAppliancePrepareMigrationRequest": {
+      "type": "object",
+      "description": "Parameters supplied to prepare the migration of a Network Virtual Appliance.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkVirtualAppliancePrepareMigrationProperties",
+          "description": "Properties of the prepare migration request."
+        }
+      }
+    },
+    "NetworkVirtualAppliancePropertiesFormat": {
+      "type": "object",
+      "description": "Network Virtual Appliance definition.",
+      "properties": {
+        "nvaSku": {
+          "$ref": "#/definitions/VirtualApplianceSkuProperties",
+          "description": "Network Virtual Appliance SKU."
+        },
+        "addressPrefix": {
+          "type": "string",
+          "description": "Address Prefix.",
+          "readOnly": true
+        },
+        "addressPrefixV6": {
+          "type": "string",
+          "description": "Address Prefix for Dual-Stack NVAs.",
+          "readOnly": true
+        },
+        "bootStrapConfigurationBlobs": {
+          "type": "array",
+          "description": "BootStrapConfigurationBlobs storage URLs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "virtualHub": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The Virtual Hub where Network Virtual Appliance is being deployed."
+        },
+        "cloudInitConfigurationBlobs": {
+          "type": "array",
+          "description": "CloudInitConfigurationBlob storage URLs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cloudInitConfiguration": {
+          "type": "string",
+          "description": "CloudInitConfiguration string in plain text."
+        },
+        "virtualApplianceAsn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "VirtualAppliance ASN. Microsoft private, public and IANA reserved ASN are not supported.",
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "sshPublicKey": {
+          "type": "string",
+          "description": "Public key for SSH login."
+        },
+        "virtualApplianceNics": {
+          "type": "array",
+          "description": "List of Virtual Appliance Network Interfaces.",
+          "items": {
+            "$ref": "#/definitions/VirtualApplianceNicProperties"
+          },
+          "readOnly": true
+        },
+        "networkProfile": {
+          "$ref": "#/definitions/NetworkVirtualAppliancePropertiesFormatNetworkProfile",
+          "description": "Network Profile containing configurations for Public and Private NIC."
+        },
+        "additionalNics": {
+          "type": "array",
+          "description": "Details required for Additional Network Interface. This property is not compatible with the NVA deployed in VNets.",
+          "items": {
+            "$ref": "#/definitions/VirtualApplianceAdditionalNicProperties"
+          },
+          "x-ms-identifiers": []
+        },
+        "internetIngressPublicIps": {
+          "type": "array",
+          "description": "List of Resource Uri of Public IPs for Internet Ingress Scenario.",
+          "items": {
+            "$ref": "#/definitions/InternetIngressPublicIpsProperties"
+          },
+          "x-ms-identifiers": []
+        },
+        "virtualApplianceSites": {
+          "type": "array",
+          "description": "List of references to VirtualApplianceSite.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "virtualApplianceConnections": {
+          "type": "array",
+          "description": "List of references to VirtualApplianceConnections.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "inboundSecurityRules": {
+          "type": "array",
+          "description": "List of references to InboundSecurityRules.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "deploymentType": {
+          "type": "string",
+          "description": "The deployment type. PartnerManaged for the SaaS NVA",
+          "readOnly": true
+        },
+        "delegation": {
+          "$ref": "#/definitions/DelegationProperties",
+          "description": "The delegation for the Virtual Appliance. Only appliable for SaaS NVA."
+        },
+        "partnerManagedResource": {
+          "$ref": "#/definitions/PartnerManagedResourceProperties",
+          "description": "The delegation for the Virtual Appliance"
+        },
+        "nvaInterfaceConfigurations": {
+          "type": "array",
+          "description": "The NVA in VNet interface configurations",
+          "maxItems": 3,
+          "items": {
+            "$ref": "#/definitions/NvaInterfaceConfigurationsProperties"
+          }
+        },
+        "addressFamily": {
+          "type": "array",
+          "description": "The address families to deploy the NVA in. [\"IPv4\", \"IPv6\"] deploys a dual-stack NVA (the vHub/VNet must also be dual-stack). [\"IPv4\"], an empty array, or omitting the field deploys an IPv4-only NVA. The value \"IPv6\" may only appear in combination with \"IPv4\"; standalone [\"IPv6\"] is reserved for future use and is rejected by the service today.",
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "./common.json#/definitions/IPVersion"
+          }
+        },
+        "privateIpAddress": {
+          "type": "string",
+          "description": "A Internal Load Balancer's HA port frontend IP address. Can be used to set routes & UDR to load balance traffic between NVA instances",
+          "readOnly": true
+        },
+        "privateIpAddressV6": {
+          "type": "string",
+          "description": "An Internal Load Balancer's HA port frontend IPv6 address. Can be used to set routes & UDR to load balance traffic between NVA instances. This field appears in dual-stack NVAs.",
+          "readOnly": true
+        },
+        "migrationStatus": {
+          "$ref": "#/definitions/NetworkVirtualApplianceMigrationStatus",
+          "description": "The migration status of the Network Virtual Appliance.",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkVirtualAppliancePropertiesFormatNetworkProfile": {
+      "type": "object",
+      "description": "Network Profile containing configurations for Public and Private NIC.",
+      "properties": {
+        "networkInterfaceConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VirtualApplianceNetworkInterfaceConfiguration"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "NetworkVirtualApplianceSiteListResult": {
+      "type": "object",
+      "description": "Paged collection of VirtualApplianceSite items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualApplianceSite items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualApplianceSite"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkVirtualApplianceSku": {
+      "type": "object",
+      "title": "Available NetworkVirtualApplianceSkus",
+      "description": "Definition of the NetworkVirtualApplianceSkus resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkVirtualApplianceSkuPropertiesFormat",
+          "description": "NetworkVirtualApplianceSku properties.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "NetworkVirtualApplianceSkuInstances": {
+      "type": "object",
+      "title": "Network Virtual Appliance Sku Instances",
+      "description": "List of available Sku and instances.",
+      "properties": {
+        "scaleUnit": {
+          "type": "string",
+          "description": "Scale Unit.",
+          "readOnly": true
+        },
+        "instanceCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Instance Count.",
+          "readOnly": true
+        }
+      }
+    },
+    "NetworkVirtualApplianceSkuListResult": {
+      "type": "object",
+      "description": "The response of a NetworkVirtualApplianceSku list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkVirtualApplianceSku items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkVirtualApplianceSku"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkVirtualApplianceSkuPropertiesFormat": {
+      "type": "object",
+      "title": "Network Virtual Appliance Sku Properties",
+      "description": "Properties specific to NetworkVirtualApplianceSkus.",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "description": "Network Virtual Appliance Sku vendor.",
+          "readOnly": true
+        },
+        "availableVersions": {
+          "type": "array",
+          "description": "Available Network Virtual Appliance versions.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "availableScaleUnits": {
+          "type": "array",
+          "description": "The list of scale units available.",
+          "items": {
+            "$ref": "#/definitions/NetworkVirtualApplianceSkuInstances"
+          }
+        }
+      }
+    },
+    "NvaInVnetSubnetReferenceProperties": {
+      "type": "object",
+      "title": "Subnet references where the NVA NICS will be deployed",
+      "description": "The resource URI of the subnets where the NVA NICS will be deployed",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource Uri of Subnet",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "NvaInterfaceConfigurationsProperties": {
+      "type": "object",
+      "description": "Specifies input parameters required NVA in VNet interface configuration.",
+      "properties": {
+        "subnet": {
+          "$ref": "#/definitions/NvaInVnetSubnetReferenceProperties",
+          "description": "A subnet resource id where the NIC will be deployed. Each subnet resource uri should be unique."
+        },
+        "type": {
+          "type": "array",
+          "description": "Specifies the NIC types for the NVA interface configuration. Allowed values: PrivateNic, PublicNic, AdditionalPrivateNic, AdditionalPublicNic. Only the combination of PrivateNic and PublicNic is currently supported.",
+          "items": {
+            "$ref": "./common.json#/definitions/NvaNicType"
+          }
+        },
+        "name": {
+          "type": "string",
+          "description": "Specifies the name of the interface. Maximum length is 70 characters.",
+          "maxLength": 70
+        }
+      }
+    },
+    "Office365PolicyProperties": {
+      "type": "object",
+      "description": "Network Virtual Appliance Sku Properties.",
+      "properties": {
+        "breakOutCategories": {
+          "$ref": "#/definitions/BreakOutCategoryPolicies",
+          "description": "Office 365 breakout categories."
+        }
+      }
+    },
+    "PartnerManagedResourceProperties": {
+      "type": "object",
+      "description": "Properties of the partner managed resource. Only appliable for SaaS NVA.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The partner managed resource id.",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "PaloAltoNetworks.Cloudngfw/firewalls"
+              }
+            ]
+          }
+        },
+        "internalLoadBalancerId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The partner managed ILB resource id",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/loadBalancers"
+              }
+            ]
+          }
+        },
+        "standardLoadBalancerId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The partner managed SLB resource id",
+          "readOnly": true,
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/loadBalancers"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "PoolAssociation": {
+      "type": "object",
+      "description": "IpamPool association information.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource id of the associated Azure resource."
+        },
+        "poolId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "IpamPool id for which the resource is associated to."
+        },
+        "description": {
+          "type": "string"
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "List of assigned IP address prefixes in the IpamPool of the associated resource.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "reservedPrefixes": {
+          "type": "array",
+          "description": "List of reserved IP address prefixes in the IpamPool of the associated resource.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "totalNumberOfIPAddresses": {
+          "type": "string",
+          "description": "Total number of assigned IP addresses of the association.",
+          "readOnly": true
+        },
+        "numberOfReservedIPAddresses": {
+          "type": "string",
+          "description": "Total number of reserved IP addresses of the association.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation time of the association.",
+          "readOnly": true
+        },
+        "reservationExpiresAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Expire time for IP addresses reserved.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "resourceId"
+      ]
+    },
+    "PoolAssociationList": {
+      "type": "object",
+      "description": "List of PoolAssociation",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PoolAssociation items on this page",
+          "items": {
+            "$ref": "#/definitions/PoolAssociation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PoolUsage": {
+      "type": "object",
+      "description": "IpamPool usage information.",
+      "properties": {
+        "addressPrefixes": {
+          "type": "array",
+          "description": "List of IP address prefixes of the resource.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "childPools": {
+          "type": "array",
+          "description": "List of IpamPool that are children of this IpamPool.",
+          "items": {
+            "$ref": "#/definitions/ResourceBasics"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "resourceId"
+          ]
+        },
+        "allocatedAddressPrefixes": {
+          "type": "array",
+          "description": "List of assigned IP address prefixes.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "reservedAddressPrefixes": {
+          "type": "array",
+          "description": "List of reserved IP address prefixes. These IP addresses could be reclaimed if not assigned in the given time.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "availableAddressPrefixes": {
+          "type": "array",
+          "description": "List of available IP address prefixes.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "totalNumberOfIPAddresses": {
+          "type": "string",
+          "description": "Total number of IP addresses managed in the IpamPool.",
+          "readOnly": true
+        },
+        "numberOfAllocatedIPAddresses": {
+          "type": "string",
+          "description": "Total number of assigned IP addresses in the IpamPool.",
+          "readOnly": true
+        },
+        "numberOfReservedIPAddresses": {
+          "type": "string",
+          "description": "Total number of reserved IP addresses in the IpamPool.",
+          "readOnly": true
+        },
+        "numberOfAvailableIPAddresses": {
+          "type": "string",
+          "description": "Total number of available IP addresses in the IpamPool.",
+          "readOnly": true
+        }
+      }
+    },
+    "PrepareNetworkPoliciesRequest": {
+      "type": "object",
+      "description": "Details of PrepareNetworkPolicies for Subnet.",
+      "properties": {
+        "serviceName": {
+          "type": "string",
+          "description": "The name of the service for which subnet is being prepared for."
+        },
+        "networkIntentPolicyConfigurations": {
+          "type": "array",
+          "description": "A list of NetworkIntentPolicyConfiguration.",
+          "items": {
+            "$ref": "#/definitions/NetworkIntentPolicyConfiguration"
+          }
+        }
+      }
+    },
+    "PrivateDnsZoneConfig": {
+      "type": "object",
+      "description": "PrivateDnsZoneConfig resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "properties": {
+          "$ref": "#/definitions/PrivateDnsZonePropertiesFormat",
+          "description": "Properties of the private dns zone configuration.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "PrivateDnsZoneGroup": {
+      "type": "object",
+      "description": "Private dns zone group resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/PrivateDnsZoneGroupPropertiesFormat",
+          "description": "Properties of the private dns zone group.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "PrivateDnsZoneGroupListResult": {
+      "type": "object",
+      "description": "Response for the ListPrivateDnsZoneGroups API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateDnsZoneGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateDnsZoneGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateDnsZoneGroupPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the private dns zone group.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private dns zone group resource.",
+          "readOnly": true
+        },
+        "privateDnsZoneConfigs": {
+          "type": "array",
+          "description": "A collection of private dns zone configurations of the private dns zone group.",
+          "items": {
+            "$ref": "#/definitions/PrivateDnsZoneConfig"
+          }
+        }
+      }
+    },
+    "PrivateDnsZonePropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the private dns zone configuration resource.",
+      "properties": {
+        "privateDnsZoneId": {
+          "type": "string",
+          "description": "The resource id of the private dns zone."
+        },
+        "recordSets": {
+          "type": "array",
+          "description": "A collection of information regarding a recordSet, holding information to identify private resources.",
+          "items": {
+            "$ref": "#/definitions/RecordSet"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "Private endpoint resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointProperties",
+          "description": "Properties of the private endpoint.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "./common.json#/definitions/ExtendedLocation",
+          "description": "The extended location of the load balancer."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "PrivateEndpointConnection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Properties of the private end point connection.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "The response of a PrivateEndpointConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateEndpointConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the PrivateEndpointConnectProperties.",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The resource of private end point.",
+          "readOnly": true
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "A collection of information about the state of the connection between service consumer and provider."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private endpoint connection resource.",
+          "readOnly": true
+        },
+        "linkIdentifier": {
+          "type": "string",
+          "description": "The consumer link id.",
+          "readOnly": true
+        },
+        "privateEndpointLocation": {
+          "type": "string",
+          "description": "The location of the private endpoint.",
+          "readOnly": true
+        }
+      }
+    },
+    "PrivateEndpointIPConfiguration": {
+      "type": "object",
+      "description": "An IP Configuration of the private endpoint.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointIPConfigurationProperties",
+          "description": "Properties of private endpoint IP configurations.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group."
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      }
+    },
+    "PrivateEndpointIPConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of an IP Configuration of the private endpoint.",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The ID of a group obtained from the remote resource that this private endpoint should connect to."
+        },
+        "memberName": {
+          "type": "string",
+          "description": "The member name of a group obtained from the remote resource that this private endpoint should connect to."
+        },
+        "privateIPAddress": {
+          "type": "string",
+          "description": "A private ip address obtained from the private endpoint's subnet."
+        }
+      }
+    },
+    "PrivateEndpointListResult": {
+      "type": "object",
+      "description": "The response of a PrivateEndpoint list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateEndpoint items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpoint"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateEndpointProperties": {
+      "type": "object",
+      "description": "Properties of the private endpoint.",
+      "properties": {
+        "subnet": {
+          "$ref": "#/definitions/Subnet",
+          "description": "The ID of the subnet from which the private IP will be allocated."
+        },
+        "networkInterfaces": {
+          "type": "array",
+          "description": "An array of references to the network interfaces created for this private endpoint.",
+          "items": {
+            "$ref": "#/definitions/NetworkInterface"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private endpoint resource.",
+          "readOnly": true
+        },
+        "ipVersionType": {
+          "type": "string",
+          "description": "Specifies the IP version type for the private IPs of the private endpoint. If not defined, this defaults to IPv4.",
+          "default": "IPv4",
+          "enum": [
+            "IPv4",
+            "IPv6",
+            "DualStack"
+          ],
+          "x-ms-enum": {
+            "name": "PrivateEndpointIPVersionType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "IPv4",
+                "value": "IPv4",
+                "description": "Indicates that the Private IPs of the private endpoint will be IPv4 only."
+              },
+              {
+                "name": "IPv6",
+                "value": "IPv6",
+                "description": "Indicates that the Private IPs of the private endpoint will be IPv6 only."
+              },
+              {
+                "name": "DualStack",
+                "value": "DualStack",
+                "description": "Indicates that the Private IPs of the private endpoint can be both IPv4 and IPv6."
+              }
+            ]
+          }
+        },
+        "privateLinkServiceConnections": {
+          "type": "array",
+          "description": "A grouping of information about the connection to the remote resource.",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkServiceConnection"
+          }
+        },
+        "manualPrivateLinkServiceConnections": {
+          "type": "array",
+          "description": "A grouping of information about the connection to the remote resource. Used when the network admin does not have access to approve connections to the remote resource.",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkServiceConnection"
+          }
+        },
+        "customDnsConfigs": {
+          "type": "array",
+          "description": "An array of custom dns configurations.",
+          "items": {
+            "$ref": "#/definitions/CustomDnsConfigPropertiesFormat"
+          }
+        },
+        "applicationSecurityGroups": {
+          "type": "array",
+          "description": "Application security groups in which the private endpoint IP configuration is included.",
+          "items": {
+            "$ref": "#/definitions/ApplicationSecurityGroup"
+          }
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "A list of IP configurations of the private endpoint. This will be used to map to the First Party Service's endpoints.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointIPConfiguration"
+          }
+        },
+        "customNetworkInterfaceName": {
+          "type": "string",
+          "description": "The custom name of the network interface attached to the private endpoint."
+        },
+        "billingSku": {
+          "$ref": "./common.json#/definitions/PrivateEndpointBillingSku",
+          "description": "The billing sku of the private endpoint."
+        }
+      }
+    },
+    "PrivateLinkService": {
+      "type": "object",
+      "description": "Private link service resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkServiceProperties",
+          "description": "Properties of the private link service.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "./common.json#/definitions/ExtendedLocation",
+          "description": "The extended location of the load balancer."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "PrivateLinkServiceConnection": {
+      "type": "object",
+      "description": "PrivateLinkServiceConnection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionProperties",
+          "description": "Properties of the private link service connection.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "PrivateLinkServiceConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the PrivateLinkServiceConnection.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private link service connection resource.",
+          "readOnly": true
+        },
+        "privateLinkServiceId": {
+          "type": "string",
+          "description": "The resource id of private link service."
+        },
+        "groupIds": {
+          "type": "array",
+          "description": "The ID(s) of the group(s) obtained from the remote resource that this private endpoint should connect to.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requestMessage": {
+          "type": "string",
+          "description": "A message passed to the owner of the remote resource with this connection request. Restricted to 140 chars."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "A collection of read-only information about the state of the connection to the remote resource."
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionState": {
+      "type": "object",
+      "description": "A collection of information about the state of the connection between service consumer and provider.",
+      "properties": {
+        "status": {
+          "type": "string",
+          "description": "Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service."
+        },
+        "description": {
+          "type": "string",
+          "description": "The reason for approval/rejection of the connection."
+        },
+        "actionsRequired": {
+          "type": "string",
+          "description": "A message indicating if changes on the service provider require any updates on the consumer."
+        }
+      }
+    },
+    "PrivateLinkServiceIpConfiguration": {
+      "type": "object",
+      "description": "The private link service ip configuration.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkServiceIpConfigurationProperties",
+          "description": "Properties of the private link service ip configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of private link service ip configuration."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "PrivateLinkServiceIpConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of private link service IP configuration.",
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "description": "The private IP address of the IP configuration."
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The private IP address allocation method."
+        },
+        "subnet": {
+          "$ref": "#/definitions/Subnet",
+          "description": "The reference to the subnet resource."
+        },
+        "primary": {
+          "type": "boolean",
+          "description": "Whether the ip configuration is primary or not."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private link service IP configuration resource.",
+          "readOnly": true
+        },
+        "privateIPAddressVersion": {
+          "$ref": "./common.json#/definitions/IPVersion",
+          "description": "Whether the specific IP configuration is IPv4 or IPv6. Default is IPv4."
+        }
+      }
+    },
+    "PrivateLinkServiceListResult": {
+      "type": "object",
+      "description": "The response of a PrivateLinkService list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateLinkService items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkService"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateLinkServiceProperties": {
+      "type": "object",
+      "description": "Properties of the private link service.",
+      "properties": {
+        "loadBalancerFrontendIpConfigurations": {
+          "type": "array",
+          "description": "An array of references to the load balancer IP configurations.",
+          "items": {
+            "$ref": "./loadBalancer.json#/definitions/FrontendIPConfiguration"
+          }
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "An array of private link service IP configurations.",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkServiceIpConfiguration"
+          }
+        },
+        "destinationIPAddress": {
+          "type": "string",
+          "description": "The destination IP address of the private link service."
+        },
+        "accessMode": {
+          "$ref": "./common.json#/definitions/AccessMode",
+          "description": "The access mode of the private link service."
+        },
+        "networkInterfaces": {
+          "type": "array",
+          "description": "An array of references to the network interfaces created for this private link service.",
+          "items": {
+            "$ref": "#/definitions/NetworkInterface"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private link service resource.",
+          "readOnly": true
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "An array of list about connections to the private endpoint.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "visibility": {
+          "$ref": "#/definitions/PrivateLinkServicePropertiesVisibility",
+          "description": "The visibility list of the private link service."
+        },
+        "autoApproval": {
+          "$ref": "#/definitions/PrivateLinkServicePropertiesAutoApproval",
+          "description": "The auto-approval list of the private link service."
+        },
+        "fqdns": {
+          "type": "array",
+          "description": "The list of Fqdn.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "alias": {
+          "type": "string",
+          "description": "The alias of the private link service.",
+          "readOnly": true
+        },
+        "enableProxyProtocol": {
+          "type": "boolean",
+          "description": "Whether the private link service is enabled for proxy protocol or not."
+        }
+      }
+    },
+    "PrivateLinkServicePropertiesAutoApproval": {
+      "type": "object",
+      "description": "The auto-approval list of the private link service.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceSet"
+        }
+      ]
+    },
+    "PrivateLinkServicePropertiesVisibility": {
+      "type": "object",
+      "description": "The visibility list of the private link service.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceSet"
+        }
+      ]
+    },
+    "PrivateLinkServiceVisibility": {
+      "type": "object",
+      "description": "Response for the CheckPrivateLinkServiceVisibility API service call.",
+      "properties": {
+        "visible": {
+          "type": "boolean",
+          "description": "Private Link Service Visibility (True/False)."
+        }
+      }
+    },
+    "PublicIPAddress": {
+      "type": "object",
+      "description": "Public IP address resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PublicIPAddressPropertiesFormat",
+          "description": "Public IP address properties.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "./common.json#/definitions/ExtendedLocation",
+          "description": "The extended location of the public ip address."
+        },
+        "sku": {
+          "$ref": "#/definitions/PublicIPAddressSku",
+          "description": "The public IP address SKU."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "zones": {
+          "type": "array",
+          "description": "A list of availability zones denoting the IP allocated for the resource needs to come from.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "PublicIPAddressDnsSettings": {
+      "type": "object",
+      "description": "Contains FQDN of the DNS record associated with the public IP address.",
+      "properties": {
+        "domainNameLabel": {
+          "type": "string",
+          "description": "The domain name label. The concatenation of the domain name label and the regionalized DNS zone make up the fully qualified domain name associated with the public IP address. If a domain name label is specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system."
+        },
+        "domainNameLabelScope": {
+          "$ref": "./common.json#/definitions/PublicIpAddressDnsSettingsDomainNameLabelScope",
+          "description": "The domain name label scope. If a domain name label and a domain name label scope are specified, an A DNS record is created for the public IP in the Microsoft Azure DNS system with a hashed value includes in FQDN."
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "The Fully Qualified Domain Name of the A DNS record associated with the public IP. This is the concatenation of the domainNameLabel and the regionalized DNS zone."
+        },
+        "reverseFqdn": {
+          "type": "string",
+          "description": "The reverse FQDN. A user-visible, fully qualified domain name that resolves to this public IP address. If the reverseFqdn is specified, then a PTR DNS record is created pointing from the IP address in the in-addr.arpa domain to the reverse FQDN."
+        }
+      }
+    },
+    "PublicIPAddressListResult": {
+      "type": "object",
+      "description": "The response of a PublicIPAddress list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PublicIPAddress items on this page",
+          "items": {
+            "$ref": "#/definitions/PublicIPAddress"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PublicIPAddressPropertiesFormat": {
+      "type": "object",
+      "description": "Public IP address properties.",
+      "properties": {
+        "publicIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The public IP address allocation method."
+        },
+        "publicIPAddressVersion": {
+          "$ref": "./common.json#/definitions/IPVersion",
+          "description": "The public IP address version."
+        },
+        "ipConfiguration": {
+          "$ref": "#/definitions/IPConfiguration",
+          "description": "The IP configuration associated with the public IP address.",
+          "readOnly": true
+        },
+        "dnsSettings": {
+          "$ref": "#/definitions/PublicIPAddressDnsSettings",
+          "description": "The FQDN of the DNS record associated with the public IP address."
+        },
+        "ddosSettings": {
+          "$ref": "#/definitions/DdosSettings",
+          "description": "The DDoS protection custom policy associated with the public IP address."
+        },
+        "ipTags": {
+          "type": "array",
+          "description": "The list of tags associated with the public IP address.",
+          "items": {
+            "$ref": "#/definitions/IpTag"
+          }
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "The IP address associated with the public IP address resource."
+        },
+        "publicIPPrefix": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The Public IP Prefix this Public IP Address should be allocated from."
+        },
+        "idleTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The idle timeout of the public IP address."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the public IP address resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the public IP address resource.",
+          "readOnly": true
+        },
+        "servicePublicIPAddress": {
+          "$ref": "#/definitions/PublicIPAddress",
+          "description": "The service public IP address of the public IP address resource."
+        },
+        "natGateway": {
+          "$ref": "#/definitions/NatGateway",
+          "description": "The NatGateway for the Public IP address."
+        },
+        "migrationPhase": {
+          "$ref": "./common.json#/definitions/PublicIPAddressMigrationPhase",
+          "description": "Migration phase of Public IP Address."
+        },
+        "linkedPublicIPAddress": {
+          "$ref": "#/definitions/PublicIPAddress",
+          "description": "The linked public IP address of the public IP address resource."
+        },
+        "deleteOption": {
+          "$ref": "./common.json#/definitions/DeleteOptions",
+          "description": "Specify what happens to the public IP address when the VM using it is deleted"
+        },
+        "upgradedToV2": {
+          "type": "boolean",
+          "description": "Whether the public IP address SKU has been upgraded from Standard to StandardV2.",
+          "readOnly": true
+        }
+      }
+    },
+    "PublicIPAddressSku": {
+      "type": "object",
+      "description": "SKU of a public IP address.",
+      "properties": {
+        "name": {
+          "$ref": "./common.json#/definitions/PublicIPAddressSkuName",
+          "description": "Name of a public IP address SKU."
+        },
+        "tier": {
+          "$ref": "./common.json#/definitions/PublicIPAddressSkuTier",
+          "description": "Tier of a public IP address SKU."
+        }
+      }
+    },
+    "PublicIPPrefix": {
+      "type": "object",
+      "description": "Public IP prefix resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PublicIPPrefixPropertiesFormat",
+          "description": "Public IP prefix properties.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "./common.json#/definitions/ExtendedLocation",
+          "description": "The extended location of the public ip address."
+        },
+        "sku": {
+          "$ref": "#/definitions/PublicIPPrefixSku",
+          "description": "The public IP prefix SKU."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "zones": {
+          "type": "array",
+          "description": "A list of availability zones denoting the IP allocated for the resource needs to come from.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "PublicIPPrefixListResult": {
+      "type": "object",
+      "description": "The response of a PublicIPPrefix list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PublicIPPrefix items on this page",
+          "items": {
+            "$ref": "#/definitions/PublicIPPrefix"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PublicIPPrefixPropertiesFormat": {
+      "type": "object",
+      "description": "Public IP prefix properties.",
+      "properties": {
+        "publicIPAddressVersion": {
+          "$ref": "./common.json#/definitions/IPVersion",
+          "description": "The public IP address version."
+        },
+        "ipTags": {
+          "type": "array",
+          "description": "The list of tags associated with the public IP prefix.",
+          "items": {
+            "$ref": "#/definitions/IpTag"
+          }
+        },
+        "prefixLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The Length of the Public IP Prefix."
+        },
+        "ipPrefix": {
+          "type": "string",
+          "description": "The allocated Prefix.",
+          "readOnly": true
+        },
+        "publicIPAddresses": {
+          "type": "array",
+          "description": "The list of all referenced PublicIPAddresses.",
+          "items": {
+            "$ref": "#/definitions/ReferencedPublicIpAddress"
+          },
+          "readOnly": true
+        },
+        "loadBalancerFrontendIpConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to load balancer frontend IP configuration associated with the public IP prefix.",
+          "readOnly": true
+        },
+        "customIPPrefix": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The customIpPrefix that this prefix is associated with."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the public IP prefix resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the public IP prefix resource.",
+          "readOnly": true
+        },
+        "natGateway": {
+          "$ref": "#/definitions/NatGateway",
+          "description": "NatGateway of Public IP Prefix."
+        },
+        "upgradedToV2": {
+          "type": "boolean",
+          "description": "Whether the public IP prefix SKU has been upgraded from Standard to StandardV2.",
+          "readOnly": true
+        }
+      }
+    },
+    "PublicIPPrefixSku": {
+      "type": "object",
+      "description": "SKU of a public IP prefix.",
+      "properties": {
+        "name": {
+          "$ref": "./common.json#/definitions/PublicIPPrefixSkuName",
+          "description": "Name of a public IP prefix SKU."
+        },
+        "tier": {
+          "$ref": "./common.json#/definitions/PublicIPPrefixSkuTier",
+          "description": "Tier of a public IP prefix SKU."
+        }
+      }
+    },
+    "PublicIpDdosProtectionStatusResult": {
+      "type": "object",
+      "description": "Response for GetPublicIpAddressDdosProtectionStatusOperation API service call.",
+      "properties": {
+        "publicIpAddressId": {
+          "type": "string",
+          "description": "Public IP ARM resource ID"
+        },
+        "publicIpAddress": {
+          "type": "string",
+          "description": "IP Address of the Public IP Resource"
+        },
+        "isWorkloadProtected": {
+          "$ref": "./common.json#/definitions/IsWorkloadProtected",
+          "description": "Value indicating whether the IP address is DDoS workload protected or not."
+        },
+        "ddosProtectionPlanId": {
+          "type": "string",
+          "description": "DDoS protection plan Resource Id of a if IP address is protected through a plan."
+        }
+      }
+    },
+    "QosDefinition": {
+      "type": "object",
+      "description": "Quality of Service defines the traffic configuration between endpoints. Mandatory to have one marking.",
+      "properties": {
+        "markings": {
+          "type": "array",
+          "description": "List of markings to be used in the configuration.",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "sourceIpRanges": {
+          "type": "array",
+          "description": "Source IP ranges.",
+          "items": {
+            "$ref": "#/definitions/QosIpRange"
+          }
+        },
+        "destinationIpRanges": {
+          "type": "array",
+          "description": "Destination IP ranges.",
+          "items": {
+            "$ref": "#/definitions/QosIpRange"
+          }
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "description": "Sources port ranges.",
+          "items": {
+            "$ref": "#/definitions/QosPortRange"
+          }
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "description": "Destination port ranges.",
+          "items": {
+            "$ref": "#/definitions/QosPortRange"
+          }
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/ProtocolType",
+          "description": "RNM supported protocol types."
+        }
+      }
+    },
+    "QosIpRange": {
+      "type": "object",
+      "description": "Qos Traffic Profiler IP Range properties.",
+      "properties": {
+        "startIP": {
+          "type": "string",
+          "description": "Start IP Address."
+        },
+        "endIP": {
+          "type": "string",
+          "description": "End IP Address."
+        }
+      }
+    },
+    "QosPortRange": {
+      "type": "object",
+      "description": "Qos Traffic Profiler Port range properties.",
+      "properties": {
+        "start": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Qos Port Range start."
+        },
+        "end": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Qos Port Range end."
+        }
+      }
+    },
+    "ReachabilityAnalysisIntent": {
+      "type": "object",
+      "description": "Configuration information or intent on which to do the analysis on.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ReachabilityAnalysisIntentProperties",
+          "description": "Represents the Reachability Analysis Intent properties."
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/CommonProxyResource"
+        }
+      ]
+    },
+    "ReachabilityAnalysisIntentListResult": {
+      "type": "object",
+      "description": "The response of a ReachabilityAnalysisIntent list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ReachabilityAnalysisIntent items on this page",
+          "items": {
+            "$ref": "#/definitions/ReachabilityAnalysisIntent"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ReachabilityAnalysisIntentProperties": {
+      "type": "object",
+      "description": "Represents the Reachability Analysis Intent properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "Provisioning states of a resource.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string"
+        },
+        "sourceResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Source resource id to verify the reachability path of."
+        },
+        "destinationResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Destination resource id to verify the reachability path of."
+        },
+        "ipTraffic": {
+          "$ref": "#/definitions/IPTraffic",
+          "description": "IP traffic information."
+        }
+      },
+      "required": [
+        "sourceResourceId",
+        "destinationResourceId",
+        "ipTraffic"
+      ]
+    },
+    "ReachabilityAnalysisRun": {
+      "type": "object",
+      "description": "Configuration information for analysis run.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ReachabilityAnalysisRunProperties",
+          "description": "Represents the Reachability Analysis Run properties."
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/CommonProxyResource"
+        }
+      ]
+    },
+    "ReachabilityAnalysisRunListResult": {
+      "type": "object",
+      "description": "The response of a ReachabilityAnalysisRun list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ReachabilityAnalysisRun items on this page",
+          "items": {
+            "$ref": "#/definitions/ReachabilityAnalysisRun"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ReachabilityAnalysisRunProperties": {
+      "type": "object",
+      "description": "Represents the Reachability Analysis Run properties.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "intentId": {
+          "type": "string",
+          "description": "Id of the intent resource to run analysis on."
+        },
+        "intentContent": {
+          "$ref": "#/definitions/IntentContent",
+          "description": "Intent information.",
+          "readOnly": true
+        },
+        "analysisResult": {
+          "type": "string",
+          "readOnly": true
+        },
+        "errorMessage": {
+          "type": "string",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "Provisioning states of a resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "intentId"
+      ]
+    },
+    "RecordSet": {
+      "type": "object",
+      "description": "A collective group of information about the record set information.",
+      "properties": {
+        "recordType": {
+          "type": "string",
+          "description": "Resource record type."
+        },
+        "recordSetName": {
+          "type": "string",
+          "description": "Recordset name."
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "Fqdn that resolves to private endpoint ip address."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the recordset.",
+          "readOnly": true
+        },
+        "ttl": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Recordset time to live."
+        },
+        "ipAddresses": {
+          "type": "array",
+          "description": "The private ip address of the private endpoint.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ReferencedPublicIpAddress": {
+      "type": "object",
+      "description": "Reference to a public IP address.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The PublicIPAddress Reference."
+        }
+      }
+    },
+    "ReserveCloudServicePublicIpAddressRequest": {
+      "type": "object",
+      "description": "The request for ReserveCloudServicePublicIpAddressOperation.",
+      "properties": {
+        "isRollback": {
+          "$ref": "./common.json#/definitions/IsRollback",
+          "description": "When true, reverts from Static to Dynamic allocation (undo reservation)."
+        }
+      },
+      "required": [
+        "isRollback"
+      ]
+    },
+    "ResourceBasics": {
+      "type": "object",
+      "description": "Representation of basic resource information.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "ResourceId of the Azure resource."
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "List of IP address prefixes of the resource.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ResourceNavigationLink": {
+      "type": "object",
+      "description": "ResourceNavigationLink resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ResourceNavigationLinkFormat",
+          "description": "Resource navigation link properties format.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "id": {
+          "type": "string",
+          "description": "Resource navigation link identifier.",
+          "readOnly": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ResourceNavigationLinkFormat": {
+      "type": "object",
+      "description": "Properties of ResourceNavigationLink.",
+      "properties": {
+        "linkedResourceType": {
+          "type": "string",
+          "description": "Resource type of the linked resource."
+        },
+        "link": {
+          "type": "string",
+          "description": "Link to the external resource."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource navigation link resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ResourceNavigationLinksListResult": {
+      "type": "object",
+      "description": "Paged collection of ResourceNavigationLink items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ResourceNavigationLink items on this page",
+          "items": {
+            "$ref": "#/definitions/ResourceNavigationLink"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ResourceSet": {
+      "type": "object",
+      "description": "The base resource set for visibility and auto-approval.",
+      "properties": {
+        "subscriptions": {
+          "type": "array",
+          "description": "The list of subscriptions.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Route": {
+      "type": "object",
+      "description": "Route resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RoutePropertiesFormat",
+          "description": "Properties of the route.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "RouteListResult": {
+      "type": "object",
+      "description": "The response of a Route list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Route items on this page",
+          "items": {
+            "$ref": "#/definitions/Route"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RouteNextHopEcmp": {
+      "type": "object",
+      "description": "The next hop definition for ECMP routes containing multiple next hop IP addresses.",
+      "properties": {
+        "nextHopIpAddresses": {
+          "type": "array",
+          "description": "List of next hop IP addresses for ECMP routing. Must contain between 2 and 64 IP addresses.",
+          "minItems": 2,
+          "maxItems": 64,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "nextHopIpAddresses"
+      ]
+    },
+    "RoutePropertiesFormat": {
+      "type": "object",
+      "description": "Route resource.",
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "The destination CIDR to which the route applies."
+        },
+        "nextHopType": {
+          "$ref": "./common.json#/definitions/RouteNextHopType",
+          "description": "The type of Azure hop the packet should be sent to."
+        },
+        "nextHopIpAddress": {
+          "type": "string",
+          "description": "The IP address packets should be forwarded to. Next hop values are only allowed in routes where the next hop type is VirtualAppliance."
+        },
+        "nextHop": {
+          "$ref": "#/definitions/RouteNextHopEcmp",
+          "description": "The next hop definition containing ECMP next hop IP addresses. Only allowed when nextHopType is VirtualApplianceEcmp."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the route resource.",
+          "readOnly": true
+        },
+        "hasBgpOverride": {
+          "type": "boolean",
+          "description": "A value indicating whether this route overrides overlapping BGP routes regardless of LPM.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "nextHopType"
+      ]
+    },
+    "RouteTable": {
+      "type": "object",
+      "description": "Route table resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RouteTablePropertiesFormat",
+          "description": "Properties of the route table.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "RouteTableListResult": {
+      "type": "object",
+      "description": "The response of a RouteTable list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RouteTable items on this page",
+          "items": {
+            "$ref": "#/definitions/RouteTable"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RouteTablePropertiesFormat": {
+      "type": "object",
+      "description": "Route Table resource.",
+      "properties": {
+        "routes": {
+          "type": "array",
+          "description": "Collection of routes contained within a route table.",
+          "items": {
+            "$ref": "#/definitions/Route"
+          }
+        },
+        "subnets": {
+          "type": "array",
+          "description": "A collection of references to subnets.",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          },
+          "readOnly": true
+        },
+        "disableBgpRoutePropagation": {
+          "type": "boolean",
+          "description": "Whether to disable the routes learned by BGP on that route table. True means disable."
+        },
+        "disablePeeringRoute": {
+          "$ref": "./common.json#/definitions/DisablePeeringRoute",
+          "description": "Whether to disable the routes learned by peering on the route table. 'None' means peering routes are enabled, 'All' means all peering routes are disabled."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the route table resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the route table.",
+          "readOnly": true
+        }
+      }
+    },
+    "SecurityPartnerProvider": {
+      "type": "object",
+      "description": "Security Partner Provider resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SecurityPartnerProviderPropertiesFormat",
+          "description": "Properties of the Security Partner Provider.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "SecurityPartnerProviderListResult": {
+      "type": "object",
+      "description": "The response of a SecurityPartnerProvider list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SecurityPartnerProvider items on this page",
+          "items": {
+            "$ref": "#/definitions/SecurityPartnerProvider"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SecurityPartnerProviderPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the Security Partner Provider.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the Security Partner Provider resource.",
+          "readOnly": true
+        },
+        "securityProviderName": {
+          "$ref": "./common.json#/definitions/SecurityProviderName",
+          "description": "The security provider name."
+        },
+        "connectionStatus": {
+          "$ref": "./common.json#/definitions/SecurityPartnerProviderConnectionStatus",
+          "description": "The connection status with the Security Partner Provider.",
+          "readOnly": true
+        },
+        "virtualHub": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The virtualHub to which the Security Partner Provider belongs."
+        }
+      }
+    },
+    "SecurityRule": {
+      "type": "object",
+      "description": "Network security rule.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SecurityRulePropertiesFormat",
+          "description": "Properties of the security rule.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "SecurityRuleListResult": {
+      "type": "object",
+      "description": "The response of a SecurityRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SecurityRule items on this page",
+          "items": {
+            "$ref": "#/definitions/SecurityRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SecurityRulePropertiesFormat": {
+      "type": "object",
+      "description": "Security rule resource.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "A description for this rule. Restricted to 140 chars."
+        },
+        "protocol": {
+          "$ref": "./common.json#/definitions/SecurityRuleProtocol",
+          "description": "Network protocol this rule applies to."
+        },
+        "sourcePortRange": {
+          "type": "string",
+          "description": "The source port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
+        },
+        "destinationPortRange": {
+          "type": "string",
+          "description": "The destination port or range. Integer or range between 0 and 65535. Asterisk '*' can also be used to match all ports."
+        },
+        "sourceAddressPrefix": {
+          "type": "string",
+          "description": "The CIDR or source IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used. If this is an ingress rule, specifies where network traffic originates from."
+        },
+        "sourceAddressPrefixes": {
+          "type": "array",
+          "description": "The CIDR or source IP ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "sourceApplicationSecurityGroups": {
+          "type": "array",
+          "description": "The application security group specified as source.",
+          "items": {
+            "$ref": "#/definitions/ApplicationSecurityGroup"
+          }
+        },
+        "destinationAddressPrefix": {
+          "type": "string",
+          "description": "The destination address prefix. CIDR or destination IP range. Asterisk '*' can also be used to match all source IPs. Default tags such as 'VirtualNetwork', 'AzureLoadBalancer' and 'Internet' can also be used."
+        },
+        "destinationAddressPrefixes": {
+          "type": "array",
+          "description": "The destination address prefixes. CIDR or destination IP ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationApplicationSecurityGroups": {
+          "type": "array",
+          "description": "The application security group specified as destination.",
+          "items": {
+            "$ref": "#/definitions/ApplicationSecurityGroup"
+          }
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "description": "The source port ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "description": "The destination port ranges.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "access": {
+          "$ref": "./common.json#/definitions/SecurityRuleAccess",
+          "description": "The network traffic is allowed or denied."
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The priority of the rule. The value can be between 100 and 4096. The priority number must be unique for each rule in the collection. The lower the priority number, the higher the priority of the rule."
+        },
+        "direction": {
+          "$ref": "./common.json#/definitions/SecurityRuleDirection",
+          "description": "The direction of the rule. The direction specifies if rule will be evaluated on incoming or outgoing traffic."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the security rule resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "protocol",
+        "access",
+        "priority",
+        "direction"
+      ]
+    },
+    "ServiceAssociationLink": {
+      "type": "object",
+      "description": "ServiceAssociationLink resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ServiceAssociationLinkPropertiesFormat",
+          "description": "Resource navigation link properties format.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ServiceAssociationLinkPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of ServiceAssociationLink.",
+      "properties": {
+        "linkedResourceType": {
+          "type": "string",
+          "description": "Resource type of the linked resource."
+        },
+        "link": {
+          "type": "string",
+          "description": "Link to the external resource."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the service association link resource.",
+          "readOnly": true
+        },
+        "allowDelete": {
+          "type": "boolean",
+          "description": "If true, the resource can be deleted."
+        },
+        "locations": {
+          "type": "array",
+          "description": "A list of locations.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ServiceAssociationLinksListResult": {
+      "type": "object",
+      "description": "Paged collection of ServiceAssociationLink items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ServiceAssociationLink items on this page",
+          "items": {
+            "$ref": "#/definitions/ServiceAssociationLink"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ServiceDelegationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of a service delegation.",
+      "properties": {
+        "serviceName": {
+          "type": "string",
+          "description": "The name of the service to whom the subnet should be delegated (e.g. Microsoft.Sql/servers)."
+        },
+        "actions": {
+          "type": "array",
+          "description": "The actions permitted to the service upon delegation.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the service delegation resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ServiceEndpointPropertiesFormat": {
+      "type": "object",
+      "description": "The service endpoint properties.",
+      "properties": {
+        "service": {
+          "type": "string",
+          "description": "The type of the endpoint service."
+        },
+        "networkIdentifier": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "SubResource as network identifier."
+        },
+        "locations": {
+          "type": "array",
+          "description": "A list of locations.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the service endpoint resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ServiceTagInformation": {
+      "type": "object",
+      "description": "The service tag information.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ServiceTagInformationPropertiesFormat",
+          "description": "Properties of the service tag information.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of service tag.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of service tag.",
+          "readOnly": true
+        },
+        "serviceTagChangeNumber": {
+          "type": "string",
+          "description": "The iteration number of service tag object for region.",
+          "readOnly": true
+        }
+      }
+    },
+    "ServiceTagInformationListResult": {
+      "type": "object",
+      "description": "Response for Get ServiceTagInformation API service call. Retrieves the list of service tag information resources.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ServiceTagInformation items on this page",
+          "items": {
+            "$ref": "#/definitions/ServiceTagInformation"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ServiceTagInformationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the service tag information.",
+      "properties": {
+        "changeNumber": {
+          "type": "string",
+          "description": "The iteration number of service tag.",
+          "readOnly": true
+        },
+        "region": {
+          "type": "string",
+          "description": "The region of service tag.",
+          "readOnly": true
+        },
+        "systemService": {
+          "type": "string",
+          "description": "The name of system service.",
+          "readOnly": true
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "The list of IP address prefixes.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "state": {
+          "type": "string",
+          "description": "The state of the service tag.",
+          "readOnly": true
+        }
+      }
+    },
+    "ServiceTagsListResult": {
+      "type": "object",
+      "description": "Response for the ListServiceTags API service call.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the cloud.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "description": "The ID of the cloud.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The azure resource type.",
+          "readOnly": true
+        },
+        "changeNumber": {
+          "type": "string",
+          "description": "The iteration number.",
+          "readOnly": true
+        },
+        "cloud": {
+          "type": "string",
+          "description": "The name of the cloud.",
+          "readOnly": true
+        },
+        "values": {
+          "type": "array",
+          "description": "The list of service tag information resources.",
+          "items": {
+            "$ref": "#/definitions/ServiceTagInformation"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to get next page of service tag information resources.",
+          "readOnly": true
+        }
+      }
+    },
+    "SessionIds": {
+      "type": "object",
+      "description": "List of session IDs.",
+      "properties": {
+        "sessionIds": {
+          "type": "array",
+          "description": "List of session IDs.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Sku": {
+      "type": "object",
+      "description": "The sku of this Bastion Host.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the sku of this Bastion Host.",
+          "default": "Standard",
+          "enum": [
+            "Basic",
+            "Standard",
+            "Developer",
+            "Premium"
+          ],
+          "x-ms-enum": {
+            "name": "BastionHostSkuName",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Basic",
+                "value": "Basic",
+                "description": "Basic"
+              },
+              {
+                "name": "Standard",
+                "value": "Standard",
+                "description": "Standard"
+              },
+              {
+                "name": "Developer",
+                "value": "Developer",
+                "description": "Developer"
+              },
+              {
+                "name": "Premium",
+                "value": "Premium",
+                "description": "Premium"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "StaticCidr": {
+      "type": "object",
+      "description": "Instance of StaticCidr resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/StaticCidrProperties",
+          "description": "Properties of static CIDR resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/CommonProxyResource"
+        }
+      ]
+    },
+    "StaticCidrList": {
+      "type": "object",
+      "description": "List of StaticCidr",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The StaticCidr items on this page",
+          "items": {
+            "$ref": "#/definitions/StaticCidr"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "StaticCidrProperties": {
+      "type": "object",
+      "description": "Properties of static CIDR resource.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "numberOfIPAddressesToAllocate": {
+          "type": "string",
+          "description": "Number of IP addresses to allocate for a static CIDR resource. The IP addresses will be assigned based on IpamPools available space."
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "List of IP address prefixes of the resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "totalNumberOfIPAddresses": {
+          "type": "string",
+          "description": "Total number of IP addresses allocated for the static CIDR resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "Provisioning states of a resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "Subnet": {
+      "type": "object",
+      "description": "Subnet in a virtual network resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SubnetPropertiesFormat",
+          "description": "Properties of the subnet.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "SubnetListResult": {
+      "type": "object",
+      "description": "The response of a Subnet list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Subnet items on this page",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SubnetPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the subnet.",
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "The address prefix for the subnet."
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "List of address prefixes for the subnet.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "networkSecurityGroup": {
+          "$ref": "#/definitions/NetworkSecurityGroup",
+          "description": "The reference to the NetworkSecurityGroup resource."
+        },
+        "routeTable": {
+          "$ref": "#/definitions/RouteTable",
+          "description": "The reference to the RouteTable resource."
+        },
+        "natGateway": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Nat gateway associated with this subnet."
+        },
+        "serviceEndpoints": {
+          "type": "array",
+          "description": "An array of service endpoints.",
+          "items": {
+            "$ref": "#/definitions/ServiceEndpointPropertiesFormat"
+          }
+        },
+        "serviceEndpointPolicies": {
+          "type": "array",
+          "description": "An array of service endpoint policies.",
+          "items": {
+            "$ref": "./expressRoute.json#/definitions/ServiceEndpointPolicy"
+          }
+        },
+        "privateEndpoints": {
+          "type": "array",
+          "description": "An array of references to private endpoints.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpoint"
+          },
+          "readOnly": true
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "An array of references to the network interface IP configurations using subnet.",
+          "items": {
+            "$ref": "#/definitions/IPConfiguration"
+          },
+          "readOnly": true
+        },
+        "ipConfigurationProfiles": {
+          "type": "array",
+          "description": "Array of IP configuration profiles which reference this subnet.",
+          "items": {
+            "$ref": "#/definitions/IPConfigurationProfile"
+          },
+          "readOnly": true
+        },
+        "ipAllocations": {
+          "type": "array",
+          "description": "Array of IpAllocation which reference this subnet.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "resourceNavigationLinks": {
+          "type": "array",
+          "description": "An array of references to the external resources using subnet.",
+          "items": {
+            "$ref": "#/definitions/ResourceNavigationLink"
+          },
+          "readOnly": true
+        },
+        "serviceAssociationLinks": {
+          "type": "array",
+          "description": "An array of references to services injecting into this subnet.",
+          "items": {
+            "$ref": "#/definitions/ServiceAssociationLink"
+          },
+          "readOnly": true
+        },
+        "delegations": {
+          "type": "array",
+          "description": "An array of references to the delegations on the subnet.",
+          "items": {
+            "$ref": "#/definitions/Delegation"
+          }
+        },
+        "purpose": {
+          "type": "string",
+          "description": "A read-only string identifying the intention of use for this subnet based on delegations and other user-defined properties.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the subnet resource.",
+          "readOnly": true
+        },
+        "privateEndpointNetworkPolicies": {
+          "type": "string",
+          "description": "Enable or Disable apply network policies on private end point in the subnet.",
+          "default": "Disabled",
+          "enum": [
+            "Enabled",
+            "Disabled",
+            "NetworkSecurityGroupEnabled",
+            "RouteTableEnabled"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkPrivateEndpointNetworkPolicies",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              },
+              {
+                "name": "NetworkSecurityGroupEnabled",
+                "value": "NetworkSecurityGroupEnabled",
+                "description": "NetworkSecurityGroupEnabled"
+              },
+              {
+                "name": "RouteTableEnabled",
+                "value": "RouteTableEnabled",
+                "description": "RouteTableEnabled"
+              }
+            ]
+          }
+        },
+        "privateLinkServiceNetworkPolicies": {
+          "type": "string",
+          "description": "Enable or Disable apply network policies on private link service in the subnet.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "name": "VirtualNetworkPrivateLinkServiceNetworkPolicies",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Enabled"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Disabled"
+              }
+            ]
+          }
+        },
+        "applicationGatewayIPConfigurations": {
+          "type": "array",
+          "description": "Application gateway IP configurations of virtual network resource.",
+          "items": {
+            "$ref": "./applicationGateway.json#/definitions/ApplicationGatewayIPConfiguration"
+          }
+        },
+        "sharingScope": {
+          "$ref": "./common.json#/definitions/SharingScope",
+          "description": "Set this property to Tenant to allow sharing subnet with other subscriptions in your AAD tenant. This property can only be set if defaultOutboundAccess is set to false, both properties can only be set if subnet is empty."
+        },
+        "defaultOutboundAccess": {
+          "type": "boolean",
+          "description": "Set this property to false to disable default outbound connectivity for all VMs in the subnet."
+        },
+        "ipamPoolPrefixAllocations": {
+          "type": "array",
+          "description": "A list of IPAM Pools for allocating IP address prefixes.",
+          "items": {
+            "$ref": "#/definitions/IpamPoolPrefixAllocation"
+          }
+        },
+        "serviceGateway": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to an existing service gateway."
+        }
+      }
+    },
+    "SwapResource": {
+      "type": "object",
+      "description": "SwapResource to represent slot type on the specified cloud service.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SwapResourceProperties",
+          "description": "Swap resource properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ProxyResourceWithReadOnlyID"
+        }
+      ]
+    },
+    "SwapResourceListResult": {
+      "type": "object",
+      "description": "SwapResource List with single entry to represent slot type on the specified cloud service.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SwapResource"
+          }
+        }
+      }
+    },
+    "SwapResourceProperties": {
+      "type": "object",
+      "description": "Swap resource properties",
+      "properties": {
+        "slotType": {
+          "$ref": "./common.json#/definitions/SlotType",
+          "description": "Specifies slot info on a cloud service"
+        }
+      }
+    },
+    "TrafficDetectionRule": {
+      "type": "object",
+      "description": "Ddos Custom Policy traffic detection rule.",
+      "properties": {
+        "trafficType": {
+          "$ref": "./common.json#/definitions/DdosTrafficType",
+          "description": "The traffic type (one of Tcp, Udp, TcpSyn) that the detection rule will be applied upon."
+        },
+        "packetsPerSecond": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The customized packets per second threshold."
+        }
+      }
+    },
+    "UnprepareNetworkPoliciesRequest": {
+      "type": "object",
+      "description": "Details of UnprepareNetworkPolicies for Subnet.",
+      "properties": {
+        "serviceName": {
+          "type": "string",
+          "description": "The name of the service for which subnet is being unprepared for."
+        }
+      }
+    },
+    "Usage": {
+      "type": "object",
+      "description": "The network resource usage.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Resource identifier.",
+          "readOnly": true
+        },
+        "unit": {
+          "$ref": "./common.json#/definitions/UsageUnit",
+          "description": "An enum describing the unit of measurement."
+        },
+        "currentValue": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The current value of the usage."
+        },
+        "limit": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The limit of usage."
+        },
+        "name": {
+          "$ref": "#/definitions/UsageName",
+          "description": "The name of the type of usage."
+        }
+      },
+      "required": [
+        "unit",
+        "currentValue",
+        "limit",
+        "name"
+      ]
+    },
+    "UsageName": {
+      "type": "object",
+      "description": "The usage names.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "A string describing the resource name."
+        },
+        "localizedValue": {
+          "type": "string",
+          "description": "A localized string describing the resource name."
+        }
+      }
+    },
+    "UsagesListResult": {
+      "type": "object",
+      "description": "The list usages operation response.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Usage items on this page",
+          "items": {
+            "$ref": "#/definitions/Usage"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VM": {
+      "type": "object",
+      "description": "Describes a Virtual Machine.",
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "VerifierWorkspace": {
+      "type": "object",
+      "description": "Instance of Verifier Workspace.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VerifierWorkspaceProperties",
+          "description": "Properties of Verifier Workspace resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "String representing unique etag for the resource document.",
+          "readOnly": true
+        },
+        "systemData": {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/systemData",
+          "description": "The system metadata related to this resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/CommonTrackedResource"
+        }
+      ]
+    },
+    "VerifierWorkspaceListResult": {
+      "type": "object",
+      "description": "The response of a VerifierWorkspace list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VerifierWorkspace items on this page",
+          "items": {
+            "$ref": "#/definitions/VerifierWorkspace"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VerifierWorkspaceProperties": {
+      "type": "object",
+      "description": "Properties of Verifier Workspace resource.",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "Provisioning states of a resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "VerifierWorkspaceUpdate": {
+      "type": "object",
+      "description": "Represents the VerifierWorkspace update API request interface.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Dictionary of <string>",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/VerifierWorkspaceUpdateProperties",
+          "description": "Represents the VerifierWorkspace update properties."
+        }
+      }
+    },
+    "VerifierWorkspaceUpdateProperties": {
+      "type": "object",
+      "description": "Represents the VerifierWorkspace update properties.",
+      "properties": {
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "VirtualApplianceAdditionalNicProperties": {
+      "type": "object",
+      "title": "Network Virtual Appliance Additional Nic Properties",
+      "description": "Network Virtual Appliance Additional NIC properties.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of additional nic"
+        },
+        "hasPublicIp": {
+          "type": "boolean",
+          "description": "Flag (true or false) for Intent for Public Ip on additional nic"
+        }
+      }
+    },
+    "VirtualApplianceIPConfiguration": {
+      "type": "object",
+      "description": "Represents a single IP configuration.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "For hub NVAs, primary IP configs must be named 'privatenicipconfig' and 'publicnicipconfig', with non-primary configs using these prefixes; no naming restrictions apply for NVAs in VNets. Maximum 80 character are allowed."
+        },
+        "properties": {
+          "$ref": "#/definitions/VirtualApplianceIPConfigurationProperties",
+          "description": "Represents a single IP configuration properties."
+        }
+      }
+    },
+    "VirtualApplianceIPConfigurationProperties": {
+      "type": "object",
+      "description": "Represents a single IP configuration properties.",
+      "properties": {
+        "primary": {
+          "type": "boolean",
+          "description": "Whether or not this is primary IP configuration of the NIC."
+        }
+      }
+    },
+    "VirtualApplianceNetworkInterfaceConfiguration": {
+      "type": "object",
+      "description": "Represents a single NIC configuration.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/NicTypeInRequest",
+          "description": "NIC type. This should be either PublicNic or PrivateNic.",
+          "x-ms-client-name": "NicType"
+        },
+        "properties": {
+          "$ref": "#/definitions/VirtualApplianceNetworkInterfaceConfigurationProperties",
+          "description": "Represents a single NIC configuration properties."
+        }
+      }
+    },
+    "VirtualApplianceNetworkInterfaceConfigurationProperties": {
+      "type": "object",
+      "description": "Represents a single NIC configuration properties.",
+      "properties": {
+        "ipConfigurations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VirtualApplianceIPConfiguration"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "VirtualApplianceNicProperties": {
+      "type": "object",
+      "description": "Network Virtual Appliance NIC properties.",
+      "properties": {
+        "nicType": {
+          "$ref": "./common.json#/definitions/NicTypeInResponse",
+          "description": "NIC type - PublicNic, PrivateNic, or AdditionalNic; AdditionalPrivateNic and AdditionalPublicNic are only supported for NVAs deployed in VNets.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "NIC name.",
+          "readOnly": true
+        },
+        "publicIpAddress": {
+          "type": "string",
+          "description": "Public IP address.",
+          "readOnly": true
+        },
+        "privateIpAddress": {
+          "type": "string",
+          "description": "Private IP address.",
+          "readOnly": true
+        },
+        "publicIpAddressV6": {
+          "type": "string",
+          "description": "Public IPv6 address. Populated for dual-stack NVAs, including on additional-NIC configurations when the NVA is dual-stack.",
+          "readOnly": true
+        },
+        "privateIpAddressV6": {
+          "type": "string",
+          "description": "Private IPv6 address. Populated for dual-stack NVAs, including on additional-NIC configurations when the NVA is dual-stack.",
+          "readOnly": true
+        },
+        "instanceName": {
+          "type": "string",
+          "description": "Instance on which nic is attached.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualApplianceSite": {
+      "type": "object",
+      "description": "Virtual Appliance Site resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualApplianceSiteProperties",
+          "description": "The properties of the Virtual Appliance Sites.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "VirtualApplianceSiteProperties": {
+      "type": "object",
+      "description": "Properties of the rule group.",
+      "properties": {
+        "addressPrefix": {
+          "type": "string",
+          "description": "Address Prefix."
+        },
+        "o365Policy": {
+          "$ref": "#/definitions/Office365PolicyProperties",
+          "description": "Office 365 Policy."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualApplianceSkuProperties": {
+      "type": "object",
+      "description": "Network Virtual Appliance Sku Properties.",
+      "properties": {
+        "vendor": {
+          "type": "string",
+          "description": "Virtual Appliance Vendor."
+        },
+        "bundledScaleUnit": {
+          "type": "string",
+          "description": "Virtual Appliance Scale Unit."
+        },
+        "marketPlaceVersion": {
+          "type": "string",
+          "description": "Virtual Appliance Version."
+        }
+      }
+    },
+    "VirtualNetwork": {
+      "type": "object",
+      "description": "Virtual Network resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkPropertiesFormat",
+          "description": "Properties of the virtual network.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "./common.json#/definitions/ExtendedLocation",
+          "description": "The extended location of the virtual network."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "VirtualNetworkBgpCommunities": {
+      "type": "object",
+      "description": "Bgp Communities sent over ExpressRoute with each route corresponding to a prefix in this VNET.",
+      "properties": {
+        "virtualNetworkCommunity": {
+          "type": "string",
+          "description": "The BGP community associated with the virtual network."
+        },
+        "regionalCommunity": {
+          "type": "string",
+          "description": "The BGP community associated with the region of the virtual network.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "virtualNetworkCommunity"
+      ]
+    },
+    "VirtualNetworkDdosProtectionStatusResult": {
+      "type": "object",
+      "description": "Response for GetVirtualNetworkDdosProtectionStatusOperation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PublicIpDdosProtectionStatusResult items on this page",
+          "items": {
+            "$ref": "#/definitions/PublicIpDdosProtectionStatusResult"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkEncryption": {
+      "type": "object",
+      "description": "Indicates if encryption is enabled on virtual network and if VM without encryption is allowed in encrypted VNet.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Indicates if encryption is enabled on the virtual network."
+        },
+        "enforcement": {
+          "$ref": "./common.json#/definitions/VirtualNetworkEncryptionEnforcement",
+          "description": "If the encrypted VNet allows VM that does not support encryption. This field is for future support, AllowUnencrypted is the only supported value at general availability."
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "VirtualNetworkListResult": {
+      "type": "object",
+      "description": "The response of a VirtualNetwork list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetwork items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetwork"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkListUsageResult": {
+      "type": "object",
+      "description": "Response for the virtual networks GetUsage API service call.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetworkUsage items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkUsage"
+          },
+          "readOnly": true
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkPeering": {
+      "type": "object",
+      "description": "Peerings in a virtual network resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkPeeringPropertiesFormat",
+          "description": "Properties of the virtual network peering.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "VirtualNetworkPeeringListResult": {
+      "type": "object",
+      "description": "The response of a VirtualNetworkPeering list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetworkPeering items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkPeering"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkPeeringPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the virtual network peering.",
+      "properties": {
+        "allowVirtualNetworkAccess": {
+          "type": "boolean",
+          "description": "Whether the VMs in the local virtual network space would be able to access the VMs in remote virtual network space."
+        },
+        "allowForwardedTraffic": {
+          "type": "boolean",
+          "description": "Whether the forwarded traffic from the VMs in the local virtual network will be allowed/disallowed in remote virtual network."
+        },
+        "allowGatewayTransit": {
+          "type": "boolean",
+          "description": "If gateway links can be used in remote virtual networking to link to this virtual network."
+        },
+        "useRemoteGateways": {
+          "type": "boolean",
+          "description": "If remote gateways can be used on this virtual network. If the flag is set to true, and allowGatewayTransit on remote peering is also true, virtual network will use gateways of remote virtual network for transit. Only one peering can have this flag set to true. This flag cannot be set if virtual network already has a gateway."
+        },
+        "remoteVirtualNetwork": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the remote virtual network. The remote virtual network can be in the same or different region (preview). See here to register for the preview and learn more (https://docs.microsoft.com/en-us/azure/virtual-network/virtual-network-create-peering)."
+        },
+        "localAddressSpace": {
+          "$ref": "#/definitions/AddressSpace",
+          "description": "The local address space of the local virtual network that is peered."
+        },
+        "localVirtualNetworkAddressSpace": {
+          "$ref": "#/definitions/AddressSpace",
+          "description": "The current local address space of the local virtual network that is peered."
+        },
+        "remoteAddressSpace": {
+          "$ref": "#/definitions/AddressSpace",
+          "description": "The reference to the address space peered with the remote virtual network."
+        },
+        "remoteVirtualNetworkAddressSpace": {
+          "$ref": "#/definitions/AddressSpace",
+          "description": "The reference to the current address space of the remote virtual network."
+        },
+        "remoteBgpCommunities": {
+          "$ref": "#/definitions/VirtualNetworkBgpCommunities",
+          "description": "The reference to the remote virtual network's Bgp Communities."
+        },
+        "remoteVirtualNetworkEncryption": {
+          "$ref": "#/definitions/VirtualNetworkEncryption",
+          "description": "The reference to the remote virtual network's encryption",
+          "readOnly": true
+        },
+        "peeringState": {
+          "$ref": "./common.json#/definitions/VirtualNetworkPeeringState",
+          "description": "The status of the virtual network peering."
+        },
+        "peeringSyncLevel": {
+          "$ref": "./common.json#/definitions/VirtualNetworkPeeringLevel",
+          "description": "The peering sync status of the virtual network peering."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual network peering resource.",
+          "readOnly": true
+        },
+        "doNotVerifyRemoteGateways": {
+          "type": "boolean",
+          "description": "If we need to verify the provisioning state of the remote gateway."
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resourceGuid property of the Virtual Network peering resource.",
+          "readOnly": true
+        },
+        "peerCompleteVnets": {
+          "type": "boolean",
+          "description": "Whether complete virtual network address space is peered."
+        },
+        "enableOnlyIPv6Peering": {
+          "type": "boolean",
+          "description": "Whether only Ipv6 address space is peered for subnet peering."
+        },
+        "localSubnetNames": {
+          "type": "array",
+          "description": "List of local subnet names that are subnet peered with remote virtual network.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "remoteSubnetNames": {
+          "type": "array",
+          "description": "List of remote subnet names from remote virtual network that are subnet peered.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VirtualNetworkPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of the virtual network.",
+      "properties": {
+        "addressSpace": {
+          "$ref": "#/definitions/AddressSpace",
+          "description": "The AddressSpace that contains an array of IP address ranges that can be used by subnets."
+        },
+        "dhcpOptions": {
+          "$ref": "#/definitions/DhcpOptions",
+          "description": "The dhcpOptions that contains an array of DNS servers available to VMs deployed in the virtual network."
+        },
+        "flowTimeoutInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The FlowTimeout value (in minutes) for the Virtual Network"
+        },
+        "subnets": {
+          "type": "array",
+          "description": "A list of subnets in a Virtual Network.",
+          "items": {
+            "$ref": "#/definitions/Subnet"
+          }
+        },
+        "virtualNetworkPeerings": {
+          "type": "array",
+          "description": "A list of peerings in a Virtual Network.",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkPeering"
+          }
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resourceGuid property of the Virtual Network resource.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual network resource.",
+          "readOnly": true
+        },
+        "enableDdosProtection": {
+          "type": "boolean",
+          "description": "Indicates if DDoS protection is enabled for all the protected resources in the virtual network. It requires a DDoS protection plan associated with the resource.",
+          "default": false
+        },
+        "enableVmProtection": {
+          "type": "boolean",
+          "description": "Indicates if VM protection is enabled for all the subnets in the virtual network.",
+          "default": false
+        },
+        "ddosProtectionPlan": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The DDoS protection plan associated with the virtual network."
+        },
+        "bgpCommunities": {
+          "$ref": "#/definitions/VirtualNetworkBgpCommunities",
+          "description": "Bgp Communities sent over ExpressRoute with each route corresponding to a prefix in this VNET."
+        },
+        "encryption": {
+          "$ref": "#/definitions/VirtualNetworkEncryption",
+          "description": "Indicates if encryption is enabled on virtual network and if VM without encryption is allowed in encrypted VNet."
+        },
+        "ipAllocations": {
+          "type": "array",
+          "description": "Array of IpAllocation which reference this VNET.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "flowLogs": {
+          "type": "array",
+          "description": "A collection of references to flow log resources.",
+          "items": {
+            "$ref": "./networkWatcher.json#/definitions/FlowLog"
+          },
+          "readOnly": true
+        },
+        "privateEndpointVNetPolicies": {
+          "$ref": "./common.json#/definitions/PrivateEndpointVNetPolicies",
+          "description": "Private Endpoint VNet Policies."
+        },
+        "defaultPublicNatGateway": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "A reference to the default public nat gateway being used by this virtual network resource.",
+          "readOnly": true
+        },
+        "summarizedGatewayPrefixes": {
+          "$ref": "#/definitions/AddressSpace",
+          "description": "A configurable list of summarized gateway prefixes advertised for the virtual network."
+        }
+      }
+    },
+    "VirtualNetworkUsage": {
+      "type": "object",
+      "description": "Usage details for subnet.",
+      "properties": {
+        "currentValue": {
+          "type": "number",
+          "format": "double",
+          "description": "Indicates number of IPs used from the Subnet.",
+          "readOnly": true
+        },
+        "id": {
+          "type": "string",
+          "description": "Subnet identifier.",
+          "readOnly": true
+        },
+        "limit": {
+          "type": "number",
+          "format": "double",
+          "description": "Indicates the size of the subnet.",
+          "readOnly": true
+        },
+        "name": {
+          "$ref": "#/definitions/VirtualNetworkUsageName",
+          "description": "The name containing common and localized value for usage.",
+          "readOnly": true
+        },
+        "unit": {
+          "type": "string",
+          "description": "Usage units. Returns 'Count'.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualNetworkUsageName": {
+      "type": "object",
+      "description": "Usage strings container.",
+      "properties": {
+        "localizedValue": {
+          "type": "string",
+          "description": "Localized subnet size and usage string.",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "description": "Subnet size and usage string.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualRouter": {
+      "type": "object",
+      "description": "VirtualRouter Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualRouterPropertiesFormat",
+          "description": "Properties of the Virtual Router.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "VirtualRouterListResult": {
+      "type": "object",
+      "description": "The response of a VirtualRouter list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualRouter items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualRouter"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualRouterPeering": {
+      "type": "object",
+      "description": "Virtual Router Peering resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualRouterPeeringProperties",
+          "description": "The properties of the Virtual Router Peering.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "VirtualRouterPeeringListResult": {
+      "type": "object",
+      "description": "The response of a VirtualRouterPeering list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualRouterPeering items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualRouterPeering"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualRouterPeeringProperties": {
+      "type": "object",
+      "description": "Properties of the rule group.",
+      "properties": {
+        "peerAsn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Peer ASN.",
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "peerIp": {
+          "type": "string",
+          "description": "Peer IP."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualRouterPropertiesFormat": {
+      "type": "object",
+      "description": "Virtual Router definition.",
+      "properties": {
+        "virtualRouterAsn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "VirtualRouter ASN.",
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "virtualRouterIps": {
+          "type": "array",
+          "description": "VirtualRouter IPs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hostedSubnet": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The Subnet on which VirtualRouter is hosted."
+        },
+        "hostedGateway": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The Gateway on which VirtualRouter is hosted."
+        },
+        "peerings": {
+          "type": "array",
+          "description": "List of references to VirtualRouterPeerings.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/virtualNetworkAppliance.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/virtualNetworkAppliance.json
@@ -1,0 +1,475 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "VirtualNetworkAppliances"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualNetworkAppliances": {
+      "get": {
+        "operationId": "VirtualNetworkAppliances_ListAll",
+        "tags": [
+          "VirtualNetworkAppliances"
+        ],
+        "description": "Gets all virtual network appliances in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkApplianceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkAppliances": {
+      "get": {
+        "operationId": "VirtualNetworkAppliances_List",
+        "tags": [
+          "VirtualNetworkAppliances"
+        ],
+        "description": "Gets all virtual network appliances in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkApplianceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualNetworkAppliances/{virtualNetworkApplianceName}": {
+      "get": {
+        "operationId": "VirtualNetworkAppliances_Get",
+        "tags": [
+          "VirtualNetworkAppliances"
+        ],
+        "description": "Gets information about the specified virtual network appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkApplianceName",
+            "in": "path",
+            "description": "The name of the virtual network appliance.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkAppliance"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualNetworkAppliances_CreateOrUpdate",
+        "tags": [
+          "VirtualNetworkAppliances"
+        ],
+        "description": "Creates or updates a virtual network appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkApplianceName",
+            "in": "path",
+            "description": "The name of the virtual network appliance.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the create or update virtual network appliance operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkAppliance"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualNetworkAppliance' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkAppliance"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualNetworkAppliance' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkAppliance"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualNetworkAppliance"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualNetworkAppliances_UpdateTags",
+        "tags": [
+          "VirtualNetworkAppliances"
+        ],
+        "description": "Updates a virtual network appliance tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkApplianceName",
+            "in": "path",
+            "description": "The name of the virtual network appliance.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to update virtual network appliance tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualNetworkAppliance"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "VirtualNetworkAppliances_Delete",
+        "tags": [
+          "VirtualNetworkAppliances"
+        ],
+        "description": "Deletes the specified virtual network appliance.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualNetworkApplianceName",
+            "in": "path",
+            "description": "The name of the virtual network appliance.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[0-9a-zA-Z]([0-9a-zA-Z_.-]{0,62}[0-9a-zA-Z_])?$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "VirtualNetworkAppliance": {
+      "type": "object",
+      "description": "A virtual network appliance in a resource group.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkAppliancePropertiesFormat",
+          "description": "Properties of the virtual network appliance.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "VirtualNetworkApplianceIpConfiguration": {
+      "type": "object",
+      "description": "The virtual network appliance ip configuration.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualNetworkApplianceIpConfigurationProperties",
+          "description": "Properties of the virtual network appliance ip configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of virtual network appliance ip configuration."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The resource type.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "VirtualNetworkApplianceIpConfigurationProperties": {
+      "type": "object",
+      "description": "Properties of virtual network appliance IP configuration.",
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "description": "The private IP address of the IP configuration."
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The private IP address allocation method."
+        },
+        "primary": {
+          "type": "boolean",
+          "description": "Whether the ip configuration is primary or not."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the private link service IP configuration resource.",
+          "readOnly": true
+        },
+        "privateIPAddressVersion": {
+          "$ref": "./common.json#/definitions/IPVersion",
+          "description": "Whether the specific IP configuration is IPv4 or IPv6. Default is IPv4."
+        }
+      }
+    },
+    "VirtualNetworkApplianceListResult": {
+      "type": "object",
+      "description": "The response of a VirtualNetworkAppliance list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualNetworkAppliance items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkAppliance"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "VirtualNetworkAppliancePropertiesFormat": {
+      "type": "object",
+      "description": "VirtualNetworkAppliance properties.",
+      "properties": {
+        "bandwidthInGbps": {
+          "type": "number",
+          "format": "double",
+          "description": "Bandwidth of the VirtualNetworkAppliance resource in Gbps."
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "A list of IPConfigurations of the virtual network appliance.",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkApplianceIpConfiguration"
+          },
+          "readOnly": true
+        },
+        "privateIPAddressVersion": {
+          "$ref": "./common.json#/definitions/VirtualNetworkApplianceIpVersionType",
+          "description": "Whether the specific virtual network appliance is IPv4 or Dual Stack. Default is IPv4."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual network appliance resource.",
+          "readOnly": true
+        },
+        "resourceGuid": {
+          "type": "string",
+          "description": "The resource GUID property of the virtual network appliance resource.",
+          "readOnly": true
+        },
+        "subnet": {
+          "$ref": "./virtualNetwork.json#/definitions/Subnet",
+          "description": "The reference to the subnet resource."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/preview/2026-08-01-preview/virtualWan.json
@@ -1,0 +1,10338 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "WebApplicationFirewallManagement",
+    "version": "2026-08-01-preview",
+    "description": "APIs to manage Microsoft Azure network resources.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "VirtualWANs"
+    },
+    {
+      "name": "VpnSites"
+    },
+    {
+      "name": "VpnServerConfigurations"
+    },
+    {
+      "name": "VpnGateways"
+    },
+    {
+      "name": "vpnLinkConnections"
+    },
+    {
+      "name": "P2SVpnGateways"
+    },
+    {
+      "name": "ExpressRouteGateways"
+    },
+    {
+      "name": "ExpressRouteConnections"
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/expressRouteGateways": {
+      "get": {
+        "operationId": "ExpressRouteGateways_ListBySubscription",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Lists ExpressRoute gateways under a given subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteGatewayList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/p2svpnGateways": {
+      "get": {
+        "operationId": "P2sVpnGateways_List",
+        "description": "Lists all the P2SVpnGateways in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListP2SVpnGatewaysResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualHubs": {
+      "get": {
+        "operationId": "VirtualHubs_List",
+        "description": "Lists all the VirtualHubs in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVirtualHubsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/virtualWans": {
+      "get": {
+        "operationId": "VirtualWans_List",
+        "description": "Lists all the VirtualWANs in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVirtualWANsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnGateways": {
+      "get": {
+        "operationId": "VpnGateways_List",
+        "description": "Lists all the VpnGateways in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnGatewaysResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnServerConfigurations": {
+      "get": {
+        "operationId": "VpnServerConfigurations_List",
+        "description": "Lists all the VpnServerConfigurations in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnServerConfigurationsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Network/vpnSites": {
+      "get": {
+        "operationId": "VpnSites_List",
+        "description": "Lists all the VpnSites in a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnSitesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways": {
+      "get": {
+        "operationId": "ExpressRouteGateways_ListByResourceGroup",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Lists ExpressRoute gateways in a given resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteGatewayList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}": {
+      "get": {
+        "operationId": "ExpressRouteGateways_Get",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Fetches the details of a ExpressRoute gateway in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRouteGateways_CreateOrUpdate",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Creates or updates a ExpressRoute gateway in a specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "putExpressRouteGatewayParameters",
+            "in": "body",
+            "description": "Parameters required in an ExpressRoute gateway PUT operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteGateway"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ExpressRouteGateway' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteGateway"
+            }
+          },
+          "201": {
+            "description": "Resource 'ExpressRouteGateway' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteGateway"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRouteGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ExpressRouteGateways_UpdateTags",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Updates express route gateway tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "expressRouteGatewayParameters",
+            "in": "body",
+            "description": "Parameters supplied to update a virtual wan express route gateway tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteGateway"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRouteGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ExpressRouteGateways_Delete",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Deletes the specified ExpressRoute gateway in a resource group. An ExpressRoute gateway resource can only be deleted when there are no connection subresources.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections": {
+      "get": {
+        "operationId": "ExpressRouteConnections_List",
+        "tags": [
+          "ExpressRouteConnections"
+        ],
+        "description": "Lists ExpressRouteConnections.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteConnectionList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/expressRouteConnections/{connectionName}": {
+      "get": {
+        "operationId": "ExpressRouteConnections_Get",
+        "tags": [
+          "ExpressRouteConnections"
+        ],
+        "description": "Gets the specified ExpressRouteConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the express route gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the express route connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ExpressRouteConnections_CreateOrUpdate",
+        "tags": [
+          "ExpressRouteConnections"
+        ],
+        "description": "Creates a connection between an ExpressRoute gateway and an ExpressRoute circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the express route gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the express route connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "putExpressRouteConnectionParameters",
+            "in": "body",
+            "description": "Parameters required in an ExpressRouteConnection PUT operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'ExpressRouteConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ExpressRouteConnection"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ExpressRouteConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ExpressRouteConnections_Delete",
+        "tags": [
+          "ExpressRouteConnections"
+        ],
+        "description": "Deletes a connection to a ExpressRoute circuit.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the express route gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the express route connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/getFailoverAllTestsDetails": {
+      "post": {
+        "operationId": "ExpressRouteGateways_GetFailoverAllTestsDetails",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Retrieves the details of all the failover tests performed on the ExpressRoute gateway for different peering locations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "The type of failover test.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "fetchLatest",
+            "in": "query",
+            "description": "Fetch only the latest tests for each peering location.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "./networkGateway.json#/definitions/ExpressRouteFailoverTestDetails"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./networkGateway.json#/definitions/ExpressRouteFailoverTestDetailsArray"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/getFailoverSingleTestDetails": {
+      "post": {
+        "operationId": "ExpressRouteGateways_GetFailoverSingleTestDetails",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Retrieves the details of a particular failover test performed on the ExpressRoute gateway based on the test Guid.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringLocation",
+            "in": "query",
+            "description": "Peering location of the test.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "failoverTestId",
+            "in": "query",
+            "description": "The unique Guid value which identifies the test.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "./networkGateway.json#/definitions/ExpressRouteFailoverSingleTestDetails"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./networkGateway.json#/definitions/ExpressRouteFailoverSingleTestDetailsArray"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/getResiliencyInformation": {
+      "post": {
+        "operationId": "ExpressRouteGateways_GetResiliencyInformation",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Retrieves the resiliency information for the ExpressRoute gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "attemptRefresh",
+            "in": "query",
+            "description": "Whether to attempt a refresh of the resiliency information.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./networkGateway.json#/definitions/GatewayResiliencyInformation"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./networkGateway.json#/definitions/GatewayResiliencyInformation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/getRoutesInformation": {
+      "post": {
+        "operationId": "ExpressRouteGateways_GetRoutesInformation",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Retrieves the route sets information for the ExpressRoute gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "attemptRefresh",
+            "in": "query",
+            "description": "Whether to attempt a refresh of the route sets.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./networkGateway.json#/definitions/GatewayRouteSetsInformation"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./networkGateway.json#/definitions/GatewayRouteSetsInformation"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/startSiteFailoverTest": {
+      "post": {
+        "operationId": "ExpressRouteGateways_StartSiteFailoverTest",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Starts failover simulation on the ExpressRoute gateway for the specified peering location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "peeringLocation",
+            "in": "query",
+            "description": "Peering location of the test.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/expressRouteGateways/{expressRouteGatewayName}/stopSiteFailoverTest": {
+      "post": {
+        "operationId": "ExpressRouteGateways_StopSiteFailoverTest",
+        "tags": [
+          "ExpressRouteGateways"
+        ],
+        "description": "Stops failover simulation on the ExpressRoute gateway for the specified peering location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "expressRouteGatewayName",
+            "in": "path",
+            "description": "The name of the ExpressRoute gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "stopParameters",
+            "in": "body",
+            "description": "Parameters supplied to stop the failover simulation on the express route gateway.",
+            "required": true,
+            "schema": {
+              "$ref": "./networkGateway.json#/definitions/ExpressRouteFailoverStopApiParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/networkVirtualApplianceConnections": {
+      "get": {
+        "operationId": "NetworkVirtualApplianceConnections_List",
+        "description": "Lists NetworkVirtualApplianceConnections under the NVA.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceConnectionList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/networkVirtualAppliances/{networkVirtualApplianceName}/networkVirtualApplianceConnections/{connectionName}": {
+      "get": {
+        "operationId": "NetworkVirtualApplianceConnections_Get",
+        "description": "Retrieves the details of specified NVA connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of the Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NetworkVirtualApplianceConnections_CreateOrUpdate",
+        "description": "Creates a connection to Network Virtual Appliance, if it doesn't exist else updates the existing NVA connection'",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of the Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "NetworkVirtualApplianceConnectionParameters",
+            "in": "body",
+            "description": "Parameters supplied in an NetworkVirtualApplianceConnection PUT operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceConnection"
+            }
+          },
+          "201": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkVirtualApplianceConnection"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/NetworkVirtualApplianceConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "NetworkVirtualApplianceConnections_Delete",
+        "description": "Deletes a NVA connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "networkVirtualApplianceName",
+            "in": "path",
+            "description": "The name of the Network Virtual Appliance.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways": {
+      "get": {
+        "operationId": "P2sVpnGateways_ListByResourceGroup",
+        "description": "Lists all the P2SVpnGateways in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListP2SVpnGatewaysResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}": {
+      "get": {
+        "operationId": "P2sVpnGateways_Get",
+        "description": "Retrieves the details of a virtual wan p2s vpn gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/P2SVpnGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "P2sVpnGateways_CreateOrUpdate",
+        "description": "Creates a virtual wan p2s vpn gateway if it doesn't exist else updates the existing gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "p2SVpnGatewayParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or Update a virtual wan p2s vpn gateway.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/P2SVpnGateway"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'P2SVpnGateway' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/P2SVpnGateway"
+            }
+          },
+          "201": {
+            "description": "Resource 'P2SVpnGateway' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/P2SVpnGateway"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/P2SVpnGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "P2sVpnGateways_UpdateTags",
+        "tags": [
+          "P2SVpnGateways"
+        ],
+        "description": "Updates virtual wan p2s vpn gateway tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "p2SVpnGatewayParameters",
+            "in": "body",
+            "description": "Parameters supplied to update a virtual wan p2s vpn gateway tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/P2SVpnGateway"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/P2SVpnGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "P2sVpnGateways_Delete",
+        "description": "Deletes a virtual wan p2s vpn gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{p2sVpnGatewayName}/disconnectP2sVpnConnections": {
+      "post": {
+        "operationId": "P2sVpnGateways_DisconnectP2sVpnConnections",
+        "tags": [
+          "P2SVpnGateways"
+        ],
+        "description": "Disconnect P2S vpn connections of the virtual wan P2SVpnGateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "p2sVpnGatewayName",
+            "in": "path",
+            "description": "The name of the P2S Vpn Gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "The parameters are supplied to disconnect p2s vpn connections.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/P2SVpnConnectionRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/generatevpnprofile": {
+      "post": {
+        "operationId": "P2sVpnGateways_GenerateVpnProfile",
+        "tags": [
+          "P2SVpnGateways"
+        ],
+        "description": "Generates VPN profile for P2S client of the P2SVpnGateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters supplied to the generate P2SVpnGateway VPN client package operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/P2SVpnProfileParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnProfileResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VpnProfileResponse"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/getP2sVpnConnectionHealth": {
+      "post": {
+        "operationId": "P2sVpnGateways_GetP2sVpnConnectionHealth",
+        "tags": [
+          "P2SVpnGateways"
+        ],
+        "description": "Gets the connection health of P2S clients of the virtual wan P2SVpnGateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/P2SVpnGateway"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/P2SVpnGateway"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/getP2sVpnConnectionHealthDetailed": {
+      "post": {
+        "operationId": "P2sVpnGateways_GetP2sVpnConnectionHealthDetailed",
+        "tags": [
+          "P2SVpnGateways"
+        ],
+        "description": "Gets the sas url to get the connection health detail of P2S clients of the virtual wan P2SVpnGateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "Request parameters supplied to get p2s vpn connections detailed health.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/P2SVpnConnectionHealthRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/P2SVpnConnectionHealth"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/P2SVpnConnectionHealth"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/p2svpnGateways/{gatewayName}/reset": {
+      "post": {
+        "operationId": "P2SVpnGateways_Reset",
+        "tags": [
+          "P2SVpnGateways"
+        ],
+        "description": "Resets the primary of the p2s vpn gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/P2SVpnGateway"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/P2SVpnGateway"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs": {
+      "get": {
+        "operationId": "VirtualHubs_ListByResourceGroup",
+        "description": "Lists all the VirtualHubs in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVirtualHubsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}": {
+      "get": {
+        "operationId": "VirtualHubs_Get",
+        "description": "Retrieves the details of a VirtualHub.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualHub"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualHubs_CreateOrUpdate",
+        "description": "Creates a VirtualHub resource if it doesn't exist else updates the existing VirtualHub.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "virtualHubParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update VirtualHub.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualHub"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualHub' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualHub"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualHub' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualHub"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualHub"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualHubs_UpdateTags",
+        "tags": [
+          "VirtualWANs"
+        ],
+        "description": "Updates VirtualHub tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "virtualHubParameters",
+            "in": "body",
+            "description": "Parameters supplied to update VirtualHub tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualHub"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "VirtualHubs_Delete",
+        "description": "Deletes a VirtualHub.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/bgpConnections": {
+      "get": {
+        "operationId": "VirtualHubBgpConnections_List",
+        "description": "Retrieves the details of all VirtualHubBgpConnections.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVirtualHubBgpConnectionResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/bgpConnections/{connectionName}": {
+      "get": {
+        "operationId": "VirtualHubBgpConnection_Get",
+        "description": "Retrieves the details of a Virtual Hub Bgp Connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BgpConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualHubBgpConnection_CreateOrUpdate",
+        "description": "Creates a VirtualHubBgpConnection resource if it doesn't exist else updates the existing VirtualHubBgpConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters of Bgp connection.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BgpConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BgpConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BgpConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'BgpConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BgpConnection"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/BgpConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualHubBgpConnection_Delete",
+        "description": "Deletes a VirtualHubBgpConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{hubName}/bgpConnections/{connectionName}/advertisedRoutes": {
+      "post": {
+        "operationId": "VirtualHubBgpConnections_ListAdvertisedRoutes",
+        "description": "Retrieves a list of routes the virtual hub bgp connection is advertising to the specified peer.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "hubName",
+            "in": "path",
+            "description": "The name of the virtual hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the bgp connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/definitions/PeerRoute"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Record%3CPeerRoute%5B%5D%3E"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{hubName}/bgpConnections/{connectionName}/learnedRoutes": {
+      "post": {
+        "operationId": "VirtualHubBgpConnections_ListLearnedRoutes",
+        "description": "Retrieves a list of routes the virtual hub bgp connection has learned.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "hubName",
+            "in": "path",
+            "description": "The name of the virtual hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the bgp connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "object",
+              "additionalProperties": {
+                "items": {
+                  "$ref": "#/definitions/PeerRoute"
+                },
+                "type": "array"
+              }
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Record%3CPeerRoute%5B%5D%3E"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/connectionPolicies": {
+      "get": {
+        "operationId": "ConnectionPolicies_List",
+        "description": "Retrieves the details of all ConnectionPolicies.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListConnectionPoliciesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/connectionPolicies/{connectionPolicyName}": {
+      "get": {
+        "operationId": "ConnectionPolicies_Get",
+        "description": "Retrieves the details of a ConnectionPolicy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionPolicyName",
+            "in": "path",
+            "description": "The name of the ConnectionPolicy that is unique within a VirtualHub. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?![.-])[a-zA-Z0-9_.-]{1,128}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConnectionPolicies_CreateOrUpdate",
+        "description": "Creates a ConnectionPolicy if it doesn't exist else updates the existing one.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionPolicyName",
+            "in": "path",
+            "description": "The name of the ConnectionPolicy that is unique within a VirtualHub. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?![.-])[a-zA-Z0-9_.-]{1,128}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Parameters supplied to create or update a ConnectionPolicy.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectionPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'ConnectionPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPolicy"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ConnectionPolicy"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ConnectionPolicies_Delete",
+        "description": "Deletes a ConnectionPolicy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionPolicyName",
+            "in": "path",
+            "description": "The name of the ConnectionPolicy that is unique within a VirtualHub. This name can be used to access the resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^(?![.-])[a-zA-Z0-9_.-]{1,128}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/effectiveRoutes": {
+      "post": {
+        "operationId": "VirtualHubs_GetEffectiveVirtualHubRoutes",
+        "description": "Gets the effective routes configured for the Virtual Hub resource or the specified resource .",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "effectiveRoutesParameters",
+            "in": "body",
+            "description": "Parameters supplied to get the effective routes for a specific resource.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/EffectiveRoutesParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualHubEffectiveRouteList"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VirtualHubEffectiveRouteList"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubRouteTables": {
+      "get": {
+        "operationId": "HubRouteTables_List",
+        "description": "Retrieves the details of all RouteTables.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListHubRouteTablesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubRouteTables/{routeTableName}": {
+      "get": {
+        "operationId": "HubRouteTables_Get",
+        "description": "Retrieves the details of a RouteTable.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HubRouteTable"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "HubRouteTables_CreateOrUpdate",
+        "description": "Creates a RouteTable resource if it doesn't exist else updates the existing RouteTable.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeTableParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update RouteTable.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HubRouteTable"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'HubRouteTable' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/HubRouteTable"
+            }
+          },
+          "201": {
+            "description": "Resource 'HubRouteTable' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/HubRouteTable"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/HubRouteTable"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "HubRouteTables_Delete",
+        "description": "Deletes a RouteTable.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubVirtualNetworkConnections": {
+      "get": {
+        "operationId": "HubVirtualNetworkConnections_List",
+        "description": "Retrieves the details of all HubVirtualNetworkConnections.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListHubVirtualNetworkConnectionsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/hubVirtualNetworkConnections/{connectionName}": {
+      "get": {
+        "operationId": "HubVirtualNetworkConnections_Get",
+        "description": "Retrieves the details of a HubVirtualNetworkConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the Virtual Hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HubVirtualNetworkConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "HubVirtualNetworkConnections_CreateOrUpdate",
+        "description": "Creates a hub virtual network connection if it doesn't exist else updates the existing one.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the Virtual Hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "hubVirtualNetworkConnectionParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update a hub virtual network connection.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HubVirtualNetworkConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HubVirtualNetworkConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'HubVirtualNetworkConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/HubVirtualNetworkConnection"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/HubVirtualNetworkConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "HubVirtualNetworkConnections_Delete",
+        "description": "Deletes a HubVirtualNetworkConnection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the Virtual Hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/inboundRoutes": {
+      "post": {
+        "operationId": "VirtualHubs_GetInboundRoutes",
+        "description": "Gets the inbound routes configured for the Virtual Hub on a particular connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "getInboundRoutesParameters",
+            "in": "body",
+            "description": "Parameters supplied to get the inbound routes for a connection resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GetInboundRoutesParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EffectiveRouteMapRouteList"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EffectiveRouteMapRouteList"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/ipConfigurations": {
+      "get": {
+        "operationId": "VirtualHubIpConfiguration_List",
+        "description": "Retrieves the details of all VirtualHubIpConfigurations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVirtualHubIpConfigurationResults"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/ipConfigurations/{ipConfigName}": {
+      "get": {
+        "operationId": "VirtualHubIpConfiguration_Get",
+        "description": "Retrieves the details of a Virtual Hub Ip configuration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ipConfigName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HubIpConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualHubIpConfiguration_CreateOrUpdate",
+        "description": "Creates a VirtualHubIpConfiguration resource if it doesn't exist else updates the existing VirtualHubIpConfiguration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ipConfigName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Hub Ip Configuration parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HubIpConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'HubIpConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/HubIpConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'HubIpConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/HubIpConfiguration"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/HubIpConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualHubIpConfiguration_Delete",
+        "description": "Deletes a VirtualHubIpConfiguration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ipConfigName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/outboundRoutes": {
+      "post": {
+        "operationId": "VirtualHubs_GetOutboundRoutes",
+        "description": "Gets the outbound routes configured for the Virtual Hub on a particular connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "getOutboundRoutesParameters",
+            "in": "body",
+            "description": "Parameters supplied to get the outbound routes for a connection resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GetOutboundRoutesParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EffectiveRouteMapRouteList"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/EffectiveRouteMapRouteList"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeMaps": {
+      "get": {
+        "operationId": "RouteMaps_List",
+        "description": "Retrieves the details of all RouteMaps.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListRouteMapsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeMaps/{routeMapName}": {
+      "get": {
+        "operationId": "RouteMaps_Get",
+        "description": "Retrieves the details of a RouteMap.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeMapName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RouteMap"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RouteMaps_CreateOrUpdate",
+        "description": "Creates a RouteMap if it doesn't exist else updates the existing one.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeMapName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeMapParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update a RouteMap.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RouteMap"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RouteMap' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RouteMap"
+            }
+          },
+          "201": {
+            "description": "Resource 'RouteMap' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RouteMap"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/RouteMap"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "RouteMaps_Delete",
+        "description": "Deletes a RouteMap.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeMapName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables": {
+      "get": {
+        "operationId": "VirtualHubRouteTableV2s_List",
+        "description": "Retrieves the details of all VirtualHubRouteTableV2s.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVirtualHubRouteTableV2sResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routeTables/{routeTableName}": {
+      "get": {
+        "operationId": "VirtualHubRouteTableV2s_Get",
+        "description": "Retrieves the details of a VirtualHubRouteTableV2.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the Virtual Hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the VirtualHubRouteTableV2.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualHubRouteTableV2"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualHubRouteTableV2s_CreateOrUpdate",
+        "description": "Creates a VirtualHubRouteTableV2 resource if it doesn't exist else updates the existing VirtualHubRouteTableV2.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the Virtual Hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the VirtualHubRouteTableV2.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "virtualHubRouteTableV2Parameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update VirtualHubRouteTableV2.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualHubRouteTableV2"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualHubRouteTableV2"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualHubRouteTableV2' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualHubRouteTableV2"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualHubRouteTableV2"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VirtualHubRouteTableV2s_Delete",
+        "description": "Deletes a VirtualHubRouteTableV2.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the Virtual Hub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routeTableName",
+            "in": "path",
+            "description": "The name of the VirtualHubRouteTableV2.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/Error"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routingIntent": {
+      "get": {
+        "operationId": "RoutingIntent_List",
+        "description": "Retrieves the details of all RoutingIntent child resources of the VirtualHub.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListRoutingIntentResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualHubs/{virtualHubName}/routingIntent/{routingIntentName}": {
+      "get": {
+        "operationId": "RoutingIntent_Get",
+        "description": "Retrieves the details of a RoutingIntent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routingIntentName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RoutingIntent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "RoutingIntent_CreateOrUpdate",
+        "description": "Creates a RoutingIntent resource if it doesn't exist else updates the existing RoutingIntent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routingIntentName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routingIntentParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update RoutingIntent.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RoutingIntent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RoutingIntent' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RoutingIntent"
+            }
+          },
+          "201": {
+            "description": "Resource 'RoutingIntent' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RoutingIntent"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/RoutingIntent"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "RoutingIntent_Delete",
+        "description": "Deletes a RoutingIntent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualHubName",
+            "in": "path",
+            "description": "The name of the VirtualHub.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "routingIntentName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans": {
+      "get": {
+        "operationId": "VirtualWans_ListByResourceGroup",
+        "description": "Lists all the VirtualWANs in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVirtualWANsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{VirtualWANName}": {
+      "get": {
+        "operationId": "VirtualWans_Get",
+        "description": "Retrieves the details of a VirtualWAN.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "VirtualWANName",
+            "in": "path",
+            "description": "The name of the VirtualWAN being retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualWAN"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VirtualWans_CreateOrUpdate",
+        "description": "Creates a VirtualWAN resource if it doesn't exist else updates the existing VirtualWAN.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "VirtualWANName",
+            "in": "path",
+            "description": "The name of the VirtualWAN being retrieved.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "WANParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update VirtualWAN.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualWAN"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VirtualWAN' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualWAN"
+            }
+          },
+          "201": {
+            "description": "Resource 'VirtualWAN' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VirtualWAN"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VirtualWAN"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VirtualWans_UpdateTags",
+        "tags": [
+          "VirtualWANs"
+        ],
+        "description": "Updates a VirtualWAN tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "VirtualWANName",
+            "in": "path",
+            "description": "The name of the VirtualWAN being retrieved.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "WANParameters",
+            "in": "body",
+            "description": "Parameters supplied to Update VirtualWAN tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualWAN"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "VirtualWans_Delete",
+        "description": "Deletes a VirtualWAN.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "VirtualWANName",
+            "in": "path",
+            "description": "The name of the VirtualWAN being retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/generateVpnProfile": {
+      "post": {
+        "operationId": "generatevirtualwanvpnserverconfigurationvpnprofile",
+        "description": "Generates a unique VPN profile for P2S clients for VirtualWan and associated VpnServerConfiguration combination in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualWANName",
+            "in": "path",
+            "description": "The name of the VirtualWAN.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vpnClientParams",
+            "in": "body",
+            "description": "Parameters supplied to the generate VirtualWan VPN profile generation operation.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VirtualWanVpnProfileParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnProfileResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VpnProfileResponse"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/supportedSecurityProviders": {
+      "get": {
+        "operationId": "SupportedSecurityProviders",
+        "description": "Gives the supported security providers for the virtual wan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualWANName",
+            "in": "path",
+            "description": "The name of the VirtualWAN.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VirtualWanSecurityProviders"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/vpnConfiguration": {
+      "post": {
+        "operationId": "VpnSitesConfiguration_Download",
+        "description": "Gives the sas-url to download the configurations for vpn-sites in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualWANName",
+            "in": "path",
+            "description": "The name of the VirtualWAN.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "request",
+            "in": "body",
+            "description": "Parameters supplied to download vpn-sites configuration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GetVpnSitesConfigurationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/virtualWans/{virtualWANName}/vpnServerConfigurations": {
+      "post": {
+        "operationId": "VpnServerConfigurationsAssociatedWithVirtualWan_List",
+        "description": "Gives the list of VpnServerConfigurations associated with Virtual Wan in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "virtualWANName",
+            "in": "path",
+            "description": "The name of the VirtualWAN.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnServerConfigurationsResponse"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VpnServerConfigurationsResponse"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways": {
+      "get": {
+        "operationId": "VpnGateways_ListByResourceGroup",
+        "description": "Lists all the VpnGateways in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnGatewaysResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}": {
+      "get": {
+        "operationId": "VpnGateways_Get",
+        "description": "Retrieves the details of a virtual wan vpn gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnGateway"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VpnGateways_CreateOrUpdate",
+        "description": "Creates a virtual wan vpn gateway if it doesn't exist else updates the existing gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vpnGatewayParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or Update a virtual wan vpn gateway.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnGateway"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VpnGateway' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnGateway"
+            }
+          },
+          "201": {
+            "description": "Resource 'VpnGateway' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnGateway"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VpnGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VpnGateways_UpdateTags",
+        "tags": [
+          "VpnGateways"
+        ],
+        "description": "Updates virtual wan vpn gateway tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vpnGatewayParameters",
+            "in": "body",
+            "description": "Parameters supplied to update a virtual wan vpn gateway tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnGateway"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VpnGateway"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VpnGateways_Delete",
+        "description": "Deletes a virtual wan vpn gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/natRules": {
+      "get": {
+        "operationId": "NatRules_ListByVpnGateway",
+        "description": "Retrieves all nat rules for a particular virtual wan vpn gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnGatewayNatRulesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/natRules/{natRuleName}": {
+      "get": {
+        "operationId": "NatRules_Get",
+        "description": "Retrieves the details of a nat ruleGet.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "natRuleName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnGatewayNatRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "NatRules_CreateOrUpdate",
+        "description": "Creates a nat rule to a scalable vpn gateway if it doesn't exist else updates the existing nat rules.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "natRuleName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "NatRuleParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or Update a Nat Rule.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnGatewayNatRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VpnGatewayNatRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnGatewayNatRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'VpnGatewayNatRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnGatewayNatRule"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VpnGatewayNatRule"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "NatRules_Delete",
+        "description": "Deletes a nat rule.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "natRuleName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/reset": {
+      "post": {
+        "operationId": "VpnGateways_Reset",
+        "tags": [
+          "VpnGateways"
+        ],
+        "description": "Resets the primary of the vpn gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ipConfigurationId",
+            "in": "query",
+            "description": "VpnGateway ipConfigurationId to specify the gateway instance.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnGateway"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/VpnGateway"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/startpacketcapture": {
+      "post": {
+        "operationId": "VpnGateways_StartPacketCapture",
+        "tags": [
+          "VpnGateways"
+        ],
+        "description": "Starts packet capture on vpn gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Vpn gateway packet capture parameters supplied to start packet capture on vpn gateway.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/VpnGatewayPacketCaptureStartParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/stoppacketcapture": {
+      "post": {
+        "operationId": "VpnGateways_StopPacketCapture",
+        "tags": [
+          "VpnGateways"
+        ],
+        "description": "Stops packet capture on vpn gateway in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Vpn gateway packet capture parameters supplied to stop packet capture on vpn gateway.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/VpnGatewayPacketCaptureStopParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections": {
+      "get": {
+        "operationId": "VpnConnections_ListByVpnGateway",
+        "description": "Retrieves all vpn connections for a particular virtual wan vpn gateway.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnConnectionsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}": {
+      "get": {
+        "operationId": "VpnConnections_Get",
+        "description": "Retrieves the details of a vpn connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VpnConnections_CreateOrUpdate",
+        "description": "Creates a vpn connection to a scalable vpn gateway if it doesn't exist else updates the existing connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "VpnConnectionParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or Update a VPN Connection.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'VpnConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnConnection"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VpnConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "VpnConnections_Delete",
+        "description": "Deletes a vpn connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{vpnConnectionName}/startpacketcapture": {
+      "post": {
+        "operationId": "VpnConnections_StartPacketCapture",
+        "description": "Starts packet capture on Vpn connection in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vpnConnectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Vpn Connection packet capture parameters supplied to start packet capture on gateway connection.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/VpnConnectionPacketCaptureStartParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{vpnConnectionName}/stoppacketcapture": {
+      "post": {
+        "operationId": "VpnConnections_StopPacketCapture",
+        "description": "Stops packet capture on Vpn connection in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vpnConnectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Vpn Connection packet capture parameters supplied to stop packet capture on gateway connection.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/VpnConnectionPacketCaptureStopParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections": {
+      "get": {
+        "operationId": "VpnLinkConnections_ListByVpnConnection",
+        "description": "Retrieves all vpn site link connections for a particular virtual wan vpn gateway vpn connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnSiteLinkConnectionsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}": {
+      "get": {
+        "operationId": "VpnSiteLinkConnections_Get",
+        "description": "Retrieves the details of a vpn site link connection.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkConnectionName",
+            "in": "path",
+            "description": "The name of the vpn link connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnSiteLinkConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}/getikesas": {
+      "post": {
+        "operationId": "VpnLinkConnections_GetIkeSas",
+        "description": "Lists IKE Security Associations for Vpn Site Link Connection in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkConnectionName",
+            "in": "path",
+            "description": "The name of the vpn link connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./common.json#/definitions/stringApplicationJson"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./networkWatcher.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "./common.json#/definitions/stringApplicationJson"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}/resetconnection": {
+      "post": {
+        "operationId": "VpnLinkConnections_ResetConnection",
+        "tags": [
+          "vpnLinkConnections"
+        ],
+        "description": "Resets the VpnLink connection specified.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkConnectionName",
+            "in": "path",
+            "description": "The name of the vpn link connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./networkWatcher.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}/sharedKeys": {
+      "get": {
+        "operationId": "VpnLinkConnections_GetAllSharedKeys",
+        "description": "Lists all shared keys of VpnLink connection specified.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkConnectionName",
+            "in": "path",
+            "description": "The name of the vpn link connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKeyResultList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}/sharedKeys/default": {
+      "get": {
+        "operationId": "VpnLinkConnections_GetDefaultSharedKey",
+        "description": "Gets the shared key of VpnLink connection specified.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkConnectionName",
+            "in": "path",
+            "description": "The name of the vpn link connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKeyResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VpnLinkConnections_SetOrInitDefaultSharedKey",
+        "description": "Sets or auto generates the shared key based on the user input. If users give a shared key value, it does the set operation. If key length is given, the operation creates a random key of the pre-defined length.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkConnectionName",
+            "in": "path",
+            "description": "The name of the vpn link connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "ConnectionSharedKeyParameters",
+            "in": "body",
+            "description": "Parameters supplied to set or auto generate the shared key for the vpn link connection.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKeyResult"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectionSharedKeyResult' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKeyResult"
+            }
+          },
+          "201": {
+            "description": "Resource 'ConnectionSharedKeyResult' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKeyResult"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ConnectionSharedKeyResult"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnGateways/{gatewayName}/vpnConnections/{connectionName}/vpnLinkConnections/{linkConnectionName}/sharedKeys/default/listSharedKey": {
+      "post": {
+        "operationId": "VpnLinkConnections_ListDefaultSharedKey",
+        "description": "Gets the value of the shared key of VpnLink connection specified.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "gatewayName",
+            "in": "path",
+            "description": "The name of the vpn gateway.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "The name of the vpn connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "linkConnectionName",
+            "in": "path",
+            "description": "The name of the vpn link connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionSharedKeyResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations": {
+      "get": {
+        "operationId": "VpnServerConfigurations_ListByResourceGroup",
+        "description": "Lists all the vpnServerConfigurations in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnServerConfigurationsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}": {
+      "get": {
+        "operationId": "VpnServerConfigurations_Get",
+        "description": "Retrieves the details of a VpnServerConfiguration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnServerConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnServerConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VpnServerConfigurations_CreateOrUpdate",
+        "description": "Creates a VpnServerConfiguration resource if it doesn't exist else updates the existing VpnServerConfiguration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnServerConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "VpnServerConfigurationParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update VpnServerConfiguration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnServerConfiguration"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VpnServerConfiguration' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnServerConfiguration"
+            }
+          },
+          "201": {
+            "description": "Resource 'VpnServerConfiguration' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnServerConfiguration"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VpnServerConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VpnServerConfigurations_UpdateTags",
+        "tags": [
+          "VpnServerConfigurations"
+        ],
+        "description": "Updates VpnServerConfiguration tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnServerConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "VpnServerConfigurationParameters",
+            "in": "body",
+            "description": "Parameters supplied to update VpnServerConfiguration tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnServerConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "VpnServerConfigurations_Delete",
+        "description": "Deletes a VpnServerConfiguration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnServerConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}/configurationPolicyGroups": {
+      "get": {
+        "operationId": "ConfigurationPolicyGroups_ListByVpnServerConfiguration",
+        "description": "Lists all the configurationPolicyGroups in a resource group for a vpnServerConfiguration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnServerConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnServerConfigurationPolicyGroupsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}/configurationPolicyGroups/{configurationPolicyGroupName}": {
+      "get": {
+        "operationId": "ConfigurationPolicyGroups_Get",
+        "description": "Retrieves the details of a ConfigurationPolicyGroup.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnServerConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "configurationPolicyGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnServerConfigurationPolicyGroup"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConfigurationPolicyGroups_CreateOrUpdate",
+        "description": "Creates a ConfigurationPolicyGroup if it doesn't exist else updates the existing one.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnServerConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "configurationPolicyGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "VpnServerConfigurationPolicyGroupParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update a VpnServerConfiguration PolicyGroup.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnServerConfigurationPolicyGroup"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VpnServerConfigurationPolicyGroup' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnServerConfigurationPolicyGroup"
+            }
+          },
+          "201": {
+            "description": "Resource 'VpnServerConfigurationPolicyGroup' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnServerConfigurationPolicyGroup"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VpnServerConfigurationPolicyGroup"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ConfigurationPolicyGroups_Delete",
+        "description": "Deletes a ConfigurationPolicyGroup.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnServerConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "configurationPolicyGroupName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnServerConfigurations/{vpnServerConfigurationName}/listRadiusSecrets": {
+      "post": {
+        "operationId": "VpnServerConfigurations_ListRadiusSecrets",
+        "tags": [
+          "VpnServerConfigurations"
+        ],
+        "description": "List all Radius servers with respective radius secrets from VpnServerConfiguration.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnServerConfigurationName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "./networkGateway.json#/definitions/RadiusAuthServerListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites": {
+      "get": {
+        "operationId": "VpnSites_ListByResourceGroup",
+        "description": "Lists all the vpnSites in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnSitesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}": {
+      "get": {
+        "operationId": "VpnSites_Get",
+        "description": "Retrieves the details of a VPN site.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnSiteName",
+            "in": "path",
+            "description": "The name of the VpnSite being retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnSite"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "VpnSites_CreateOrUpdate",
+        "description": "Creates a VpnSite resource if it doesn't exist else updates the existing VpnSite.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnSiteName",
+            "in": "path",
+            "description": "The name of the VpnSite being retrieved.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "VpnSiteParameters",
+            "in": "body",
+            "description": "Parameters supplied to create or update VpnSite.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/VpnSite"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'VpnSite' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnSite"
+            }
+          },
+          "201": {
+            "description": "Resource 'VpnSite' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/VpnSite"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/VpnSite"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "VpnSites_UpdateTags",
+        "tags": [
+          "VpnSites"
+        ],
+        "description": "Updates VpnSite tags.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnSiteName",
+            "in": "path",
+            "description": "The name of the VpnSite being retrieved.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "VpnSiteParameters",
+            "in": "body",
+            "description": "Parameters supplied to update VpnSite tags.",
+            "required": true,
+            "schema": {
+              "$ref": "./common.json#/definitions/TagsObject"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnSite"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "VpnSites_Delete",
+        "description": "Deletes a VpnSite.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnSiteName",
+            "in": "path",
+            "description": "The name of the VpnSite being retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}/vpnSiteLinks": {
+      "get": {
+        "operationId": "VpnSiteLinks_ListByVpnSite",
+        "description": "Lists all the vpnSiteLinks in a resource group for a vpn site.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnSiteName",
+            "in": "path",
+            "description": "The name of the VpnSite being retrieved.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ListVpnSiteLinksResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/vpnSites/{vpnSiteName}/vpnSiteLinks/{vpnSiteLinkName}": {
+      "get": {
+        "operationId": "VpnSiteLinks_Get",
+        "description": "Retrieves the details of a VPN site link.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "vpnSiteName",
+            "in": "path",
+            "description": "The name of the VpnSite being retrieved.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "vpnSiteLinkName",
+            "in": "path",
+            "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/VpnSiteLink"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "./common.json#/definitions/CloudError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AadAuthenticationParameters": {
+      "type": "object",
+      "description": "AAD Vpn authentication type related parameters.",
+      "properties": {
+        "aadTenant": {
+          "type": "string",
+          "description": "AAD Vpn authentication parameter AAD tenant."
+        },
+        "aadAudience": {
+          "type": "string",
+          "description": "AAD Vpn authentication parameter AAD audience."
+        },
+        "aadIssuer": {
+          "type": "string",
+          "description": "AAD Vpn authentication parameter AAD issuer."
+        }
+      }
+    },
+    "Action": {
+      "type": "object",
+      "description": "Action to be taken on a route matching a RouteMap criterion.",
+      "properties": {
+        "type": {
+          "$ref": "./common.json#/definitions/RouteMapActionType",
+          "description": "Type of action to be taken. Supported types are 'Remove', 'Add', 'Replace', and 'Drop.'"
+        },
+        "parameters": {
+          "type": "array",
+          "description": "List of parameters relevant to the action.For instance if type is drop then parameters has list of prefixes to be dropped.If type is add, parameters would have list of ASN numbers to be added",
+          "items": {
+            "$ref": "#/definitions/Parameter"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "BgpConnection": {
+      "type": "object",
+      "description": "Virtual Appliance Site resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BgpConnectionProperties",
+          "description": "The properties of the Bgp connections.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "BgpConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the bgp connection.",
+      "properties": {
+        "peerAsn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Peer ASN.",
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "peerIp": {
+          "type": "string",
+          "description": "Peer IP."
+        },
+        "hubVirtualNetworkConnection": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The reference to the HubVirtualNetworkConnection resource."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the resource.",
+          "readOnly": true
+        },
+        "connectionState": {
+          "$ref": "./common.json#/definitions/HubBgpConnectionStatus",
+          "description": "The current state of the VirtualHub to Peer.",
+          "readOnly": true
+        },
+        "routingConfiguration": {
+          "$ref": "#/definitions/RoutingConfiguration",
+          "description": "The routing configuration indicating the associated and propagated route tables for this connection."
+        }
+      }
+    },
+    "ConnectionPolicy": {
+      "type": "object",
+      "description": "ConnectionPolicy resource defined for VirtualHub.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectionPolicyProperties",
+          "description": "Properties of the ConnectionPolicy resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ConnectionPolicyProperties": {
+      "type": "object",
+      "description": "Properties of the ConnectionPolicy resource.",
+      "properties": {
+        "enableInternetSecurity": {
+          "type": "boolean",
+          "description": "Enable internet security."
+        },
+        "routingConfiguration": {
+          "$ref": "#/definitions/RoutingConfiguration",
+          "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the ConnectionPolicy resource.",
+          "readOnly": true
+        },
+        "associatedConnections": {
+          "type": "array",
+          "description": "List of connection names (e.g. VpnConnection, HubVirtualNetworkConnection) associated with this ConnectionPolicy. These are resource names, not Azure resource IDs, consistent with the established VirtualWAN pattern used by HubRouteTable.associatedConnections.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ConnectionSharedKeyResult": {
+      "type": "object",
+      "description": "SharedKey Resource .",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SharedKeyProperties",
+          "description": "Properties of the shared key."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "ConnectionSharedKeyResultList": {
+      "type": "object",
+      "description": "The list of shared keys for the vpn link connection. It should only contain one shared key for each vpn link connection.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ConnectionSharedKeyResult items on this page",
+          "items": {
+            "$ref": "#/definitions/ConnectionSharedKeyResult"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Criterion": {
+      "type": "object",
+      "description": "A matching criteria which matches routes based on route prefix, community, and AS path.",
+      "properties": {
+        "routePrefix": {
+          "type": "array",
+          "description": "List of route prefixes which this criteria matches.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "community": {
+          "type": "array",
+          "description": "List of BGP communities which this criteria matches.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "asPath": {
+          "type": "array",
+          "description": "List of AS paths which this criteria matches.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "matchCondition": {
+          "$ref": "./common.json#/definitions/RouteMapMatchCondition",
+          "description": "Match condition to apply RouteMap rules."
+        }
+      }
+    },
+    "DeviceProperties": {
+      "type": "object",
+      "description": "List of properties of the device.",
+      "properties": {
+        "deviceVendor": {
+          "type": "string",
+          "description": "Name of the device Vendor."
+        },
+        "deviceModel": {
+          "type": "string",
+          "description": "Model of the device."
+        },
+        "linkSpeedInMbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Link speed."
+        }
+      }
+    },
+    "EffectiveRouteMapRoute": {
+      "type": "object",
+      "description": "The effective RouteMap route configured on the connection resource.",
+      "properties": {
+        "prefix": {
+          "type": "string",
+          "description": "The address prefix of the route."
+        },
+        "bgpCommunities": {
+          "type": "string",
+          "description": "BGP communities of the route."
+        },
+        "asPath": {
+          "type": "string",
+          "description": "The ASPath of this route."
+        }
+      }
+    },
+    "EffectiveRouteMapRouteList": {
+      "type": "object",
+      "description": "EffectiveRouteMapRoute List.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of Effective RouteMap Routes configured on the connection resource.",
+          "items": {
+            "$ref": "#/definitions/EffectiveRouteMapRoute"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "EffectiveRoutesParameters": {
+      "type": "object",
+      "description": "The parameters specifying the resource whose effective routes are being requested.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "The resource whose effective routes are being requested."
+        },
+        "virtualWanResourceType": {
+          "type": "string",
+          "description": "The type of the specified resource like RouteTable, ExpressRouteConnection, HubVirtualNetworkConnection, VpnConnection and P2SConnection."
+        }
+      }
+    },
+    "ExpressRouteCircuitPeeringId": {
+      "type": "object",
+      "description": "ExpressRoute circuit peering identifier.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the ExpressRoute circuit peering."
+        }
+      }
+    },
+    "ExpressRouteConnection": {
+      "type": "object",
+      "description": "ExpressRouteConnection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteConnectionProperties",
+          "description": "Properties of the express route connection.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource."
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "ExpressRouteConnectionId": {
+      "type": "object",
+      "description": "The ID of the ExpressRouteConnection.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The ID of the ExpressRouteConnection.",
+          "readOnly": true
+        }
+      }
+    },
+    "ExpressRouteConnectionList": {
+      "type": "object",
+      "description": "ExpressRouteConnection list.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of ExpressRoute connections.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteConnection"
+          }
+        }
+      }
+    },
+    "ExpressRouteConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the ExpressRouteConnection subresource.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route connection resource.",
+          "readOnly": true
+        },
+        "expressRouteCircuitPeering": {
+          "$ref": "#/definitions/ExpressRouteCircuitPeeringId",
+          "description": "The ExpressRoute circuit peering."
+        },
+        "authorizationKey": {
+          "type": "string",
+          "description": "Authorization key to establish the connection."
+        },
+        "routingWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The routing weight associated to the connection."
+        },
+        "enableInternetSecurity": {
+          "type": "boolean",
+          "description": "Enable internet security."
+        },
+        "expressRouteGatewayBypass": {
+          "type": "boolean",
+          "description": "Enable FastPath to vWan Firewall hub."
+        },
+        "enablePrivateLinkFastPath": {
+          "type": "boolean",
+          "description": "Bypass the ExpressRoute gateway when accessing private-links. ExpressRoute FastPath (expressRouteGatewayBypass) must be enabled."
+        },
+        "routingConfiguration": {
+          "$ref": "#/definitions/RoutingConfiguration",
+          "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
+        }
+      },
+      "required": [
+        "expressRouteCircuitPeering"
+      ]
+    },
+    "ExpressRouteGateway": {
+      "type": "object",
+      "description": "ExpressRoute gateway resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ExpressRouteGatewayProperties",
+          "description": "Properties of the express route gateway.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ExpressRouteGatewayList": {
+      "type": "object",
+      "description": "List of ExpressRoute gateways.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of ExpressRoute gateways.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteGateway"
+          }
+        }
+      }
+    },
+    "ExpressRouteGatewayProperties": {
+      "type": "object",
+      "description": "ExpressRoute gateway resource properties.",
+      "properties": {
+        "autoScaleConfiguration": {
+          "$ref": "#/definitions/ExpressRouteGatewayPropertiesAutoScaleConfiguration",
+          "description": "Configuration for auto scaling."
+        },
+        "expressRouteConnections": {
+          "type": "array",
+          "description": "List of ExpressRoute connections to the ExpressRoute gateway.",
+          "items": {
+            "$ref": "#/definitions/ExpressRouteConnection"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the express route gateway resource.",
+          "readOnly": true
+        },
+        "virtualHub": {
+          "$ref": "#/definitions/VirtualHubId",
+          "description": "The Virtual Hub where the ExpressRoute gateway is or will be deployed."
+        },
+        "allowNonVirtualWanTraffic": {
+          "type": "boolean",
+          "description": "Configures this gateway to accept traffic from non Virtual WAN networks."
+        }
+      },
+      "required": [
+        "virtualHub"
+      ]
+    },
+    "ExpressRouteGatewayPropertiesAutoScaleConfiguration": {
+      "type": "object",
+      "description": "Configuration for auto scaling.",
+      "properties": {
+        "bounds": {
+          "$ref": "#/definitions/ExpressRouteGatewayPropertiesAutoScaleConfigurationBounds",
+          "description": "Minimum and maximum number of scale units to deploy."
+        }
+      }
+    },
+    "ExpressRouteGatewayPropertiesAutoScaleConfigurationBounds": {
+      "type": "object",
+      "description": "Minimum and maximum number of scale units to deploy.",
+      "properties": {
+        "min": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of scale units deployed for ExpressRoute gateway."
+        },
+        "max": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of scale units deployed for ExpressRoute gateway."
+        }
+      }
+    },
+    "GetInboundRoutesParameters": {
+      "type": "object",
+      "description": "The parameters specifying the connection resource whose inbound routes are being requested.",
+      "properties": {
+        "resourceUri": {
+          "type": "string",
+          "description": "The connection resource whose inbound routes are being requested."
+        },
+        "connectionType": {
+          "type": "string",
+          "description": "The type of the specified connection resource like ExpressRouteConnection, HubVirtualNetworkConnection, VpnConnection and P2SConnection."
+        }
+      }
+    },
+    "GetOutboundRoutesParameters": {
+      "type": "object",
+      "description": "The parameters specifying the connection resource whose outbound routes are being requested.",
+      "properties": {
+        "resourceUri": {
+          "type": "string",
+          "description": "The connection resource whose outbound routes are being requested."
+        },
+        "connectionType": {
+          "type": "string",
+          "description": "The type of the specified connection resource like ExpressRouteConnection, HubVirtualNetworkConnection, VpnConnection and P2SConnection."
+        }
+      }
+    },
+    "GetVpnSitesConfigurationRequest": {
+      "type": "object",
+      "description": "List of Vpn-Sites.",
+      "properties": {
+        "vpnSites": {
+          "type": "array",
+          "description": "List of resource-ids of the vpn-sites for which config is to be downloaded.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "outputBlobSasUrl": {
+          "type": "string",
+          "description": "The sas-url to download the configurations for vpn-sites."
+        }
+      },
+      "required": [
+        "outputBlobSasUrl"
+      ]
+    },
+    "HubIPConfigurationPropertiesFormat": {
+      "type": "object",
+      "description": "Properties of IP configuration.",
+      "properties": {
+        "privateIPAddress": {
+          "type": "string",
+          "description": "The private IP address of the IP configuration."
+        },
+        "privateIPAllocationMethod": {
+          "$ref": "./common.json#/definitions/IPAllocationMethod",
+          "description": "The private IP address allocation method."
+        },
+        "subnet": {
+          "$ref": "./virtualNetwork.json#/definitions/Subnet",
+          "description": "The reference to the subnet resource."
+        },
+        "publicIPAddress": {
+          "$ref": "./virtualNetwork.json#/definitions/PublicIPAddress",
+          "description": "The reference to the public IP resource."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the IP configuration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "HubIpConfiguration": {
+      "type": "object",
+      "description": "IpConfigurations.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/HubIPConfigurationPropertiesFormat",
+          "description": "The properties of the Virtual Hub IPConfigurations.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "HubRoute": {
+      "type": "object",
+      "description": "RouteTable route.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the Route that is unique within a RouteTable. This name can be used to access this route."
+        },
+        "destinationType": {
+          "type": "string",
+          "description": "The type of destinations (eg: CIDR, ResourceId, Service)."
+        },
+        "destinations": {
+          "type": "array",
+          "description": "List of all destinations.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nextHopType": {
+          "type": "string",
+          "description": "The type of next hop (eg: ResourceId)."
+        },
+        "nextHop": {
+          "type": "string",
+          "description": "NextHop resource ID."
+        }
+      },
+      "required": [
+        "name",
+        "destinationType",
+        "destinations",
+        "nextHopType",
+        "nextHop"
+      ]
+    },
+    "HubRouteTable": {
+      "type": "object",
+      "description": "RouteTable resource in a virtual hub.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/HubRouteTableProperties",
+          "description": "Properties of the RouteTable resource.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "HubRouteTableProperties": {
+      "type": "object",
+      "description": "Parameters for RouteTable.",
+      "properties": {
+        "routes": {
+          "type": "array",
+          "description": "List of all routes.",
+          "items": {
+            "$ref": "#/definitions/HubRoute"
+          }
+        },
+        "labels": {
+          "type": "array",
+          "description": "List of labels associated with this route table.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "associatedConnections": {
+          "type": "array",
+          "description": "List of all connections associated with this route table.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "propagatingConnections": {
+          "type": "array",
+          "description": "List of all connections that advertise to this route table.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the RouteTable resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "HubVirtualNetworkConnection": {
+      "type": "object",
+      "description": "HubVirtualNetworkConnection Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/HubVirtualNetworkConnectionProperties",
+          "description": "Properties of the hub virtual network connection.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "HubVirtualNetworkConnectionProperties": {
+      "type": "object",
+      "description": "Parameters for HubVirtualNetworkConnection.",
+      "properties": {
+        "remoteVirtualNetwork": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Reference to the remote virtual network."
+        },
+        "allowHubToRemoteVnetTransit": {
+          "type": "boolean",
+          "description": "Deprecated: VirtualHub to RemoteVnet transit to enabled or not."
+        },
+        "allowRemoteVnetToUseHubVnetGateways": {
+          "type": "boolean",
+          "description": "Deprecated: Allow RemoteVnet to use Virtual Hub's gateways."
+        },
+        "connectionPolicy": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The resource id of the ConnectionPolicy associated with this HubVirtualNetworkConnection."
+        },
+        "enableInternetSecurity": {
+          "type": "boolean",
+          "description": "Enable internet security."
+        },
+        "routingConfiguration": {
+          "$ref": "#/definitions/RoutingConfiguration",
+          "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
+        },
+        "enableOnlyIpv6Peering": {
+          "$ref": "./common.json#/definitions/EnableOnlyIpv6PeeringState",
+          "description": "Enable Only IPv6 Peering for this connection.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the hub virtual network connection resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "ListConnectionPoliciesResult": {
+      "type": "object",
+      "description": "List of ConnectionPolicies and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ConnectionPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/ConnectionPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListHubRouteTablesResult": {
+      "type": "object",
+      "description": "List of RouteTables and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The HubRouteTable items on this page",
+          "items": {
+            "$ref": "#/definitions/HubRouteTable"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListHubVirtualNetworkConnectionsResult": {
+      "type": "object",
+      "description": "List of HubVirtualNetworkConnections and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The HubVirtualNetworkConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/HubVirtualNetworkConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListP2SVpnGatewaysResult": {
+      "type": "object",
+      "description": "Result of the request to list P2SVpnGateways. It contains a list of P2SVpnGateways and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The P2SVpnGateway items on this page",
+          "items": {
+            "$ref": "#/definitions/P2SVpnGateway"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListRouteMapsResult": {
+      "type": "object",
+      "description": "List of RouteMaps and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RouteMap items on this page",
+          "items": {
+            "$ref": "#/definitions/RouteMap"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListRoutingIntentResult": {
+      "type": "object",
+      "description": "List of the routing intent result and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The RoutingIntent items on this page",
+          "items": {
+            "$ref": "#/definitions/RoutingIntent"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVirtualHubBgpConnectionResults": {
+      "type": "object",
+      "description": "VirtualHubBgpConnections list.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BgpConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/BgpConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVirtualHubIpConfigurationResults": {
+      "type": "object",
+      "description": "VirtualHubIpConfigurations list.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The HubIpConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/HubIpConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVirtualHubRouteTableV2sResult": {
+      "type": "object",
+      "description": "List of VirtualHubRouteTableV2s and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualHubRouteTableV2 items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualHubRouteTableV2"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVirtualHubsResult": {
+      "type": "object",
+      "description": "Result of the request to list VirtualHubs. It contains a list of VirtualHubs and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualHub items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualHub"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVirtualWANsResult": {
+      "type": "object",
+      "description": "Result of the request to list VirtualWANs. It contains a list of VirtualWANs and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VirtualWAN items on this page",
+          "items": {
+            "$ref": "#/definitions/VirtualWAN"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVpnConnectionsResult": {
+      "type": "object",
+      "description": "Result of the request to list all vpn connections to a virtual wan vpn gateway. It contains a list of Vpn Connections and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VpnConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/VpnConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVpnGatewayNatRulesResult": {
+      "type": "object",
+      "description": "Result of the request to list all nat rules to a virtual wan vpn gateway. It contains a list of Nat rules and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VpnGatewayNatRule items on this page",
+          "items": {
+            "$ref": "#/definitions/VpnGatewayNatRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVpnGatewaysResult": {
+      "type": "object",
+      "description": "Result of the request to list VpnGateways. It contains a list of VpnGateways and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VpnGateway items on this page",
+          "items": {
+            "$ref": "#/definitions/VpnGateway"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVpnServerConfigurationPolicyGroupsResult": {
+      "type": "object",
+      "description": "Result of the request to list VpnServerConfigurationPolicyGroups. It contains a list of VpnServerConfigurationPolicyGroups and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VpnServerConfigurationPolicyGroup items on this page",
+          "items": {
+            "$ref": "#/definitions/VpnServerConfigurationPolicyGroup"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVpnServerConfigurationsResult": {
+      "type": "object",
+      "description": "Result of the request to list all VpnServerConfigurations. It contains a list of VpnServerConfigurations and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VpnServerConfiguration items on this page",
+          "items": {
+            "$ref": "#/definitions/VpnServerConfiguration"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVpnSiteLinkConnectionsResult": {
+      "type": "object",
+      "description": "Result of the request to list all vpn connections to a virtual wan vpn gateway. It contains a list of Vpn Connections and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VpnSiteLinkConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/VpnSiteLinkConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVpnSiteLinksResult": {
+      "type": "object",
+      "description": "Result of the request to list VpnSiteLinks. It contains a list of VpnSiteLinks and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VpnSiteLink items on this page",
+          "items": {
+            "$ref": "#/definitions/VpnSiteLink"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ListVpnSitesResult": {
+      "type": "object",
+      "description": "Result of the request to list VpnSites. It contains a list of VpnSites and a URL nextLink to get the next set of results.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The VpnSite items on this page",
+          "items": {
+            "$ref": "#/definitions/VpnSite"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkVirtualApplianceConnection": {
+      "type": "object",
+      "description": "NetworkVirtualApplianceConnection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkVirtualApplianceConnectionProperties",
+          "description": "Properties of the express route connection.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "NetworkVirtualApplianceConnectionList": {
+      "type": "object",
+      "description": "NetworkVirtualApplianceConnection list.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The NetworkVirtualApplianceConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/NetworkVirtualApplianceConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "NetworkVirtualApplianceConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the NetworkVirtualApplianceConnection subresource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the NetworkVirtualApplianceConnection resource.",
+          "readOnly": true
+        },
+        "asn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Network Virtual Appliance ASN.",
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "tunnelIdentifier": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Unique identifier for the connection.",
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "bgpPeerAddress": {
+          "type": "array",
+          "description": "List of bgpPeerAddresses for the NVA instances",
+          "items": {
+            "type": "string"
+          }
+        },
+        "enableInternetSecurity": {
+          "type": "boolean",
+          "description": "Enable internet security."
+        },
+        "routingConfiguration": {
+          "$ref": "#/definitions/RoutingConfiguration",
+          "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
+        }
+      }
+    },
+    "O365BreakOutCategoryPolicies": {
+      "type": "object",
+      "description": "Office365 breakout categories.",
+      "properties": {
+        "allow": {
+          "type": "boolean",
+          "description": "Flag to control allow category."
+        },
+        "optimize": {
+          "type": "boolean",
+          "description": "Flag to control optimize category."
+        },
+        "default": {
+          "type": "boolean",
+          "description": "Flag to control default category."
+        }
+      }
+    },
+    "O365PolicyProperties": {
+      "type": "object",
+      "description": "The Office365 breakout policy.",
+      "properties": {
+        "breakOutCategories": {
+          "$ref": "#/definitions/O365BreakOutCategoryPolicies",
+          "description": "Office365 breakout categories."
+        }
+      }
+    },
+    "P2SConnectionConfiguration": {
+      "type": "object",
+      "description": "P2SConnectionConfiguration Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/P2SConnectionConfigurationProperties",
+          "description": "Properties of the P2S connection configuration.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "P2SConnectionConfigurationProperties": {
+      "type": "object",
+      "description": "Parameters for P2SConnectionConfiguration.",
+      "properties": {
+        "vpnClientAddressPool": {
+          "$ref": "./virtualNetwork.json#/definitions/AddressSpace",
+          "description": "The reference to the address space resource which represents Address space for P2S VpnClient."
+        },
+        "routingConfiguration": {
+          "$ref": "#/definitions/RoutingConfiguration",
+          "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
+        },
+        "enableInternetSecurity": {
+          "type": "boolean",
+          "description": "Flag indicating whether the enable internet security flag is turned on for the P2S Connections or not."
+        },
+        "configurationPolicyGroupAssociations": {
+          "type": "array",
+          "description": "List of Configuration Policy Groups that this P2SConnectionConfiguration is attached to.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "previousConfigurationPolicyGroupAssociations": {
+          "type": "array",
+          "description": "List of previous Configuration Policy Groups that this P2SConnectionConfiguration was attached to.",
+          "items": {
+            "$ref": "#/definitions/VpnServerConfigurationPolicyGroup"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the P2SConnectionConfiguration resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "P2SVpnConnectionHealth": {
+      "type": "object",
+      "description": "P2S Vpn connection detailed health written to sas url.",
+      "properties": {
+        "sasUrl": {
+          "type": "string",
+          "description": "Returned sas url of the blob to which the p2s vpn connection detailed health will be written."
+        }
+      }
+    },
+    "P2SVpnConnectionHealthRequest": {
+      "type": "object",
+      "description": "List of P2S Vpn connection health request.",
+      "properties": {
+        "vpnUserNamesFilter": {
+          "type": "array",
+          "description": "The list of p2s vpn user names whose p2s vpn connection detailed health to retrieve for.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "outputBlobSasUrl": {
+          "type": "string",
+          "description": "The sas-url to download the P2S Vpn connection health detail."
+        }
+      }
+    },
+    "P2SVpnConnectionRequest": {
+      "type": "object",
+      "description": "List of p2s vpn connections to be disconnected.",
+      "properties": {
+        "vpnConnectionIds": {
+          "type": "array",
+          "description": "List of p2s vpn connection Ids.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "P2SVpnGateway": {
+      "type": "object",
+      "description": "P2SVpnGateway Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/P2SVpnGatewayProperties",
+          "description": "Properties of the P2SVpnGateway.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/TrackedResourceWithSettableIdOptionalLocation"
+        }
+      ]
+    },
+    "P2SVpnGatewayProperties": {
+      "type": "object",
+      "description": "Parameters for P2SVpnGateway.",
+      "properties": {
+        "virtualHub": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The VirtualHub to which the gateway belongs."
+        },
+        "p2SConnectionConfigurations": {
+          "type": "array",
+          "description": "List of all p2s connection configurations of the gateway.",
+          "items": {
+            "$ref": "#/definitions/P2SConnectionConfiguration"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the P2S VPN gateway resource.",
+          "readOnly": true
+        },
+        "vpnGatewayScaleUnit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The scale unit for this p2s vpn gateway."
+        },
+        "vpnServerConfiguration": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The VpnServerConfiguration to which the p2sVpnGateway is attached to."
+        },
+        "vpnClientConnectionHealth": {
+          "$ref": "#/definitions/VpnClientConnectionHealth",
+          "description": "All P2S VPN clients' connection health status.",
+          "readOnly": true
+        },
+        "customDnsServers": {
+          "type": "array",
+          "description": "List of all customer specified DNS servers IP addresses.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "isRoutingPreferenceInternet": {
+          "type": "boolean",
+          "description": "Enable Routing Preference property for the Public IP Interface of the P2SVpnGateway."
+        }
+      }
+    },
+    "P2SVpnProfileParameters": {
+      "type": "object",
+      "description": "Vpn Client Parameters for package generation.",
+      "properties": {
+        "authenticationMethod": {
+          "$ref": "./common.json#/definitions/AuthenticationMethod",
+          "description": "VPN client authentication method."
+        }
+      }
+    },
+    "Parameter": {
+      "type": "object",
+      "description": "Parameters for an Action.",
+      "properties": {
+        "routePrefix": {
+          "type": "array",
+          "description": "List of route prefixes.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "community": {
+          "type": "array",
+          "description": "List of BGP communities.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "asPath": {
+          "type": "array",
+          "description": "List of AS paths.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PeerRoute": {
+      "type": "object",
+      "description": "Peer routing details.",
+      "properties": {
+        "localAddress": {
+          "type": "string",
+          "description": "The peer's local address.",
+          "readOnly": true
+        },
+        "network": {
+          "type": "string",
+          "description": "The route's network prefix.",
+          "readOnly": true
+        },
+        "nextHop": {
+          "type": "string",
+          "description": "The route's next hop.",
+          "readOnly": true
+        },
+        "sourcePeer": {
+          "type": "string",
+          "description": "The peer this route was learned from.",
+          "readOnly": true
+        },
+        "origin": {
+          "type": "string",
+          "description": "The source this route was learned from.",
+          "readOnly": true
+        },
+        "asPath": {
+          "type": "string",
+          "description": "The route's AS path sequence.",
+          "readOnly": true
+        },
+        "weight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The route's weight.",
+          "readOnly": true
+        }
+      }
+    },
+    "PropagatedRouteTable": {
+      "type": "object",
+      "description": "The list of RouteTables to advertise the routes to.",
+      "properties": {
+        "labels": {
+          "type": "array",
+          "description": "The list of labels.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ids": {
+          "type": "array",
+          "description": "The list of resource ids of all the RouteTables.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        }
+      }
+    },
+    "Record<PeerRoute[]>": {
+      "type": "object",
+      "additionalProperties": {
+        "items": {
+          "$ref": "#/definitions/PeerRoute"
+        },
+        "type": "array"
+      }
+    },
+    "RouteMap": {
+      "type": "object",
+      "description": "The RouteMap child resource of a Virtual hub.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RouteMapProperties",
+          "description": "Properties of the RouteMap resource.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/ReadOnlySubResourceModel"
+        }
+      ]
+    },
+    "RouteMapProperties": {
+      "type": "object",
+      "description": "Properties of RouteMap resource",
+      "properties": {
+        "associatedInboundConnections": {
+          "type": "array",
+          "description": "List of connections which have this RoutMap associated for inbound traffic.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "associatedOutboundConnections": {
+          "type": "array",
+          "description": "List of connections which have this RoutMap associated for outbound traffic.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rules": {
+          "type": "array",
+          "description": "List of RouteMap rules to be applied.",
+          "items": {
+            "$ref": "#/definitions/RouteMapRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the RouteMap resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "RouteMapRule": {
+      "type": "object",
+      "description": "A RouteMap Rule.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The unique name for the rule."
+        },
+        "matchCriteria": {
+          "type": "array",
+          "description": "List of matching criterion which will be applied to traffic.",
+          "items": {
+            "$ref": "#/definitions/Criterion"
+          },
+          "x-ms-identifiers": []
+        },
+        "actions": {
+          "type": "array",
+          "description": "List of actions which will be applied on a match.",
+          "items": {
+            "$ref": "#/definitions/Action"
+          },
+          "x-ms-identifiers": []
+        },
+        "nextStepIfMatched": {
+          "$ref": "./common.json#/definitions/NextStep",
+          "description": "Next step after rule is evaluated. Current supported behaviors are 'Continue'(to next rule) and 'Terminate'."
+        }
+      }
+    },
+    "RoutingConfiguration": {
+      "type": "object",
+      "description": "Routing Configuration indicating the associated and propagated route tables for this connection.",
+      "properties": {
+        "associatedRouteTable": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The resource id RouteTable associated with this RoutingConfiguration."
+        },
+        "propagatedRouteTables": {
+          "$ref": "#/definitions/PropagatedRouteTable",
+          "description": "The list of RouteTables to advertise the routes to."
+        },
+        "vnetRoutes": {
+          "$ref": "#/definitions/VnetRoute",
+          "description": "List of routes that control routing from VirtualHub into a virtual network connection."
+        },
+        "inboundRouteMap": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The resource id of the RouteMap associated with this RoutingConfiguration for inbound learned routes."
+        },
+        "outboundRouteMap": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The resource id of theRouteMap associated with this RoutingConfiguration for outbound advertised routes."
+        }
+      }
+    },
+    "RoutingIntent": {
+      "type": "object",
+      "description": "The routing intent child resource of a Virtual hub.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RoutingIntentProperties",
+          "description": "Properties of the RoutingIntent resource.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "RoutingIntentProperties": {
+      "type": "object",
+      "description": "The properties of a RoutingIntent resource.",
+      "properties": {
+        "routingPolicies": {
+          "type": "array",
+          "description": "List of routing policies.",
+          "items": {
+            "$ref": "#/definitions/RoutingPolicy"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the RoutingIntent resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "RoutingPolicy": {
+      "type": "object",
+      "description": "The routing policy object used in a RoutingIntent resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The unique name for the routing policy."
+        },
+        "destinations": {
+          "type": "array",
+          "description": "List of all destinations which this routing policy is applicable to (for example: Internet, PrivateTraffic).",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nextHop": {
+          "type": "string",
+          "description": "The next hop resource id on which this routing policy is applicable to."
+        }
+      },
+      "required": [
+        "name",
+        "destinations",
+        "nextHop"
+      ]
+    },
+    "SharedKeyProperties": {
+      "type": "object",
+      "description": "Parameters for SharedKey.",
+      "properties": {
+        "sharedKey": {
+          "type": "string",
+          "format": "password",
+          "description": "The value of the shared key for the vpn link connection.",
+          "x-ms-secret": true
+        },
+        "sharedKeyLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The length of the shared key for the vpn link connection.",
+          "minimum": 1,
+          "maximum": 128
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the SharedKey resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "StaticRoute": {
+      "type": "object",
+      "description": "List of all Static Routes.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the StaticRoute that is unique within a VnetRoute."
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "List of all address prefixes.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nextHopIpAddress": {
+          "type": "string",
+          "description": "The ip address of the next hop."
+        }
+      }
+    },
+    "StaticRoutesConfig": {
+      "type": "object",
+      "description": "Configuration for static routes on this HubVnetConnectionConfiguration for static routes on this HubVnetConnection.",
+      "properties": {
+        "propagateStaticRoutes": {
+          "type": "boolean",
+          "description": "Boolean indicating whether static routes on this connection are automatically propagate to route tables which this connection propagates to."
+        },
+        "vnetLocalRouteOverrideCriteria": {
+          "$ref": "./common.json#/definitions/VnetLocalRouteOverrideCriteria",
+          "description": "Parameter determining whether NVA in spoke vnet is bypassed for traffic with destination in spoke."
+        }
+      }
+    },
+    "VirtualHub": {
+      "type": "object",
+      "description": "VirtualHub Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualHubProperties",
+          "description": "Properties of the virtual hub.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind of service virtual hub. This is metadata used for the Azure portal experience for Route Server.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/TrackedResourceWithSettableIdOptionalLocation"
+        }
+      ]
+    },
+    "VirtualHubEffectiveRoute": {
+      "type": "object",
+      "description": "The effective route configured on the virtual hub or specified resource.",
+      "properties": {
+        "addressPrefixes": {
+          "type": "array",
+          "description": "The list of address prefixes.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nextHops": {
+          "type": "array",
+          "description": "The list of next hops.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nextHopType": {
+          "type": "string",
+          "description": "The type of the next hop."
+        },
+        "asPath": {
+          "type": "string",
+          "description": "The ASPath of this route."
+        },
+        "routeOrigin": {
+          "type": "string",
+          "description": "The origin of this route."
+        }
+      }
+    },
+    "VirtualHubEffectiveRouteList": {
+      "type": "object",
+      "description": "EffectiveRoutes List.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The list of effective routes configured on the virtual hub or the specified resource.",
+          "items": {
+            "$ref": "#/definitions/VirtualHubEffectiveRoute"
+          }
+        }
+      }
+    },
+    "VirtualHubId": {
+      "type": "object",
+      "description": "Virtual Hub identifier.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The resource URI for the Virtual Hub where the ExpressRoute gateway is or will be deployed. The Virtual Hub resource and the ExpressRoute gateway resource reside in the same subscription."
+        }
+      }
+    },
+    "VirtualHubProperties": {
+      "type": "object",
+      "description": "Parameters for VirtualHub.",
+      "properties": {
+        "virtualWan": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The VirtualWAN to which the VirtualHub belongs."
+        },
+        "vpnGateway": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The VpnGateway associated with this VirtualHub."
+        },
+        "p2SVpnGateway": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The P2SVpnGateway associated with this VirtualHub."
+        },
+        "expressRouteGateway": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The expressRouteGateway associated with this VirtualHub."
+        },
+        "azureFirewall": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The azureFirewall associated with this VirtualHub."
+        },
+        "securityPartnerProvider": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The securityPartnerProvider associated with this VirtualHub."
+        },
+        "addressPrefix": {
+          "type": "string",
+          "description": "Address-prefix for this VirtualHub."
+        },
+        "routeTable": {
+          "$ref": "#/definitions/VirtualHubRouteTable",
+          "description": "The routeTable associated with this virtual hub."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual hub resource.",
+          "readOnly": true
+        },
+        "securityProviderName": {
+          "type": "string",
+          "description": "The Security Provider name."
+        },
+        "virtualHubRouteTableV2s": {
+          "type": "array",
+          "description": "List of all virtual hub route table v2s associated with this VirtualHub.",
+          "items": {
+            "$ref": "#/definitions/VirtualHubRouteTableV2"
+          }
+        },
+        "sku": {
+          "type": "string",
+          "description": "The sku of this VirtualHub."
+        },
+        "routingState": {
+          "$ref": "./common.json#/definitions/RoutingState",
+          "description": "The routing state.",
+          "readOnly": true
+        },
+        "bgpConnections": {
+          "type": "array",
+          "description": "List of references to Bgp Connections.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "List of references to IpConfigurations.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "routeMaps": {
+          "type": "array",
+          "description": "List of references to RouteMaps.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "virtualRouterAsn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "VirtualRouter ASN.",
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "virtualRouterIps": {
+          "type": "array",
+          "description": "VirtualRouter IPs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "addressPrefixV6": {
+          "type": "string",
+          "description": "IPv6 Address-prefix for this VirtualHub."
+        },
+        "virtualRouterIpsV6": {
+          "type": "array",
+          "description": "VirtualRouter IPv6 IPs.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowBranchToBranchTraffic": {
+          "type": "boolean",
+          "description": "Flag to control transit for VirtualRouter hub."
+        },
+        "preferredRoutingGateway": {
+          "$ref": "./common.json#/definitions/PreferredRoutingGateway",
+          "description": "The preferred gateway to route on-prem traffic"
+        },
+        "hubRoutingPreference": {
+          "$ref": "./common.json#/definitions/HubRoutingPreference",
+          "description": "The hubRoutingPreference of this VirtualHub."
+        },
+        "virtualRouterAutoScaleConfiguration": {
+          "$ref": "#/definitions/VirtualRouterAutoScaleConfiguration",
+          "description": "The VirtualHub Router autoscale configuration."
+        }
+      }
+    },
+    "VirtualHubRoute": {
+      "type": "object",
+      "description": "VirtualHub route.",
+      "properties": {
+        "addressPrefixes": {
+          "type": "array",
+          "description": "List of all addressPrefixes.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nextHopIpAddress": {
+          "type": "string",
+          "description": "NextHop ip address."
+        }
+      }
+    },
+    "VirtualHubRouteTable": {
+      "type": "object",
+      "description": "VirtualHub route table.",
+      "properties": {
+        "routes": {
+          "type": "array",
+          "description": "List of all routes.",
+          "items": {
+            "$ref": "#/definitions/VirtualHubRoute"
+          }
+        }
+      }
+    },
+    "VirtualHubRouteTableV2": {
+      "type": "object",
+      "description": "VirtualHubRouteTableV2 Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualHubRouteTableV2Properties",
+          "description": "Properties of the virtual hub route table v2.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "VirtualHubRouteTableV2Properties": {
+      "type": "object",
+      "description": "Parameters for VirtualHubRouteTableV2.",
+      "properties": {
+        "routes": {
+          "type": "array",
+          "description": "List of all routes.",
+          "items": {
+            "$ref": "#/definitions/VirtualHubRouteV2"
+          }
+        },
+        "attachedConnections": {
+          "type": "array",
+          "description": "List of all connections attached to this route table v2.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual hub route table v2 resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualHubRouteV2": {
+      "type": "object",
+      "description": "VirtualHubRouteTableV2 route.",
+      "properties": {
+        "destinationType": {
+          "type": "string",
+          "description": "The type of destinations."
+        },
+        "destinations": {
+          "type": "array",
+          "description": "List of all destinations.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "nextHopType": {
+          "type": "string",
+          "description": "The type of next hops."
+        },
+        "nextHops": {
+          "type": "array",
+          "description": "NextHops ip address.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VirtualRouterAutoScaleConfiguration": {
+      "type": "object",
+      "description": "The VirtualHub Router autoscale configuration.",
+      "properties": {
+        "minCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum number of scale units for VirtualHub Router.",
+          "minimum": 0
+        }
+      }
+    },
+    "VirtualWAN": {
+      "type": "object",
+      "description": "VirtualWAN Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VirtualWanProperties",
+          "description": "Properties of the virtual WAN.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/TrackedResourceWithSettableIdOptionalLocation"
+        }
+      ]
+    },
+    "VirtualWanProperties": {
+      "type": "object",
+      "description": "Parameters for VirtualWAN.",
+      "properties": {
+        "disableVpnEncryption": {
+          "type": "boolean",
+          "description": "Vpn encryption to be disabled or not."
+        },
+        "virtualHubs": {
+          "type": "array",
+          "description": "List of VirtualHubs in the VirtualWAN.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "vpnSites": {
+          "type": "array",
+          "description": "List of VpnSites in the VirtualWAN.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "allowBranchToBranchTraffic": {
+          "type": "boolean",
+          "description": "True if branch to branch traffic is allowed."
+        },
+        "allowVnetToVnetTraffic": {
+          "type": "boolean",
+          "description": "True if Vnet to Vnet traffic is allowed."
+        },
+        "office365LocalBreakoutCategory": {
+          "$ref": "./common.json#/definitions/OfficeTrafficCategory",
+          "description": "The office local breakout category.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the virtual WAN resource.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of the VirtualWAN."
+        }
+      }
+    },
+    "VirtualWanSecurityProvider": {
+      "type": "object",
+      "description": "Collection of SecurityProviders.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the security provider."
+        },
+        "url": {
+          "type": "string",
+          "description": "Url of the security provider."
+        },
+        "type": {
+          "$ref": "./common.json#/definitions/VirtualWanSecurityProviderType",
+          "description": "Name of the security provider.",
+          "readOnly": true
+        }
+      }
+    },
+    "VirtualWanSecurityProviders": {
+      "type": "object",
+      "description": "Collection of SecurityProviders.",
+      "properties": {
+        "supportedProviders": {
+          "type": "array",
+          "description": "List of VirtualWAN security providers.",
+          "items": {
+            "$ref": "#/definitions/VirtualWanSecurityProvider"
+          }
+        }
+      }
+    },
+    "VirtualWanVpnProfileParameters": {
+      "type": "object",
+      "description": "Virtual Wan Vpn profile parameters Vpn profile generation.",
+      "properties": {
+        "vpnServerConfigurationResourceId": {
+          "type": "string",
+          "description": "VpnServerConfiguration partial resource uri with which VirtualWan is associated to."
+        },
+        "authenticationMethod": {
+          "$ref": "./common.json#/definitions/AuthenticationMethod",
+          "description": "VPN client authentication method."
+        }
+      }
+    },
+    "VnetRoute": {
+      "type": "object",
+      "description": "List of routes that control routing from VirtualHub into a virtual network connection.",
+      "properties": {
+        "staticRoutesConfig": {
+          "$ref": "#/definitions/StaticRoutesConfig",
+          "description": "Configuration for static routes on this HubVnetConnection."
+        },
+        "staticRoutes": {
+          "type": "array",
+          "description": "List of all Static Routes.",
+          "items": {
+            "$ref": "#/definitions/StaticRoute"
+          }
+        },
+        "bgpConnections": {
+          "type": "array",
+          "description": "The list of references to HubBgpConnection objects.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "VpnClientConnectionHealth": {
+      "type": "object",
+      "description": "VpnClientConnectionHealth properties.",
+      "properties": {
+        "totalIngressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Total of the Ingress Bytes Transferred in this P2S Vpn connection.",
+          "readOnly": true
+        },
+        "totalEgressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Total of the Egress Bytes Transferred in this connection.",
+          "readOnly": true
+        },
+        "vpnClientConnectionsCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The total of p2s vpn clients connected at this time to this P2SVpnGateway."
+        },
+        "allocatedIpAddresses": {
+          "type": "array",
+          "description": "List of allocated ip addresses to the connected p2s vpn clients.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VpnConnection": {
+      "type": "object",
+      "description": "VpnConnection Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VpnConnectionProperties",
+          "description": "Properties of the VPN connection.",
+          "x-ms-client-flatten": true
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the resource that is unique within a resource group. This name can be used to access the resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResource"
+        }
+      ]
+    },
+    "VpnConnectionPacketCaptureStartParameters": {
+      "type": "object",
+      "description": "Vpn Connection packet capture parameters supplied to start packet capture on gateway connection.",
+      "properties": {
+        "filterData": {
+          "type": "string",
+          "description": "Start Packet capture parameters on vpn connection."
+        },
+        "linkConnectionNames": {
+          "type": "array",
+          "description": "List of site link connection names.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VpnConnectionPacketCaptureStopParameters": {
+      "type": "object",
+      "description": "Vpn Connection packet capture parameters supplied to stop packet capture on gateway connection.",
+      "properties": {
+        "sasUrl": {
+          "type": "string",
+          "description": "SAS url for packet capture on vpn connection."
+        },
+        "linkConnectionNames": {
+          "type": "array",
+          "description": "List of site link connection names.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VpnConnectionProperties": {
+      "type": "object",
+      "description": "Parameters for VpnConnection.",
+      "properties": {
+        "remoteVpnSite": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Id of the connected vpn site."
+        },
+        "routingWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Routing weight for vpn connection."
+        },
+        "dpdTimeoutSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "DPD timeout in seconds for vpn connection."
+        },
+        "connectionStatus": {
+          "$ref": "./common.json#/definitions/VpnConnectionStatus",
+          "description": "The connection status.",
+          "readOnly": true
+        },
+        "vpnConnectionProtocolType": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionProtocol",
+          "description": "Connection protocol used for this connection."
+        },
+        "ingressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Ingress bytes transferred.",
+          "readOnly": true
+        },
+        "egressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Egress bytes transferred.",
+          "readOnly": true
+        },
+        "connectionBandwidth": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Expected bandwidth in MBPS."
+        },
+        "sharedKey": {
+          "type": "string",
+          "description": "Deprecated: SharedKey for the vpn connection. This is no more used."
+        },
+        "enableBgp": {
+          "type": "boolean",
+          "description": "EnableBgp flag."
+        },
+        "usePolicyBasedTrafficSelectors": {
+          "type": "boolean",
+          "description": "Enable policy-based traffic selectors."
+        },
+        "ipsecPolicies": {
+          "type": "array",
+          "description": "The IPSec Policies to be considered by this connection.",
+          "items": {
+            "$ref": "./networkGateway.json#/definitions/IpsecPolicy"
+          }
+        },
+        "trafficSelectorPolicies": {
+          "type": "array",
+          "description": "The Traffic Selector Policies to be considered by this connection.",
+          "items": {
+            "$ref": "./networkGateway.json#/definitions/TrafficSelectorPolicy"
+          }
+        },
+        "enableRateLimiting": {
+          "type": "boolean",
+          "description": "EnableBgp flag."
+        },
+        "enableInternetSecurity": {
+          "type": "boolean",
+          "description": "Enable internet security."
+        },
+        "useLocalAzureIpAddress": {
+          "type": "boolean",
+          "description": "Use local azure ip to initiate connection."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the VPN connection resource.",
+          "readOnly": true
+        },
+        "vpnLinkConnections": {
+          "type": "array",
+          "description": "List of all vpn site link connections to the gateway.",
+          "items": {
+            "$ref": "#/definitions/VpnSiteLinkConnection"
+          }
+        },
+        "routingConfiguration": {
+          "$ref": "#/definitions/RoutingConfiguration",
+          "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
+        }
+      }
+    },
+    "VpnGateway": {
+      "type": "object",
+      "description": "VpnGateway Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VpnGatewayProperties",
+          "description": "Properties of the VPN gateway.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/TrackedResourceWithSettableIdOptionalLocation"
+        }
+      ]
+    },
+    "VpnGatewayIpConfiguration": {
+      "type": "object",
+      "description": "IP Configuration of a VPN Gateway Resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier of the IP configuration for a VPN Gateway."
+        },
+        "publicIpAddress": {
+          "type": "string",
+          "description": "The public IP address of this IP configuration."
+        },
+        "privateIpAddress": {
+          "type": "string",
+          "description": "The private IP address of this IP configuration."
+        }
+      }
+    },
+    "VpnGatewayNatRule": {
+      "type": "object",
+      "description": "VpnGatewayNatRule Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VpnGatewayNatRuleProperties",
+          "description": "Properties of the VpnGateway NAT rule.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "VpnGatewayNatRuleProperties": {
+      "type": "object",
+      "description": "Parameters for VpnGatewayNatRule.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the NAT Rule resource.",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "./common.json#/definitions/VpnNatRuleType",
+          "description": "The type of NAT rule for VPN NAT."
+        },
+        "mode": {
+          "$ref": "./common.json#/definitions/VpnNatRuleMode",
+          "description": "The Source NAT direction of a VPN NAT."
+        },
+        "internalMappings": {
+          "type": "array",
+          "description": "The private IP address internal mapping for NAT.",
+          "items": {
+            "$ref": "#/definitions/VpnNatRuleMapping"
+          }
+        },
+        "externalMappings": {
+          "type": "array",
+          "description": "The private IP address external mapping for NAT.",
+          "items": {
+            "$ref": "#/definitions/VpnNatRuleMapping"
+          }
+        },
+        "ipConfigurationId": {
+          "type": "string",
+          "description": "The IP Configuration ID this NAT rule applies to."
+        },
+        "egressVpnSiteLinkConnections": {
+          "type": "array",
+          "description": "List of egress VpnSiteLinkConnections.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "ingressVpnSiteLinkConnections": {
+          "type": "array",
+          "description": "List of ingress VpnSiteLinkConnections.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "VpnGatewayPacketCaptureStartParameters": {
+      "type": "object",
+      "description": "Start packet capture parameters.",
+      "properties": {
+        "filterData": {
+          "type": "string",
+          "description": "Start Packet capture parameters on vpn gateway."
+        }
+      }
+    },
+    "VpnGatewayPacketCaptureStopParameters": {
+      "type": "object",
+      "description": "Stop packet capture parameters.",
+      "properties": {
+        "sasUrl": {
+          "type": "string",
+          "description": "SAS url for packet capture on vpn gateway."
+        }
+      }
+    },
+    "VpnGatewayProperties": {
+      "type": "object",
+      "description": "Parameters for VpnGateway.",
+      "properties": {
+        "virtualHub": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The VirtualHub to which the gateway belongs."
+        },
+        "connections": {
+          "type": "array",
+          "description": "List of all vpn connections to the gateway.",
+          "items": {
+            "$ref": "#/definitions/VpnConnection"
+          }
+        },
+        "bgpSettings": {
+          "$ref": "./networkGateway.json#/definitions/BgpSettings",
+          "description": "Local network gateway's BGP speaker settings."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the VPN gateway resource.",
+          "readOnly": true
+        },
+        "vpnGatewayScaleUnit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The scale unit for this vpn gateway."
+        },
+        "ipConfigurations": {
+          "type": "array",
+          "description": "List of all IPs configured on the gateway.",
+          "items": {
+            "$ref": "#/definitions/VpnGatewayIpConfiguration"
+          },
+          "readOnly": true
+        },
+        "enableBgpRouteTranslationForNat": {
+          "type": "boolean",
+          "description": "Enable BGP routes translation for NAT on this VpnGateway."
+        },
+        "isRoutingPreferenceInternet": {
+          "type": "boolean",
+          "description": "Enable Routing Preference property for the Public IP Interface of the VpnGateway."
+        },
+        "natRules": {
+          "type": "array",
+          "description": "List of all the nat Rules associated with the gateway.",
+          "items": {
+            "$ref": "#/definitions/VpnGatewayNatRule"
+          }
+        }
+      }
+    },
+    "VpnLinkBgpSettings": {
+      "type": "object",
+      "description": "BGP settings details for a link.",
+      "properties": {
+        "asn": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The BGP speaker's ASN."
+        },
+        "bgpPeeringAddress": {
+          "type": "string",
+          "description": "The BGP peering address and BGP identifier of this BGP speaker."
+        }
+      }
+    },
+    "VpnLinkProviderProperties": {
+      "type": "object",
+      "description": "List of properties of a link provider.",
+      "properties": {
+        "linkProviderName": {
+          "type": "string",
+          "description": "Name of the link provider."
+        },
+        "linkSpeedInMbps": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Link speed."
+        }
+      }
+    },
+    "VpnNatRuleMapping": {
+      "type": "object",
+      "description": "Vpn NatRule mapping.",
+      "properties": {
+        "addressSpace": {
+          "type": "string",
+          "description": "Address space for Vpn NatRule mapping."
+        },
+        "portRange": {
+          "type": "string",
+          "description": "Port range for Vpn NatRule mapping."
+        }
+      }
+    },
+    "VpnProfileResponse": {
+      "type": "object",
+      "description": "Vpn Profile Response for package generation.",
+      "properties": {
+        "profileUrl": {
+          "type": "string",
+          "description": "URL to the VPN profile."
+        }
+      }
+    },
+    "VpnServerConfigRadiusClientRootCertificate": {
+      "type": "object",
+      "description": "Properties of the Radius client root certificate of VpnServerConfiguration.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The certificate name."
+        },
+        "thumbprint": {
+          "type": "string",
+          "description": "The Radius client root certificate thumbprint."
+        }
+      }
+    },
+    "VpnServerConfigRadiusServerRootCertificate": {
+      "type": "object",
+      "description": "Properties of Radius Server root certificate of VpnServerConfiguration.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The certificate name."
+        },
+        "publicCertData": {
+          "type": "string",
+          "description": "The certificate public data."
+        }
+      }
+    },
+    "VpnServerConfigVpnClientRevokedCertificate": {
+      "type": "object",
+      "description": "Properties of the revoked VPN client certificate of VpnServerConfiguration.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The certificate name."
+        },
+        "thumbprint": {
+          "type": "string",
+          "description": "The revoked VPN client certificate thumbprint."
+        }
+      }
+    },
+    "VpnServerConfigVpnClientRootCertificate": {
+      "type": "object",
+      "description": "Properties of VPN client root certificate of VpnServerConfiguration.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The certificate name."
+        },
+        "publicCertData": {
+          "type": "string",
+          "description": "The certificate public data."
+        }
+      }
+    },
+    "VpnServerConfiguration": {
+      "type": "object",
+      "description": "VpnServerConfiguration Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VpnServerConfigurationProperties",
+          "description": "Properties of the P2SVpnServer configuration.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/TrackedResourceWithSettableName"
+        }
+      ]
+    },
+    "VpnServerConfigurationPolicyGroup": {
+      "type": "object",
+      "description": "VpnServerConfigurationPolicyGroup Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VpnServerConfigurationPolicyGroupProperties",
+          "description": "Properties of the VpnServerConfigurationPolicyGroup.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "VpnServerConfigurationPolicyGroupMember": {
+      "type": "object",
+      "description": "VpnServerConfiguration PolicyGroup member",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the VpnServerConfigurationPolicyGroupMember."
+        },
+        "attributeType": {
+          "$ref": "./common.json#/definitions/VpnPolicyMemberAttributeType",
+          "description": "The Vpn Policy member attribute type."
+        },
+        "attributeValue": {
+          "type": "string",
+          "description": "The value of Attribute used for this VpnServerConfigurationPolicyGroupMember."
+        }
+      }
+    },
+    "VpnServerConfigurationPolicyGroupProperties": {
+      "type": "object",
+      "description": "Parameters for VpnServerConfigurationPolicyGroup.",
+      "properties": {
+        "isDefault": {
+          "type": "boolean",
+          "description": "Shows if this is a Default VpnServerConfigurationPolicyGroup or not."
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Priority for VpnServerConfigurationPolicyGroup."
+        },
+        "policyMembers": {
+          "type": "array",
+          "description": "Multiple PolicyMembers for VpnServerConfigurationPolicyGroup.",
+          "items": {
+            "$ref": "#/definitions/VpnServerConfigurationPolicyGroupMember"
+          },
+          "x-ms-identifiers": []
+        },
+        "p2SConnectionConfigurations": {
+          "type": "array",
+          "description": "List of references to P2SConnectionConfigurations.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          },
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the VpnServerConfigurationPolicyGroup resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "VpnServerConfigurationProperties": {
+      "type": "object",
+      "description": "Parameters for VpnServerConfiguration.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the VpnServerConfiguration that is unique within a resource group."
+        },
+        "vpnProtocols": {
+          "type": "array",
+          "description": "VPN protocols for the VpnServerConfiguration.",
+          "items": {
+            "$ref": "./common.json#/definitions/VpnGatewayTunnelingProtocol"
+          }
+        },
+        "vpnAuthenticationTypes": {
+          "type": "array",
+          "description": "VPN authentication types for the VpnServerConfiguration.",
+          "items": {
+            "$ref": "./common.json#/definitions/VpnAuthenticationType"
+          }
+        },
+        "vpnClientRootCertificates": {
+          "type": "array",
+          "description": "VPN client root certificate of VpnServerConfiguration.",
+          "items": {
+            "$ref": "#/definitions/VpnServerConfigVpnClientRootCertificate"
+          }
+        },
+        "vpnClientRevokedCertificates": {
+          "type": "array",
+          "description": "VPN client revoked certificate of VpnServerConfiguration.",
+          "items": {
+            "$ref": "#/definitions/VpnServerConfigVpnClientRevokedCertificate"
+          }
+        },
+        "radiusServerRootCertificates": {
+          "type": "array",
+          "description": "Radius Server root certificate of VpnServerConfiguration.",
+          "items": {
+            "$ref": "#/definitions/VpnServerConfigRadiusServerRootCertificate"
+          }
+        },
+        "radiusClientRootCertificates": {
+          "type": "array",
+          "description": "Radius client root certificate of VpnServerConfiguration.",
+          "items": {
+            "$ref": "#/definitions/VpnServerConfigRadiusClientRootCertificate"
+          }
+        },
+        "vpnClientIpsecPolicies": {
+          "type": "array",
+          "description": "VpnClientIpsecPolicies for VpnServerConfiguration.",
+          "items": {
+            "$ref": "./networkGateway.json#/definitions/IpsecPolicy"
+          }
+        },
+        "radiusServerAddress": {
+          "type": "string",
+          "description": "The radius server address property of the VpnServerConfiguration resource for point to site client connection."
+        },
+        "radiusServerSecret": {
+          "type": "string",
+          "format": "password",
+          "description": "The radius secret property of the VpnServerConfiguration resource for point to site client connection. We will no longer return radiusServerSecret in VpnServerConfiguration Create/Update/Get/List/UpdateTags APIs response. Please use VpnServerConfiguration ListRadiusSecrets API to fetch radius server secrets.",
+          "x-ms-secret": true
+        },
+        "radiusServers": {
+          "type": "array",
+          "description": "Multiple Radius Server configuration for VpnServerConfiguration.",
+          "items": {
+            "$ref": "./networkGateway.json#/definitions/RadiusServer"
+          }
+        },
+        "aadAuthenticationParameters": {
+          "$ref": "#/definitions/AadAuthenticationParameters",
+          "description": "The set of aad vpn authentication parameters."
+        },
+        "provisioningState": {
+          "type": "string",
+          "description": "The provisioning state of the VpnServerConfiguration resource. Possible values are: 'Updating', 'Deleting', and 'Failed'.",
+          "readOnly": true
+        },
+        "p2SVpnGateways": {
+          "type": "array",
+          "description": "List of references to P2SVpnGateways.",
+          "items": {
+            "$ref": "#/definitions/P2SVpnGateway"
+          },
+          "readOnly": true
+        },
+        "configurationPolicyGroups": {
+          "type": "array",
+          "description": "List of all VpnServerConfigurationPolicyGroups.",
+          "items": {
+            "$ref": "#/definitions/VpnServerConfigurationPolicyGroup"
+          }
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      }
+    },
+    "VpnServerConfigurationsResponse": {
+      "type": "object",
+      "description": "VpnServerConfigurations list associated with VirtualWan Response.",
+      "properties": {
+        "vpnServerConfigurationResourceIds": {
+          "type": "array",
+          "description": "List of VpnServerConfigurations associated with VirtualWan.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VpnSite": {
+      "type": "object",
+      "description": "VpnSite Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VpnSiteProperties",
+          "description": "Properties of the VPN site.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/TrackedResourceWithSettableIdOptionalLocation"
+        }
+      ]
+    },
+    "VpnSiteLink": {
+      "type": "object",
+      "description": "VpnSiteLink Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VpnSiteLinkProperties",
+          "description": "Properties of the VPN site link.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "VpnSiteLinkConnection": {
+      "type": "object",
+      "description": "VpnSiteLinkConnection Resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/VpnSiteLinkConnectionProperties",
+          "description": "Properties of the VPN site link connection.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "A unique read-only string that changes whenever the resource is updated.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "./common.json#/definitions/SubResourceModel"
+        }
+      ]
+    },
+    "VpnSiteLinkConnectionProperties": {
+      "type": "object",
+      "description": "Parameters for VpnConnection.",
+      "properties": {
+        "vpnSiteLink": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "Id of the connected vpn site link."
+        },
+        "routingWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Routing weight for vpn connection."
+        },
+        "vpnLinkConnectionMode": {
+          "$ref": "./common.json#/definitions/VpnLinkConnectionMode",
+          "description": "Vpn link connection mode."
+        },
+        "connectionStatus": {
+          "$ref": "./common.json#/definitions/VpnConnectionStatus",
+          "description": "The connection status.",
+          "readOnly": true
+        },
+        "vpnConnectionProtocolType": {
+          "$ref": "./common.json#/definitions/VirtualNetworkGatewayConnectionProtocol",
+          "description": "Connection protocol used for this connection."
+        },
+        "ingressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Ingress bytes transferred.",
+          "readOnly": true
+        },
+        "egressBytesTransferred": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Egress bytes transferred.",
+          "readOnly": true
+        },
+        "connectionBandwidth": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Expected bandwidth in MBPS."
+        },
+        "sharedKey": {
+          "type": "string",
+          "format": "password",
+          "description": "SharedKey for the vpn link connection. We will no longer return sharedKey in any Create/Update/Get/List/UpdateTags VpnGateway/VpnConnection/VpnLinkConnection APIs response. Please use 'Vpn Link Connections - List Default Shared Key' API to fetch Vpn link connection sharedKey.",
+          "x-ms-secret": true
+        },
+        "enableBgp": {
+          "type": "boolean",
+          "description": "EnableBgp flag."
+        },
+        "vpnGatewayCustomBgpAddresses": {
+          "type": "array",
+          "description": "vpnGatewayCustomBgpAddresses used by this connection.",
+          "items": {
+            "$ref": "./networkGateway.json#/definitions/GatewayCustomBgpIpAddressIpConfiguration"
+          },
+          "x-ms-identifiers": []
+        },
+        "usePolicyBasedTrafficSelectors": {
+          "type": "boolean",
+          "description": "Enable policy-based traffic selectors."
+        },
+        "ipsecPolicies": {
+          "type": "array",
+          "description": "The IPSec Policies to be considered by this connection.",
+          "items": {
+            "$ref": "./networkGateway.json#/definitions/IpsecPolicy"
+          }
+        },
+        "enableRateLimiting": {
+          "type": "boolean",
+          "description": "EnableBgp flag."
+        },
+        "useLocalAzureIpAddress": {
+          "type": "boolean",
+          "description": "Use local azure ip to initiate connection."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the VPN site link connection resource.",
+          "readOnly": true
+        },
+        "ingressNatRules": {
+          "type": "array",
+          "description": "List of ingress NatRules.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "egressNatRules": {
+          "type": "array",
+          "description": "List of egress NatRules.",
+          "items": {
+            "$ref": "./common.json#/definitions/SubResource"
+          }
+        },
+        "dpdTimeoutSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Dead Peer Detection timeout in seconds for VpnLink connection."
+        }
+      }
+    },
+    "VpnSiteLinkProperties": {
+      "type": "object",
+      "description": "Parameters for VpnSite.",
+      "properties": {
+        "linkProperties": {
+          "$ref": "#/definitions/VpnLinkProviderProperties",
+          "description": "The link provider properties."
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "The ip-address for the vpn-site-link."
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "FQDN of vpn-site-link."
+        },
+        "bgpProperties": {
+          "$ref": "#/definitions/VpnLinkBgpSettings",
+          "description": "The set of bgp properties."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the VPN site link resource.",
+          "readOnly": true
+        }
+      }
+    },
+    "VpnSiteProperties": {
+      "type": "object",
+      "description": "Parameters for VpnSite.",
+      "properties": {
+        "virtualWan": {
+          "$ref": "./common.json#/definitions/SubResource",
+          "description": "The VirtualWAN to which the vpnSite belongs."
+        },
+        "deviceProperties": {
+          "$ref": "#/definitions/DeviceProperties",
+          "description": "The device properties."
+        },
+        "ipAddress": {
+          "type": "string",
+          "description": "The ip-address for the vpn-site."
+        },
+        "siteKey": {
+          "type": "string",
+          "description": "The key for vpn-site that can be used for connections."
+        },
+        "addressSpace": {
+          "$ref": "./virtualNetwork.json#/definitions/AddressSpace",
+          "description": "The AddressSpace that contains an array of IP address ranges."
+        },
+        "bgpProperties": {
+          "$ref": "./networkGateway.json#/definitions/BgpSettings",
+          "description": "The set of bgp properties."
+        },
+        "provisioningState": {
+          "$ref": "./common.json#/definitions/ProvisioningState",
+          "description": "The provisioning state of the VPN site resource.",
+          "readOnly": true
+        },
+        "isSecuritySite": {
+          "type": "boolean",
+          "description": "IsSecuritySite flag."
+        },
+        "vpnSiteLinks": {
+          "type": "array",
+          "description": "List of all vpn site links.",
+          "items": {
+            "$ref": "#/definitions/VpnSiteLink"
+          }
+        },
+        "o365Policy": {
+          "$ref": "#/definitions/O365PolicyProperties",
+          "description": "Office365 Policy."
+        }
+      }
+    }
+  },
+  "parameters": {}
+}


### PR DESCRIPTION
## Summary
- Adds Microsoft.Network API version `2026-08-01-preview`.
- Adds NSP `createMode` and immutable `remotePerimeterId` for geo-linked perimeter creation.
- Adds the service-managed `Dormant` NSP link status.
- Adds and validates NSP examples and generated OpenAPI artifacts.

## Validation
- TypeSpec compilation completed successfully.
- `oav validate-spec` completed successfully for `networkSecurityPerimeter.json`.
- `oav validate-example` completed successfully for NSP examples.

## Related work
- NSP BCDR WI-4: Geo-Linked Perimeter creation and chaining.