### PR TITLE
Preserve Java DPS resource parameter order

### DIFF
--- a/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/client.tsp
+++ b/specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices/client.tsp
@@ -286,7 +286,7 @@ op IotDpsResourceDeleteCustomized(
 @@override(
   ProvisioningServiceDescriptions.delete,
   IotDpsResourceDeleteCustomized,
-  "python,go,java"
+  "python,go"
 );
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Change the base type back to TrackedResource for backward compatibility"
@@ -409,7 +409,7 @@ op IotDpsResourceGetCustomized(
 @@override(
   ProvisioningServiceDescriptions.get,
   IotDpsResourceGetCustomized,
-  "python,go,java"
+  "python,go"
 );
 
 #suppress "@azure-tools/typespec-azure-core/casing-style" "customization"


### PR DESCRIPTION
## Summary

- exclude Java from the customized Device Provisioning Service `get` and `delete` operations
- preserve Java's existing resource-group-first parameter order

PR https://github.com/Azure/azure-sdk-for-java/pull/47048 regenerated these methods with both `String` parameters reversed while handwritten tests retained the previous order, causing runtime requests with swapped resource and resource-group names.

## Validation

- `tsp compile specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices --no-emit`
