### PR TITLE
feat(routines): add dispatch authorization

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -12404,6 +12404,12 @@
                 "model": {
                   "contentType": "text/plain"
                 },
+                "languages": {
+                  "contentType": "application/json"
+                },
+                "keywords": {
+                  "contentType": "application/json"
+                },
                 "response_format": {
                   "contentType": "application/json"
                 },
@@ -19111,16 +19117,24 @@
                       "deprecated": true
                     },
                     "safety_identifier": {
-                      "type": "string",
-                      "maxLength": 64,
-                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     },
                     "prompt_cache_key": {
-                      "type": "string",
-                      "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-                    },
-                    "service_tier": {
-                      "$ref": "#/components/schemas/OpenAI.ServiceTier"
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     },
                     "prompt_cache_retention": {
                       "anyOf": [
@@ -19189,6 +19203,9 @@
                     },
                     "prompt": {
                       "$ref": "#/components/schemas/OpenAI.Prompt"
+                    },
+                    "service_tier": {
+                      "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                     },
                     "truncation": {
                       "anyOf": [
@@ -19334,7 +19351,7 @@
                     "conversation": {
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/OpenAI.ConversationReference"
+                          "$ref": "#/components/schemas/OpenAI.ResponseConversation"
                         },
                         {
                           "type": "null"
@@ -19478,16 +19495,24 @@
                     "deprecated": true
                   },
                   "safety_identifier": {
-                    "type": "string",
-                    "maxLength": 64,
-                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "prompt_cache_key": {
-                    "type": "string",
-                    "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-                  },
-                  "service_tier": {
-                    "$ref": "#/components/schemas/OpenAI.ServiceTier"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "prompt_cache_retention": {
                     "anyOf": [
@@ -19559,6 +19584,9 @@
                   },
                   "prompt": {
                     "$ref": "#/components/schemas/OpenAI.Prompt"
+                  },
+                  "service_tier": {
+                    "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                   },
                   "truncation": {
                     "anyOf": [
@@ -41104,6 +41132,8 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
+                  "gpt-transcribe",
+                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -41112,11 +41142,26 @@
                 ]
               }
             ],
-            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
+            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -41147,6 +41192,8 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
+                  "gpt-transcribe",
+                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -41155,11 +41202,19 @@
                 ]
               }
             ],
-            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
+            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio."
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "description": "The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format."
           },
           "prompt": {
             "type": "string",
@@ -43553,6 +43608,9 @@
           "reasoning_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
+          "text_tokens": {
+            "$ref": "#/components/schemas/OpenAI.integer"
+          },
           "rejected_prediction_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           }
@@ -43565,6 +43623,12 @@
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cached_tokens": {
+            "$ref": "#/components/schemas/OpenAI.integer"
+          },
+          "text_tokens": {
+            "$ref": "#/components/schemas/OpenAI.integer"
+          },
+          "image_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cache_write_tokens": {
@@ -45161,7 +45225,6 @@
         "required": [
           "id",
           "type",
-          "call_id",
           "output"
         ],
         "properties": {
@@ -45181,6 +45244,14 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the tool that produced the output."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -45597,7 +45668,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -46061,20 +46133,6 @@
         "description": "The conversation that this response belongs to.",
         "title": "Conversation object"
       },
-      "OpenAI.ConversationReference": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the conversation that this response was associated with."
-          }
-        },
-        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
-        "title": "Conversation"
-      },
       "OpenAI.ConversationResource": {
         "type": "object",
         "required": [
@@ -46476,16 +46534,24 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "type": "string",
-            "maxLength": 64,
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "prompt_cache_key": {
-            "type": "string",
-            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTier"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -46516,6 +46582,9 @@
           "model": {
             "type": "string",
             "description": "The model deployment to use for this chat completion."
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "modalities": {
             "$ref": "#/components/schemas/OpenAI.ResponseModalities"
@@ -46945,6 +47014,16 @@
           "model": {
             "type": "string",
             "description": "The model deployment used for the creation of this chat completion."
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.Metadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "service_tier": {
             "$ref": "#/components/schemas/OpenAI.ServiceTier"
@@ -48355,7 +48434,7 @@
                 }
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
           },
           "prompt": {
             "type": "string",
@@ -48378,7 +48457,7 @@
                 "type": "null"
               }
             ],
-            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`."
+            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`."
           },
           "model": {
             "anyOf": [
@@ -48389,6 +48468,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
@@ -48399,7 +48480,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -48548,6 +48629,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "dall-e-3",
                   "gpt-image-1",
@@ -48558,7 +48641,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
             "x-oaiTypeLabel": "string",
             "default": "dall-e-2"
           },
@@ -48710,7 +48793,7 @@
                 "type": "null"
               }
             ],
-            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`.",
+            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`.",
             "default": "auto"
           },
           "style": {
@@ -50064,7 +50147,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
+            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n  The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -50076,6 +50159,7 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
+                  "gpt-transcribe",
                   "gpt-4o-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
@@ -50083,12 +50167,26 @@
                 ]
               }
             ],
-            "description": "ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
+            "description": "ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
             "x-oaiTypeLabel": "string"
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency."
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`."
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -50216,6 +50314,13 @@
             "type": "string",
             "description": "The transcribed text."
           },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.TranscriptionLanguage"
+            },
+            "description": "The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected."
+          },
           "logprobs": {
             "type": "array",
             "items": {
@@ -50335,7 +50440,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
+            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -51444,6 +51549,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "gpt-image-1",
                   "gpt-image-1-mini",
                   "chatgpt-image-latest"
@@ -51453,7 +51560,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image editing.",
+            "description": "The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.",
             "x-oaiTypeLabel": "string",
             "default": "gpt-image-1.5"
           },
@@ -51600,7 +51707,7 @@
                 "type": "null"
               }
             ],
-            "description": "Background behavior for generated image output.",
+            "description": "Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.",
             "default": "auto"
           },
           "stream": {
@@ -55142,7 +55249,9 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5"
+                  "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21"
                 ]
               }
             ],
@@ -55210,7 +55319,7 @@
               "opaque",
               "auto"
             ],
-            "description": "Background type for the generated image. One of `transparent`,\n  `opaque`, or `auto`. Default: `auto`.",
+            "description": "Set the background of the generated image. One of `transparent`,\n  `opaque`, or `auto`. Transparent backgrounds are available for\n  supported GPT Image models. For `gpt-image-2` and\n  `gpt-image-2-2026-04-21`, this support is in preview. When using\n  `transparent`, set the output format to `png` or `webp`. Default: `auto`.",
             "default": "auto"
           },
           "input_fidelity": {
@@ -56280,7 +56389,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 10485760,
+            "maxLength": 20971520,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -56594,7 +56703,6 @@
       "OpenAI.InputItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
-          "call_id",
           "type",
           "output"
         ],
@@ -56610,10 +56718,14 @@
             ]
           },
           "call_id": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 64,
-            "description": "The unique ID of the function tool call generated by the model."
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "type": {
             "type": "string",
@@ -56647,6 +56759,26 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "caller": {
             "anyOf": [
@@ -57230,7 +57362,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -58013,7 +58146,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 10485760,
+            "maxLength": 20971520,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -59085,7 +59218,6 @@
         "required": [
           "id",
           "type",
-          "call_id",
           "output"
         ],
         "properties": {
@@ -59105,6 +59237,14 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the tool that produced the output."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -59474,7 +59614,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -59977,7 +60118,6 @@
       "OpenAI.ItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
-          "call_id",
           "type",
           "output"
         ],
@@ -59993,10 +60133,14 @@
             ]
           },
           "call_id": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 64,
-            "description": "The unique ID of the function tool call generated by the model."
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "type": {
             "type": "string",
@@ -60030,6 +60174,26 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "caller": {
             "anyOf": [
@@ -60666,7 +60830,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -61685,7 +61850,6 @@
         "required": [
           "id",
           "type",
-          "call_id",
           "output"
         ],
         "properties": {
@@ -61705,6 +61869,14 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the tool that produced the output."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -62127,7 +62299,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -64002,9 +64175,7 @@
         "type": "object",
         "required": [
           "type",
-          "text",
-          "annotations",
-          "logprobs"
+          "text"
         ],
         "properties": {
           "type": {
@@ -64615,13 +64786,25 @@
           "owned_by": {
             "type": "string",
             "description": "The organization that owns the model."
+          },
+          "shutdown_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The date when the model will shut down, or null if not announced."
           }
         },
         "description": "Describes an OpenAI model offering that can be used with the API.",
         "title": "Model",
         "x-oaiMeta": {
           "name": "The model object",
-          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
+          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\",\n  \"shutdown_date\": \"2026-10-23\"\n}\n"
         }
       },
       "OpenAI.Moderation": {
@@ -65233,7 +65416,6 @@
           },
           "description": {
             "type": "string",
-            "minLength": 1,
             "description": "A description of the namespace shown to the model."
           },
           "tools": {
@@ -65400,9 +65582,7 @@
         "type": "object",
         "required": [
           "type",
-          "text",
-          "annotations",
-          "logprobs"
+          "text"
         ],
         "properties": {
           "type": {
@@ -66382,7 +66562,6 @@
         "required": [
           "id",
           "type",
-          "call_id",
           "output"
         ],
         "properties": {
@@ -66402,6 +66581,14 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the tool that produced the output."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -66771,7 +66958,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -67264,9 +67452,7 @@
         "type": "object",
         "required": [
           "type",
-          "text",
-          "annotations",
-          "logprobs"
+          "text"
         ],
         "properties": {
           "type": {
@@ -67778,6 +67964,7 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
+            "message": "#/components/schemas/OpenAI.RealtimeConversationItemMessage",
             "function_call": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall",
             "function_call_output": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput",
             "mcp_approval_response": "#/components/schemas/OpenAI.RealtimeMCPApprovalResponse",
@@ -67939,6 +68126,351 @@
           ]
         }
       },
+      "OpenAI.RealtimeConversationItemMessage": {
+        "type": "object",
+        "required": [
+          "role",
+          "type"
+        ],
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageType"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ]
+          }
+        },
+        "discriminator": {
+          "propertyName": "role",
+          "mapping": {
+            "system": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem",
+            "user": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUser",
+            "assistant": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItem"
+          }
+        ]
+      },
+      "OpenAI.RealtimeConversationItemMessageAssistant": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "realtime.item"
+            ],
+            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
+            "x-stainless-const": true
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the item. Always `message`.",
+            "x-stainless-const": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "incomplete",
+              "in_progress"
+            ],
+            "description": "The status of the item. Has no effect on the conversation."
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "assistant"
+            ],
+            "description": "The role of the message sender. Always `assistant`.",
+            "x-stainless-const": true
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent"
+            },
+            "description": "The content of the message."
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
+            "readOnly": true
+          },
+          "response_id": {
+            "type": "string",
+            "description": "The id of the response that produced this item, when applicable.",
+            "readOnly": true
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
+          }
+        ],
+        "description": "An assistant message item in a Realtime conversation.",
+        "title": "Realtime assistant message item",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "OpenAI.RealtimeConversationItemMessageAssistantContent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "output_text",
+              "output_audio"
+            ]
+          },
+          "text": {
+            "type": "string"
+          },
+          "audio": {
+            "type": "string"
+          },
+          "transcript": {
+            "type": "string"
+          }
+        }
+      },
+      "OpenAI.RealtimeConversationItemMessageSystem": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "realtime.item"
+            ],
+            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
+            "x-stainless-const": true
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the item. Always `message`.",
+            "x-stainless-const": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "incomplete",
+              "in_progress"
+            ],
+            "description": "The status of the item. Has no effect on the conversation."
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "system"
+            ],
+            "description": "The role of the message sender. Always `system`.",
+            "x-stainless-const": true
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent"
+            },
+            "description": "The content of the message."
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
+            "readOnly": true
+          },
+          "response_id": {
+            "type": "string",
+            "description": "The id of the response that produced this item, when applicable.",
+            "readOnly": true
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
+          }
+        ],
+        "description": "A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. \"the user is now asking about a different topic\"), use system messages.",
+        "title": "Realtime system message item",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "OpenAI.RealtimeConversationItemMessageSystemContent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "input_text"
+            ],
+            "x-stainless-const": true
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "OpenAI.RealtimeConversationItemMessageType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "system",
+              "user",
+              "assistant"
+            ]
+          }
+        ]
+      },
+      "OpenAI.RealtimeConversationItemMessageUser": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "realtime.item"
+            ],
+            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
+            "x-stainless-const": true
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the item. Always `message`.",
+            "x-stainless-const": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "incomplete",
+              "in_progress"
+            ],
+            "description": "The status of the item. Has no effect on the conversation."
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user"
+            ],
+            "description": "The role of the message sender. Always `user`.",
+            "x-stainless-const": true
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent"
+            },
+            "description": "The content of the message."
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
+            "readOnly": true
+          },
+          "response_id": {
+            "type": "string",
+            "description": "The id of the response that produced this item, when applicable.",
+            "readOnly": true
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
+          }
+        ],
+        "description": "A user message item in a Realtime conversation.",
+        "title": "Realtime user message item",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "OpenAI.RealtimeConversationItemMessageUserContent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "input_text",
+              "input_audio",
+              "input_image"
+            ]
+          },
+          "text": {
+            "type": "string"
+          },
+          "audio": {
+            "type": "string"
+          },
+          "image_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "detail": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "low",
+              "high"
+            ],
+            "default": "auto"
+          },
+          "transcript": {
+            "type": "string"
+          }
+        }
+      },
       "OpenAI.RealtimeConversationItemType": {
         "anyOf": [
           {
@@ -67952,7 +68484,8 @@
               "mcp_approval_response",
               "mcp_list_tools",
               "mcp_call",
-              "mcp_approval_request"
+              "mcp_approval_request",
+              "message"
             ]
           }
         ]
@@ -70076,16 +70609,24 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "type": "string",
-            "maxLength": 64,
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "prompt_cache_key": {
-            "type": "string",
-            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTier"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -70154,6 +70695,9 @@
           },
           "prompt": {
             "$ref": "#/components/schemas/OpenAI.Prompt"
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
           },
           "truncation": {
             "anyOf": [
@@ -70299,7 +70843,7 @@
           "conversation": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.ConversationReference"
+                "$ref": "#/components/schemas/OpenAI.ResponseConversation"
               },
               {
                 "type": "null"
@@ -70846,6 +71390,20 @@
           "example": "{\n  \"type\": \"response.content_part.done\",\n  \"item_id\": \"msg_123\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"sequence_number\": 1,\n  \"part\": {\n    \"type\": \"output_text\",\n    \"text\": \"In a shimmering forest under a sky full of stars, a lonely unicorn named Lila discovered a hidden pond that glowed with moonlight. Every night, she would leave sparkling, magical flowers by the water's edge, hoping to share her beauty with others. One enchanting evening, she woke to find a group of friendly animals gathered around, eager to be friends and share in her magic.\",\n    \"annotations\": []\n  }\n}\n"
         }
       },
+      "OpenAI.ResponseConversation": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the conversation that this response was associated with."
+          }
+        },
+        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
+        "title": "Conversation"
+      },
       "OpenAI.ResponseCreatedEvent": {
         "type": "object",
         "required": [
@@ -71002,6 +71560,7 @@
           "server_error",
           "rate_limit_exceeded",
           "invalid_prompt",
+          "data_residency_mismatch",
           "bio_policy",
           "vector_store_timeout",
           "invalid_image",
@@ -71606,6 +72165,22 @@
           "partial_image_b64": {
             "type": "string",
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
+          },
+          "size": {
+            "type": "string",
+            "description": "The image size that was used."
+          },
+          "quality": {
+            "type": "string",
+            "description": "The image quality that was used."
+          },
+          "background": {
+            "type": "string",
+            "description": "The background setting that was used."
+          },
+          "output_format": {
+            "type": "string",
+            "description": "The output format that was used."
           }
         },
         "allOf": [
@@ -72142,7 +72717,7 @@
           },
           "item": {
             "$ref": "#/components/schemas/OpenAI.OutputItem",
-            "description": "The output item that was added."
+            "description": "The output item that was added. For reasoning items, `encrypted_content`\n  may be incomplete while the item is in progress. Use the reasoning item\n  from the corresponding `response.output_item.done` event when passing it\n  as input to a subsequent request."
           }
         },
         "allOf": [
@@ -72254,7 +72829,7 @@
         "x-oaiMeta": {
           "name": "response.output_text.annotation.added",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"text_annotation\",\n    \"text\": \"This is a test annotation\",\n    \"start\": 0,\n    \"end\": 10\n  },\n  \"sequence_number\": 1\n}\n"
+          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"file_citation\",\n    \"file_id\": \"file-abc\",\n    \"index\": 0,\n    \"filename\": \"example.txt\"\n  },\n  \"sequence_number\": 1\n}\n"
         }
       },
       "OpenAI.ResponsePromptVariables": {
@@ -72779,6 +73354,238 @@
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
       },
+      "OpenAI.ResponseShellCallCommandAddedStreamingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "sequence_number",
+          "output_index",
+          "command_index",
+          "command"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "response.shell_call_command.added"
+            ],
+            "description": "The type of the event, always `response.shell_call_command.added`.",
+            "x-stainless-const": true
+          },
+          "sequence_number": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The sequence number of the event that was emitted."
+          },
+          "output_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the output item that was updated."
+          },
+          "command_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the shell command that was added."
+          },
+          "command": {
+            "type": "string",
+            "description": "The shell command that was added."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
+          }
+        ],
+        "description": "A streaming event that indicated a shell command was added to a tool call.",
+        "title": "Response shell command added event"
+      },
+      "OpenAI.ResponseShellCallCommandDeltaStreamingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "sequence_number",
+          "output_index",
+          "command_index",
+          "delta"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "response.shell_call_command.delta"
+            ],
+            "description": "The type of the event, always `response.shell_call_command.delta`.",
+            "x-stainless-const": true
+          },
+          "sequence_number": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The sequence number of the event that was emitted."
+          },
+          "output_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the output item that was updated."
+          },
+          "command_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the shell command that was updated."
+          },
+          "delta": {
+            "type": "string",
+            "description": "The shell command delta that was appended."
+          },
+          "obfuscation": {
+            "type": "string",
+            "description": "An obfuscation string that was added to pad the event payload."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
+          }
+        ],
+        "description": "A streaming event that indicated a shell command was incrementally updated.",
+        "title": "Response shell command delta event"
+      },
+      "OpenAI.ResponseShellCallCommandDoneStreamingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "sequence_number",
+          "output_index",
+          "command_index",
+          "command"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "response.shell_call_command.done"
+            ],
+            "description": "The type of the event, always `response.shell_call_command.done`.",
+            "x-stainless-const": true
+          },
+          "sequence_number": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The sequence number of the event that was emitted."
+          },
+          "output_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the output item that was updated."
+          },
+          "command_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the shell command that was completed."
+          },
+          "command": {
+            "type": "string",
+            "description": "The final shell command that was emitted."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
+          }
+        ],
+        "description": "A streaming event that indicated a shell command was completed.",
+        "title": "Response shell command done event"
+      },
+      "OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "sequence_number",
+          "item_id",
+          "output_index",
+          "command_index",
+          "delta"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "response.shell_call_output_content.delta"
+            ],
+            "description": "The type of the event, always `response.shell_call_output_content.delta`.",
+            "x-stainless-const": true
+          },
+          "sequence_number": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The sequence number of the event that was emitted."
+          },
+          "item_id": {
+            "type": "string",
+            "description": "The ID of the output item that was updated."
+          },
+          "output_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the output item that was updated."
+          },
+          "command_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the shell command that produced output."
+          },
+          "delta": {
+            "$ref": "#/components/schemas/OpenAI.ShellCallOutputDelta",
+            "description": "The stdout/stderr delta that was emitted."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
+          }
+        ],
+        "description": "A streaming event that indicated shell call output was incrementally added.",
+        "title": "Response shell call output content delta event"
+      },
+      "OpenAI.ResponseShellCallOutputContentDoneStreamingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "sequence_number",
+          "item_id",
+          "output_index",
+          "command_index",
+          "output"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "response.shell_call_output_content.done"
+            ],
+            "description": "The type of the event, always `response.shell_call_output_content.done`.",
+            "x-stainless-const": true
+          },
+          "sequence_number": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The sequence number of the event that was emitted."
+          },
+          "item_id": {
+            "type": "string",
+            "description": "The ID of the output item that was updated."
+          },
+          "output_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the output item that was updated."
+          },
+          "command_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the shell command that produced output."
+          },
+          "output": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputContent"
+            },
+            "description": "The output contents emitted for the shell command."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
+          }
+        ],
+        "description": "A streaming event that indicated shell call output was completed.",
+        "title": "Response shell call output content done event"
+      },
       "OpenAI.ResponseStreamEvent": {
         "type": "object",
         "required": [
@@ -72839,6 +73646,11 @@
             "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
             "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
             "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
+            "response.shell_call_command.added": "#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent",
+            "response.shell_call_command.delta": "#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent",
+            "response.shell_call_command.done": "#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent",
+            "response.shell_call_output_content.delta": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent",
+            "response.shell_call_output_content.done": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent",
             "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
             "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
             "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
@@ -72846,7 +73658,8 @@
             "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
             "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
           }
-        }
+        },
+        "description": "Event emitted while a response is streamed."
       },
       "OpenAI.ResponseStreamEventType": {
         "anyOf": [
@@ -72875,6 +73688,11 @@
               "response.file_search_call.searching",
               "response.function_call_arguments.delta",
               "response.function_call_arguments.done",
+              "response.shell_call_command.added",
+              "response.shell_call_command.delta",
+              "response.shell_call_command.done",
+              "response.shell_call_output_content.delta",
+              "response.shell_call_output_content.done",
               "response.in_progress",
               "response.failed",
               "response.incomplete",
@@ -74542,23 +75360,60 @@
               "default",
               "flex",
               "scale",
-              "priority"
+              "priority",
+              "fast"
             ]
           },
           {
             "type": "null"
           }
         ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
+        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
       },
       "OpenAI.ServiceTierEnum": {
         "type": "string",
         "enum": [
           "auto",
           "default",
+          "fast",
           "flex",
           "priority"
         ]
+      },
+      "OpenAI.ServiceTierResponses": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "auto",
+              "default",
+              "flex",
+              "scale",
+              "priority",
+              "fast",
+              "ultrafast"
+            ]
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
+      },
+      "OpenAI.ShellCallOutputDelta": {
+        "type": "object",
+        "properties": {
+          "stdout": {
+            "type": "string",
+            "description": "The stdout delta that was emitted."
+          },
+          "stderr": {
+            "type": "string",
+            "description": "The stderr delta that was emitted."
+          }
+        },
+        "description": "A delta of stdout/stderr emitted while a shell call was running.",
+        "title": "Shell call output delta"
       },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
@@ -75836,6 +76691,19 @@
           "logprobs"
         ]
       },
+      "OpenAI.TranscriptionLanguage": {
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "The code of a language detected in the audio."
+          }
+        },
+        "description": "A language detected in transcribed audio."
+      },
       "OpenAI.TranscriptionSegment": {
         "type": "object",
         "required": [
@@ -76910,7 +77778,7 @@
             "type": "null"
           }
         ],
-        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`."
+        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`. The default is\n`medium`."
       },
       "OpenAI.VideoCharacterResource": {
         "type": "object",
@@ -77517,6 +78385,11 @@
               "web_search"
             ],
             "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
+          },
+          "external_web_access": {
+            "type": "boolean",
+            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
+            "default": true
           },
           "filters": {
             "anyOf": [
@@ -83243,6 +84116,21 @@
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
           },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
+          },
           "prompt": {
             "type": "string",
             "description": "An optional text to guide the model's style or continue a previous audio\n  segment.\n  For `whisper-1`, the [prompt is a list of keywords](/docs/guides/speech-to-text#prompting).\n  For `gpt-4o-transcribe` models (excluding `gpt-4o-transcribe-diarize`), the prompt is a free text string, for example \"expect words related to technology\".\n  Prompt is not supported with `gpt-realtime-whisper` in GA Realtime sessions."
@@ -84679,6 +85567,11 @@
             "enum": [
               "web_search"
             ]
+          },
+          "external_web_access": {
+            "type": "boolean",
+            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
+            "default": true
           },
           "filters": {
             "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -79265,7 +79265,8 @@
           },
           "enabled": {
             "type": "boolean",
-            "description": "Whether the routine is enabled."
+            "description": "Whether the routine is enabled. If omitted when creating a new routine, the service defaults this value to true. If omitted on update, the service preserves the existing enabled state.",
+            "default": true
           },
           "triggers": {
             "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -12404,12 +12404,6 @@
                 "model": {
                   "contentType": "text/plain"
                 },
-                "languages": {
-                  "contentType": "application/json"
-                },
-                "keywords": {
-                  "contentType": "application/json"
-                },
                 "response_format": {
                   "contentType": "application/json"
                 },
@@ -19117,24 +19111,16 @@
                       "deprecated": true
                     },
                     "safety_identifier": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
+                      "type": "string",
+                      "maxLength": 64,
+                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                     },
                     "prompt_cache_key": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
+                      "type": "string",
+                      "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                    },
+                    "service_tier": {
+                      "$ref": "#/components/schemas/OpenAI.ServiceTier"
                     },
                     "prompt_cache_retention": {
                       "anyOf": [
@@ -19203,9 +19189,6 @@
                     },
                     "prompt": {
                       "$ref": "#/components/schemas/OpenAI.Prompt"
-                    },
-                    "service_tier": {
-                      "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                     },
                     "truncation": {
                       "anyOf": [
@@ -19351,7 +19334,7 @@
                     "conversation": {
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/OpenAI.ResponseConversation"
+                          "$ref": "#/components/schemas/OpenAI.ConversationReference"
                         },
                         {
                           "type": "null"
@@ -19495,24 +19478,16 @@
                     "deprecated": true
                   },
                   "safety_identifier": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "type": "string",
+                    "maxLength": 64,
+                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                   },
                   "prompt_cache_key": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "type": "string",
+                    "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                  },
+                  "service_tier": {
+                    "$ref": "#/components/schemas/OpenAI.ServiceTier"
                   },
                   "prompt_cache_retention": {
                     "anyOf": [
@@ -19584,9 +19559,6 @@
                   },
                   "prompt": {
                     "$ref": "#/components/schemas/OpenAI.Prompt"
-                  },
-                  "service_tier": {
-                    "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                   },
                   "truncation": {
                     "anyOf": [
@@ -41132,8 +41104,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
-                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -41142,26 +41112,11 @@
                 ]
               }
             ],
-            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
+            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -41192,8 +41147,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
-                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -41202,19 +41155,11 @@
                 ]
               }
             ],
-            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
+            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format."
           },
           "prompt": {
             "type": "string",
@@ -43608,9 +43553,6 @@
           "reasoning_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
-          "text_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
           "rejected_prediction_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           }
@@ -43623,12 +43565,6 @@
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cached_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "text_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "image_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cache_write_tokens": {
@@ -45225,6 +45161,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -45244,14 +45181,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -45668,8 +45597,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -46133,6 +46061,20 @@
         "description": "The conversation that this response belongs to.",
         "title": "Conversation object"
       },
+      "OpenAI.ConversationReference": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the conversation that this response was associated with."
+          }
+        },
+        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
+        "title": "Conversation"
+      },
       "OpenAI.ConversationResource": {
         "type": "object",
         "required": [
@@ -46534,24 +46476,16 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "maxLength": 64,
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -46582,9 +46516,6 @@
           "model": {
             "type": "string",
             "description": "The model deployment to use for this chat completion."
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "modalities": {
             "$ref": "#/components/schemas/OpenAI.ResponseModalities"
@@ -47014,16 +46945,6 @@
           "model": {
             "type": "string",
             "description": "The model deployment used for the creation of this chat completion."
-          },
-          "metadata": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "service_tier": {
             "$ref": "#/components/schemas/OpenAI.ServiceTier"
@@ -48434,7 +48355,7 @@
                 }
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
           },
           "prompt": {
             "type": "string",
@@ -48457,7 +48378,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`."
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`."
           },
           "model": {
             "anyOf": [
@@ -48468,8 +48389,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
@@ -48480,7 +48399,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -48629,8 +48548,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "dall-e-3",
                   "gpt-image-1",
@@ -48641,7 +48558,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
             "x-oaiTypeLabel": "string",
             "default": "dall-e-2"
           },
@@ -48793,7 +48710,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`.",
             "default": "auto"
           },
           "style": {
@@ -50147,7 +50064,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n  The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
+            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -50159,7 +50076,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
                   "gpt-4o-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
@@ -50167,26 +50083,12 @@
                 ]
               }
             ],
