### PR TITLE
Add multi-tool suppression lookup

### DIFF
--- a/.github/shared/package.json
+++ b/.github/shared/package.json
@@ -23,6 +23,7 @@
     "./spec-model-error": "./src/spec-model-error.js",
     "./spec-model": "./src/spec-model.js",
     "./swagger": "./src/swagger.js",
+    "./swagger-suppressions": "./src/swagger-suppressions.js",
     "./tag": "./src/tag.js",
     "./time": "./src/time.js",
     "./test/examples": "./test/examples.js"

--- a/.github/shared/src/swagger-suppressions.js
+++ b/.github/shared/src/swagger-suppressions.js
@@ -1,0 +1,8 @@
+export const SWAGGER_SUPPRESSION_TOOLS = Object.freeze({
+  lintDiff: "SwaggerLintDiff",
+  modelValidation: "SwaggerModelValidation",
+  semanticValidation: "SwaggerSemanticValidation",
+  breakingChange: "SwaggerBreakingChange",
+  breakingChangeCrossVersion: "SwaggerBreakingChangeCrossVersion",
+  all: "SwaggerAll",
+});

--- a/eng/tools/suppressions/README.md
+++ b/eng/tools/suppressions/README.md
@@ -71,7 +71,7 @@ npx get-suppressions TypeSpecRequirement specification/foo/data-plane/Foo/stable
 
 ### Library
 
