### PR TITLE
Remove minItems constraint from RunAfter.items (Chaos preview versions)

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -6273,7 +6273,6 @@
         "items": {
           "type": "array",
           "description": "Array of action dependencies.",
-          "minItems": 1,
           "items": {
             "$ref": "#/definitions/ActionDependency"
           },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/openapi.json
@@ -6739,7 +6739,6 @@
         "items": {
           "type": "array",
           "description": "Array of action dependencies.",
-          "minItems": 1,
           "items": {
             "$ref": "#/definitions/ActionDependency"
           },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenario.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenario.models.tsp
@@ -207,7 +207,6 @@ model RunAfter {
   /**
    * Array of action dependencies.
    */
-  @minItems(1)
   @identifiers(#["name"])
   items: ActionDependency[];
 }


### PR DESCRIPTION
### Summary

Removes `minItems: 1` from `RunAfter.items` in `2026-05-01-preview` and `2026-08-01-preview`.

### Why this is a spec bug fix

The spec declared `minItems: 1` on `RunAfter.items`, but the Chaos service backend **never enforced this constraint**. The generated backend baseline did not validate it, so clients have always been able to send `runAfter` with an empty `items` array successfully.

This divergence was latent until a recent model simplification regenerated validation directly from the spec. That regeneration began enforcing `minItems`, which broke the Azure portal for scenarios sending an empty `items` array.

This change **realigns the spec with actual, long-standing service behavior**. It does not change what the service accepts - it corrects the spec to describe what the service has always done.

### Impact

- **Constraint relaxation only.** No request that was previously valid becomes invalid.
- **Preview versions only.** Stable `2025-01-01` is unaffected - `RunAfter` does not exist in that version.
- No client that worked before stops working. Clients that were incorrectly blocked by spec-derived validation are unblocked.

### Requested approval

`BreakingChange-Approved-BugFix` - the spec described a constraint the service never implemented.

### Changes

- `scenario.models.tsp` - removed `@minItems(1)` from `RunAfter.items`
- Regenerated `openapi.json` for both preview versions

`Scenario.actions` `minItems: 1` is intentionally unchanged.