-            "description": "ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
+            "description": "ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
             "x-oaiTypeLabel": "string"
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -50314,13 +50216,6 @@
             "type": "string",
             "description": "The transcribed text."
           },
-          "languages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.TranscriptionLanguage"
-            },
-            "description": "The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected."
-          },
           "logprobs": {
             "type": "array",
             "items": {
@@ -50440,7 +50335,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
+            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -51549,8 +51444,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "gpt-image-1",
                   "gpt-image-1-mini",
                   "chatgpt-image-latest"
@@ -51560,7 +51453,7 @@
                 "type": "null"
               }
             ],
-            "description": "The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.",
+            "description": "The model to use for image editing.",
             "x-oaiTypeLabel": "string",
             "default": "gpt-image-1.5"
           },
@@ -51707,7 +51600,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Background behavior for generated image output.",
             "default": "auto"
           },
           "stream": {
@@ -55249,9 +55142,7 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21"
+                  "gpt-image-1.5"
                 ]
               }
             ],
@@ -55319,7 +55210,7 @@
               "opaque",
               "auto"
             ],
-            "description": "Set the background of the generated image. One of `transparent`,\n  `opaque`, or `auto`. Transparent backgrounds are available for\n  supported GPT Image models. For `gpt-image-2` and\n  `gpt-image-2-2026-04-21`, this support is in preview. When using\n  `transparent`, set the output format to `png` or `webp`. Default: `auto`.",
+            "description": "Background type for the generated image. One of `transparent`,\n  `opaque`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "input_fidelity": {
@@ -56389,7 +56280,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -56703,6 +56594,7 @@
       "OpenAI.InputItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
+          "call_id",
           "type",
           "output"
         ],
@@ -56718,14 +56610,10 @@
             ]
           },
           "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "The unique ID of the function tool call generated by the model."
           },
           "type": {
             "type": "string",
@@ -56759,26 +56647,6 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "namespace": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "caller": {
             "anyOf": [
@@ -57362,8 +57230,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -58146,7 +58013,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -59218,6 +59085,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -59237,14 +59105,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -59614,8 +59474,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -60118,6 +59977,7 @@
       "OpenAI.ItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
+          "call_id",
           "type",
           "output"
         ],
@@ -60133,14 +59993,10 @@
             ]
           },
           "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "The unique ID of the function tool call generated by the model."
           },
           "type": {
             "type": "string",
@@ -60174,26 +60030,6 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "namespace": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "caller": {
             "anyOf": [
@@ -60830,8 +60666,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -61850,6 +61685,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -61869,14 +61705,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -62299,8 +62127,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -64175,7 +64002,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -64786,25 +64615,13 @@
           "owned_by": {
             "type": "string",
             "description": "The organization that owns the model."
-          },
-          "shutdown_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The date when the model will shut down, or null if not announced."
           }
         },
         "description": "Describes an OpenAI model offering that can be used with the API.",
         "title": "Model",
         "x-oaiMeta": {
           "name": "The model object",
-          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\",\n  \"shutdown_date\": \"2026-10-23\"\n}\n"
+          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
         }
       },
       "OpenAI.Moderation": {
@@ -65416,6 +65233,7 @@
           },
           "description": {
             "type": "string",
+            "minLength": 1,
             "description": "A description of the namespace shown to the model."
           },
           "tools": {
@@ -65582,7 +65400,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -66562,6 +66382,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -66581,14 +66402,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -66958,8 +66771,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -67452,7 +67264,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -67964,7 +67778,6 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.RealtimeConversationItemMessage",
             "function_call": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall",
             "function_call_output": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput",
             "mcp_approval_response": "#/components/schemas/OpenAI.RealtimeMCPApprovalResponse",
@@ -68126,351 +67939,6 @@
           ]
         }
       },
-      "OpenAI.RealtimeConversationItemMessage": {
-        "type": "object",
-        "required": [
-          "role",
-          "type"
-        ],
-        "properties": {
-          "role": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageType"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ]
-          }
-        },
-        "discriminator": {
-          "propertyName": "role",
-          "mapping": {
-            "system": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem",
-            "user": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUser",
-            "assistant": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItem"
-          }
-        ]
-      },
-      "OpenAI.RealtimeConversationItemMessageAssistant": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "assistant"
-            ],
-            "description": "The role of the message sender. Always `assistant`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "An assistant message item in a Realtime conversation.",
-        "title": "Realtime assistant message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageAssistantContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "output_text",
-              "output_audio"
-            ]
-          },
-          "text": {
-            "type": "string"
-          },
-          "audio": {
-            "type": "string"
-          },
-          "transcript": {
-            "type": "string"
-          }
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageSystem": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "system"
-            ],
-            "description": "The role of the message sender. Always `system`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. \"the user is now asking about a different topic\"), use system messages.",
-        "title": "Realtime system message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageSystemContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "input_text"
-            ],
-            "x-stainless-const": true
-          },
-          "text": {
-            "type": "string"
-          }
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "system",
-              "user",
-              "assistant"
-            ]
-          }
-        ]
-      },
-      "OpenAI.RealtimeConversationItemMessageUser": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user"
-            ],
-            "description": "The role of the message sender. Always `user`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "A user message item in a Realtime conversation.",
-        "title": "Realtime user message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageUserContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "input_text",
-              "input_audio",
-              "input_image"
-            ]
-          },
-          "text": {
-            "type": "string"
-          },
-          "audio": {
-            "type": "string"
-          },
-          "image_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "detail": {
-            "type": "string",
-            "enum": [
-              "auto",
-              "low",
-              "high"
-            ],
-            "default": "auto"
-          },
-          "transcript": {
-            "type": "string"
-          }
-        }
-      },
       "OpenAI.RealtimeConversationItemType": {
         "anyOf": [
           {
@@ -68484,8 +67952,7 @@
               "mcp_approval_response",
               "mcp_list_tools",
               "mcp_call",
-              "mcp_approval_request",
-              "message"
+              "mcp_approval_request"
             ]
           }
         ]
@@ -70609,24 +70076,16 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "maxLength": 64,
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -70695,9 +70154,6 @@
           },
           "prompt": {
             "$ref": "#/components/schemas/OpenAI.Prompt"
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
           },
           "truncation": {
             "anyOf": [
@@ -70843,7 +70299,7 @@
           "conversation": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.ResponseConversation"
+                "$ref": "#/components/schemas/OpenAI.ConversationReference"
               },
               {
                 "type": "null"
@@ -71390,20 +70846,6 @@
           "example": "{\n  \"type\": \"response.content_part.done\",\n  \"item_id\": \"msg_123\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"sequence_number\": 1,\n  \"part\": {\n    \"type\": \"output_text\",\n    \"text\": \"In a shimmering forest under a sky full of stars, a lonely unicorn named Lila discovered a hidden pond that glowed with moonlight. Every night, she would leave sparkling, magical flowers by the water's edge, hoping to share her beauty with others. One enchanting evening, she woke to find a group of friendly animals gathered around, eager to be friends and share in her magic.\",\n    \"annotations\": []\n  }\n}\n"
         }
       },
-      "OpenAI.ResponseConversation": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the conversation that this response was associated with."
-          }
-        },
-        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
-        "title": "Conversation"
-      },
       "OpenAI.ResponseCreatedEvent": {
         "type": "object",
         "required": [
@@ -71560,7 +71002,6 @@
           "server_error",
           "rate_limit_exceeded",
           "invalid_prompt",
-          "data_residency_mismatch",
           "bio_policy",
           "vector_store_timeout",
           "invalid_image",
@@ -72165,22 +71606,6 @@
           "partial_image_b64": {
             "type": "string",
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
-          },
-          "size": {
-            "type": "string",
-            "description": "The image size that was used."
-          },
-          "quality": {
-            "type": "string",
-            "description": "The image quality that was used."
-          },
-          "background": {
-            "type": "string",
-            "description": "The background setting that was used."
-          },
-          "output_format": {
-            "type": "string",
-            "description": "The output format that was used."
           }
         },
         "allOf": [
@@ -72717,7 +72142,7 @@
           },
           "item": {
             "$ref": "#/components/schemas/OpenAI.OutputItem",
-            "description": "The output item that was added. For reasoning items, `encrypted_content`\n  may be incomplete while the item is in progress. Use the reasoning item\n  from the corresponding `response.output_item.done` event when passing it\n  as input to a subsequent request."
+            "description": "The output item that was added."
           }
         },
         "allOf": [
@@ -72829,7 +72254,7 @@
         "x-oaiMeta": {
           "name": "response.output_text.annotation.added",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"file_citation\",\n    \"file_id\": \"file-abc\",\n    \"index\": 0,\n    \"filename\": \"example.txt\"\n  },\n  \"sequence_number\": 1\n}\n"
+          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"text_annotation\",\n    \"text\": \"This is a test annotation\",\n    \"start\": 0,\n    \"end\": 10\n  },\n  \"sequence_number\": 1\n}\n"
         }
       },
       "OpenAI.ResponsePromptVariables": {
@@ -73354,238 +72779,6 @@
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
       },
-      "OpenAI.ResponseShellCallCommandAddedStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "command"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.added"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.added`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was added."
-          },
-          "command": {
-            "type": "string",
-            "description": "The shell command that was added."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was added to a tool call.",
-        "title": "Response shell command added event"
-      },
-      "OpenAI.ResponseShellCallCommandDeltaStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "delta"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.delta"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.delta`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was updated."
-          },
-          "delta": {
-            "type": "string",
-            "description": "The shell command delta that was appended."
-          },
-          "obfuscation": {
-            "type": "string",
-            "description": "An obfuscation string that was added to pad the event payload."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was incrementally updated.",
-        "title": "Response shell command delta event"
-      },
-      "OpenAI.ResponseShellCallCommandDoneStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "command"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.done"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.done`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was completed."
-          },
-          "command": {
-            "type": "string",
-            "description": "The final shell command that was emitted."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was completed.",
-        "title": "Response shell command done event"
-      },
-      "OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "item_id",
-          "output_index",
-          "command_index",
-          "delta"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_output_content.delta"
-            ],
-            "description": "The type of the event, always `response.shell_call_output_content.delta`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "item_id": {
-            "type": "string",
-            "description": "The ID of the output item that was updated."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that produced output."
-          },
-          "delta": {
-            "$ref": "#/components/schemas/OpenAI.ShellCallOutputDelta",
-            "description": "The stdout/stderr delta that was emitted."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated shell call output was incrementally added.",
-        "title": "Response shell call output content delta event"
-      },
-      "OpenAI.ResponseShellCallOutputContentDoneStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "item_id",
-          "output_index",
-          "command_index",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_output_content.done"
-            ],
-            "description": "The type of the event, always `response.shell_call_output_content.done`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "item_id": {
-            "type": "string",
-            "description": "The ID of the output item that was updated."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that produced output."
-          },
-          "output": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputContent"
-            },
-            "description": "The output contents emitted for the shell command."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated shell call output was completed.",
-        "title": "Response shell call output content done event"
-      },
       "OpenAI.ResponseStreamEvent": {
         "type": "object",
         "required": [
@@ -73646,11 +72839,6 @@
             "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
             "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
             "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
-            "response.shell_call_command.added": "#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent",
-            "response.shell_call_command.delta": "#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent",
-            "response.shell_call_command.done": "#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent",
-            "response.shell_call_output_content.delta": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent",
-            "response.shell_call_output_content.done": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent",
             "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
             "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
             "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
@@ -73658,8 +72846,7 @@
             "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
             "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
           }
-        },
-        "description": "Event emitted while a response is streamed."
+        }
       },
       "OpenAI.ResponseStreamEventType": {
         "anyOf": [
@@ -73688,11 +72875,6 @@
               "response.file_search_call.searching",
               "response.function_call_arguments.delta",
               "response.function_call_arguments.done",
-              "response.shell_call_command.added",
-              "response.shell_call_command.delta",
-              "response.shell_call_command.done",
-              "response.shell_call_output_content.delta",
-              "response.shell_call_output_content.done",
               "response.in_progress",
               "response.failed",
               "response.incomplete",
@@ -75360,60 +74542,23 @@
               "default",
               "flex",
               "scale",
-              "priority",
-              "fast"
+              "priority"
             ]
           },
           {
             "type": "null"
           }
         ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
+        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
       },
       "OpenAI.ServiceTierEnum": {
         "type": "string",
         "enum": [
           "auto",
           "default",
-          "fast",
           "flex",
           "priority"
         ]
-      },
-      "OpenAI.ServiceTierResponses": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "auto",
-              "default",
-              "flex",
-              "scale",
-              "priority",
-              "fast",
-              "ultrafast"
-            ]
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
-      },
-      "OpenAI.ShellCallOutputDelta": {
-        "type": "object",
-        "properties": {
-          "stdout": {
-            "type": "string",
-            "description": "The stdout delta that was emitted."
-          },
-          "stderr": {
-            "type": "string",
-            "description": "The stderr delta that was emitted."
-          }
-        },
-        "description": "A delta of stdout/stderr emitted while a shell call was running.",
-        "title": "Shell call output delta"
       },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
@@ -76691,19 +75836,6 @@
           "logprobs"
         ]
       },
-      "OpenAI.TranscriptionLanguage": {
-        "type": "object",
-        "required": [
-          "code"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "The code of a language detected in the audio."
-          }
-        },
-        "description": "A language detected in transcribed audio."
-      },
       "OpenAI.TranscriptionSegment": {
         "type": "object",
         "required": [
@@ -77778,7 +76910,7 @@
             "type": "null"
           }
         ],
-        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`. The default is\n`medium`."
+        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`."
       },
       "OpenAI.VideoCharacterResource": {
         "type": "object",
@@ -78385,11 +77517,6 @@
               "web_search"
             ],
             "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
-          },
-          "external_web_access": {
-            "type": "boolean",
-            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
-            "default": true
           },
           "filters": {
             "anyOf": [
@@ -80112,6 +79239,21 @@
           ]
         }
       },
+      "RoutineAuthorization": {
+        "type": "object",
+        "properties": {
+          "identity": {
+            "$ref": "#/components/schemas/RoutineDispatchIdentity",
+            "description": "The identity used when dispatching the routine. When omitted, dispatch uses the target agent identity."
+          }
+        },
+        "description": "Optional authorization configuration for a routine dispatch.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V2Preview"
+          ]
+        }
+      },
       "RoutineCreateOrUpdateRequest": {
         "type": "object",
         "properties": {
@@ -80134,9 +79276,33 @@
           "action": {
             "$ref": "#/components/schemas/RoutineAction",
             "description": "The action executed when the routine fires."
+          },
+          "authorization": {
+            "$ref": "#/components/schemas/RoutineAuthorization",
+            "description": "Optional authorization configuration for dispatching a newly created routine. Ignored when updating an existing routine."
           }
         },
         "description": "The request body used to create or update a routine.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V2Preview"
+          ]
+        }
+      },
+      "RoutineDispatchIdentity": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "agent",
+              "creator"
+            ]
+          }
+        ],
+        "description": "The supported identities for routine dispatch authorization.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V2Preview"
@@ -84076,21 +83242,6 @@
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
           },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
-          },
           "prompt": {
             "type": "string",
             "description": "An optional text to guide the model's style or continue a previous audio\n  segment.\n  For `whisper-1`, the [prompt is a list of keywords](/docs/guides/speech-to-text#prompting).\n  For `gpt-4o-transcribe` models (excluding `gpt-4o-transcribe-diarize`), the prompt is a free text string, for example \"expect words related to technology\".\n  Prompt is not supported with `gpt-realtime-whisper` in GA Realtime sessions."
@@ -85527,11 +84678,6 @@
             "enum": [
               "web_search"
             ]
-          },
-          "external_web_access": {
-            "type": "boolean",
-            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
-            "default": true
           },
           "filters": {
             "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -79265,8 +79265,7 @@
           },
           "enabled": {
             "type": "boolean",
-            "description": "Whether the routine is enabled. If omitted when creating a new routine, the service defaults this value to true. If omitted on update, the service preserves the existing enabled state.",
-            "default": true
+            "description": "Whether the routine is enabled."
           },
           "triggers": {
             "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -79244,7 +79244,7 @@
         "properties": {
           "identity": {
             "$ref": "#/components/schemas/RoutineDispatchIdentity",
-            "description": "The identity used when dispatching the routine. When omitted, dispatch uses the target agent identity."
+            "description": "The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch."
           }
         },
         "description": "Optional authorization configuration for a routine dispatch.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -79244,7 +79244,8 @@
         "properties": {
           "identity": {
             "$ref": "#/components/schemas/RoutineDispatchIdentity",
-            "description": "The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch."
+            "description": "The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch.",
+            "default": "agent"
           }
         },
         "description": "Optional authorization configuration for a routine dispatch.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -9210,10 +9210,6 @@ paths:
             encoding:
               model:
                 contentType: text/plain
-              languages:
-                contentType: application/json
-              keywords:
-                contentType: application/json
               response_format:
                 contentType: application/json
               temperature:
@@ -25183,13 +25179,16 @@ paths:
                         Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                     deprecated: true
                   safety_identifier:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
+                    type: string
+                    maxLength: 64
+                    description: |-
+                      A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   prompt_cache_key:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
+                    type: string
+                    description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                  service_tier:
+                    $ref: '#/components/schemas/OpenAI.ServiceTier'
                   prompt_cache_retention:
                     anyOf:
                       - type: string
@@ -25223,8 +25222,6 @@ paths:
                       - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                   prompt:
                     $ref: '#/components/schemas/OpenAI.Prompt'
-                  service_tier:
-                    $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                   truncation:
                     anyOf:
                       - type: string
@@ -25314,7 +25311,7 @@ paths:
                     default: true
                   conversation:
                     anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ResponseConversation'
+                      - $ref: '#/components/schemas/OpenAI.ConversationReference'
                       - type: 'null'
                   max_output_tokens:
                     anyOf:
@@ -25396,13 +25393,16 @@ paths:
                       Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   deprecated: true
                 safety_identifier:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
+                  type: string
+                  maxLength: 64
+                  description: |-
+                    A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                 prompt_cache_key:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
+                  type: string
+                  description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                service_tier:
+                  $ref: '#/components/schemas/OpenAI.ServiceTier'
                 prompt_cache_retention:
                   anyOf:
                     - type: string
@@ -25438,8 +25438,6 @@ paths:
                     - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                 prompt:
                   $ref: '#/components/schemas/OpenAI.Prompt'
-                service_tier:
-                  $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                 truncation:
                   anyOf:
                     - type: string
@@ -48579,31 +48577,18 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
-                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
+          description: The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
         language:
           type: string
           description: |-
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -48633,23 +48618,15 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
-                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
+          description: The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
         language:
           type: string
           description: The language of the input audio.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format.
         prompt:
           type: string
           description: The prompt configured for input audio transcription, when present.
@@ -50381,8 +50358,6 @@ components:
           $ref: '#/components/schemas/OpenAI.integer'
         reasoning_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
-        text_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
         rejected_prediction_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
     OpenAI.CompletionUsagePromptTokensDetails:
@@ -50391,10 +50366,6 @@ components:
         audio_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cached_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
-        text_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
-        image_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cache_write_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
@@ -51527,6 +51498,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -51544,12 +51516,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -51837,7 +51803,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -52161,6 +52126,16 @@ components:
           description: The unique ID of the conversation.
       description: The conversation that this response belongs to.
       title: Conversation object
+    OpenAI.ConversationReference:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: The unique ID of the conversation that this response was associated with.
+      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
+      title: Conversation
     OpenAI.ConversationResource:
       type: object
       required:
@@ -52405,13 +52380,16 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          maxLength: 64
+          description: |-
+            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTier'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -52435,8 +52413,6 @@ components:
         model:
           type: string
           description: The model deployment to use for this chat completion.
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTier'
         modalities:
           $ref: '#/components/schemas/OpenAI.ResponseModalities'
         verbosity:
@@ -52763,10 +52739,6 @@ components:
         model:
           type: string
           description: The model deployment used for the creation of this chat completion.
-        metadata:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
         service_tier:
           $ref: '#/components/schemas/OpenAI.ServiceTier'
         system_fingerprint:
@@ -53811,7 +53783,7 @@ components:
                 contentEncoding: base64
           description: |-
             The image(s) to edit. Must be a supported image file or an array of images.
-              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`
+              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`
               file less than 50MB. You can provide up to 16 images.
               `chatgpt-image-latest` follows the same input constraints as GPT image models.
               For `dall-e-2`, you can only provide one image, and it should be a square
@@ -53830,27 +53802,24 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
         model:
           anyOf:
             - type: string
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.
+          description: The model to use for image generation. Defaults to `gpt-image-1.5`.
           x-oaiTypeLabel: string
         'n':
           anyOf:
@@ -53942,14 +53911,12 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - dall-e-3
                 - gpt-image-1
                 - gpt-image-1-mini
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
+          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
           x-oaiTypeLabel: string
           default: dall-e-2
         'n':
@@ -54047,13 +54014,12 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
           default: auto
         style:
           anyOf:
@@ -54947,9 +54913,7 @@ components:
       type: object
       properties:
         file:
-          description: |-
-            The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-              The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
+          description: 'The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -54957,26 +54921,15 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
                 - gpt-4o-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe-diarize
-          description: ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
+          description: ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
           x-oaiTypeLabel: string
         language:
           type: string
           description: The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`.
         prompt:
           type: string
           description: An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text#prompting) should match the audio language. This field is not supported when using `gpt-4o-transcribe-diarize`.