-The package also exposes `getSuppressions` for programmatic use:
+The package exposes `getSuppressions` and `getSuppressionsForTools` for programmatic use:
 
 ```ts
 import { getSuppressions, Suppression } from "@azure-tools/suppressions";
@@ -84,6 +84,37 @@ const suppressions: Suppression[] = await getSuppressions(
 
 `getSuppressions(tool, path)` resolves `path`, throws if it does not exist, walks up the directory
 tree collecting `suppressions.yaml` files, and returns the matching `Suppression[]`.
+
+Use `getSuppressionsForTools(tools, path)` when a check recognizes multiple tool names:
+
+```ts
+import { getSuppressionsForTools } from "@azure-tools/suppressions";
+
+const suppressions = await getSuppressionsForTools(
+  ["SwaggerLintDiff", "SwaggerAll"],
+  "specification/foo/data-plane/Foo/stable/2023-01-01/Foo.json",
+);
+```
+
+The function checks unique tool names in the order provided and returns all matching entries.
+Callers remain responsible for interpreting rule-scoped suppressions.
+
+A directory glob can suppress every Swagger file below an API-version folder:
+
+```yaml
+- tool: SwaggerLintDiff
+  path: data-plane/Foo/stable/2023-01-01/**
+  reason: Temporarily skip LintDiff for this API version.
+```
+
+Swagger wrappers recognize these tool names:
+
+- `SwaggerLintDiff`
+- `SwaggerModelValidation`
+- `SwaggerSemanticValidation`
+- `SwaggerBreakingChange`
+- `SwaggerBreakingChangeCrossVersion`
+- `SwaggerAll` for all of the wrappers above
 
 ## Folder structure & contributing
 
@@ -101,9 +132,9 @@ eng/tools/suppressions
 ### `src`
 
 - [`src/suppressions.ts`](./src/suppressions.ts) — the core implementation: `getSuppressions`,
-  `getSuppressionsFromYaml`, the `Suppression` type, and the zod schema that validates
-  `suppressions.yaml`.
-- [`src/index.ts`](./src/index.ts) — the package entry point. Exports `getSuppressions` and
+  `getSuppressionsForTools`, `getSuppressionsFromYaml`, the `Suppression` type, and the zod schema
+  that validates `suppressions.yaml`.
+- [`src/index.ts`](./src/index.ts) — the package entry point. Exports the suppression APIs and
   `Suppression`, and provides `main` for the CLI.
 
 ### `cmd`

--- a/eng/tools/suppressions/src/index.ts
+++ b/eng/tools/suppressions/src/index.ts
@@ -1,5 +1,5 @@
 import { exit } from "process";
-import { getSuppressions, type Suppression } from "./suppressions.ts";
+import { getSuppressions, getSuppressionsForTools, type Suppression } from "./suppressions.ts";
 
 function getUsage(): string {
   return (
@@ -29,4 +29,4 @@ export async function main() {
   }
 }
 
-export { getSuppressions, type Suppression };
+export { getSuppressions, getSuppressionsForTools, type Suppression };

--- a/eng/tools/suppressions/src/suppressions.ts
+++ b/eng/tools/suppressions/src/suppressions.ts
@@ -104,6 +104,28 @@ export async function getSuppressions(
 }
 
 /**
+ * Returns the suppressions for any of the specified tools applicable to a path.
+ *
+ * Tool names are evaluated in the order provided. Duplicate names are ignored.
+ *
+ * @param tools Names of tools. Matched against property "tool" in suppressions.yaml.
+ * @param path Path to file or directory under analysis.
+ * @param context Values made available to conditional suppressions.
+ * @returns Array of suppressions matching any tool and path (may be empty).
+ */
+export async function getSuppressionsForTools(
+  tools: readonly string[],
+  path: string,
+  context: Record<string, unknown> = {},
+): Promise<Suppression[]> {
+  return (
+    await Promise.all(
+      [...new Set(tools)].map(async (tool) => await getSuppressions(tool, path, context)),
+    )
+  ).flat();
+}
+
+/**
  * Returns the suppressions for a tool applicable to a path, given the path and content of the suppressions.yaml.
  * Extracted for unit testing.
  *

--- a/eng/tools/suppressions/test/e2e/suppressFooJson/suppressions.yaml
+++ b/eng/tools/suppressions/test/e2e/suppressFooJson/suppressions.yaml
@@ -1,3 +1,7 @@
 - tool: TestTool
   path: foo.json
   reason: test
+
+- tool: TestTool2
+  path: foo.json
+  reason: test 2

--- a/eng/tools/suppressions/test/suppressions.e2e.test.ts
+++ b/eng/tools/suppressions/test/suppressions.e2e.test.ts
@@ -1,6 +1,6 @@
 import { join } from "path";
 import { expect, test } from "vitest";
-import { type Suppression, getSuppressions } from "../src/suppressions.ts";
+import { type Suppression, getSuppressions, getSuppressionsForTools } from "../src/suppressions.ts";
 
 /**
  * Returns the suppressions for a tool (default "TestTool") applicable to a path under folder "e2e".
@@ -51,7 +51,33 @@ test.concurrent("suppress foo.json, get foo.json w/ different tool", async () =>
     join("suppressFooJson", "foo.json"),
     "TestTool2",
   );
-  expect(suppressions).toEqual([]);
+  expect(suppressions).toEqual([
+    {
+      tool: "TestTool2",
+      paths: ["foo.json"],
+      reason: "test 2",
+    },
+  ]);
+});
+
+test.concurrent("get suppressions for multiple tools", async () => {
+  const suppressions = await getSuppressionsForTools(
+    ["TestTool2", "TestTool", "TestTool2"],
+    join(__dirname, "e2e", "suppressFooJson", "foo.json"),
+  );
+
+  expect(suppressions).toEqual([
+    {
+      tool: "TestTool2",
+      paths: ["foo.json"],
+      reason: "test 2",
+    },
+    {
+      tool: "TestTool",
+      paths: ["foo.json"],
+      reason: "test",
+    },
+  ]);
 });
 
 test.concurrent("merge, get bar.json", async () => {

--- a/eng/tools/suppressions/test/suppressions.e2e.test.ts
+++ b/eng/tools/suppressions/test/suppressions.e2e.test.ts
@@ -49,15 +49,9 @@ test.concurrent("suppress foo.json, get bar.json", async () => {
 test.concurrent("suppress foo.json, get foo.json w/ different tool", async () => {
   const suppressions: Suppression[] = await getTestSuppressions(
     join("suppressFooJson", "foo.json"),
-    "TestTool2",
+    "TestToolNotExist",
   );
-  expect(suppressions).toEqual([
-    {
-      tool: "TestTool2",
-      paths: ["foo.json"],
-      reason: "test 2",
-    },
-  ]);
+  expect(suppressions).toEqual([]);
 });
 
 test.concurrent("get suppressions for multiple tools", async () => {


### PR DESCRIPTION
## Summary
- add getSuppressionsForTools for checks that recognize multiple suppression names
- add shared Swagger suppression identifiers, including SwaggerAll
- document multi-tool and directory suppression usage

## Stack
1. #45372 - core suppressions support
2. #45373 - OAV runner integration
3. #45374 - LintDiff integration
4. #45375 - breaking-change integration