### PR TITLE
Add csharp customizations for ServiceLinker migration

### DIFF
--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/back-compatible.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/back-compatible.tsp
@@ -47,31 +47,35 @@ using TypeSpec.Versioning;
 // These ensure consistent operationId generation in the output
 
 // LinkerResources interface operations with Connector_ prefix
-@@clientLocation(LinkerResources.get, "Connector");
+@@clientLocation(LinkerResources.get, "Connector", "!csharp");
 @@clientName(LinkerResources.get, "Get");
-@@clientLocation(LinkerResources.createOrUpdate, "Connector");
+@@clientLocation(LinkerResources.createOrUpdate, "Connector", "!csharp");
 @@clientName(LinkerResources.createOrUpdate, "CreateOrUpdate");
-@@clientLocation(LinkerResources.update, "Connector");
+@@clientLocation(LinkerResources.update, "Connector", "!csharp");
 @@clientName(LinkerResources.update, "Update");
-@@clientLocation(LinkerResources.delete, "Connector");
+@@clientLocation(LinkerResources.delete, "Connector", "!csharp");
 @@clientName(LinkerResources.delete, "Delete");
-@@clientLocation(LinkerResources.list, "Connector");
+@@clientLocation(LinkerResources.list, "Connector", "!csharp");
 @@clientName(LinkerResources.list, "List");
-@@clientLocation(LinkerResources.validate, "Connector");
+@@clientLocation(LinkerResources.validate, "Connector", "!csharp");
 @@clientName(LinkerResources.validate, "Validate");
-@@clientLocation(LinkerResources.generateConfigurations, "Connector");
+@@clientLocation(
+  LinkerResources.generateConfigurations,
+  "Connector",
+  "!csharp"
+);
 @@clientName(LinkerResources.generateConfigurations, "GenerateConfigurations");
 
 // DryrunResources interface operations with Connector_ prefix
-@@clientLocation(DryrunResources.getDryrun, "Connector");
+@@clientLocation(DryrunResources.getDryrun, "Connector", "!csharp");
 @@clientName(DryrunResources.getDryrun, "GetDryrun");
-@@clientLocation(DryrunResources.createDryrun, "Connector");
+@@clientLocation(DryrunResources.createDryrun, "Connector", "!csharp");
 @@clientName(DryrunResources.createDryrun, "CreateDryrun");
-@@clientLocation(DryrunResources.updateDryrun, "Connector");
+@@clientLocation(DryrunResources.updateDryrun, "Connector", "!csharp");
 @@clientName(DryrunResources.updateDryrun, "UpdateDryrun");
-@@clientLocation(DryrunResources.deleteDryrun, "Connector");
+@@clientLocation(DryrunResources.deleteDryrun, "Connector", "!csharp");
 @@clientName(DryrunResources.deleteDryrun, "DeleteDryrun");