@@ -55094,11 +55047,6 @@ components:
         text:
           type: string
           description: The transcribed text.
-        languages:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.TranscriptionLanguage'
-          description: The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected.
         logprobs:
           type: array
           items:
@@ -55221,7 +55169,7 @@ components:
       type: object
       properties:
         file:
-          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.'
+          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -55978,13 +55926,11 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.
+          description: The model to use for image editing.
           x-oaiTypeLabel: string
           default: gpt-image-1.5
         images:
@@ -56076,7 +56022,7 @@ components:
                 - opaque
                 - auto
             - type: 'null'
-          description: Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.
+          description: Background behavior for generated image output.
           default: auto
         stream:
           anyOf:
@@ -58632,8 +58578,6 @@ components:
                 - gpt-image-1
                 - gpt-image-1-mini
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
           default: gpt-image-1
         quality:
           type: string
@@ -58687,11 +58631,8 @@ components:
             - opaque
             - auto
           description: |-
-            Set the background of the generated image. One of `transparent`,
-              `opaque`, or `auto`. Transparent backgrounds are available for
-              supported GPT Image models. For `gpt-image-2` and
-              `gpt-image-2-2026-04-21`, this support is in preview. When using
-              `transparent`, set the output format to `png` or `webp`. Default: `auto`.
+            Background type for the generated image. One of `transparent`,
+              `opaque`, or `auto`. Default: `auto`.
           default: auto
         input_fidelity:
           anyOf:
@@ -59418,7 +59359,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
@@ -59629,6 +59570,7 @@ components:
     OpenAI.InputItemFunctionCallOutputItemParam:
       type: object
       required:
+        - call_id
         - type
         - output
       properties:
@@ -59637,9 +59579,10 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: The unique ID of the function tool call generated by the model.
         type:
           type: string
           enum:
@@ -59657,14 +59600,6 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
-        name:
-          anyOf:
-            - type: string
-            - type: 'null'
-        namespace:
-          anyOf:
-            - type: string
-            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -60038,7 +59973,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -60562,7 +60496,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
@@ -61298,6 +61232,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -61315,12 +61250,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -61572,7 +61501,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -61927,6 +61855,7 @@ components:
     OpenAI.ItemFunctionCallOutputItemParam:
       type: object
       required:
+        - call_id
         - type
         - output
       properties:
@@ -61935,9 +61864,10 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: The unique ID of the function tool call generated by the model.
         type:
           type: string
           enum:
@@ -61955,14 +61885,6 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
-        name:
-          anyOf:
-            - type: string
-            - type: 'null'
-        namespace:
-          anyOf:
-            - type: string
-            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -62380,7 +62302,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -63094,6 +63015,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -63111,12 +63033,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -63412,7 +63328,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -64771,6 +64686,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -65210,12 +65127,6 @@ components:
         owned_by:
           type: string
           description: The organization that owns the model.
-        shutdown_date:
-          anyOf:
-            - type: string
-              format: date
-            - type: 'null'
-          description: The date when the model will shut down, or null if not announced.
       description: Describes an OpenAI model offering that can be used with the API.
       title: Model
       x-oaiMeta:
@@ -65225,8 +65136,7 @@ components:
             "id": "VAR_chat_model_id",
             "object": "model",
             "created": 1686935002,
-            "owned_by": "openai",
-            "shutdown_date": "2026-10-23"
+            "owned_by": "openai"
           }
     OpenAI.Moderation:
       type: object
@@ -65597,6 +65507,7 @@ components:
           description: The namespace name used in tool calls (for example, `crm`).
         description:
           type: string
+          minLength: 1
           description: A description of the namespace shown to the model.
         tools:
           type: array
@@ -65726,6 +65637,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -66416,6 +66329,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -66433,12 +66347,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -66690,7 +66598,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -67046,6 +66953,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -67400,7 +67309,6 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
           function_call: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall'
           function_call_output: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput'
           mcp_approval_response: '#/components/schemas/OpenAI.RealtimeMCPApprovalResponse'
@@ -67517,248 +67425,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessage:
-      type: object
-      required:
-        - role
-        - type
-      properties:
-        role:
-          $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageType'
-        type:
-          type: string
-          enum:
-            - message
-      discriminator:
-        propertyName: role
-        mapping:
-          system: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem'
-          user: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUser'
-          assistant: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItem'
-    OpenAI.RealtimeConversationItemMessageAssistant:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - assistant
-          description: The role of the message sender. Always `assistant`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: An assistant message item in a Realtime conversation.
-      title: Realtime assistant message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageAssistantContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - output_text
-            - output_audio
-        text:
-          type: string
-        audio:
-          type: string
-        transcript:
-          type: string
-    OpenAI.RealtimeConversationItemMessageSystem:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - system
-          description: The role of the message sender. Always `system`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. "the user is now asking about a different topic"), use system messages.
-      title: Realtime system message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageSystemContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - input_text
-          x-stainless-const: true
-        text:
-          type: string
-    OpenAI.RealtimeConversationItemMessageType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - system
-            - user
-            - assistant
-    OpenAI.RealtimeConversationItemMessageUser:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - user
-          description: The role of the message sender. Always `user`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: A user message item in a Realtime conversation.
-      title: Realtime user message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageUserContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - input_text
-            - input_audio
-            - input_image
-        text:
-          type: string
-        audio:
-          type: string
-        image_url:
-          type: string
-          format: uri
-        detail:
-          type: string
-          enum:
-            - auto
-            - low
-            - high
-          default: auto
-        transcript:
-          type: string
     OpenAI.RealtimeConversationItemType:
       anyOf:
         - type: string
@@ -67770,7 +67436,6 @@ components:
             - mcp_list_tools
             - mcp_call
             - mcp_approval_request
-            - message
     OpenAI.RealtimeCreateClientSecretRequest:
       type: object
       properties:
@@ -69477,13 +69142,16 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          maxLength: 64
+          description: |-
+            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTier'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -69517,8 +69185,6 @@ components:
             - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
         prompt:
           $ref: '#/components/schemas/OpenAI.Prompt'
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
         truncation:
           anyOf:
             - type: string
@@ -69608,7 +69274,7 @@ components:
           default: true
         conversation:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.ResponseConversation'
+            - $ref: '#/components/schemas/OpenAI.ConversationReference'
             - type: 'null'
         max_output_tokens:
           anyOf:
@@ -70120,16 +69786,6 @@ components:
               "annotations": []
             }
           }
-    OpenAI.ResponseConversation:
-      type: object
-      required:
-        - id
-      properties:
-        id:
-          type: string
-          description: The unique ID of the conversation that this response was associated with.
-      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
-      title: Conversation
     OpenAI.ResponseCreatedEvent:
       type: object
       required:
@@ -70293,7 +69949,6 @@ components:
         - server_error
         - rate_limit_exceeded
         - invalid_prompt
-        - data_residency_mismatch
         - bio_policy
         - vector_store_timeout
         - invalid_image
@@ -70825,18 +70480,6 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
-        size:
-          type: string
-          description: The image size that was used.
-        quality:
-          type: string
-          description: The image quality that was used.
-        background:
-          type: string
-          description: The background setting that was used.
-        output_format:
-          type: string
-          description: The output format that was used.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
@@ -71358,11 +71001,7 @@ components:
           description: The sequence number of this event.
         item:
           $ref: '#/components/schemas/OpenAI.OutputItem'
-          description: |-
-            The output item that was added. For reasoning items, `encrypted_content`
-              may be incomplete while the item is in progress. Use the reasoning item
-              from the corresponding `response.output_item.done` event when passing it
-              as input to a subsequent request.
+          description: The output item that was added.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
@@ -71480,10 +71119,10 @@ components:
             "content_index": 0,
             "annotation_index": 0,
             "annotation": {
-              "type": "file_citation",
-              "file_id": "file-abc",
-              "index": 0,
-              "filename": "example.txt"
+              "type": "text_annotation",
+              "text": "This is a test annotation",
+              "start": 0,
+              "end": 10
             },
             "sequence_number": 1
           }
@@ -71952,174 +71591,6 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
-    OpenAI.ResponseShellCallCommandAddedStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - command
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.added
-          description: The type of the event, always `response.shell_call_command.added`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was added.
-        command:
-          type: string
-          description: The shell command that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was added to a tool call.
-      title: Response shell command added event
-    OpenAI.ResponseShellCallCommandDeltaStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - delta
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.delta
-          description: The type of the event, always `response.shell_call_command.delta`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was updated.
-        delta:
-          type: string
-          description: The shell command delta that was appended.
-        obfuscation:
-          type: string
-          description: An obfuscation string that was added to pad the event payload.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was incrementally updated.
-      title: Response shell command delta event
-    OpenAI.ResponseShellCallCommandDoneStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - command
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.done
-          description: The type of the event, always `response.shell_call_command.done`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was completed.
-        command:
-          type: string
-          description: The final shell command that was emitted.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was completed.
-      title: Response shell command done event
-    OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - item_id
-        - output_index
-        - command_index
-        - delta
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_output_content.delta
-          description: The type of the event, always `response.shell_call_output_content.delta`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        item_id:
-          type: string
-          description: The ID of the output item that was updated.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that produced output.
-        delta:
-          $ref: '#/components/schemas/OpenAI.ShellCallOutputDelta'
-          description: The stdout/stderr delta that was emitted.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated shell call output was incrementally added.
-      title: Response shell call output content delta event
-    OpenAI.ResponseShellCallOutputContentDoneStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - item_id
-        - output_index
-        - command_index
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_output_content.done
-          description: The type of the event, always `response.shell_call_output_content.done`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        item_id:
-          type: string
-          description: The ID of the output item that was updated.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that produced output.
-        output:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
-          description: The output contents emitted for the shell command.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated shell call output was completed.
-      title: Response shell call output content done event
     OpenAI.ResponseStreamEvent:
       type: object
       required:
@@ -72177,18 +71648,12 @@ components:
           response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
           response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
           response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
-          response.shell_call_command.added: '#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent'
-          response.shell_call_command.delta: '#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent'
-          response.shell_call_command.done: '#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent'
-          response.shell_call_output_content.delta: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent'
-          response.shell_call_output_content.done: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent'
           response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
           response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
           response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
           response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
           response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
           response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
-      description: Event emitted while a response is streamed.
     OpenAI.ResponseStreamEventType:
       anyOf:
         - type: string
@@ -72213,11 +71678,6 @@ components:
             - response.file_search_call.searching
             - response.function_call_arguments.delta
             - response.function_call_arguments.done
-            - response.shell_call_command.added
-            - response.shell_call_command.delta
-            - response.shell_call_command.done
-            - response.shell_call_output_content.delta
-            - response.shell_call_output_content.done
             - response.in_progress
             - response.failed
             - response.incomplete
@@ -73460,14 +72920,12 @@ components:
             - flex
             - scale
             - priority
-            - fast
         - type: 'null'
       description: |-
         Specifies the processing type used for serving the request.
         - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
         - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
-        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
-        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
+        - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
     OpenAI.ServiceTierEnum:
@@ -73475,41 +72933,8 @@ components:
       enum:
         - auto
         - default
-        - fast
         - flex
         - priority
-    OpenAI.ServiceTierResponses:
-      anyOf:
-        - type: string
-          enum:
-            - auto
-            - default
-            - flex
-            - scale
-            - priority
-            - fast
-            - ultrafast
-        - type: 'null'
-      description: |-
-        Specifies the processing type used for serving the request.
-        - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
-        - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
-        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
-        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
-        - If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.
-        - When not set, the default behavior is 'auto'.
-        When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
-    OpenAI.ShellCallOutputDelta:
-      type: object
-      properties:
-        stdout:
-          type: string
-          description: The stdout delta that was emitted.
-        stderr:
-          type: string
-          description: The stderr delta that was emitted.
-      description: A delta of stdout/stderr emitted while a shell call was running.
-      title: Shell call output delta
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -74445,15 +73870,6 @@ components:
       type: string
       enum:
         - logprobs
-    OpenAI.TranscriptionLanguage:
-      type: object
-      required:
-        - code
-      properties:
-        code:
-          type: string
-          description: The code of a language detected in the audio.
-      description: A language detected in transcribed audio.
     OpenAI.TranscriptionSegment:
       type: object
       required:
@@ -75267,8 +74683,7 @@ components:
       description: |-
         Constrains the verbosity of the model's response. Lower values will result in
         more concise responses, while higher values will result in more verbose responses.
-        Currently supported values are `low`, `medium`, and `high`. The default is
-        `medium`.
+        Currently supported values are `low`, `medium`, and `high`.
     OpenAI.VideoCharacterResource:
       type: object
       required:
@@ -75669,10 +75084,6 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
-        external_web_access:
-          type: boolean
-          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
-          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
@@ -76854,6 +76265,16 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V2Preview
+    RoutineAuthorization:
+      type: object
+      properties:
+        identity:
+          $ref: '#/components/schemas/RoutineDispatchIdentity'
+          description: The identity used when dispatching the routine. When omitted, dispatch uses the target agent identity.
+      description: Optional authorization configuration for a routine dispatch.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V2Preview
     RoutineCreateOrUpdateRequest:
       type: object
       properties:
@@ -76872,7 +76293,21 @@ components:
         action:
           $ref: '#/components/schemas/RoutineAction'
           description: The action executed when the routine fires.
+        authorization:
+          $ref: '#/components/schemas/RoutineAuthorization'
+          description: Optional authorization configuration for dispatching a newly created routine. Ignored when updating an existing routine.
       description: The request body used to create or update a routine.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V2Preview
+    RoutineDispatchIdentity:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - agent
+            - creator
+      description: The supported identities for routine dispatch authorization.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V2Preview
@@ -79646,17 +79081,6 @@ components:
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -80647,10 +80071,6 @@ components:
           type: string
           enum:
             - web_search
-        external_web_access:
-          type: boolean
-          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
-          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -76271,6 +76271,7 @@ components:
         identity:
           $ref: '#/components/schemas/RoutineDispatchIdentity'
           description: The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch.
+          default: agent
       description: Optional authorization configuration for a routine dispatch.
       x-ms-foundry-meta:
         conditional_previews:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -76270,7 +76270,7 @@ components:
       properties:
         identity:
           $ref: '#/components/schemas/RoutineDispatchIdentity'
-          description: The identity used when dispatching the routine. When omitted, dispatch uses the target agent identity.
+          description: The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch.
       description: Optional authorization configuration for a routine dispatch.
       x-ms-foundry-meta:
         conditional_previews:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -9210,6 +9210,10 @@ paths:
             encoding:
               model:
                 contentType: text/plain
+              languages:
+                contentType: application/json
+              keywords:
+                contentType: application/json
               response_format:
                 contentType: application/json
               temperature:
@@ -25179,16 +25183,13 @@ paths:
                         Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                     deprecated: true
                   safety_identifier:
-                    type: string
-                    maxLength: 64
-                    description: |-
-                      A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                    anyOf:
+                      - type: string
+                      - type: 'null'
                   prompt_cache_key:
-                    type: string
-                    description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-                  service_tier:
-                    $ref: '#/components/schemas/OpenAI.ServiceTier'
+                    anyOf:
+                      - type: string
+                      - type: 'null'
                   prompt_cache_retention:
                     anyOf:
                       - type: string
@@ -25222,6 +25223,8 @@ paths:
                       - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                   prompt:
                     $ref: '#/components/schemas/OpenAI.Prompt'
+                  service_tier:
+                    $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                   truncation:
                     anyOf:
                       - type: string
@@ -25311,7 +25314,7 @@ paths:
                     default: true
                   conversation:
                     anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ConversationReference'
+                      - $ref: '#/components/schemas/OpenAI.ResponseConversation'
                       - type: 'null'
                   max_output_tokens:
                     anyOf:
@@ -25393,16 +25396,13 @@ paths:
                       Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   deprecated: true
                 safety_identifier:
-                  type: string
-                  maxLength: 64
-                  description: |-
-                    A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                  anyOf:
+                    - type: string
+                    - type: 'null'
                 prompt_cache_key:
-                  type: string
-                  description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-                service_tier:
-                  $ref: '#/components/schemas/OpenAI.ServiceTier'
+                  anyOf:
+                    - type: string
+                    - type: 'null'
                 prompt_cache_retention:
                   anyOf:
                     - type: string
@@ -25438,6 +25438,8 @@ paths:
                     - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                 prompt:
                   $ref: '#/components/schemas/OpenAI.Prompt'
+                service_tier:
+                  $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                 truncation:
                   anyOf:
                     - type: string
@@ -48577,18 +48579,31 @@ components:
             - type: string
               enum:
                 - whisper-1
+                - gpt-transcribe
+                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
+          description: The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
         language:
           type: string
           description: |-
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
+        languages:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
+        keywords:
+          type: array
+          items:
+            type: string
+          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -48618,15 +48633,23 @@ components:
             - type: string
               enum:
                 - whisper-1
+                - gpt-transcribe
+                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
+          description: The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
         language:
           type: string
           description: The language of the input audio.
+        languages:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format.
         prompt:
           type: string
           description: The prompt configured for input audio transcription, when present.
@@ -50358,6 +50381,8 @@ components:
           $ref: '#/components/schemas/OpenAI.integer'
         reasoning_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
+        text_tokens:
+          $ref: '#/components/schemas/OpenAI.integer'
         rejected_prediction_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
     OpenAI.CompletionUsagePromptTokensDetails:
@@ -50366,6 +50391,10 @@ components:
         audio_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cached_tokens:
+          $ref: '#/components/schemas/OpenAI.integer'
+        text_tokens:
+          $ref: '#/components/schemas/OpenAI.integer'
+        image_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cache_write_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
@@ -51498,7 +51527,6 @@ components:
       required:
         - id
         - type
-        - call_id
         - output
       properties:
         id:
@@ -51516,6 +51544,12 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the tool that produced the output.
+        namespace:
+          type: string
+          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -51803,6 +51837,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -52126,16 +52161,6 @@ components:
           description: The unique ID of the conversation.
       description: The conversation that this response belongs to.
       title: Conversation object
-    OpenAI.ConversationReference:
-      type: object
-      required:
-        - id
-      properties:
-        id:
-          type: string
-          description: The unique ID of the conversation that this response was associated with.
-      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
-      title: Conversation
     OpenAI.ConversationResource:
       type: object
       required:
@@ -52380,16 +52405,13 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          type: string
-          maxLength: 64
-          description: |-
-            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+          anyOf:
+            - type: string
+            - type: 'null'
         prompt_cache_key:
-          type: string
-          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTier'
+          anyOf:
+            - type: string
+            - type: 'null'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -52413,6 +52435,8 @@ components:
         model:
           type: string
           description: The model deployment to use for this chat completion.
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTier'
         modalities:
           $ref: '#/components/schemas/OpenAI.ResponseModalities'
         verbosity:
@@ -52739,6 +52763,10 @@ components:
         model:
           type: string
           description: The model deployment used for the creation of this chat completion.
+        metadata:
+          anyOf:
+            - $ref: '#/components/schemas/OpenAI.Metadata'
+            - type: 'null'
         service_tier:
           $ref: '#/components/schemas/OpenAI.ServiceTier'
         system_fingerprint:
@@ -53783,7 +53811,7 @@ components:
                 contentEncoding: base64
           description: |-
             The image(s) to edit. Must be a supported image file or an array of images.
-              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`
+              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`
               file less than 50MB. You can provide up to 16 images.
               `chatgpt-image-latest` follows the same input constraints as GPT image models.
               For `dall-e-2`, you can only provide one image, and it should be a square
@@ -53802,24 +53830,27 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Allows to set transparency for the background of the generated image(s).
-              This parameter is only supported for the GPT image models. Must be one of
-              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
-              model will automatically determine the best background for the image.
-              If `transparent`, the output format needs to support transparency, so it
-              should be set to either `png` (default value) or `webp`.
+            Set the background of the generated image(s). This parameter is only
+              supported for the GPT image models. Must be one of `transparent`, `opaque`,
+              or `auto` (default value). When `auto` is used, the model will automatically
+              determine the best background for the image.
+              Transparent backgrounds are available for supported GPT Image models. For
+              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
+              using `transparent`, set the output format to `png` or `webp`.
         model:
           anyOf:
             - type: string
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image generation. Defaults to `gpt-image-1.5`.
+          description: The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.
           x-oaiTypeLabel: string
         'n':
           anyOf:
@@ -53911,12 +53942,14 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - dall-e-3
                 - gpt-image-1
                 - gpt-image-1-mini
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
+          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
           x-oaiTypeLabel: string
           default: dall-e-2
         'n':
@@ -54014,12 +54047,13 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Allows to set transparency for the background of the generated image(s).
-              This parameter is only supported for the GPT image models. Must be one of
-              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
-              model will automatically determine the best background for the image.
-              If `transparent`, the output format needs to support transparency, so it
-              should be set to either `png` (default value) or `webp`.
+            Set the background of the generated image(s). This parameter is only
+              supported for the GPT image models. Must be one of `transparent`, `opaque`,
+              or `auto` (default value). When `auto` is used, the model will automatically
+              determine the best background for the image.
+              Transparent backgrounds are available for supported GPT Image models. For
+              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
+              using `transparent`, set the output format to `png` or `webp`.
           default: auto
         style:
           anyOf:
@@ -54913,7 +54947,9 @@ components:
       type: object
       properties:
         file:
-          description: 'The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
+          description: |-
+            The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+              The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -54921,15 +54957,26 @@ components:
             - type: string
               enum:
                 - whisper-1
+                - gpt-transcribe
                 - gpt-4o-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe-diarize
-          description: ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
+          description: ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
           x-oaiTypeLabel: string
         language:
           type: string
           description: The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency.
+        languages:
+          type: array
+          items:
+            type: string
+          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`.
+        keywords:
+          type: array
+          items:
+            type: string
+          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`.
         prompt:
           type: string
           description: An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text#prompting) should match the audio language. This field is not supported when using `gpt-4o-transcribe-diarize`.
@@ -55047,6 +55094,11 @@ components:
         text:
           type: string
           description: The transcribed text.
+        languages:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.TranscriptionLanguage'
+          description: The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected.
         logprobs:
           type: array
           items:
@@ -55169,7 +55221,7 @@ components:
       type: object
       properties:
         file:
-          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
+          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.'
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -55926,11 +55978,13 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image editing.
+          description: The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.
           x-oaiTypeLabel: string
           default: gpt-image-1.5
         images:
@@ -56022,7 +56076,7 @@ components:
                 - opaque
                 - auto
             - type: 'null'
-          description: Background behavior for generated image output.
+          description: Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.
           default: auto
         stream:
           anyOf:
@@ -58578,6 +58632,8 @@ components:
                 - gpt-image-1
                 - gpt-image-1-mini
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
           default: gpt-image-1
         quality:
           type: string
@@ -58631,8 +58687,11 @@ components:
             - opaque
             - auto
           description: |-
-            Background type for the generated image. One of `transparent`,
-              `opaque`, or `auto`. Default: `auto`.
+            Set the background of the generated image. One of `transparent`,
+              `opaque`, or `auto`. Transparent backgrounds are available for
+              supported GPT Image models. For `gpt-image-2` and
+              `gpt-image-2-2026-04-21`, this support is in preview. When using
+              `transparent`, set the output format to `png` or `webp`. Default: `auto`.
           default: auto
         input_fidelity:
           anyOf:
@@ -59359,7 +59418,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 10485760
+          maxLength: 20971520
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
@@ -59570,7 +59629,6 @@ components:
     OpenAI.InputItemFunctionCallOutputItemParam:
       type: object
       required:
-        - call_id
         - type
         - output
       properties:
@@ -59579,10 +59637,9 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          type: string
-          minLength: 1
-          maxLength: 64
-          description: The unique ID of the function tool call generated by the model.
+          anyOf:
+            - type: string
+            - type: 'null'
         type:
           type: string
           enum:
@@ -59600,6 +59657,14 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+        namespace:
+          anyOf:
+            - type: string
+            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -59973,6 +60038,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -60496,7 +60562,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 10485760
+          maxLength: 20971520
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
@@ -61232,7 +61298,6 @@ components:
       required:
         - id
         - type
-        - call_id
         - output
       properties:
         id:
@@ -61250,6 +61315,12 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the tool that produced the output.
+        namespace:
+          type: string
+          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -61501,6 +61572,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -61855,7 +61927,6 @@ components:
     OpenAI.ItemFunctionCallOutputItemParam:
       type: object
       required:
-        - call_id
         - type
         - output
       properties:
@@ -61864,10 +61935,9 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          type: string
-          minLength: 1
-          maxLength: 64
-          description: The unique ID of the function tool call generated by the model.
+          anyOf:
+            - type: string
+            - type: 'null'
         type:
           type: string
           enum:
@@ -61885,6 +61955,14 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+        namespace:
+          anyOf:
+            - type: string
+            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -62302,6 +62380,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -63015,7 +63094,6 @@ components:
       required:
         - id
         - type
-        - call_id
         - output
       properties:
         id:
@@ -63033,6 +63111,12 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the tool that produced the output.
+        namespace:
+          type: string
+          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -63328,6 +63412,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -64686,8 +64771,6 @@ components:
       required:
         - type
         - text
-        - annotations
-        - logprobs
       properties:
         type:
           type: string
@@ -65127,6 +65210,12 @@ components:
         owned_by:
           type: string
           description: The organization that owns the model.
+        shutdown_date:
+          anyOf:
+            - type: string
+              format: date
+            - type: 'null'
+          description: The date when the model will shut down, or null if not announced.
       description: Describes an OpenAI model offering that can be used with the API.
       title: Model
       x-oaiMeta:
@@ -65136,7 +65225,8 @@ components:
             "id": "VAR_chat_model_id",
             "object": "model",
             "created": 1686935002,
-            "owned_by": "openai"
+            "owned_by": "openai",
+            "shutdown_date": "2026-10-23"
           }
     OpenAI.Moderation:
       type: object
@@ -65507,7 +65597,6 @@ components:
           description: The namespace name used in tool calls (for example, `crm`).
         description:
           type: string
-          minLength: 1
           description: A description of the namespace shown to the model.
         tools:
           type: array
@@ -65637,8 +65726,6 @@ components:
       required:
         - type
         - text
-        - annotations
-        - logprobs
       properties:
         type:
           type: string
@@ -66329,7 +66416,6 @@ components:
       required:
         - id
         - type
-        - call_id
         - output
       properties:
         id:
@@ -66347,6 +66433,12 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the tool that produced the output.
+        namespace:
+          type: string
+          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -66598,6 +66690,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -66953,8 +67046,6 @@ components:
       required:
         - type
         - text
-        - annotations
-        - logprobs
       properties:
         type:
           type: string
@@ -67309,6 +67400,7 @@ components:
       discriminator:
         propertyName: type
         mapping:
+          message: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
           function_call: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall'
           function_call_output: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput'
           mcp_approval_response: '#/components/schemas/OpenAI.RealtimeMCPApprovalResponse'
@@ -67425,6 +67517,248 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    OpenAI.RealtimeConversationItemMessage:
+      type: object
+      required:
+        - role
+        - type
+      properties:
+        role:
+          $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageType'
+        type:
+          type: string
+          enum:
+            - message
+      discriminator:
+        propertyName: role
+        mapping:
+          system: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem'
+          user: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUser'
+          assistant: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant'
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItem'
+    OpenAI.RealtimeConversationItemMessageAssistant:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        id:
+          type: string
+          description: The unique ID of the item. This may be provided by the client or generated by the server.
+        object:
+          type: string
+          enum:
+            - realtime.item
+          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
+          x-stainless-const: true
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the item. Always `message`.
+          x-stainless-const: true
+        status:
+          type: string
+          enum:
+            - completed
+            - incomplete
+            - in_progress
+          description: The status of the item. Has no effect on the conversation.
+        role:
+          type: string
+          enum:
+            - assistant
+          description: The role of the message sender. Always `assistant`.
+          x-stainless-const: true
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent'
+          description: The content of the message.
+        created_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the item was persisted.
+          readOnly: true
+        response_id:
+          type: string
+          description: The id of the response that produced this item, when applicable.
+          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
+      description: An assistant message item in a Realtime conversation.
+      title: Realtime assistant message item
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    OpenAI.RealtimeConversationItemMessageAssistantContent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - output_text
+            - output_audio
+        text:
+          type: string
+        audio:
+          type: string
+        transcript:
+          type: string
+    OpenAI.RealtimeConversationItemMessageSystem:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        id:
+          type: string
+          description: The unique ID of the item. This may be provided by the client or generated by the server.
+        object:
+          type: string
+          enum:
+            - realtime.item
+          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
+          x-stainless-const: true
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the item. Always `message`.
+          x-stainless-const: true
+        status:
+          type: string
+          enum:
+            - completed
+            - incomplete
+            - in_progress
+          description: The status of the item. Has no effect on the conversation.
+        role:
+          type: string
+          enum:
+            - system
+          description: The role of the message sender. Always `system`.
+          x-stainless-const: true
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent'
+          description: The content of the message.
+        created_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the item was persisted.
+          readOnly: true
+        response_id:
+          type: string
+          description: The id of the response that produced this item, when applicable.
+          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
+      description: A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. "the user is now asking about a different topic"), use system messages.
+      title: Realtime system message item
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    OpenAI.RealtimeConversationItemMessageSystemContent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - input_text
+          x-stainless-const: true
+        text:
+          type: string
+    OpenAI.RealtimeConversationItemMessageType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - system
+            - user
+            - assistant
+    OpenAI.RealtimeConversationItemMessageUser:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        id:
+          type: string
+          description: The unique ID of the item. This may be provided by the client or generated by the server.
+        object:
+          type: string
+          enum:
+            - realtime.item
+          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
+          x-stainless-const: true
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the item. Always `message`.
+          x-stainless-const: true
+        status:
+          type: string
+          enum:
+            - completed
+            - incomplete
+            - in_progress
+          description: The status of the item. Has no effect on the conversation.
+        role:
+          type: string
+          enum:
+            - user
+          description: The role of the message sender. Always `user`.
+          x-stainless-const: true
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent'
+          description: The content of the message.
+        created_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the item was persisted.
+          readOnly: true
+        response_id:
+          type: string
+          description: The id of the response that produced this item, when applicable.
+          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
+      description: A user message item in a Realtime conversation.
+      title: Realtime user message item
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    OpenAI.RealtimeConversationItemMessageUserContent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - input_text
+            - input_audio
+            - input_image
+        text:
+          type: string
+        audio:
+          type: string
+        image_url:
+          type: string
+          format: uri
+        detail:
+          type: string
+          enum:
+            - auto
+            - low
+            - high
+          default: auto
+        transcript:
+          type: string
     OpenAI.RealtimeConversationItemType:
       anyOf:
         - type: string
@@ -67436,6 +67770,7 @@ components:
             - mcp_list_tools
             - mcp_call
             - mcp_approval_request
+            - message
     OpenAI.RealtimeCreateClientSecretRequest:
       type: object
       properties:
@@ -69142,16 +69477,13 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          type: string
-          maxLength: 64
-          description: |-
-            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+          anyOf:
+            - type: string
+            - type: 'null'
         prompt_cache_key:
-          type: string
-          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTier'
+          anyOf:
+            - type: string
+            - type: 'null'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -69185,6 +69517,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
         prompt:
           $ref: '#/components/schemas/OpenAI.Prompt'
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
         truncation:
           anyOf:
             - type: string
@@ -69274,7 +69608,7 @@ components:
           default: true
         conversation:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.ConversationReference'
+            - $ref: '#/components/schemas/OpenAI.ResponseConversation'
             - type: 'null'
         max_output_tokens:
           anyOf:
@@ -69786,6 +70120,16 @@ components:
               "annotations": []
             }
           }
+    OpenAI.ResponseConversation:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: The unique ID of the conversation that this response was associated with.
+      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
+      title: Conversation
     OpenAI.ResponseCreatedEvent:
       type: object
       required:
@@ -69949,6 +70293,7 @@ components:
         - server_error
         - rate_limit_exceeded
         - invalid_prompt
+        - data_residency_mismatch
         - bio_policy
         - vector_store_timeout
         - invalid_image
@@ -70480,6 +70825,18 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
+        size:
+          type: string
+          description: The image size that was used.
+        quality:
+          type: string
+          description: The image quality that was used.
+        background:
+          type: string
+          description: The background setting that was used.
+        output_format:
+          type: string
+          description: The output format that was used.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
@@ -71001,7 +71358,11 @@ components:
           description: The sequence number of this event.
         item:
           $ref: '#/components/schemas/OpenAI.OutputItem'
-          description: The output item that was added.
+          description: |-
+            The output item that was added. For reasoning items, `encrypted_content`
+              may be incomplete while the item is in progress. Use the reasoning item
+              from the corresponding `response.output_item.done` event when passing it
+              as input to a subsequent request.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
@@ -71119,10 +71480,10 @@ components:
             "content_index": 0,
             "annotation_index": 0,
             "annotation": {
-              "type": "text_annotation",
-              "text": "This is a test annotation",
-              "start": 0,
-              "end": 10
+              "type": "file_citation",
+              "file_id": "file-abc",
+              "index": 0,
+              "filename": "example.txt"
             },
             "sequence_number": 1
           }
@@ -71591,6 +71952,174 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
+    OpenAI.ResponseShellCallCommandAddedStreamingEvent:
+      type: object
+      required:
+        - type
+        - sequence_number
+        - output_index
+        - command_index
+        - command
+      properties:
+        type:
+          type: string
+          enum:
+            - response.shell_call_command.added
+          description: The type of the event, always `response.shell_call_command.added`.
+          x-stainless-const: true
+        sequence_number:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The sequence number of the event that was emitted.
+        output_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the output item that was updated.
+        command_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the shell command that was added.
+        command:
+          type: string
+          description: The shell command that was added.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
+      description: A streaming event that indicated a shell command was added to a tool call.
+      title: Response shell command added event
+    OpenAI.ResponseShellCallCommandDeltaStreamingEvent:
+      type: object
+      required:
+        - type
+        - sequence_number
+        - output_index
+        - command_index
+        - delta
+      properties:
+        type:
+          type: string
+          enum:
+            - response.shell_call_command.delta
+          description: The type of the event, always `response.shell_call_command.delta`.
+          x-stainless-const: true
+        sequence_number:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The sequence number of the event that was emitted.
+        output_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the output item that was updated.
+        command_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the shell command that was updated.
+        delta:
+          type: string
+          description: The shell command delta that was appended.
+        obfuscation:
+          type: string
+          description: An obfuscation string that was added to pad the event payload.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
+      description: A streaming event that indicated a shell command was incrementally updated.
+      title: Response shell command delta event
+    OpenAI.ResponseShellCallCommandDoneStreamingEvent:
+      type: object
+      required:
+        - type
+        - sequence_number
+        - output_index
+        - command_index
+        - command
+      properties:
+        type:
+          type: string
+          enum:
+            - response.shell_call_command.done
+          description: The type of the event, always `response.shell_call_command.done`.
+          x-stainless-const: true
+        sequence_number:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The sequence number of the event that was emitted.
+        output_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the output item that was updated.
+        command_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the shell command that was completed.
+        command:
+          type: string
+          description: The final shell command that was emitted.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
+      description: A streaming event that indicated a shell command was completed.
+      title: Response shell command done event
+    OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent:
+      type: object
+      required:
+        - type
+        - sequence_number
+        - item_id
+        - output_index
+        - command_index
+        - delta
+      properties:
+        type:
+          type: string
+          enum:
+            - response.shell_call_output_content.delta
+          description: The type of the event, always `response.shell_call_output_content.delta`.
+          x-stainless-const: true
+        sequence_number:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The sequence number of the event that was emitted.
+        item_id:
+          type: string
+          description: The ID of the output item that was updated.
+        output_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the output item that was updated.
+        command_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the shell command that produced output.
+        delta:
+          $ref: '#/components/schemas/OpenAI.ShellCallOutputDelta'
+          description: The stdout/stderr delta that was emitted.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
+      description: A streaming event that indicated shell call output was incrementally added.
+      title: Response shell call output content delta event
+    OpenAI.ResponseShellCallOutputContentDoneStreamingEvent:
+      type: object
+      required:
+        - type
+        - sequence_number
+        - item_id
+        - output_index
+        - command_index
+        - output
+      properties:
+        type:
+          type: string
+          enum:
+            - response.shell_call_output_content.done
+          description: The type of the event, always `response.shell_call_output_content.done`.
+          x-stainless-const: true
+        sequence_number:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The sequence number of the event that was emitted.
+        item_id:
+          type: string
+          description: The ID of the output item that was updated.
+        output_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the output item that was updated.
+        command_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the shell command that produced output.
+        output:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
+          description: The output contents emitted for the shell command.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
+      description: A streaming event that indicated shell call output was completed.
+      title: Response shell call output content done event
     OpenAI.ResponseStreamEvent:
       type: object
       required:
@@ -71648,12 +72177,18 @@ components:
           response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
           response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
           response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
+          response.shell_call_command.added: '#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent'
+          response.shell_call_command.delta: '#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent'
+          response.shell_call_command.done: '#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent'
+          response.shell_call_output_content.delta: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent'
+          response.shell_call_output_content.done: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent'
           response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
           response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
           response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
           response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
           response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
           response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
+      description: Event emitted while a response is streamed.
     OpenAI.ResponseStreamEventType:
       anyOf:
         - type: string
@@ -71678,6 +72213,11 @@ components:
             - response.file_search_call.searching
             - response.function_call_arguments.delta
             - response.function_call_arguments.done
+            - response.shell_call_command.added
+            - response.shell_call_command.delta
+            - response.shell_call_command.done
+            - response.shell_call_output_content.delta
+            - response.shell_call_output_content.done
             - response.in_progress
             - response.failed
             - response.incomplete
@@ -72920,12 +73460,14 @@ components:
             - flex
             - scale
             - priority
+            - fast
         - type: 'null'
       description: |-
         Specifies the processing type used for serving the request.
         - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
         - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
-        - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
+        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
+        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
     OpenAI.ServiceTierEnum:
@@ -72933,8 +73475,41 @@ components:
       enum:
         - auto
         - default
+        - fast
         - flex
         - priority
+    OpenAI.ServiceTierResponses:
+      anyOf:
+        - type: string
+          enum:
+            - auto
+            - default
+            - flex
+            - scale
+            - priority
+            - fast
+            - ultrafast
+        - type: 'null'
+      description: |-
+        Specifies the processing type used for serving the request.
+        - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
+        - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
+        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
+        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
+        - If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.
+        - When not set, the default behavior is 'auto'.
+        When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
+    OpenAI.ShellCallOutputDelta:
+      type: object
+      properties:
+        stdout:
+          type: string
+          description: The stdout delta that was emitted.
+        stderr:
+          type: string
+          description: The stderr delta that was emitted.
+      description: A delta of stdout/stderr emitted while a shell call was running.
+      title: Shell call output delta
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -73870,6 +74445,15 @@ components:
       type: string
       enum:
         - logprobs
+    OpenAI.TranscriptionLanguage:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: string
+          description: The code of a language detected in the audio.
+      description: A language detected in transcribed audio.
     OpenAI.TranscriptionSegment:
       type: object
       required:
@@ -74683,7 +75267,8 @@ components:
       description: |-
         Constrains the verbosity of the model's response. Lower values will result in
         more concise responses, while higher values will result in more verbose responses.
-        Currently supported values are `low`, `medium`, and `high`.
+        Currently supported values are `low`, `medium`, and `high`. The default is
+        `medium`.
     OpenAI.VideoCharacterResource:
       type: object
       required:
@@ -75084,6 +75669,10 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
+        external_web_access:
+          type: boolean
+          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
+          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
@@ -79082,6 +79671,17 @@ components:
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
+        languages:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
+        keywords:
+          type: array
+          items:
+            type: string
+          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -80072,6 +80672,10 @@ components:
           type: string
           enum:
             - web_search
+        external_web_access:
+          type: boolean
+          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
+          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -76285,8 +76285,7 @@ components:
           description: A human-readable description of the routine.
         enabled:
           type: boolean
-          description: Whether the routine is enabled. If omitted when creating a new routine, the service defaults this value to true. If omitted on update, the service preserves the existing enabled state.
-          default: true
+          description: Whether the routine is enabled.
         triggers:
           type: object
           unevaluatedProperties:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -76285,7 +76285,8 @@ components:
           description: A human-readable description of the routine.
         enabled:
           type: boolean
-          description: Whether the routine is enabled.
+          description: Whether the routine is enabled. If omitted when creating a new routine, the service defaults this value to true. If omitted on update, the service preserves the existing enabled state.
+          default: true
         triggers:
           type: object
           unevaluatedProperties:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -83817,7 +83817,8 @@
           },
           "enabled": {
             "type": "boolean",
-            "description": "Whether the routine is enabled."
+            "description": "Whether the routine is enabled. If omitted when creating a new routine, the service defaults this value to true. If omitted on update, the service preserves the existing enabled state.",
+            "default": true
           },
           "triggers": {
             "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -83817,8 +83817,7 @@
           },
           "enabled": {
             "type": "boolean",
-            "description": "Whether the routine is enabled. If omitted when creating a new routine, the service defaults this value to true. If omitted on update, the service preserves the existing enabled state.",
-            "default": true
+            "description": "Whether the routine is enabled."
           },
           "triggers": {
             "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -83796,7 +83796,7 @@
         "properties": {
           "identity": {
             "$ref": "#/components/schemas/RoutineDispatchIdentity",
-            "description": "The identity used when dispatching the routine. When omitted, dispatch uses the target agent identity."
+            "description": "The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch."
           }
         },
         "description": "Optional authorization configuration for a routine dispatch.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -83796,7 +83796,8 @@
         "properties": {
           "identity": {
             "$ref": "#/components/schemas/RoutineDispatchIdentity",
-            "description": "The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch."
+            "description": "The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch.",
+            "default": "agent"
           }
         },
         "description": "Optional authorization configuration for a routine dispatch.",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -15198,12 +15198,6 @@
                 "model": {
                   "contentType": "text/plain"
                 },
-                "languages": {
-                  "contentType": "application/json"
-                },
-                "keywords": {
-                  "contentType": "application/json"
-                },
                 "response_format": {
                   "contentType": "application/json"
                 },
@@ -21911,24 +21905,16 @@
                       "deprecated": true
                     },
                     "safety_identifier": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
+                      "type": "string",
+                      "maxLength": 64,
+                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                     },
                     "prompt_cache_key": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
+                      "type": "string",
+                      "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                    },
+                    "service_tier": {
+                      "$ref": "#/components/schemas/OpenAI.ServiceTier"
                     },
                     "prompt_cache_retention": {
                       "anyOf": [
@@ -21997,9 +21983,6 @@
                     },
                     "prompt": {
                       "$ref": "#/components/schemas/OpenAI.Prompt"
-                    },
-                    "service_tier": {
-                      "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                     },
                     "truncation": {
                       "anyOf": [
@@ -22145,7 +22128,7 @@
                     "conversation": {
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/OpenAI.ResponseConversation"
+                          "$ref": "#/components/schemas/OpenAI.ConversationReference"
                         },
                         {
                           "type": "null"
@@ -22297,24 +22280,16 @@
                     "deprecated": true
                   },
                   "safety_identifier": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "type": "string",
+                    "maxLength": 64,
+                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                   },
                   "prompt_cache_key": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "type": "string",
+                    "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                  },
+                  "service_tier": {
+                    "$ref": "#/components/schemas/OpenAI.ServiceTier"
                   },
                   "prompt_cache_retention": {
                     "anyOf": [
@@ -22386,9 +22361,6 @@
                   },
                   "prompt": {
                     "$ref": "#/components/schemas/OpenAI.Prompt"
-                  },
-                  "service_tier": {
-                    "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                   },
                   "truncation": {
                     "anyOf": [
@@ -45565,8 +45537,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
-                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -45575,26 +45545,11 @@
                 ]
               }
             ],
-            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
+            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -45625,8 +45580,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
-                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -45635,19 +45588,11 @@
                 ]
               }
             ],
-            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
+            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format."
           },
           "prompt": {
             "type": "string",
@@ -48041,9 +47986,6 @@
           "reasoning_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
-          "text_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
           "rejected_prediction_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           }
@@ -48056,12 +47998,6 @@
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cached_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "text_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "image_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cache_write_tokens": {
@@ -49658,6 +49594,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -49677,14 +49614,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -50101,8 +50030,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -50566,6 +50494,20 @@
         "description": "The conversation that this response belongs to.",
         "title": "Conversation object"
       },
+      "OpenAI.ConversationReference": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the conversation that this response was associated with."
+          }
+        },
+        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
+        "title": "Conversation"
+      },
       "OpenAI.ConversationResource": {
         "type": "object",
         "required": [
@@ -50967,24 +50909,16 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "maxLength": 64,
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -51015,9 +50949,6 @@
           "model": {
             "type": "string",
             "description": "The model deployment to use for this chat completion."
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "modalities": {
             "$ref": "#/components/schemas/OpenAI.ResponseModalities"
@@ -51447,16 +51378,6 @@
           "model": {
             "type": "string",
             "description": "The model deployment used for the creation of this chat completion."
-          },
-          "metadata": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "service_tier": {
             "$ref": "#/components/schemas/OpenAI.ServiceTier"
@@ -52867,7 +52788,7 @@
                 }
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
           },
           "prompt": {
             "type": "string",
@@ -52890,7 +52811,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`."
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`."
           },
           "model": {
             "anyOf": [
@@ -52901,8 +52822,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
@@ -52913,7 +52832,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -53062,8 +52981,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "dall-e-3",
                   "gpt-image-1",
@@ -53074,7 +52991,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
             "x-oaiTypeLabel": "string",
             "default": "dall-e-2"
           },
@@ -53226,7 +53143,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`.",
             "default": "auto"
           },
           "style": {
@@ -54580,7 +54497,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n  The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
+            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -54592,7 +54509,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
                   "gpt-4o-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
@@ -54600,26 +54516,12 @@
                 ]
               }
             ],
-            "description": "ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
+            "description": "ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
             "x-oaiTypeLabel": "string"
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -54747,13 +54649,6 @@
             "type": "string",
             "description": "The transcribed text."
           },
-          "languages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.TranscriptionLanguage"
-            },
-            "description": "The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected."
-          },
           "logprobs": {
             "type": "array",
             "items": {
@@ -54873,7 +54768,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
+            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -55982,8 +55877,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "gpt-image-1",
                   "gpt-image-1-mini",
                   "chatgpt-image-latest"
@@ -55993,7 +55886,7 @@
                 "type": "null"
               }
             ],
-            "description": "The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.",
+            "description": "The model to use for image editing.",
             "x-oaiTypeLabel": "string",
             "default": "gpt-image-1.5"
           },
@@ -56140,7 +56033,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Background behavior for generated image output.",
             "default": "auto"
           },
           "stream": {
@@ -59682,9 +59575,7 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21"
+                  "gpt-image-1.5"
                 ]
               }
             ],
@@ -59752,7 +59643,7 @@
               "opaque",
               "auto"
             ],
-            "description": "Set the background of the generated image. One of `transparent`,\n  `opaque`, or `auto`. Transparent backgrounds are available for\n  supported GPT Image models. For `gpt-image-2` and\n  `gpt-image-2-2026-04-21`, this support is in preview. When using\n  `transparent`, set the output format to `png` or `webp`. Default: `auto`.",
+            "description": "Background type for the generated image. One of `transparent`,\n  `opaque`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "input_fidelity": {
@@ -60822,7 +60713,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -61136,6 +61027,7 @@
       "OpenAI.InputItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
+          "call_id",
           "type",
           "output"
         ],
@@ -61151,14 +61043,10 @@
             ]
           },
           "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "The unique ID of the function tool call generated by the model."
           },
           "type": {
             "type": "string",
@@ -61192,26 +61080,6 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "namespace": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "caller": {
             "anyOf": [
@@ -61795,8 +61663,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -62579,7 +62446,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -63651,6 +63518,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -63670,14 +63538,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -64047,8 +63907,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -64551,6 +64410,7 @@
       "OpenAI.ItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
+          "call_id",
           "type",
           "output"
         ],
@@ -64566,14 +64426,10 @@
             ]
           },
           "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "The unique ID of the function tool call generated by the model."
           },
           "type": {
             "type": "string",
@@ -64607,26 +64463,6 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "namespace": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "caller": {
             "anyOf": [
@@ -65263,8 +65099,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -66283,6 +66118,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -66302,14 +66138,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -66732,8 +66560,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -68608,7 +68435,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -69219,25 +69048,13 @@
           "owned_by": {
             "type": "string",
             "description": "The organization that owns the model."
-          },
-          "shutdown_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The date when the model will shut down, or null if not announced."
           }
         },
         "description": "Describes an OpenAI model offering that can be used with the API.",
         "title": "Model",
         "x-oaiMeta": {
           "name": "The model object",
-          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\",\n  \"shutdown_date\": \"2026-10-23\"\n}\n"
+          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
         }
       },
       "OpenAI.Moderation": {
@@ -69849,6 +69666,7 @@
           },
           "description": {
             "type": "string",
+            "minLength": 1,
             "description": "A description of the namespace shown to the model."
           },
           "tools": {
@@ -70015,7 +69833,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -71006,6 +70826,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -71025,14 +70846,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -71402,8 +71215,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -71896,7 +71708,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -72408,7 +72222,6 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.RealtimeConversationItemMessage",
             "function_call": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall",
             "function_call_output": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput",
             "mcp_approval_response": "#/components/schemas/OpenAI.RealtimeMCPApprovalResponse",
@@ -72570,351 +72383,6 @@
           ]
         }
       },
-      "OpenAI.RealtimeConversationItemMessage": {
-        "type": "object",
-        "required": [
-          "role",
-          "type"
-        ],
-        "properties": {
-          "role": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageType"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ]
-          }
-        },
-        "discriminator": {
-          "propertyName": "role",
-          "mapping": {
-            "system": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem",
-            "user": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUser",
-            "assistant": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItem"
-          }
-        ]
-      },
-      "OpenAI.RealtimeConversationItemMessageAssistant": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "assistant"
-            ],
-            "description": "The role of the message sender. Always `assistant`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "An assistant message item in a Realtime conversation.",
-        "title": "Realtime assistant message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageAssistantContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "output_text",
-              "output_audio"
-            ]
-          },
-          "text": {
-            "type": "string"
-          },
-          "audio": {
-            "type": "string"
-          },
-          "transcript": {
-            "type": "string"
-          }
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageSystem": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "system"
-            ],
-            "description": "The role of the message sender. Always `system`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. \"the user is now asking about a different topic\"), use system messages.",
-        "title": "Realtime system message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageSystemContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "input_text"
-            ],
-            "x-stainless-const": true
-          },
-          "text": {
-            "type": "string"
-          }
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "system",
-              "user",
-              "assistant"
-            ]
-          }
-        ]
-      },
-      "OpenAI.RealtimeConversationItemMessageUser": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user"
-            ],
-            "description": "The role of the message sender. Always `user`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "A user message item in a Realtime conversation.",
-        "title": "Realtime user message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageUserContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "input_text",
-              "input_audio",
-              "input_image"
-            ]
-          },
-          "text": {
-            "type": "string"
-          },
-          "audio": {
-            "type": "string"
-          },
-          "image_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "detail": {
-            "type": "string",
-            "enum": [
-              "auto",
-              "low",
-              "high"
-            ],
-            "default": "auto"
-          },
-          "transcript": {
-            "type": "string"
-          }
-        }
-      },
       "OpenAI.RealtimeConversationItemType": {
         "anyOf": [
           {
@@ -72928,8 +72396,7 @@
               "mcp_approval_response",
               "mcp_list_tools",
               "mcp_call",
-              "mcp_approval_request",
-              "message"
+              "mcp_approval_request"
             ]
           }
         ]
@@ -75053,24 +74520,16 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "maxLength": 64,
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -75139,9 +74598,6 @@
           },
           "prompt": {
             "$ref": "#/components/schemas/OpenAI.Prompt"
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
           },
           "truncation": {
             "anyOf": [
@@ -75287,7 +74743,7 @@
           "conversation": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.ResponseConversation"
+                "$ref": "#/components/schemas/OpenAI.ConversationReference"
               },
               {
                 "type": "null"
@@ -75842,20 +75298,6 @@
           "example": "{\n  \"type\": \"response.content_part.done\",\n  \"item_id\": \"msg_123\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"sequence_number\": 1,\n  \"part\": {\n    \"type\": \"output_text\",\n    \"text\": \"In a shimmering forest under a sky full of stars, a lonely unicorn named Lila discovered a hidden pond that glowed with moonlight. Every night, she would leave sparkling, magical flowers by the water's edge, hoping to share her beauty with others. One enchanting evening, she woke to find a group of friendly animals gathered around, eager to be friends and share in her magic.\",\n    \"annotations\": []\n  }\n}\n"
         }
       },
-      "OpenAI.ResponseConversation": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the conversation that this response was associated with."
-          }
-        },
-        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
-        "title": "Conversation"
-      },
       "OpenAI.ResponseCreatedEvent": {
         "type": "object",
         "required": [
@@ -76012,7 +75454,6 @@
           "server_error",
           "rate_limit_exceeded",
           "invalid_prompt",
-          "data_residency_mismatch",
           "bio_policy",
           "vector_store_timeout",
           "invalid_image",
@@ -76617,22 +76058,6 @@
           "partial_image_b64": {
             "type": "string",
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
-          },
-          "size": {
-            "type": "string",
-            "description": "The image size that was used."
-          },
-          "quality": {
-            "type": "string",
-            "description": "The image quality that was used."
-          },
-          "background": {
-            "type": "string",
-            "description": "The background setting that was used."
-          },
-          "output_format": {
-            "type": "string",
-            "description": "The output format that was used."
           }
         },
         "allOf": [
@@ -77169,7 +76594,7 @@
           },
           "item": {
             "$ref": "#/components/schemas/OpenAI.OutputItem",
-            "description": "The output item that was added. For reasoning items, `encrypted_content`\n  may be incomplete while the item is in progress. Use the reasoning item\n  from the corresponding `response.output_item.done` event when passing it\n  as input to a subsequent request."
+            "description": "The output item that was added."
           }
         },
         "allOf": [
@@ -77281,7 +76706,7 @@
         "x-oaiMeta": {
           "name": "response.output_text.annotation.added",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"file_citation\",\n    \"file_id\": \"file-abc\",\n    \"index\": 0,\n    \"filename\": \"example.txt\"\n  },\n  \"sequence_number\": 1\n}\n"
+          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"text_annotation\",\n    \"text\": \"This is a test annotation\",\n    \"start\": 0,\n    \"end\": 10\n  },\n  \"sequence_number\": 1\n}\n"
         }
       },
       "OpenAI.ResponsePromptVariables": {
@@ -77806,238 +77231,6 @@
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
       },
-      "OpenAI.ResponseShellCallCommandAddedStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "command"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.added"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.added`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was added."
-          },
-          "command": {
-            "type": "string",
-            "description": "The shell command that was added."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was added to a tool call.",
-        "title": "Response shell command added event"
-      },
-      "OpenAI.ResponseShellCallCommandDeltaStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "delta"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.delta"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.delta`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was updated."
-          },
-          "delta": {
-            "type": "string",
-            "description": "The shell command delta that was appended."
-          },
-          "obfuscation": {
-            "type": "string",
-            "description": "An obfuscation string that was added to pad the event payload."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was incrementally updated.",
-        "title": "Response shell command delta event"
-      },
-      "OpenAI.ResponseShellCallCommandDoneStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "command"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.done"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.done`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was completed."
-          },
-          "command": {
-            "type": "string",
-            "description": "The final shell command that was emitted."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was completed.",
-        "title": "Response shell command done event"
-      },
-      "OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "item_id",
-          "output_index",
-          "command_index",
-          "delta"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_output_content.delta"
-            ],
-            "description": "The type of the event, always `response.shell_call_output_content.delta`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "item_id": {
-            "type": "string",
-            "description": "The ID of the output item that was updated."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that produced output."
-          },
-          "delta": {
-            "$ref": "#/components/schemas/OpenAI.ShellCallOutputDelta",
-            "description": "The stdout/stderr delta that was emitted."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated shell call output was incrementally added.",
-        "title": "Response shell call output content delta event"
-      },
-      "OpenAI.ResponseShellCallOutputContentDoneStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "item_id",
-          "output_index",
-          "command_index",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_output_content.done"
-            ],
-            "description": "The type of the event, always `response.shell_call_output_content.done`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "item_id": {
-            "type": "string",
-            "description": "The ID of the output item that was updated."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that produced output."
-          },
-          "output": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputContent"
-            },
-            "description": "The output contents emitted for the shell command."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated shell call output was completed.",
-        "title": "Response shell call output content done event"
-      },
       "OpenAI.ResponseStreamEvent": {
         "type": "object",
         "required": [
@@ -78098,11 +77291,6 @@
             "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
             "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
             "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
-            "response.shell_call_command.added": "#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent",
-            "response.shell_call_command.delta": "#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent",
-            "response.shell_call_command.done": "#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent",
-            "response.shell_call_output_content.delta": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent",
-            "response.shell_call_output_content.done": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent",
             "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
             "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
             "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
@@ -78110,8 +77298,7 @@
             "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
             "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
           }
-        },
-        "description": "Event emitted while a response is streamed."
+        }
       },
       "OpenAI.ResponseStreamEventType": {
         "anyOf": [
@@ -78140,11 +77327,6 @@
               "response.file_search_call.searching",
               "response.function_call_arguments.delta",
               "response.function_call_arguments.done",
-              "response.shell_call_command.added",
-              "response.shell_call_command.delta",
-              "response.shell_call_command.done",
-              "response.shell_call_output_content.delta",
-              "response.shell_call_output_content.done",
               "response.in_progress",
               "response.failed",
               "response.incomplete",
@@ -79812,60 +78994,23 @@
               "default",
               "flex",
               "scale",
-              "priority",
-              "fast"
+              "priority"
             ]
           },
           {
             "type": "null"
           }
         ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
+        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
       },
       "OpenAI.ServiceTierEnum": {
         "type": "string",
         "enum": [
           "auto",
           "default",
-          "fast",
           "flex",
           "priority"
         ]
-      },
-      "OpenAI.ServiceTierResponses": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "auto",
-              "default",
-              "flex",
-              "scale",
-              "priority",
-              "fast",
-              "ultrafast"
-            ]
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
-      },
-      "OpenAI.ShellCallOutputDelta": {
-        "type": "object",
-        "properties": {
-          "stdout": {
-            "type": "string",
-            "description": "The stdout delta that was emitted."
-          },
-          "stderr": {
-            "type": "string",
-            "description": "The stderr delta that was emitted."
-          }
-        },
-        "description": "A delta of stdout/stderr emitted while a shell call was running.",
-        "title": "Shell call output delta"
       },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
@@ -81145,19 +80290,6 @@
           "logprobs"
         ]
       },
-      "OpenAI.TranscriptionLanguage": {
-        "type": "object",
-        "required": [
-          "code"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "The code of a language detected in the audio."
-          }
-        },
-        "description": "A language detected in transcribed audio."
-      },
       "OpenAI.TranscriptionSegment": {
         "type": "object",
         "required": [
@@ -82232,7 +81364,7 @@
             "type": "null"
           }
         ],
-        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`. The default is\n`medium`."
+        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`."
       },
       "OpenAI.VideoCharacterResource": {
         "type": "object",
@@ -82839,11 +81971,6 @@
               "web_search"
             ],
             "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
-          },
-          "external_web_access": {
-            "type": "boolean",
-            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
-            "default": true
           },
           "filters": {
             "anyOf": [
@@ -84664,6 +83791,21 @@
           ]
         }
       },