-@@clientLocation(DryrunResources.listDryrun, "Connector");
+@@clientLocation(DryrunResources.listDryrun, "Connector", "!csharp");
 @@clientName(DryrunResources.listDryrun, "ListDryrun");
 
 // Linker interface operations with Linkers_ prefix

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
@@ -304,6 +304,11 @@ op dryrunResourcesListDryrun(
 @@clientName(DaprConfigurationResource, "DaprConfiguration", "csharp");
 @@clientName(DeleteOrUpdateBehavior, "LinkerDeleteOrUpdateBehavior", "csharp");
 @@clientName(DryrunParameters, "DryrunContent", "csharp");
+@@clientName(
+  EasyAuthMicrosoftEntraIDAuthInfo,
+  "EasyAuthMicrosoftEntraIdAuthInfo",
+  "csharp"
+);
 @@clientName(FabricPlatform, "FabricPlatformTargetService", "csharp");
 @@clientName(FirewallRules, "LinkerFirewallRules", "csharp");
 @@clientName(Linker, "LinkerResources", "csharp");

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
@@ -267,3 +267,97 @@ op dryrunResourcesListDryrun(
 ): DryrunList;
 
 @@override(DryrunResources.listDryrun, dryrunResourcesListDryrun);
+
+// C# customizations preserve the shipped SDK surface and disambiguate dry-run resources.
+@@clientName(AuthInfoBase, "AuthBaseInfo", "csharp");
+@@clientName(Microsoft.ServiceLinker.AuthType, "LinkerAuthType", "csharp");
+@@clientName(
+  AzureKeyVaultProperties.connectAsKubernetesCsiDriver,
+  "DoesConnectAsKubernetesCsiDriver",
+  "csharp"
+);
+@@clientName(AzureResource, "AzureResourceInfo", "csharp");
+@@clientName(
+  AzureResourcePropertiesBase,
+  "AzureResourceBaseProperties",
+  "csharp"
+);
+@@clientName(ClientType, "LinkerClientType", "csharp");
+@@clientName(ConfigurationResult, "SourceConfigurationResult", "csharp");
+@@clientName(
+  ConfluentBootstrapServer,
+  "ConfluentBootstrapServerInfo",
+  "csharp"
+);
+@@clientName(ConfluentSchemaRegistry, "ConfluentSchemaRegistryInfo", "csharp");
+@@clientName(
+  CreateOrUpdateDryrunParameters,
+  "CreateOrUpdateDryrunContent",
+  "csharp"
+);
+@@clientName(DryrunParameters, "DryrunContent", "csharp");
+@@clientName(Linker, "LinkerResources", "csharp");
+@@clientName(LinkerPatch, "LinkerResourcePatch", "csharp");
+@@clientName(LinkerResources, "ConnectorResources", "csharp");
+@@clientName(Linkers, "Dryruns", "csharp");
+@@clientName(SecretInfoBase, "SecretBaseInfo", "csharp");
+@@clientName(SecretStore.keyVaultId, "SecretStoreKeyVaultId", "csharp");
+@@clientName(SecretStore, "LinkerSecretStore", "csharp");
+@@clientName(SecretType, "LinkerSecretType", "csharp");
+@@clientName(TargetServiceBase, "TargetServiceBaseInfo", "csharp");
+@@clientName(
+  ValidateOperationResult,
+  "LinkerValidateOperationResult",
+  "csharp"
+);
+@@clientName(ValidateResult.reportEndTimeUtc, "ReportEndOn", "csharp");
+@@clientName(ValidateResult.reportStartTimeUtc, "ReportStartOn", "csharp");
+@@clientName(ValidationResultItem, "LinkerValidationResultItemInfo", "csharp");
+@@clientName(ValidationResultStatus, "LinkerValidationResultStatus", "csharp");
+@@clientName(ValueSecretInfo, "RawValueSecretInfo", "csharp");
+@@clientName(VNetSolution, "VnetSolution", "csharp");
+@@clientName(VNetSolution.type, "SolutionType", "csharp");
+@@clientName(VNetSolutionType, "VnetSolutionType", "csharp");
+
+@@alternateType(AzureResource.id, Azure.Core.armResourceIdentifier, "csharp");
+@@alternateType(
+  SecretStore.keyVaultId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  ValidateOperationResult.resourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  ValidateResult.sourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  ValidateResult.targetId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+
+@@clientLocation(DryrunResources.createDryrun, "ConnectorDryrun", "csharp");
+@@clientLocation(DryrunResources.deleteDryrun, "ConnectorDryrun", "csharp");
+@@clientLocation(DryrunResources.getDryrun, "ConnectorDryrun", "csharp");
+@@clientLocation(DryrunResources.listDryrun, "ConnectorDryrun", "csharp");
+@@clientLocation(DryrunResources.updateDryrun, "ConnectorDryrun", "csharp");
+
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
+  LinkerProperties.secretStore,
+  "csharp"
+);
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
+  LinkerProperties.vNetSolution,
+  "csharp"
+);
+
+@@usage(ConfigurationResult, Usage.output, "csharp");
+@@usage(ValidateResult, Usage.output, "csharp");
+@@usage(ValidationResultItem, Usage.output, "csharp");

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
@@ -275,6 +275,11 @@ op dryrunResourcesListDryrun(
 @@clientName(AuthMode, "LinkerAuthMode", "csharp");
 @@clientName(Microsoft.ServiceLinker.AuthType, "LinkerAuthType", "csharp");
 @@clientName(
+  AzureAppConfigProperties.connectWithKubernetesExtension,
+  "IsConnectedWithKubernetesExtension",
+  "csharp"
+);
+@@clientName(
   AzureKeyVaultProperties.connectAsKubernetesCsiDriver,
   "DoesConnectAsKubernetesCsiDriver",
   "csharp"
@@ -288,6 +293,7 @@ op dryrunResourcesListDryrun(
 @@clientName(ClientType, "LinkerClientType", "csharp");
 @@clientName(ConfigurationInfo, "LinkerConfigurationInfo", "csharp");
 @@clientName(ConfigurationName, "LinkerConfigurationName", "csharp");
+@@clientName(ConfigurationName.required, "IsRequired", "csharp");
 @@clientName(ConfigurationNameItem, "LinkerConfigurationNameItem", "csharp");
 @@clientName(ConfigurationResult, "SourceConfigurationResult", "csharp");
 @@clientName(
@@ -304,6 +310,7 @@ op dryrunResourcesListDryrun(
 @@clientName(DaprConfigurationResource, "DaprConfiguration", "csharp");
 @@clientName(DeleteOrUpdateBehavior, "LinkerDeleteOrUpdateBehavior", "csharp");
 @@clientName(DryrunParameters, "DryrunContent", "csharp");
+@@clientName(DryrunResource, "LinkerDryrun", "csharp");
 @@clientName(
   EasyAuthMicrosoftEntraIDAuthInfo,
   "EasyAuthMicrosoftEntraIdAuthInfo",
@@ -314,7 +321,7 @@ op dryrunResourcesListDryrun(
 @@clientName(Linker, "LinkerResources", "csharp");
 @@clientName(LinkerPatch, "LinkerResourcePatch", "csharp");
 @@clientName(LinkerResources, "ConnectorResources", "csharp");
-@@clientName(Linkers, "Dryruns", "csharp");
+@@clientName(Linkers, "LinkerDryruns", "csharp");
 @@clientName(PublicNetworkSolution, "LinkerPublicNetworkSolution", "csharp");
 @@clientName(SecretInfoBase, "SecretBaseInfo", "csharp");
 @@clientName(SecretSourceType, "LinkerSecretSourceType", "csharp");
@@ -336,6 +343,14 @@ op dryrunResourcesListDryrun(
 @@clientName(VNetSolution, "VnetSolution", "csharp");
 @@clientName(VNetSolution.type, "SolutionType", "csharp");
 @@clientName(VNetSolutionType, "VnetSolutionType", "csharp");
+
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
+@@clientOption(
+  LinkerResources.get,
+  "resource-name",
+  "LinkerConnector",
+  "csharp"
+);
 
 @@alternateType(AzureResource.id, Azure.Core.armResourceIdentifier, "csharp");
 @@alternateType(

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
@@ -269,7 +269,10 @@ op dryrunResourcesListDryrun(
 @@override(DryrunResources.listDryrun, dryrunResourcesListDryrun);
 
 // C# customizations preserve the shipped SDK surface and disambiguate dry-run resources.
+@@clientName(ActionType, "LinkerActionType", "csharp");
+@@clientName(AllowType, "LinkerAllowType", "csharp");
 @@clientName(AuthInfoBase, "AuthBaseInfo", "csharp");
+@@clientName(AuthMode, "LinkerAuthMode", "csharp");
 @@clientName(Microsoft.ServiceLinker.AuthType, "LinkerAuthType", "csharp");
 @@clientName(
   AzureKeyVaultProperties.connectAsKubernetesCsiDriver,
@@ -283,6 +286,9 @@ op dryrunResourcesListDryrun(
   "csharp"
 );
 @@clientName(ClientType, "LinkerClientType", "csharp");
+@@clientName(ConfigurationInfo, "LinkerConfigurationInfo", "csharp");
+@@clientName(ConfigurationName, "LinkerConfigurationName", "csharp");
+@@clientName(ConfigurationNameItem, "LinkerConfigurationNameItem", "csharp");
 @@clientName(ConfigurationResult, "SourceConfigurationResult", "csharp");
 @@clientName(
   ConfluentBootstrapServer,
@@ -297,14 +303,18 @@ op dryrunResourcesListDryrun(
 );
 @@clientName(DaprConfigurationResource, "DaprConfiguration", "csharp");
 @@clientName(DryrunParameters, "DryrunContent", "csharp");
+@@clientName(FabricPlatform, "FabricPlatformTargetService", "csharp");
+@@clientName(FirewallRules, "LinkerFirewallRules", "csharp");
 @@clientName(Linker, "LinkerResources", "csharp");
 @@clientName(LinkerPatch, "LinkerResourcePatch", "csharp");
 @@clientName(LinkerResources, "ConnectorResources", "csharp");
 @@clientName(Linkers, "Dryruns", "csharp");
+@@clientName(PublicNetworkSolution, "LinkerPublicNetworkSolution", "csharp");
 @@clientName(SecretInfoBase, "SecretBaseInfo", "csharp");
 @@clientName(SecretStore.keyVaultId, "SecretStoreKeyVaultId", "csharp");
 @@clientName(SecretStore, "LinkerSecretStore", "csharp");
 @@clientName(SecretType, "LinkerSecretType", "csharp");
+@@clientName(SelfHostedServer, "SelfHostedServerTargetService", "csharp");
 @@clientName(TargetServiceBase, "TargetServiceBaseInfo", "csharp");
 @@clientName(
   ValidateOperationResult,

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
@@ -302,6 +302,7 @@ op dryrunResourcesListDryrun(
   "csharp"
 );
 @@clientName(DaprConfigurationResource, "DaprConfiguration", "csharp");
+@@clientName(DeleteOrUpdateBehavior, "LinkerDeleteOrUpdateBehavior", "csharp");
 @@clientName(DryrunParameters, "DryrunContent", "csharp");
 @@clientName(FabricPlatform, "FabricPlatformTargetService", "csharp");
 @@clientName(FirewallRules, "LinkerFirewallRules", "csharp");
@@ -311,6 +312,7 @@ op dryrunResourcesListDryrun(
 @@clientName(Linkers, "Dryruns", "csharp");
 @@clientName(PublicNetworkSolution, "LinkerPublicNetworkSolution", "csharp");
 @@clientName(SecretInfoBase, "SecretBaseInfo", "csharp");
+@@clientName(SecretSourceType, "LinkerSecretSourceType", "csharp");
 @@clientName(SecretStore.keyVaultId, "SecretStoreKeyVaultId", "csharp");
 @@clientName(SecretStore, "LinkerSecretStore", "csharp");
 @@clientName(SecretType, "LinkerSecretType", "csharp");

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
@@ -295,6 +295,7 @@ op dryrunResourcesListDryrun(
   "CreateOrUpdateDryrunContent",
   "csharp"
 );
+@@clientName(DaprConfigurationResource, "DaprConfiguration", "csharp");
 @@clientName(DryrunParameters, "DryrunContent", "csharp");
 @@clientName(Linker, "LinkerResources", "csharp");
 @@clientName(LinkerPatch, "LinkerResourcePatch", "csharp");

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
@@ -344,14 +344,6 @@ op dryrunResourcesListDryrun(
 @@clientName(VNetSolution.type, "SolutionType", "csharp");
 @@clientName(VNetSolutionType, "VnetSolutionType", "csharp");
 
-#suppress "@azure-tools/typespec-client-generator-core/client-option" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@@clientOption(
-  LinkerResources.get,
-  "resource-name",
-  "LinkerConnector",
-  "csharp"
-);
-
 @@alternateType(AzureResource.id, Azure.Core.armResourceIdentifier, "csharp");
 @@alternateType(
   SecretStore.keyVaultId,
@@ -373,12 +365,6 @@ op dryrunResourcesListDryrun(
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-
-@@clientLocation(DryrunResources.createDryrun, "ConnectorDryrun", "csharp");
-@@clientLocation(DryrunResources.deleteDryrun, "ConnectorDryrun", "csharp");
-@@clientLocation(DryrunResources.getDryrun, "ConnectorDryrun", "csharp");
-@@clientLocation(DryrunResources.listDryrun, "ConnectorDryrun", "csharp");
-@@clientLocation(DryrunResources.updateDryrun, "ConnectorDryrun", "csharp");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 @@Azure.ClientGenerator.Core.Legacy.flattenProperty(

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
@@ -376,7 +376,3 @@ op dryrunResourcesListDryrun(
   LinkerProperties.vNetSolution,
   "csharp"
 );
-
-@@usage(ConfigurationResult, Usage.output, "csharp");
-@@usage(ValidateResult, Usage.output, "csharp");
-@@usage(ValidationResultItem, Usage.output, "csharp");

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
@@ -311,6 +311,7 @@ op dryrunResourcesListDryrun(
 @@clientName(DeleteOrUpdateBehavior, "LinkerDeleteOrUpdateBehavior", "csharp");
 @@clientName(DryrunParameters, "DryrunContent", "csharp");
 @@clientName(DryrunResource, "LinkerDryrun", "csharp");
+@@clientName(DryrunResources, "ConnectorDryrunResources", "csharp");
 @@clientName(
   EasyAuthMicrosoftEntraIDAuthInfo,
   "EasyAuthMicrosoftEntraIdAuthInfo",
@@ -320,7 +321,7 @@ op dryrunResourcesListDryrun(
 @@clientName(FirewallRules, "LinkerFirewallRules", "csharp");
 @@clientName(Linker, "LinkerResources", "csharp");
 @@clientName(LinkerPatch, "LinkerResourcePatch", "csharp");
-@@clientName(LinkerResources, "ConnectorResources", "csharp");
+@@clientName(LinkerResources, "LinkerConnectorResources", "csharp");
 @@clientName(Linkers, "LinkerDryruns", "csharp");
 @@clientName(PublicNetworkSolution, "LinkerPublicNetworkSolution", "csharp");
 @@clientName(SecretInfoBase, "SecretBaseInfo", "csharp");

--- a/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
+++ b/specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker/client.tsp
@@ -311,7 +311,7 @@ op dryrunResourcesListDryrun(
 @@clientName(DeleteOrUpdateBehavior, "LinkerDeleteOrUpdateBehavior", "csharp");
 @@clientName(DryrunParameters, "DryrunContent", "csharp");
 @@clientName(DryrunResource, "LinkerDryrun", "csharp");
-@@clientName(DryrunResources, "ConnectorDryrunResources", "csharp");
+@@clientName(DryrunResources, "ConnectorDryruns", "csharp");
 @@clientName(
   EasyAuthMicrosoftEntraIDAuthInfo,
   "EasyAuthMicrosoftEntraIdAuthInfo",
@@ -321,7 +321,7 @@ op dryrunResourcesListDryrun(
 @@clientName(FirewallRules, "LinkerFirewallRules", "csharp");
 @@clientName(Linker, "LinkerResources", "csharp");
 @@clientName(LinkerPatch, "LinkerResourcePatch", "csharp");
-@@clientName(LinkerResources, "LinkerConnectorResources", "csharp");
+@@clientName(LinkerResources, "LinkerConnectors", "csharp");
 @@clientName(Linkers, "LinkerDryruns", "csharp");
 @@clientName(PublicNetworkSolution, "LinkerPublicNetworkSolution", "csharp");
 @@clientName(SecretInfoBase, "SecretBaseInfo", "csharp");


### PR DESCRIPTION
## Summary
- add C#-scoped naming and type customizations for the ServiceLinker management SDK migration
- disambiguate dry-run resource operation groups
- preserve the shipped .NET API surface while generating from TypeSpec

## Validation
- TypeSpec compilation succeeds