+      "RoutineAuthorization": {
+        "type": "object",
+        "properties": {
+          "identity": {
+            "$ref": "#/components/schemas/RoutineDispatchIdentity",
+            "description": "The identity used when dispatching the routine. When omitted, dispatch uses the target agent identity."
+          }
+        },
+        "description": "Optional authorization configuration for a routine dispatch.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V2Preview"
+          ]
+        }
+      },
       "RoutineCreateOrUpdateRequest": {
         "type": "object",
         "properties": {
@@ -84686,9 +83828,33 @@
           "action": {
             "$ref": "#/components/schemas/RoutineAction",
             "description": "The action executed when the routine fires."
+          },
+          "authorization": {
+            "$ref": "#/components/schemas/RoutineAuthorization",
+            "description": "Optional authorization configuration for dispatching a newly created routine. Ignored when updating an existing routine."
           }
         },
         "description": "The request body used to create or update a routine.",
+        "x-ms-foundry-meta": {
+          "conditional_previews": [
+            "Routines=V2Preview"
+          ]
+        }
+      },
+      "RoutineDispatchIdentity": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "agent",
+              "creator"
+            ]
+          }
+        ],
+        "description": "The supported identities for routine dispatch authorization.",
         "x-ms-foundry-meta": {
           "conditional_previews": [
             "Routines=V2Preview"
@@ -88731,21 +87897,6 @@
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
           },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
-          },
           "prompt": {
             "type": "string",
             "description": "An optional text to guide the model's style or continue a previous audio\n  segment.\n  For `whisper-1`, the [prompt is a list of keywords](/docs/guides/speech-to-text#prompting).\n  For `gpt-4o-transcribe` models (excluding `gpt-4o-transcribe-diarize`), the prompt is a free text string, for example \"expect words related to technology\".\n  Prompt is not supported with `gpt-realtime-whisper` in GA Realtime sessions."
@@ -90182,11 +89333,6 @@
             "enum": [
               "web_search"
             ]
-          },
-          "external_web_access": {
-            "type": "boolean",
-            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
-            "default": true
           },
           "filters": {
             "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -15198,6 +15198,12 @@
                 "model": {
                   "contentType": "text/plain"
                 },
+                "languages": {
+                  "contentType": "application/json"
+                },
+                "keywords": {
+                  "contentType": "application/json"
+                },
                 "response_format": {
                   "contentType": "application/json"
                 },
@@ -21905,16 +21911,24 @@
                       "deprecated": true
                     },
                     "safety_identifier": {
-                      "type": "string",
-                      "maxLength": 64,
-                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     },
                     "prompt_cache_key": {
-                      "type": "string",
-                      "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-                    },
-                    "service_tier": {
-                      "$ref": "#/components/schemas/OpenAI.ServiceTier"
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     },
                     "prompt_cache_retention": {
                       "anyOf": [
@@ -21983,6 +21997,9 @@
                     },
                     "prompt": {
                       "$ref": "#/components/schemas/OpenAI.Prompt"
+                    },
+                    "service_tier": {
+                      "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                     },
                     "truncation": {
                       "anyOf": [
@@ -22128,7 +22145,7 @@
                     "conversation": {
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/OpenAI.ConversationReference"
+                          "$ref": "#/components/schemas/OpenAI.ResponseConversation"
                         },
                         {
                           "type": "null"
@@ -22280,16 +22297,24 @@
                     "deprecated": true
                   },
                   "safety_identifier": {
-                    "type": "string",
-                    "maxLength": 64,
-                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "prompt_cache_key": {
-                    "type": "string",
-                    "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-                  },
-                  "service_tier": {
-                    "$ref": "#/components/schemas/OpenAI.ServiceTier"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "prompt_cache_retention": {
                     "anyOf": [
@@ -22361,6 +22386,9 @@
                   },
                   "prompt": {
                     "$ref": "#/components/schemas/OpenAI.Prompt"
+                  },
+                  "service_tier": {
+                    "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                   },
                   "truncation": {
                     "anyOf": [
@@ -45537,6 +45565,8 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
+                  "gpt-transcribe",
+                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -45545,11 +45575,26 @@
                 ]
               }
             ],
-            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
+            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -45580,6 +45625,8 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
+                  "gpt-transcribe",
+                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -45588,11 +45635,19 @@
                 ]
               }
             ],
-            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
+            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio."
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "description": "The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format."
           },
           "prompt": {
             "type": "string",
@@ -47986,6 +48041,9 @@
           "reasoning_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
+          "text_tokens": {
+            "$ref": "#/components/schemas/OpenAI.integer"
+          },
           "rejected_prediction_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           }
@@ -47998,6 +48056,12 @@
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cached_tokens": {
+            "$ref": "#/components/schemas/OpenAI.integer"
+          },
+          "text_tokens": {
+            "$ref": "#/components/schemas/OpenAI.integer"
+          },
+          "image_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cache_write_tokens": {
@@ -49594,7 +49658,6 @@
         "required": [
           "id",
           "type",
-          "call_id",
           "output"
         ],
         "properties": {
@@ -49614,6 +49677,14 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the tool that produced the output."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -50030,7 +50101,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -50494,20 +50566,6 @@
         "description": "The conversation that this response belongs to.",
         "title": "Conversation object"
       },
-      "OpenAI.ConversationReference": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the conversation that this response was associated with."
-          }
-        },
-        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
-        "title": "Conversation"
-      },
       "OpenAI.ConversationResource": {
         "type": "object",
         "required": [
@@ -50909,16 +50967,24 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "type": "string",
-            "maxLength": 64,
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "prompt_cache_key": {
-            "type": "string",
-            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTier"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -50949,6 +51015,9 @@
           "model": {
             "type": "string",
             "description": "The model deployment to use for this chat completion."
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "modalities": {
             "$ref": "#/components/schemas/OpenAI.ResponseModalities"
@@ -51378,6 +51447,16 @@
           "model": {
             "type": "string",
             "description": "The model deployment used for the creation of this chat completion."
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.Metadata"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "service_tier": {
             "$ref": "#/components/schemas/OpenAI.ServiceTier"
@@ -52788,7 +52867,7 @@
                 }
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
           },
           "prompt": {
             "type": "string",
@@ -52811,7 +52890,7 @@
                 "type": "null"
               }
             ],
-            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`."
+            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`."
           },
           "model": {
             "anyOf": [
@@ -52822,6 +52901,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
@@ -52832,7 +52913,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -52981,6 +53062,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "dall-e-3",
                   "gpt-image-1",
@@ -52991,7 +53074,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
             "x-oaiTypeLabel": "string",
             "default": "dall-e-2"
           },
@@ -53143,7 +53226,7 @@
                 "type": "null"
               }
             ],
-            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`.",
+            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`.",
             "default": "auto"
           },
           "style": {
@@ -54497,7 +54580,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
+            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n  The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -54509,6 +54592,7 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
+                  "gpt-transcribe",
                   "gpt-4o-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
@@ -54516,12 +54600,26 @@
                 ]
               }
             ],
-            "description": "ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
+            "description": "ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
             "x-oaiTypeLabel": "string"
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency."
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`."
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -54649,6 +54747,13 @@
             "type": "string",
             "description": "The transcribed text."
           },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.TranscriptionLanguage"
+            },
+            "description": "The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected."
+          },
           "logprobs": {
             "type": "array",
             "items": {
@@ -54768,7 +54873,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
+            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -55877,6 +55982,8 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21",
                   "gpt-image-1",
                   "gpt-image-1-mini",
                   "chatgpt-image-latest"
@@ -55886,7 +55993,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image editing.",
+            "description": "The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.",
             "x-oaiTypeLabel": "string",
             "default": "gpt-image-1.5"
           },
@@ -56033,7 +56140,7 @@
                 "type": "null"
               }
             ],
-            "description": "Background behavior for generated image output.",
+            "description": "Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.",
             "default": "auto"
           },
           "stream": {
@@ -59575,7 +59682,9 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5"
+                  "gpt-image-1.5",
+                  "gpt-image-2",
+                  "gpt-image-2-2026-04-21"
                 ]
               }
             ],
@@ -59643,7 +59752,7 @@
               "opaque",
               "auto"
             ],
-            "description": "Background type for the generated image. One of `transparent`,\n  `opaque`, or `auto`. Default: `auto`.",
+            "description": "Set the background of the generated image. One of `transparent`,\n  `opaque`, or `auto`. Transparent backgrounds are available for\n  supported GPT Image models. For `gpt-image-2` and\n  `gpt-image-2-2026-04-21`, this support is in preview. When using\n  `transparent`, set the output format to `png` or `webp`. Default: `auto`.",
             "default": "auto"
           },
           "input_fidelity": {
@@ -60713,7 +60822,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 10485760,
+            "maxLength": 20971520,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -61027,7 +61136,6 @@
       "OpenAI.InputItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
-          "call_id",
           "type",
           "output"
         ],
@@ -61043,10 +61151,14 @@
             ]
           },
           "call_id": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 64,
-            "description": "The unique ID of the function tool call generated by the model."
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "type": {
             "type": "string",
@@ -61080,6 +61192,26 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "caller": {
             "anyOf": [
@@ -61663,7 +61795,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -62446,7 +62579,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 10485760,
+            "maxLength": 20971520,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -63518,7 +63651,6 @@
         "required": [
           "id",
           "type",
-          "call_id",
           "output"
         ],
         "properties": {
@@ -63538,6 +63670,14 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the tool that produced the output."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -63907,7 +64047,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -64410,7 +64551,6 @@
       "OpenAI.ItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
-          "call_id",
           "type",
           "output"
         ],
@@ -64426,10 +64566,14 @@
             ]
           },
           "call_id": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 64,
-            "description": "The unique ID of the function tool call generated by the model."
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "type": {
             "type": "string",
@@ -64463,6 +64607,26 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "caller": {
             "anyOf": [
@@ -65099,7 +65263,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -66118,7 +66283,6 @@
         "required": [
           "id",
           "type",
-          "call_id",
           "output"
         ],
         "properties": {
@@ -66138,6 +66302,14 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the tool that produced the output."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -66560,7 +66732,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -68435,9 +68608,7 @@
         "type": "object",
         "required": [
           "type",
-          "text",
-          "annotations",
-          "logprobs"
+          "text"
         ],
         "properties": {
           "type": {
@@ -69048,13 +69219,25 @@
           "owned_by": {
             "type": "string",
             "description": "The organization that owns the model."
+          },
+          "shutdown_date": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "The date when the model will shut down, or null if not announced."
           }
         },
         "description": "Describes an OpenAI model offering that can be used with the API.",
         "title": "Model",
         "x-oaiMeta": {
           "name": "The model object",
-          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
+          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\",\n  \"shutdown_date\": \"2026-10-23\"\n}\n"
         }
       },
       "OpenAI.Moderation": {
@@ -69666,7 +69849,6 @@
           },
           "description": {
             "type": "string",
-            "minLength": 1,
             "description": "A description of the namespace shown to the model."
           },
           "tools": {
@@ -69833,9 +70015,7 @@
         "type": "object",
         "required": [
           "type",
-          "text",
-          "annotations",
-          "logprobs"
+          "text"
         ],
         "properties": {
           "type": {
@@ -70826,7 +71006,6 @@
         "required": [
           "id",
           "type",
-          "call_id",
           "output"
         ],
         "properties": {
@@ -70846,6 +71025,14 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the tool that produced the output."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -71215,7 +71402,8 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {}
+            "unevaluatedProperties": {},
+            "description": "The error from the tool call, if any."
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -71708,9 +71896,7 @@
         "type": "object",
         "required": [
           "type",
-          "text",
-          "annotations",
-          "logprobs"
+          "text"
         ],
         "properties": {
           "type": {
@@ -72222,6 +72408,7 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
+            "message": "#/components/schemas/OpenAI.RealtimeConversationItemMessage",
             "function_call": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall",
             "function_call_output": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput",
             "mcp_approval_response": "#/components/schemas/OpenAI.RealtimeMCPApprovalResponse",
@@ -72383,6 +72570,351 @@
           ]
         }
       },
+      "OpenAI.RealtimeConversationItemMessage": {
+        "type": "object",
+        "required": [
+          "role",
+          "type"
+        ],
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageType"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ]
+          }
+        },
+        "discriminator": {
+          "propertyName": "role",
+          "mapping": {
+            "system": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem",
+            "user": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUser",
+            "assistant": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItem"
+          }
+        ]
+      },
+      "OpenAI.RealtimeConversationItemMessageAssistant": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "realtime.item"
+            ],
+            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
+            "x-stainless-const": true
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the item. Always `message`.",
+            "x-stainless-const": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "incomplete",
+              "in_progress"
+            ],
+            "description": "The status of the item. Has no effect on the conversation."
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "assistant"
+            ],
+            "description": "The role of the message sender. Always `assistant`.",
+            "x-stainless-const": true
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent"
+            },
+            "description": "The content of the message."
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
+            "readOnly": true
+          },
+          "response_id": {
+            "type": "string",
+            "description": "The id of the response that produced this item, when applicable.",
+            "readOnly": true
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
+          }
+        ],
+        "description": "An assistant message item in a Realtime conversation.",
+        "title": "Realtime assistant message item",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "OpenAI.RealtimeConversationItemMessageAssistantContent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "output_text",
+              "output_audio"
+            ]
+          },
+          "text": {
+            "type": "string"
+          },
+          "audio": {
+            "type": "string"
+          },
+          "transcript": {
+            "type": "string"
+          }
+        }
+      },
+      "OpenAI.RealtimeConversationItemMessageSystem": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "realtime.item"
+            ],
+            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
+            "x-stainless-const": true
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the item. Always `message`.",
+            "x-stainless-const": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "incomplete",
+              "in_progress"
+            ],
+            "description": "The status of the item. Has no effect on the conversation."
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "system"
+            ],
+            "description": "The role of the message sender. Always `system`.",
+            "x-stainless-const": true
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent"
+            },
+            "description": "The content of the message."
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
+            "readOnly": true
+          },
+          "response_id": {
+            "type": "string",
+            "description": "The id of the response that produced this item, when applicable.",
+            "readOnly": true
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
+          }
+        ],
+        "description": "A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. \"the user is now asking about a different topic\"), use system messages.",
+        "title": "Realtime system message item",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "OpenAI.RealtimeConversationItemMessageSystemContent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "input_text"
+            ],
+            "x-stainless-const": true
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "OpenAI.RealtimeConversationItemMessageType": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "system",
+              "user",
+              "assistant"
+            ]
+          }
+        ]
+      },
+      "OpenAI.RealtimeConversationItemMessageUser": {
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "content"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
+          },
+          "object": {
+            "type": "string",
+            "enum": [
+              "realtime.item"
+            ],
+            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
+            "x-stainless-const": true
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "message"
+            ],
+            "description": "The type of the item. Always `message`.",
+            "x-stainless-const": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "completed",
+              "incomplete",
+              "in_progress"
+            ],
+            "description": "The status of the item. Has no effect on the conversation."
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "user"
+            ],
+            "description": "The role of the message sender. Always `user`.",
+            "x-stainless-const": true
+          },
+          "content": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent"
+            },
+            "description": "The content of the message."
+          },
+          "created_at": {
+            "$ref": "#/components/schemas/FoundryTimestamp",
+            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
+            "readOnly": true
+          },
+          "response_id": {
+            "type": "string",
+            "description": "The id of the response that produced this item, when applicable.",
+            "readOnly": true
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
+          }
+        ],
+        "description": "A user message item in a Realtime conversation.",
+        "title": "Realtime user message item",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "OpenAI.RealtimeConversationItemMessageUserContent": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "input_text",
+              "input_audio",
+              "input_image"
+            ]
+          },
+          "text": {
+            "type": "string"
+          },
+          "audio": {
+            "type": "string"
+          },
+          "image_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "detail": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "low",
+              "high"
+            ],
+            "default": "auto"
+          },
+          "transcript": {
+            "type": "string"
+          }
+        }
+      },
       "OpenAI.RealtimeConversationItemType": {
         "anyOf": [
           {
@@ -72396,7 +72928,8 @@
               "mcp_approval_response",
               "mcp_list_tools",
               "mcp_call",
-              "mcp_approval_request"
+              "mcp_approval_request",
+              "message"
             ]
           }
         ]
@@ -74520,16 +75053,24 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "type": "string",
-            "maxLength": 64,
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "prompt_cache_key": {
-            "type": "string",
-            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTier"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -74598,6 +75139,9 @@
           },
           "prompt": {
             "$ref": "#/components/schemas/OpenAI.Prompt"
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
           },
           "truncation": {
             "anyOf": [
@@ -74743,7 +75287,7 @@
           "conversation": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.ConversationReference"
+                "$ref": "#/components/schemas/OpenAI.ResponseConversation"
               },
               {
                 "type": "null"
@@ -75298,6 +75842,20 @@
           "example": "{\n  \"type\": \"response.content_part.done\",\n  \"item_id\": \"msg_123\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"sequence_number\": 1,\n  \"part\": {\n    \"type\": \"output_text\",\n    \"text\": \"In a shimmering forest under a sky full of stars, a lonely unicorn named Lila discovered a hidden pond that glowed with moonlight. Every night, she would leave sparkling, magical flowers by the water's edge, hoping to share her beauty with others. One enchanting evening, she woke to find a group of friendly animals gathered around, eager to be friends and share in her magic.\",\n    \"annotations\": []\n  }\n}\n"
         }
       },
+      "OpenAI.ResponseConversation": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the conversation that this response was associated with."
+          }
+        },
+        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
+        "title": "Conversation"
+      },
       "OpenAI.ResponseCreatedEvent": {
         "type": "object",
         "required": [
@@ -75454,6 +76012,7 @@
           "server_error",
           "rate_limit_exceeded",
           "invalid_prompt",
+          "data_residency_mismatch",
           "bio_policy",
           "vector_store_timeout",
           "invalid_image",
@@ -76058,6 +76617,22 @@
           "partial_image_b64": {
             "type": "string",
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
+          },
+          "size": {
+            "type": "string",
+            "description": "The image size that was used."
+          },
+          "quality": {
+            "type": "string",
+            "description": "The image quality that was used."
+          },
+          "background": {
+            "type": "string",
+            "description": "The background setting that was used."
+          },
+          "output_format": {
+            "type": "string",
+            "description": "The output format that was used."
           }
         },
         "allOf": [
@@ -76594,7 +77169,7 @@
           },
           "item": {
             "$ref": "#/components/schemas/OpenAI.OutputItem",
-            "description": "The output item that was added."
+            "description": "The output item that was added. For reasoning items, `encrypted_content`\n  may be incomplete while the item is in progress. Use the reasoning item\n  from the corresponding `response.output_item.done` event when passing it\n  as input to a subsequent request."
           }
         },
         "allOf": [
@@ -76706,7 +77281,7 @@
         "x-oaiMeta": {
           "name": "response.output_text.annotation.added",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"text_annotation\",\n    \"text\": \"This is a test annotation\",\n    \"start\": 0,\n    \"end\": 10\n  },\n  \"sequence_number\": 1\n}\n"
+          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"file_citation\",\n    \"file_id\": \"file-abc\",\n    \"index\": 0,\n    \"filename\": \"example.txt\"\n  },\n  \"sequence_number\": 1\n}\n"
         }
       },
       "OpenAI.ResponsePromptVariables": {
@@ -77231,6 +77806,238 @@
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
       },
+      "OpenAI.ResponseShellCallCommandAddedStreamingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "sequence_number",
+          "output_index",
+          "command_index",
+          "command"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "response.shell_call_command.added"
+            ],
+            "description": "The type of the event, always `response.shell_call_command.added`.",
+            "x-stainless-const": true
+          },
+          "sequence_number": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The sequence number of the event that was emitted."
+          },
+          "output_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the output item that was updated."
+          },
+          "command_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the shell command that was added."
+          },
+          "command": {
+            "type": "string",
+            "description": "The shell command that was added."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
+          }
+        ],
+        "description": "A streaming event that indicated a shell command was added to a tool call.",
+        "title": "Response shell command added event"
+      },
+      "OpenAI.ResponseShellCallCommandDeltaStreamingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "sequence_number",
+          "output_index",
+          "command_index",
+          "delta"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "response.shell_call_command.delta"
+            ],
+            "description": "The type of the event, always `response.shell_call_command.delta`.",
+            "x-stainless-const": true
+          },
+          "sequence_number": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The sequence number of the event that was emitted."
+          },
+          "output_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the output item that was updated."
+          },
+          "command_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the shell command that was updated."
+          },
+          "delta": {
+            "type": "string",
+            "description": "The shell command delta that was appended."
+          },
+          "obfuscation": {
+            "type": "string",
+            "description": "An obfuscation string that was added to pad the event payload."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
+          }
+        ],
+        "description": "A streaming event that indicated a shell command was incrementally updated.",
+        "title": "Response shell command delta event"
+      },
+      "OpenAI.ResponseShellCallCommandDoneStreamingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "sequence_number",
+          "output_index",
+          "command_index",
+          "command"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "response.shell_call_command.done"
+            ],
+            "description": "The type of the event, always `response.shell_call_command.done`.",
+            "x-stainless-const": true
+          },
+          "sequence_number": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The sequence number of the event that was emitted."
+          },
+          "output_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the output item that was updated."
+          },
+          "command_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the shell command that was completed."
+          },
+          "command": {
+            "type": "string",
+            "description": "The final shell command that was emitted."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
+          }
+        ],
+        "description": "A streaming event that indicated a shell command was completed.",
+        "title": "Response shell command done event"
+      },
+      "OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "sequence_number",
+          "item_id",
+          "output_index",
+          "command_index",
+          "delta"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "response.shell_call_output_content.delta"
+            ],
+            "description": "The type of the event, always `response.shell_call_output_content.delta`.",
+            "x-stainless-const": true
+          },
+          "sequence_number": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The sequence number of the event that was emitted."
+          },
+          "item_id": {
+            "type": "string",
+            "description": "The ID of the output item that was updated."
+          },
+          "output_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the output item that was updated."
+          },
+          "command_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the shell command that produced output."
+          },
+          "delta": {
+            "$ref": "#/components/schemas/OpenAI.ShellCallOutputDelta",
+            "description": "The stdout/stderr delta that was emitted."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
+          }
+        ],
+        "description": "A streaming event that indicated shell call output was incrementally added.",
+        "title": "Response shell call output content delta event"
+      },
+      "OpenAI.ResponseShellCallOutputContentDoneStreamingEvent": {
+        "type": "object",
+        "required": [
+          "type",
+          "sequence_number",
+          "item_id",
+          "output_index",
+          "command_index",
+          "output"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "response.shell_call_output_content.done"
+            ],
+            "description": "The type of the event, always `response.shell_call_output_content.done`.",
+            "x-stainless-const": true
+          },
+          "sequence_number": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The sequence number of the event that was emitted."
+          },
+          "item_id": {
+            "type": "string",
+            "description": "The ID of the output item that was updated."
+          },
+          "output_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the output item that was updated."
+          },
+          "command_index": {
+            "$ref": "#/components/schemas/OpenAI.integer",
+            "description": "The index of the shell command that produced output."
+          },
+          "output": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputContent"
+            },
+            "description": "The output contents emitted for the shell command."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
+          }
+        ],
+        "description": "A streaming event that indicated shell call output was completed.",
+        "title": "Response shell call output content done event"
+      },
       "OpenAI.ResponseStreamEvent": {
         "type": "object",
         "required": [
@@ -77291,6 +78098,11 @@
             "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
             "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
             "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
+            "response.shell_call_command.added": "#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent",
+            "response.shell_call_command.delta": "#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent",
+            "response.shell_call_command.done": "#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent",
+            "response.shell_call_output_content.delta": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent",
+            "response.shell_call_output_content.done": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent",
             "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
             "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
             "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
@@ -77298,7 +78110,8 @@
             "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
             "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
           }
-        }
+        },
+        "description": "Event emitted while a response is streamed."
       },
       "OpenAI.ResponseStreamEventType": {
         "anyOf": [
@@ -77327,6 +78140,11 @@
               "response.file_search_call.searching",
               "response.function_call_arguments.delta",
               "response.function_call_arguments.done",
+              "response.shell_call_command.added",
+              "response.shell_call_command.delta",
+              "response.shell_call_command.done",
+              "response.shell_call_output_content.delta",
+              "response.shell_call_output_content.done",
               "response.in_progress",
               "response.failed",
               "response.incomplete",
@@ -78994,23 +79812,60 @@
               "default",
               "flex",
               "scale",
-              "priority"
+              "priority",
+              "fast"
             ]
           },
           {
             "type": "null"
           }
         ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
+        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
       },
       "OpenAI.ServiceTierEnum": {
         "type": "string",
         "enum": [
           "auto",
           "default",
+          "fast",
           "flex",
           "priority"
         ]
+      },
+      "OpenAI.ServiceTierResponses": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "auto",
+              "default",
+              "flex",
+              "scale",
+              "priority",
+              "fast",
+              "ultrafast"
+            ]
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
+      },
+      "OpenAI.ShellCallOutputDelta": {
+        "type": "object",
+        "properties": {
+          "stdout": {
+            "type": "string",
+            "description": "The stdout delta that was emitted."
+          },
+          "stderr": {
+            "type": "string",
+            "description": "The stderr delta that was emitted."
+          }
+        },
+        "description": "A delta of stdout/stderr emitted while a shell call was running.",
+        "title": "Shell call output delta"
       },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
@@ -80290,6 +81145,19 @@
           "logprobs"
         ]
       },
+      "OpenAI.TranscriptionLanguage": {
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "The code of a language detected in the audio."
+          }
+        },
+        "description": "A language detected in transcribed audio."
+      },
       "OpenAI.TranscriptionSegment": {
         "type": "object",
         "required": [
@@ -81364,7 +82232,7 @@
             "type": "null"
           }
         ],
-        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`."
+        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`. The default is\n`medium`."
       },
       "OpenAI.VideoCharacterResource": {
         "type": "object",
@@ -81971,6 +82839,11 @@
               "web_search"
             ],
             "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
+          },
+          "external_web_access": {
+            "type": "boolean",
+            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
+            "default": true
           },
           "filters": {
             "anyOf": [
@@ -87898,6 +88771,21 @@
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
           },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
+          },
+          "keywords": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
+          },
           "prompt": {
             "type": "string",
             "description": "An optional text to guide the model's style or continue a previous audio\n  segment.\n  For `whisper-1`, the [prompt is a list of keywords](/docs/guides/speech-to-text#prompting).\n  For `gpt-4o-transcribe` models (excluding `gpt-4o-transcribe-diarize`), the prompt is a free text string, for example \"expect words related to technology\".\n  Prompt is not supported with `gpt-realtime-whisper` in GA Realtime sessions."
@@ -89334,6 +90222,11 @@
             "enum": [
               "web_search"
             ]
+          },
+          "external_web_access": {
+            "type": "boolean",
+            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
+            "default": true
           },
           "filters": {
             "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -79405,7 +79405,7 @@ components:
       properties:
         identity:
           $ref: '#/components/schemas/RoutineDispatchIdentity'
-          description: The identity used when dispatching the routine. When omitted, dispatch uses the target agent identity.
+          description: The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch.
       description: Optional authorization configuration for a routine dispatch.
       x-ms-foundry-meta:
         conditional_previews:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -79420,8 +79420,7 @@ components:
           description: A human-readable description of the routine.
         enabled:
           type: boolean
-          description: Whether the routine is enabled. If omitted when creating a new routine, the service defaults this value to true. If omitted on update, the service preserves the existing enabled state.
-          default: true
+          description: Whether the routine is enabled.
         triggers:
           type: object
           unevaluatedProperties:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -11051,6 +11051,10 @@ paths:
             encoding:
               model:
                 contentType: text/plain
+              languages:
+                contentType: application/json
+              keywords:
+                contentType: application/json
               response_format:
                 contentType: application/json
               temperature:
@@ -27020,16 +27024,13 @@ paths:
                         Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                     deprecated: true
                   safety_identifier:
-                    type: string
-                    maxLength: 64
-                    description: |-
-                      A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                    anyOf:
+                      - type: string
+                      - type: 'null'
                   prompt_cache_key:
-                    type: string
-                    description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-                  service_tier:
-                    $ref: '#/components/schemas/OpenAI.ServiceTier'
+                    anyOf:
+                      - type: string
+                      - type: 'null'
                   prompt_cache_retention:
                     anyOf:
                       - type: string
@@ -27063,6 +27064,8 @@ paths:
                       - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                   prompt:
                     $ref: '#/components/schemas/OpenAI.Prompt'
+                  service_tier:
+                    $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                   truncation:
                     anyOf:
                       - type: string
@@ -27152,7 +27155,7 @@ paths:
                     default: true
                   conversation:
                     anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ConversationReference'
+                      - $ref: '#/components/schemas/OpenAI.ResponseConversation'
                       - type: 'null'
                   max_output_tokens:
                     anyOf:
@@ -27246,16 +27249,13 @@ paths:
                       Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   deprecated: true
                 safety_identifier:
-                  type: string
-                  maxLength: 64
-                  description: |-
-                    A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+                  anyOf:
+                    - type: string
+                    - type: 'null'
                 prompt_cache_key:
-                  type: string
-                  description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-                service_tier:
-                  $ref: '#/components/schemas/OpenAI.ServiceTier'
+                  anyOf:
+                    - type: string
+                    - type: 'null'
                 prompt_cache_retention:
                   anyOf:
                     - type: string
@@ -27291,6 +27291,8 @@ paths:
                     - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                 prompt:
                   $ref: '#/components/schemas/OpenAI.Prompt'
+                service_tier:
+                  $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                 truncation:
                   anyOf:
                     - type: string
@@ -51625,18 +51627,31 @@ components:
             - type: string
               enum:
                 - whisper-1
+                - gpt-transcribe
+                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
+          description: The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
         language:
           type: string
           description: |-
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
+        languages:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
+        keywords:
+          type: array
+          items:
+            type: string
+          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -51666,15 +51681,23 @@ components:
             - type: string
               enum:
                 - whisper-1
+                - gpt-transcribe
+                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
+          description: The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
         language:
           type: string
           description: The language of the input audio.
+        languages:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format.
         prompt:
           type: string
           description: The prompt configured for input audio transcription, when present.
@@ -53406,6 +53429,8 @@ components:
           $ref: '#/components/schemas/OpenAI.integer'
         reasoning_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
+        text_tokens:
+          $ref: '#/components/schemas/OpenAI.integer'
         rejected_prediction_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
     OpenAI.CompletionUsagePromptTokensDetails:
@@ -53414,6 +53439,10 @@ components:
         audio_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cached_tokens:
+          $ref: '#/components/schemas/OpenAI.integer'
+        text_tokens:
+          $ref: '#/components/schemas/OpenAI.integer'
+        image_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cache_write_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
@@ -54546,7 +54575,6 @@ components:
       required:
         - id
         - type
-        - call_id
         - output
       properties:
         id:
@@ -54564,6 +54592,12 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the tool that produced the output.
+        namespace:
+          type: string
+          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -54851,6 +54885,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -55174,16 +55209,6 @@ components:
           description: The unique ID of the conversation.
       description: The conversation that this response belongs to.
       title: Conversation object
-    OpenAI.ConversationReference:
-      type: object
-      required:
-        - id
-      properties:
-        id:
-          type: string
-          description: The unique ID of the conversation that this response was associated with.
-      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
-      title: Conversation
     OpenAI.ConversationResource:
       type: object
       required:
@@ -55428,16 +55453,13 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          type: string
-          maxLength: 64
-          description: |-
-            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+          anyOf:
+            - type: string
+            - type: 'null'
         prompt_cache_key:
-          type: string
-          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTier'
+          anyOf:
+            - type: string
+            - type: 'null'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -55461,6 +55483,8 @@ components:
         model:
           type: string
           description: The model deployment to use for this chat completion.
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTier'
         modalities:
           $ref: '#/components/schemas/OpenAI.ResponseModalities'
         verbosity:
@@ -55787,6 +55811,10 @@ components:
         model:
           type: string
           description: The model deployment used for the creation of this chat completion.
+        metadata:
+          anyOf:
+            - $ref: '#/components/schemas/OpenAI.Metadata'
+            - type: 'null'
         service_tier:
           $ref: '#/components/schemas/OpenAI.ServiceTier'
         system_fingerprint:
@@ -56831,7 +56859,7 @@ components:
                 contentEncoding: base64
           description: |-
             The image(s) to edit. Must be a supported image file or an array of images.
-              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`
+              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`
               file less than 50MB. You can provide up to 16 images.
               `chatgpt-image-latest` follows the same input constraints as GPT image models.
               For `dall-e-2`, you can only provide one image, and it should be a square
@@ -56850,24 +56878,27 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Allows to set transparency for the background of the generated image(s).
-              This parameter is only supported for the GPT image models. Must be one of
-              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
-              model will automatically determine the best background for the image.
-              If `transparent`, the output format needs to support transparency, so it
-              should be set to either `png` (default value) or `webp`.
+            Set the background of the generated image(s). This parameter is only
+              supported for the GPT image models. Must be one of `transparent`, `opaque`,
+              or `auto` (default value). When `auto` is used, the model will automatically
+              determine the best background for the image.
+              Transparent backgrounds are available for supported GPT Image models. For
+              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
+              using `transparent`, set the output format to `png` or `webp`.
         model:
           anyOf:
             - type: string
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image generation. Defaults to `gpt-image-1.5`.
+          description: The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.
           x-oaiTypeLabel: string
         'n':
           anyOf:
@@ -56959,12 +56990,14 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - dall-e-3
                 - gpt-image-1
                 - gpt-image-1-mini
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
+          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
           x-oaiTypeLabel: string
           default: dall-e-2
         'n':
@@ -57062,12 +57095,13 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Allows to set transparency for the background of the generated image(s).
-              This parameter is only supported for the GPT image models. Must be one of
-              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
-              model will automatically determine the best background for the image.
-              If `transparent`, the output format needs to support transparency, so it
-              should be set to either `png` (default value) or `webp`.
+            Set the background of the generated image(s). This parameter is only
+              supported for the GPT image models. Must be one of `transparent`, `opaque`,
+              or `auto` (default value). When `auto` is used, the model will automatically
+              determine the best background for the image.
+              Transparent backgrounds are available for supported GPT Image models. For
+              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
+              using `transparent`, set the output format to `png` or `webp`.
           default: auto
         style:
           anyOf:
@@ -57961,7 +57995,9 @@ components:
       type: object
       properties:
         file:
-          description: 'The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
+          description: |-
+            The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
+              The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -57969,15 +58005,26 @@ components:
             - type: string
               enum:
                 - whisper-1
+                - gpt-transcribe
                 - gpt-4o-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe-diarize
-          description: ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
+          description: ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
           x-oaiTypeLabel: string
         language:
           type: string
           description: The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency.
+        languages:
+          type: array
+          items:
+            type: string
+          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`.
+        keywords:
+          type: array
+          items:
+            type: string
+          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`.
         prompt:
           type: string
           description: An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text#prompting) should match the audio language. This field is not supported when using `gpt-4o-transcribe-diarize`.
@@ -58095,6 +58142,11 @@ components:
         text:
           type: string
           description: The transcribed text.
+        languages:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.TranscriptionLanguage'
+          description: The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected.
         logprobs:
           type: array
           items:
@@ -58217,7 +58269,7 @@ components:
       type: object
       properties:
         file:
-          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
+          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.'
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -58974,11 +59026,13 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image editing.
+          description: The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.
           x-oaiTypeLabel: string
           default: gpt-image-1.5
         images:
@@ -59070,7 +59124,7 @@ components:
                 - opaque
                 - auto
             - type: 'null'
-          description: Background behavior for generated image output.
+          description: Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.
           default: auto
         stream:
           anyOf:
@@ -61626,6 +61680,8 @@ components:
                 - gpt-image-1
                 - gpt-image-1-mini
                 - gpt-image-1.5
+                - gpt-image-2
+                - gpt-image-2-2026-04-21
           default: gpt-image-1
         quality:
           type: string
@@ -61679,8 +61735,11 @@ components:
             - opaque
             - auto
           description: |-
-            Background type for the generated image. One of `transparent`,
-              `opaque`, or `auto`. Default: `auto`.
+            Set the background of the generated image. One of `transparent`,
+              `opaque`, or `auto`. Transparent backgrounds are available for
+              supported GPT Image models. For `gpt-image-2` and
+              `gpt-image-2-2026-04-21`, this support is in preview. When using
+              `transparent`, set the output format to `png` or `webp`. Default: `auto`.
           default: auto
         input_fidelity:
           anyOf:
@@ -62407,7 +62466,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 10485760
+          maxLength: 20971520
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
@@ -62618,7 +62677,6 @@ components:
     OpenAI.InputItemFunctionCallOutputItemParam:
       type: object
       required:
-        - call_id
         - type
         - output
       properties:
@@ -62627,10 +62685,9 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          type: string
-          minLength: 1
-          maxLength: 64
-          description: The unique ID of the function tool call generated by the model.
+          anyOf:
+            - type: string
+            - type: 'null'
         type:
           type: string
           enum:
@@ -62648,6 +62705,14 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+        namespace:
+          anyOf:
+            - type: string
+            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -63021,6 +63086,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -63544,7 +63610,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 10485760
+          maxLength: 20971520
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
@@ -64280,7 +64346,6 @@ components:
       required:
         - id
         - type
-        - call_id
         - output
       properties:
         id:
@@ -64298,6 +64363,12 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the tool that produced the output.
+        namespace:
+          type: string
+          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -64549,6 +64620,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -64903,7 +64975,6 @@ components:
     OpenAI.ItemFunctionCallOutputItemParam:
       type: object
       required:
-        - call_id
         - type
         - output
       properties:
@@ -64912,10 +64983,9 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          type: string
-          minLength: 1
-          maxLength: 64
-          description: The unique ID of the function tool call generated by the model.
+          anyOf:
+            - type: string
+            - type: 'null'
         type:
           type: string
           enum:
@@ -64933,6 +65003,14 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
+        name:
+          anyOf:
+            - type: string
+            - type: 'null'
+        namespace:
+          anyOf:
+            - type: string
+            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -65350,6 +65428,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -66063,7 +66142,6 @@ components:
       required:
         - id
         - type
-        - call_id
         - output
       properties:
         id:
@@ -66081,6 +66159,12 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the tool that produced the output.
+        namespace:
+          type: string
+          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -66376,6 +66460,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -67734,8 +67819,6 @@ components:
       required:
         - type
         - text
-        - annotations
-        - logprobs
       properties:
         type:
           type: string
@@ -68175,6 +68258,12 @@ components:
         owned_by:
           type: string
           description: The organization that owns the model.
+        shutdown_date:
+          anyOf:
+            - type: string
+              format: date
+            - type: 'null'
+          description: The date when the model will shut down, or null if not announced.
       description: Describes an OpenAI model offering that can be used with the API.
       title: Model
       x-oaiMeta:
@@ -68184,7 +68273,8 @@ components:
             "id": "VAR_chat_model_id",
             "object": "model",
             "created": 1686935002,
-            "owned_by": "openai"
+            "owned_by": "openai",
+            "shutdown_date": "2026-10-23"
           }
     OpenAI.Moderation:
       type: object
@@ -68555,7 +68645,6 @@ components:
           description: The namespace name used in tool calls (for example, `crm`).
         description:
           type: string
-          minLength: 1
           description: A description of the namespace shown to the model.
         tools:
           type: array
@@ -68685,8 +68774,6 @@ components:
       required:
         - type
         - text
-        - annotations
-        - logprobs
       properties:
         type:
           type: string
@@ -69382,7 +69469,6 @@ components:
       required:
         - id
         - type
-        - call_id
         - output
       properties:
         id:
@@ -69400,6 +69486,12 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
+        name:
+          type: string
+          description: The name of the tool that produced the output.
+        namespace:
+          type: string
+          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -69651,6 +69743,7 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
+          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -70006,8 +70099,6 @@ components:
       required:
         - type
         - text
-        - annotations
-        - logprobs
       properties:
         type:
           type: string
@@ -70362,6 +70453,7 @@ components:
       discriminator:
         propertyName: type
         mapping:
+          message: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
           function_call: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall'
           function_call_output: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput'
           mcp_approval_response: '#/components/schemas/OpenAI.RealtimeMCPApprovalResponse'
@@ -70478,6 +70570,248 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    OpenAI.RealtimeConversationItemMessage:
+      type: object
+      required:
+        - role
+        - type
+      properties:
+        role:
+          $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageType'
+        type:
+          type: string
+          enum:
+            - message
+      discriminator:
+        propertyName: role
+        mapping:
+          system: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem'
+          user: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUser'
+          assistant: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant'
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItem'
+    OpenAI.RealtimeConversationItemMessageAssistant:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        id:
+          type: string
+          description: The unique ID of the item. This may be provided by the client or generated by the server.
+        object:
+          type: string
+          enum:
+            - realtime.item
+          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
+          x-stainless-const: true
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the item. Always `message`.
+          x-stainless-const: true
+        status:
+          type: string
+          enum:
+            - completed
+            - incomplete
+            - in_progress
+          description: The status of the item. Has no effect on the conversation.
+        role:
+          type: string
+          enum:
+            - assistant
+          description: The role of the message sender. Always `assistant`.
+          x-stainless-const: true
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent'
+          description: The content of the message.
+        created_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the item was persisted.
+          readOnly: true
+        response_id:
+          type: string
+          description: The id of the response that produced this item, when applicable.
+          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
+      description: An assistant message item in a Realtime conversation.
+      title: Realtime assistant message item
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    OpenAI.RealtimeConversationItemMessageAssistantContent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - output_text
+            - output_audio
+        text:
+          type: string
+        audio:
+          type: string
+        transcript:
+          type: string
+    OpenAI.RealtimeConversationItemMessageSystem:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        id:
+          type: string
+          description: The unique ID of the item. This may be provided by the client or generated by the server.
+        object:
+          type: string
+          enum:
+            - realtime.item
+          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
+          x-stainless-const: true
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the item. Always `message`.
+          x-stainless-const: true
+        status:
+          type: string
+          enum:
+            - completed
+            - incomplete
+            - in_progress
+          description: The status of the item. Has no effect on the conversation.
+        role:
+          type: string
+          enum:
+            - system
+          description: The role of the message sender. Always `system`.
+          x-stainless-const: true
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent'
+          description: The content of the message.
+        created_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the item was persisted.
+          readOnly: true
+        response_id:
+          type: string
+          description: The id of the response that produced this item, when applicable.
+          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
+      description: A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. "the user is now asking about a different topic"), use system messages.
+      title: Realtime system message item
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    OpenAI.RealtimeConversationItemMessageSystemContent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - input_text
+          x-stainless-const: true
+        text:
+          type: string
+    OpenAI.RealtimeConversationItemMessageType:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - system
+            - user
+            - assistant
+    OpenAI.RealtimeConversationItemMessageUser:
+      type: object
+      required:
+        - type
+        - role
+        - content
+      properties:
+        id:
+          type: string
+          description: The unique ID of the item. This may be provided by the client or generated by the server.
+        object:
+          type: string
+          enum:
+            - realtime.item
+          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
+          x-stainless-const: true
+        type:
+          type: string
+          enum:
+            - message
+          description: The type of the item. Always `message`.
+          x-stainless-const: true
+        status:
+          type: string
+          enum:
+            - completed
+            - incomplete
+            - in_progress
+          description: The status of the item. Has no effect on the conversation.
+        role:
+          type: string
+          enum:
+            - user
+          description: The role of the message sender. Always `user`.
+          x-stainless-const: true
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent'
+          description: The content of the message.
+        created_at:
+          $ref: '#/components/schemas/FoundryTimestamp'
+          description: The Unix timestamp (in seconds) for when the item was persisted.
+          readOnly: true
+        response_id:
+          type: string
+          description: The id of the response that produced this item, when applicable.
+          readOnly: true
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
+      description: A user message item in a Realtime conversation.
+      title: Realtime user message item
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    OpenAI.RealtimeConversationItemMessageUserContent:
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - input_text
+            - input_audio
+            - input_image
+        text:
+          type: string
+        audio:
+          type: string
+        image_url:
+          type: string
+          format: uri
+        detail:
+          type: string
+          enum:
+            - auto
+            - low
+            - high
+          default: auto
+        transcript:
+          type: string
     OpenAI.RealtimeConversationItemType:
       anyOf:
         - type: string
@@ -70489,6 +70823,7 @@ components:
             - mcp_list_tools
             - mcp_call
             - mcp_approval_request
+            - message
     OpenAI.RealtimeCreateClientSecretRequest:
       type: object
       properties:
@@ -72195,16 +72530,13 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          type: string
-          maxLength: 64
-          description: |-
-            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
-              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
+          anyOf:
+            - type: string
+            - type: 'null'
         prompt_cache_key:
-          type: string
-          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTier'
+          anyOf:
+            - type: string
+            - type: 'null'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -72238,6 +72570,8 @@ components:
             - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
         prompt:
           $ref: '#/components/schemas/OpenAI.Prompt'
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
         truncation:
           anyOf:
             - type: string
@@ -72327,7 +72661,7 @@ components:
           default: true
         conversation:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.ConversationReference'
+            - $ref: '#/components/schemas/OpenAI.ResponseConversation'
             - type: 'null'
         max_output_tokens:
           anyOf:
@@ -72851,6 +73185,16 @@ components:
               "annotations": []
             }
           }
+    OpenAI.ResponseConversation:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: The unique ID of the conversation that this response was associated with.
+      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
+      title: Conversation
     OpenAI.ResponseCreatedEvent:
       type: object
       required:
@@ -73014,6 +73358,7 @@ components:
         - server_error
         - rate_limit_exceeded
         - invalid_prompt
+        - data_residency_mismatch
         - bio_policy
         - vector_store_timeout
         - invalid_image
@@ -73545,6 +73890,18 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
+        size:
+          type: string
+          description: The image size that was used.
+        quality:
+          type: string
+          description: The image quality that was used.
+        background:
+          type: string
+          description: The background setting that was used.
+        output_format:
+          type: string
+          description: The output format that was used.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
@@ -74066,7 +74423,11 @@ components:
           description: The sequence number of this event.
         item:
           $ref: '#/components/schemas/OpenAI.OutputItem'
-          description: The output item that was added.
+          description: |-
+            The output item that was added. For reasoning items, `encrypted_content`
+              may be incomplete while the item is in progress. Use the reasoning item
+              from the corresponding `response.output_item.done` event when passing it
+              as input to a subsequent request.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
@@ -74184,10 +74545,10 @@ components:
             "content_index": 0,
             "annotation_index": 0,
             "annotation": {
-              "type": "text_annotation",
-              "text": "This is a test annotation",
-              "start": 0,
-              "end": 10
+              "type": "file_citation",
+              "file_id": "file-abc",
+              "index": 0,
+              "filename": "example.txt"
             },
             "sequence_number": 1
           }
@@ -74656,6 +75017,174 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
+    OpenAI.ResponseShellCallCommandAddedStreamingEvent:
+      type: object
+      required:
+        - type
+        - sequence_number
+        - output_index
+        - command_index
+        - command
+      properties:
+        type:
+          type: string
+          enum:
+            - response.shell_call_command.added
+          description: The type of the event, always `response.shell_call_command.added`.
+          x-stainless-const: true
+        sequence_number:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The sequence number of the event that was emitted.
+        output_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the output item that was updated.
+        command_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the shell command that was added.
+        command:
+          type: string
+          description: The shell command that was added.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
+      description: A streaming event that indicated a shell command was added to a tool call.
+      title: Response shell command added event
+    OpenAI.ResponseShellCallCommandDeltaStreamingEvent:
+      type: object
+      required:
+        - type
+        - sequence_number
+        - output_index
+        - command_index
+        - delta
+      properties:
+        type:
+          type: string
+          enum:
+            - response.shell_call_command.delta
+          description: The type of the event, always `response.shell_call_command.delta`.
+          x-stainless-const: true
+        sequence_number:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The sequence number of the event that was emitted.
+        output_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the output item that was updated.
+        command_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the shell command that was updated.
+        delta:
+          type: string
+          description: The shell command delta that was appended.
+        obfuscation:
+          type: string
+          description: An obfuscation string that was added to pad the event payload.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
+      description: A streaming event that indicated a shell command was incrementally updated.
+      title: Response shell command delta event
+    OpenAI.ResponseShellCallCommandDoneStreamingEvent:
+      type: object
+      required:
+        - type
+        - sequence_number
+        - output_index
+        - command_index
+        - command
+      properties:
+        type:
+          type: string
+          enum:
+            - response.shell_call_command.done
+          description: The type of the event, always `response.shell_call_command.done`.
+          x-stainless-const: true
+        sequence_number:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The sequence number of the event that was emitted.
+        output_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the output item that was updated.
+        command_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the shell command that was completed.
+        command:
+          type: string
+          description: The final shell command that was emitted.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
+      description: A streaming event that indicated a shell command was completed.
+      title: Response shell command done event
+    OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent:
+      type: object
+      required:
+        - type
+        - sequence_number
+        - item_id
+        - output_index
+        - command_index
+        - delta
+      properties:
+        type:
+          type: string
+          enum:
+            - response.shell_call_output_content.delta
+          description: The type of the event, always `response.shell_call_output_content.delta`.
+          x-stainless-const: true
+        sequence_number:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The sequence number of the event that was emitted.
+        item_id:
+          type: string
+          description: The ID of the output item that was updated.
+        output_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the output item that was updated.
+        command_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the shell command that produced output.
+        delta:
+          $ref: '#/components/schemas/OpenAI.ShellCallOutputDelta'
+          description: The stdout/stderr delta that was emitted.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
+      description: A streaming event that indicated shell call output was incrementally added.
+      title: Response shell call output content delta event
+    OpenAI.ResponseShellCallOutputContentDoneStreamingEvent:
+      type: object
+      required:
+        - type
+        - sequence_number
+        - item_id
+        - output_index
+        - command_index
+        - output
+      properties:
+        type:
+          type: string
+          enum:
+            - response.shell_call_output_content.done
+          description: The type of the event, always `response.shell_call_output_content.done`.
+          x-stainless-const: true
+        sequence_number:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The sequence number of the event that was emitted.
+        item_id:
+          type: string
+          description: The ID of the output item that was updated.
+        output_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the output item that was updated.
+        command_index:
+          $ref: '#/components/schemas/OpenAI.integer'
+          description: The index of the shell command that produced output.
+        output:
+          type: array
+          items:
+            $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
+          description: The output contents emitted for the shell command.
+      allOf:
+        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
+      description: A streaming event that indicated shell call output was completed.
+      title: Response shell call output content done event
     OpenAI.ResponseStreamEvent:
       type: object
       required:
@@ -74713,12 +75242,18 @@ components:
           response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
           response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
           response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
+          response.shell_call_command.added: '#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent'
+          response.shell_call_command.delta: '#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent'
+          response.shell_call_command.done: '#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent'
+          response.shell_call_output_content.delta: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent'
+          response.shell_call_output_content.done: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent'
           response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
           response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
           response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
           response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
           response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
           response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
+      description: Event emitted while a response is streamed.
     OpenAI.ResponseStreamEventType:
       anyOf:
         - type: string
@@ -74743,6 +75278,11 @@ components:
             - response.file_search_call.searching
             - response.function_call_arguments.delta
             - response.function_call_arguments.done
+            - response.shell_call_command.added
+            - response.shell_call_command.delta
+            - response.shell_call_command.done
+            - response.shell_call_output_content.delta
+            - response.shell_call_output_content.done
             - response.in_progress
             - response.failed
             - response.incomplete
@@ -75985,12 +76525,14 @@ components:
             - flex
             - scale
             - priority
+            - fast
         - type: 'null'
       description: |-
         Specifies the processing type used for serving the request.
         - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
         - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
-        - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
+        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
+        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
     OpenAI.ServiceTierEnum:
@@ -75998,8 +76540,41 @@ components:
       enum:
         - auto
         - default
+        - fast
         - flex
         - priority
+    OpenAI.ServiceTierResponses:
+      anyOf:
+        - type: string
+          enum:
+            - auto
+            - default
+            - flex
+            - scale
+            - priority
+            - fast
+            - ultrafast
+        - type: 'null'
+      description: |-
+        Specifies the processing type used for serving the request.
+        - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
+        - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
+        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
+        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
+        - If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.
+        - When not set, the default behavior is 'auto'.
+        When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
+    OpenAI.ShellCallOutputDelta:
+      type: object
+      properties:
+        stdout:
+          type: string
+          description: The stdout delta that was emitted.
+        stderr:
+          type: string
+          description: The stderr delta that was emitted.
+      description: A delta of stdout/stderr emitted while a shell call was running.
+      title: Shell call output delta
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -76937,6 +77512,15 @@ components:
       type: string
       enum:
         - logprobs
+    OpenAI.TranscriptionLanguage:
+      type: object
+      required:
+        - code
+      properties:
+        code:
+          type: string
+          description: The code of a language detected in the audio.
+      description: A language detected in transcribed audio.
     OpenAI.TranscriptionSegment:
       type: object
       required:
@@ -77750,7 +78334,8 @@ components:
       description: |-
         Constrains the verbosity of the model's response. Lower values will result in
         more concise responses, while higher values will result in more verbose responses.
-        Currently supported values are `low`, `medium`, and `high`.
+        Currently supported values are `low`, `medium`, and `high`. The default is
+        `medium`.
     OpenAI.VideoCharacterResource:
       type: object
       required:
@@ -78151,6 +78736,10 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
+        external_web_access:
+          type: boolean
+          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
+          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
@@ -82286,6 +82875,17 @@ components:
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
+        languages:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
+        keywords:
+          type: array
+          items:
+            type: string
+          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -83276,6 +83876,10 @@ components:
           type: string
           enum:
             - web_search
+        external_web_access:
+          type: boolean
+          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
+          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -79420,7 +79420,8 @@ components:
           description: A human-readable description of the routine.
         enabled:
           type: boolean
-          description: Whether the routine is enabled.
+          description: Whether the routine is enabled. If omitted when creating a new routine, the service defaults this value to true. If omitted on update, the service preserves the existing enabled state.
+          default: true
         triggers:
           type: object
           unevaluatedProperties:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -79406,6 +79406,7 @@ components:
         identity:
           $ref: '#/components/schemas/RoutineDispatchIdentity'
           description: The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch.
+          default: agent
       description: Optional authorization configuration for a routine dispatch.
       x-ms-foundry-meta:
         conditional_previews:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -11051,10 +11051,6 @@ paths:
             encoding:
               model:
                 contentType: text/plain
-              languages:
-                contentType: application/json
-              keywords:
-                contentType: application/json
               response_format:
                 contentType: application/json
               temperature:
@@ -27024,13 +27020,16 @@ paths:
                         Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                     deprecated: true
                   safety_identifier:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
+                    type: string
+                    maxLength: 64
+                    description: |-
+                      A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   prompt_cache_key:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
+                    type: string
+                    description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                  service_tier:
+                    $ref: '#/components/schemas/OpenAI.ServiceTier'
                   prompt_cache_retention:
                     anyOf:
                       - type: string
@@ -27064,8 +27063,6 @@ paths:
                       - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                   prompt:
                     $ref: '#/components/schemas/OpenAI.Prompt'
-                  service_tier:
-                    $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                   truncation:
                     anyOf:
                       - type: string
@@ -27155,7 +27152,7 @@ paths:
                     default: true
                   conversation:
                     anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ResponseConversation'
+                      - $ref: '#/components/schemas/OpenAI.ConversationReference'
                       - type: 'null'
                   max_output_tokens:
                     anyOf:
@@ -27249,13 +27246,16 @@ paths:
                       Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   deprecated: true
                 safety_identifier:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
+                  type: string
+                  maxLength: 64
+                  description: |-
+                    A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                 prompt_cache_key:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
+                  type: string
+                  description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                service_tier:
+                  $ref: '#/components/schemas/OpenAI.ServiceTier'
                 prompt_cache_retention:
                   anyOf:
                     - type: string
@@ -27291,8 +27291,6 @@ paths:
                     - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                 prompt:
                   $ref: '#/components/schemas/OpenAI.Prompt'
-                service_tier:
-                  $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                 truncation:
                   anyOf:
                     - type: string
@@ -51627,31 +51625,18 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
-                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
+          description: The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
         language:
           type: string
           description: |-
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -51681,23 +51666,15 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
-                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
+          description: The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
         language:
           type: string
           description: The language of the input audio.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format.
         prompt:
           type: string
           description: The prompt configured for input audio transcription, when present.
@@ -53429,8 +53406,6 @@ components:
           $ref: '#/components/schemas/OpenAI.integer'
         reasoning_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
-        text_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
         rejected_prediction_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
     OpenAI.CompletionUsagePromptTokensDetails:
@@ -53439,10 +53414,6 @@ components:
         audio_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cached_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
-        text_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
-        image_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cache_write_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
@@ -54575,6 +54546,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -54592,12 +54564,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -54885,7 +54851,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -55209,6 +55174,16 @@ components:
           description: The unique ID of the conversation.
       description: The conversation that this response belongs to.
       title: Conversation object
+    OpenAI.ConversationReference:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: The unique ID of the conversation that this response was associated with.
+      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
+      title: Conversation
     OpenAI.ConversationResource:
       type: object
       required:
@@ -55453,13 +55428,16 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          maxLength: 64
+          description: |-
+            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTier'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -55483,8 +55461,6 @@ components:
         model:
           type: string
           description: The model deployment to use for this chat completion.
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTier'
         modalities:
           $ref: '#/components/schemas/OpenAI.ResponseModalities'
         verbosity:
@@ -55811,10 +55787,6 @@ components:
         model:
           type: string
           description: The model deployment used for the creation of this chat completion.
-        metadata:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
         service_tier:
           $ref: '#/components/schemas/OpenAI.ServiceTier'
         system_fingerprint:
@@ -56859,7 +56831,7 @@ components:
                 contentEncoding: base64
           description: |-
             The image(s) to edit. Must be a supported image file or an array of images.
-              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`
+              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`
               file less than 50MB. You can provide up to 16 images.
               `chatgpt-image-latest` follows the same input constraints as GPT image models.
               For `dall-e-2`, you can only provide one image, and it should be a square
@@ -56878,27 +56850,24 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
         model:
           anyOf:
             - type: string
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.
+          description: The model to use for image generation. Defaults to `gpt-image-1.5`.
           x-oaiTypeLabel: string
         'n':
           anyOf:
@@ -56990,14 +56959,12 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - dall-e-3
                 - gpt-image-1
                 - gpt-image-1-mini
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
+          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
           x-oaiTypeLabel: string
           default: dall-e-2
         'n':
@@ -57095,13 +57062,12 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
           default: auto
         style:
           anyOf:
@@ -57995,9 +57961,7 @@ components:
       type: object
       properties:
         file:
-          description: |-
-            The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-              The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
+          description: 'The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -58005,26 +57969,15 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
                 - gpt-4o-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe-diarize
-          description: ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
+          description: ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
           x-oaiTypeLabel: string
         language:
           type: string
           description: The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`.
         prompt:
           type: string
           description: An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text#prompting) should match the audio language. This field is not supported when using `gpt-4o-transcribe-diarize`.
@@ -58142,11 +58095,6 @@ components:
         text:
           type: string
           description: The transcribed text.
-        languages:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.TranscriptionLanguage'
-          description: The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected.
         logprobs:
           type: array
           items:
@@ -58269,7 +58217,7 @@ components:
       type: object
       properties:
         file:
-          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.'
+          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -59026,13 +58974,11 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.
+          description: The model to use for image editing.
           x-oaiTypeLabel: string
           default: gpt-image-1.5
         images:
@@ -59124,7 +59070,7 @@ components:
                 - opaque
                 - auto
             - type: 'null'
-          description: Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.
+          description: Background behavior for generated image output.
           default: auto
         stream:
           anyOf:
@@ -61680,8 +61626,6 @@ components:
                 - gpt-image-1
                 - gpt-image-1-mini
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
           default: gpt-image-1
         quality:
           type: string
@@ -61735,11 +61679,8 @@ components:
             - opaque
             - auto
           description: |-
-            Set the background of the generated image. One of `transparent`,
-              `opaque`, or `auto`. Transparent backgrounds are available for
-              supported GPT Image models. For `gpt-image-2` and
-              `gpt-image-2-2026-04-21`, this support is in preview. When using
-              `transparent`, set the output format to `png` or `webp`. Default: `auto`.
+            Background type for the generated image. One of `transparent`,
+              `opaque`, or `auto`. Default: `auto`.
           default: auto
         input_fidelity:
           anyOf:
@@ -62466,7 +62407,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
@@ -62677,6 +62618,7 @@ components:
     OpenAI.InputItemFunctionCallOutputItemParam:
       type: object
       required:
+        - call_id
         - type
         - output
       properties:
@@ -62685,9 +62627,10 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: The unique ID of the function tool call generated by the model.
         type:
           type: string
           enum:
@@ -62705,14 +62648,6 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
-        name:
-          anyOf:
-            - type: string
-            - type: 'null'
-        namespace:
-          anyOf:
-            - type: string
-            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -63086,7 +63021,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -63610,7 +63544,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
@@ -64346,6 +64280,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -64363,12 +64298,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -64620,7 +64549,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -64975,6 +64903,7 @@ components:
     OpenAI.ItemFunctionCallOutputItemParam:
       type: object
       required:
+        - call_id
         - type
         - output
       properties:
@@ -64983,9 +64912,10 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: The unique ID of the function tool call generated by the model.
         type:
           type: string
           enum:
@@ -65003,14 +64933,6 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
-        name:
-          anyOf:
-            - type: string
-            - type: 'null'
-        namespace:
-          anyOf:
-            - type: string
-            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -65428,7 +65350,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -66142,6 +66063,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -66159,12 +66081,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -66460,7 +66376,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -67819,6 +67734,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -68258,12 +68175,6 @@ components:
         owned_by:
           type: string
           description: The organization that owns the model.
-        shutdown_date:
-          anyOf:
-            - type: string
-              format: date
-            - type: 'null'
-          description: The date when the model will shut down, or null if not announced.
       description: Describes an OpenAI model offering that can be used with the API.
       title: Model
       x-oaiMeta:
@@ -68273,8 +68184,7 @@ components:
             "id": "VAR_chat_model_id",
             "object": "model",
             "created": 1686935002,
-            "owned_by": "openai",
-            "shutdown_date": "2026-10-23"
+            "owned_by": "openai"
           }
     OpenAI.Moderation:
       type: object
@@ -68645,6 +68555,7 @@ components:
           description: The namespace name used in tool calls (for example, `crm`).
         description:
           type: string
+          minLength: 1
           description: A description of the namespace shown to the model.
         tools:
           type: array
@@ -68774,6 +68685,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -69469,6 +69382,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -69486,12 +69400,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -69743,7 +69651,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -70099,6 +70006,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -70453,7 +70362,6 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
           function_call: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall'
           function_call_output: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput'
           mcp_approval_response: '#/components/schemas/OpenAI.RealtimeMCPApprovalResponse'
@@ -70570,248 +70478,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessage:
-      type: object
-      required:
-        - role
-        - type
-      properties:
-        role:
-          $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageType'
-        type:
-          type: string
-          enum:
-            - message
-      discriminator:
-        propertyName: role
-        mapping:
-          system: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem'
-          user: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUser'
-          assistant: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItem'
-    OpenAI.RealtimeConversationItemMessageAssistant:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - assistant
-          description: The role of the message sender. Always `assistant`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: An assistant message item in a Realtime conversation.
-      title: Realtime assistant message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageAssistantContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - output_text
-            - output_audio
-        text:
-          type: string
-        audio:
-          type: string
-        transcript:
-          type: string
-    OpenAI.RealtimeConversationItemMessageSystem:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - system
-          description: The role of the message sender. Always `system`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. "the user is now asking about a different topic"), use system messages.
-      title: Realtime system message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageSystemContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - input_text
-          x-stainless-const: true
-        text:
-          type: string
-    OpenAI.RealtimeConversationItemMessageType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - system
-            - user
-            - assistant
-    OpenAI.RealtimeConversationItemMessageUser:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - user
-          description: The role of the message sender. Always `user`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: A user message item in a Realtime conversation.
-      title: Realtime user message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageUserContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - input_text
-            - input_audio
-            - input_image
-        text:
-          type: string
-        audio:
-          type: string
-        image_url:
-          type: string
-          format: uri
-        detail:
-          type: string
-          enum:
-            - auto
-            - low
-            - high
-          default: auto
-        transcript:
-          type: string
     OpenAI.RealtimeConversationItemType:
       anyOf:
         - type: string
@@ -70823,7 +70489,6 @@ components:
             - mcp_list_tools
             - mcp_call
             - mcp_approval_request
-            - message
     OpenAI.RealtimeCreateClientSecretRequest:
       type: object
       properties:
@@ -72530,13 +72195,16 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          maxLength: 64
+          description: |-
+            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTier'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -72570,8 +72238,6 @@ components:
             - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
         prompt:
           $ref: '#/components/schemas/OpenAI.Prompt'
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
         truncation:
           anyOf:
             - type: string
@@ -72661,7 +72327,7 @@ components:
           default: true
         conversation:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.ResponseConversation'
+            - $ref: '#/components/schemas/OpenAI.ConversationReference'
             - type: 'null'
         max_output_tokens:
           anyOf:
@@ -73185,16 +72851,6 @@ components:
               "annotations": []
             }
           }
-    OpenAI.ResponseConversation:
-      type: object
-      required:
-        - id
-      properties:
-        id:
-          type: string
-          description: The unique ID of the conversation that this response was associated with.
-      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
-      title: Conversation
     OpenAI.ResponseCreatedEvent:
       type: object
       required:
@@ -73358,7 +73014,6 @@ components:
         - server_error
         - rate_limit_exceeded
         - invalid_prompt
-        - data_residency_mismatch
         - bio_policy
         - vector_store_timeout
         - invalid_image
@@ -73890,18 +73545,6 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
-        size:
-          type: string
-          description: The image size that was used.
-        quality:
-          type: string
-          description: The image quality that was used.
-        background:
-          type: string
-          description: The background setting that was used.
-        output_format:
-          type: string
-          description: The output format that was used.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
@@ -74423,11 +74066,7 @@ components:
           description: The sequence number of this event.
         item:
           $ref: '#/components/schemas/OpenAI.OutputItem'
-          description: |-
-            The output item that was added. For reasoning items, `encrypted_content`
-              may be incomplete while the item is in progress. Use the reasoning item
-              from the corresponding `response.output_item.done` event when passing it
-              as input to a subsequent request.
+          description: The output item that was added.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
@@ -74545,10 +74184,10 @@ components:
             "content_index": 0,
             "annotation_index": 0,
             "annotation": {
-              "type": "file_citation",
-              "file_id": "file-abc",
-              "index": 0,
-              "filename": "example.txt"
+              "type": "text_annotation",
+              "text": "This is a test annotation",
+              "start": 0,
+              "end": 10
             },
             "sequence_number": 1
           }
@@ -75017,174 +74656,6 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
-    OpenAI.ResponseShellCallCommandAddedStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - command
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.added
-          description: The type of the event, always `response.shell_call_command.added`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was added.
-        command:
-          type: string
-          description: The shell command that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was added to a tool call.
-      title: Response shell command added event
-    OpenAI.ResponseShellCallCommandDeltaStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - delta
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.delta
-          description: The type of the event, always `response.shell_call_command.delta`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was updated.
-        delta:
-          type: string
-          description: The shell command delta that was appended.
-        obfuscation:
-          type: string
-          description: An obfuscation string that was added to pad the event payload.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was incrementally updated.
-      title: Response shell command delta event
-    OpenAI.ResponseShellCallCommandDoneStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - command
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.done
-          description: The type of the event, always `response.shell_call_command.done`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was completed.
-        command:
-          type: string
-          description: The final shell command that was emitted.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was completed.
-      title: Response shell command done event
-    OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - item_id
-        - output_index
-        - command_index
-        - delta
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_output_content.delta
-          description: The type of the event, always `response.shell_call_output_content.delta`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        item_id:
-          type: string
-          description: The ID of the output item that was updated.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that produced output.
-        delta:
-          $ref: '#/components/schemas/OpenAI.ShellCallOutputDelta'
-          description: The stdout/stderr delta that was emitted.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated shell call output was incrementally added.
-      title: Response shell call output content delta event
-    OpenAI.ResponseShellCallOutputContentDoneStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - item_id
-        - output_index
-        - command_index
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_output_content.done
-          description: The type of the event, always `response.shell_call_output_content.done`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        item_id:
-          type: string
-          description: The ID of the output item that was updated.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that produced output.
-        output:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
-          description: The output contents emitted for the shell command.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated shell call output was completed.
-      title: Response shell call output content done event
     OpenAI.ResponseStreamEvent:
       type: object
       required:
@@ -75242,18 +74713,12 @@ components:
           response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
           response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
           response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
-          response.shell_call_command.added: '#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent'
-          response.shell_call_command.delta: '#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent'
-          response.shell_call_command.done: '#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent'
-          response.shell_call_output_content.delta: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent'
-          response.shell_call_output_content.done: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent'
           response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
           response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
           response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
           response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
           response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
           response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
-      description: Event emitted while a response is streamed.
     OpenAI.ResponseStreamEventType:
       anyOf:
         - type: string
@@ -75278,11 +74743,6 @@ components:
             - response.file_search_call.searching
             - response.function_call_arguments.delta
             - response.function_call_arguments.done
-            - response.shell_call_command.added
-            - response.shell_call_command.delta
-            - response.shell_call_command.done
-            - response.shell_call_output_content.delta
-            - response.shell_call_output_content.done
             - response.in_progress
             - response.failed
             - response.incomplete
@@ -76525,14 +75985,12 @@ components:
             - flex
             - scale
             - priority
-            - fast
         - type: 'null'
       description: |-
         Specifies the processing type used for serving the request.
         - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
         - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
-        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
-        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
+        - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
     OpenAI.ServiceTierEnum:
@@ -76540,41 +75998,8 @@ components:
       enum:
         - auto
         - default
-        - fast
         - flex
         - priority
-    OpenAI.ServiceTierResponses:
-      anyOf:
-        - type: string
-          enum:
-            - auto
-            - default
-            - flex
-            - scale
-            - priority
-            - fast
-            - ultrafast
-        - type: 'null'
-      description: |-
-        Specifies the processing type used for serving the request.
-        - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
-        - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
-        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
-        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
-        - If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.
-        - When not set, the default behavior is 'auto'.
-        When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
-    OpenAI.ShellCallOutputDelta:
-      type: object
-      properties:
-        stdout:
-          type: string
-          description: The stdout delta that was emitted.
-        stderr:
-          type: string
-          description: The stderr delta that was emitted.
-      description: A delta of stdout/stderr emitted while a shell call was running.
-      title: Shell call output delta
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -77512,15 +76937,6 @@ components:
       type: string
       enum:
         - logprobs
-    OpenAI.TranscriptionLanguage:
-      type: object
-      required:
-        - code
-      properties:
-        code:
-          type: string
-          description: The code of a language detected in the audio.
-      description: A language detected in transcribed audio.
     OpenAI.TranscriptionSegment:
       type: object
       required:
@@ -78334,8 +77750,7 @@ components:
       description: |-
         Constrains the verbosity of the model's response. Lower values will result in
         more concise responses, while higher values will result in more verbose responses.
-        Currently supported values are `low`, `medium`, and `high`. The default is
-        `medium`.
+        Currently supported values are `low`, `medium`, and `high`.
     OpenAI.VideoCharacterResource:
       type: object
       required:
@@ -78736,10 +78151,6 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
-        external_web_access:
-          type: boolean
-          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
-          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
@@ -79989,6 +79400,16 @@ components:
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V2Preview
+    RoutineAuthorization:
+      type: object
+      properties:
+        identity:
+          $ref: '#/components/schemas/RoutineDispatchIdentity'
+          description: The identity used when dispatching the routine. When omitted, dispatch uses the target agent identity.
+      description: Optional authorization configuration for a routine dispatch.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V2Preview
     RoutineCreateOrUpdateRequest:
       type: object
       properties:
@@ -80007,7 +79428,21 @@ components:
         action:
           $ref: '#/components/schemas/RoutineAction'
           description: The action executed when the routine fires.
+        authorization:
+          $ref: '#/components/schemas/RoutineAuthorization'
+          description: Optional authorization configuration for dispatching a newly created routine. Ignored when updating an existing routine.
       description: The request body used to create or update a routine.
+      x-ms-foundry-meta:
+        conditional_previews:
+          - Routines=V2Preview
+    RoutineDispatchIdentity:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - agent
+            - creator
+      description: The supported identities for routine dispatch authorization.
       x-ms-foundry-meta:
         conditional_previews:
           - Routines=V2Preview
@@ -82850,17 +82285,6 @@ components:
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -83851,10 +83275,6 @@ components:
           type: string
           enum:
             - web_search
-        external_web_access:
-          type: boolean
-          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
-          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -272,7 +272,7 @@ model Routine {
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model RoutineAuthorization {
   @doc("The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch.")
-  identity?: RoutineDispatchIdentity;
+  identity?: RoutineDispatchIdentity = RoutineDispatchIdentity.agent;
 }
 
 #suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -283,8 +283,8 @@ model RoutineCreateOrUpdateRequest {
   @maxLength(1024)
   description?: string;
 
-  @doc("Whether the routine is enabled. If omitted when creating a new routine, the service defaults this value to true. If omitted on update, the service preserves the existing enabled state.")
-  enabled?: boolean = true;
+  @doc("Whether the routine is enabled.")
+  enabled?: boolean;
 
   @doc("The triggers configured for the routine. In v1, exactly one trigger entry is supported.")
   triggers?: RoutineTriggers;

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -283,8 +283,8 @@ model RoutineCreateOrUpdateRequest {
   @maxLength(1024)
   description?: string;
 
-  @doc("Whether the routine is enabled.")
-  enabled?: boolean;
+  @doc("Whether the routine is enabled. If omitted when creating a new routine, the service defaults this value to true. If omitted on update, the service preserves the existing enabled state.")
+  enabled?: boolean = true;
 
   @doc("The triggers configured for the routine. In v1, exactly one trigger entry is supported.")
   triggers?: RoutineTriggers;

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -109,6 +109,18 @@ union RoutineRunStatus {
   string,
 }
 
+@doc("The supported identities for routine dispatch authorization.")
+@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
+union RoutineDispatchIdentity {
+  string,
+
+  @doc("Dispatches with the target agent identity and a foundation token.")
+  agent: "agent",
+
+  @doc("Dispatches as the principal that created the routine.")
+  creator: "creator",
+}
+
 alias RoutineTriggers = Record<RoutineTrigger>;
 
 @doc("Base model for a routine trigger.")
@@ -256,6 +268,13 @@ model Routine {
   updated_at?: FoundryTimestamp;
 }
 
+@doc("Optional authorization configuration for a routine dispatch.")
+@extension("x-ms-foundry-meta", RoutineRequiredPreviews)
+model RoutineAuthorization {
+  @doc("The identity used when dispatching the routine. When omitted, dispatch uses the target agent identity.")
+  identity?: RoutineDispatchIdentity;
+}
+
 #suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @doc("The request body used to create or update a routine.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
@@ -272,6 +291,9 @@ model RoutineCreateOrUpdateRequest {
 
   @doc("The action executed when the routine fires.")
   action?: RoutineAction;
+
+  @doc("Optional authorization configuration for dispatching a newly created routine. Ignored when updating an existing routine.")
+  authorization?: RoutineAuthorization;
 }
 
 @doc("Base model for a manual dispatch payload.")

--- a/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/routines/models.tsp
@@ -117,7 +117,7 @@ union RoutineDispatchIdentity {
   @doc("Dispatches with the target agent identity and a foundation token.")
   agent: "agent",
 
-  @doc("Dispatches as the principal that created the routine.")
+  @doc("An explicit customer opt-in to dispatch as the principal that created the routine.")
   creator: "creator",
 }
 
@@ -271,7 +271,7 @@ model Routine {
 @doc("Optional authorization configuration for a routine dispatch.")
 @extension("x-ms-foundry-meta", RoutineRequiredPreviews)
 model RoutineAuthorization {
-  @doc("The identity used when dispatching the routine. When omitted, dispatch uses the target agent identity.")
+  @doc("The identity used when dispatching the routine. Defaults to agent when omitted; set to creator only when the customer opts in to creator identity dispatch.")
   identity?: RoutineDispatchIdentity;
 }
 


### PR DESCRIPTION
Expose an optional authorization identity on routine creation and generate the matching OpenAPI schemas.

Authored-by: GitHub Copilot for VS Code 1.130.0

Model: GitHub Copilot

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
