### PR TITLE
Add prompt-edge agent definition

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -9165,6 +9165,7 @@
           "propertyName": "kind",
           "mapping": {
             "prompt": "#/components/schemas/PromptAgentDefinition",
+            "prompt-edge": "#/components/schemas/PromptEdgeAgentDefinition",
             "workflow": "#/components/schemas/WorkflowAgentDefinition",
             "hosted": "#/components/schemas/HostedAgentDefinition"
           }
@@ -9194,6 +9195,7 @@
             "type": "string",
             "enum": [
               "prompt",
+              "prompt-edge",
               "hosted",
               "workflow"
             ]
@@ -9248,7 +9250,8 @@
             "type": "string",
             "enum": [
               "activity_protocol",
-              "responses"
+              "responses",
+              "mcp"
             ]
           }
         ]
@@ -36105,6 +36108,96 @@
           }
         ],
         "description": "Prompt-based evaluator"
+      },
+      "PromptEdgeAgentDefinition": {
+        "type": "object",
+        "required": [
+          "kind",
+          "model"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "prompt-edge"
+            ]
+          },
+          "model": {
+            "type": "string",
+            "description": "The model deployment to use for this agent."
+          },
+          "instructions": {
+            "type": "string",
+            "nullable": true,
+            "description": "A system (or developer) message inserted into the model's context."
+          },
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "minimum": 0,
+            "maximum": 2,
+            "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\nWe generally recommend altering this or `top_p` but not both.",
+            "default": 1
+          },
+          "top_p": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "minimum": 0,
+            "maximum": 1,
+            "description": "An alternative to sampling with temperature, called nucleus sampling,\nwhere the model considers the results of the tokens with top_p probability\nmass. So 0.1 means only the tokens comprising the top 10% probability mass\nare considered.\n\nWe generally recommend altering this or `temperature` but not both.",
+            "default": 1
+          },
+          "reasoning": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.Reasoning"
+              }
+            ],
+            "nullable": true
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.Tool"
+            },
+            "description": "An array of tools the model may call while generating a response. You\ncan specify which tool to use by setting the `tool_choice` parameter."
+          },
+          "tool_choice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
+              }
+            ],
+            "description": "How the model should select which tool (or tools) to use when generating a response.\nSee the `tools` parameter to see how to specify which tools the model can call."
+          },
+          "text": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PromptAgentDefinitionTextOptions"
+              }
+            ],
+            "description": "Configuration options for a text response from the model. Can be plain text or structured JSON data."
+          },
+          "structured_inputs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/StructuredInputDefinition"
+            },
+            "description": "Set of structured inputs that can participate in prompt template substitution or tool argument bindings."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentDefinition"
+          }
+        ],
+        "description": "A prompt agent definition that runs on a registered Foundry Local Agent service."
       },
       "ProtocolVersionRecord": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -12250,6 +12250,7 @@
           "propertyName": "kind",
           "mapping": {
             "prompt": "#/components/schemas/PromptAgentDefinition",
+            "prompt-edge": "#/components/schemas/PromptEdgeAgentDefinition",
             "workflow": "#/components/schemas/WorkflowAgentDefinition",
             "hosted": "#/components/schemas/HostedAgentDefinition",
             "container_app": "#/components/schemas/ContainerAppAgentDefinition"
@@ -12359,6 +12360,7 @@
               "activity",
               "responses",
               "a2a",
+              "mcp",
               "invocations"
             ]
           }
@@ -12619,6 +12621,7 @@
             "type": "string",
             "enum": [
               "prompt",
+              "prompt-edge",
               "hosted",
               "workflow",
               "container_app"
@@ -12739,6 +12742,7 @@
             "enum": [
               "activity_protocol",
               "responses",
+              "mcp",
               "invocations"
             ]
           }
@@ -40793,6 +40797,96 @@
           }
         ],
         "description": "Prompt-based evaluator"
+      },
+      "PromptEdgeAgentDefinition": {
+        "type": "object",
+        "required": [
+          "kind",
+          "model"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "prompt-edge"
+            ]
+          },
+          "model": {
+            "type": "string",
+            "description": "The model deployment to use for this agent."
+          },
+          "instructions": {
+            "type": "string",
+            "nullable": true,
+            "description": "A system (or developer) message inserted into the model's context."
+          },
+          "temperature": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "minimum": 0,
+            "maximum": 2,
+            "description": "What sampling temperature to use, between 0 and 2. Higher values like 0.8 will make the output more random, while lower values like 0.2 will make it more focused and deterministic.\nWe generally recommend altering this or `top_p` but not both.",
+            "default": 1
+          },
+          "top_p": {
+            "type": "number",
+            "format": "float",
+            "nullable": true,
+            "minimum": 0,
+            "maximum": 1,
+            "description": "An alternative to sampling with temperature, called nucleus sampling,\nwhere the model considers the results of the tokens with top_p probability\nmass. So 0.1 means only the tokens comprising the top 10% probability mass\nare considered.\n\nWe generally recommend altering this or `temperature` but not both.",
+            "default": 1
+          },
+          "reasoning": {
+            "type": "object",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/OpenAI.Reasoning"
+              }
+            ],
+            "nullable": true
+          },
+          "tools": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OpenAI.Tool"
+            },
+            "description": "An array of tools the model may call while generating a response. You\ncan specify which tool to use by setting the `tool_choice` parameter."
+          },
+          "tool_choice": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/OpenAI.ToolChoiceParam"
+              }
+            ],
+            "description": "How the model should select which tool (or tools) to use when generating a response.\nSee the `tools` parameter to see how to specify which tools the model can call."
+          },
+          "text": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PromptAgentDefinitionTextOptions"
+              }
+            ],
+            "description": "Configuration options for a text response from the model. Can be plain text or structured JSON data."
+          },
+          "structured_inputs": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/StructuredInputDefinition"
+            },
+            "description": "Set of structured inputs that can participate in prompt template substitution or tool argument bindings."
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AgentDefinition"
+          }
+        ],
+        "description": "A prompt agent definition that runs on a registered Foundry Local Agent service."
       },
       "ProtocolVersionRecord": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -314,6 +314,7 @@ union AgentEndpointProtocol {
 union AgentKind {
   string,
   prompt: "prompt",
+  prompt_edge: "prompt-edge",
   hosted: "hosted",
   workflow: "workflow",
 
@@ -339,7 +340,16 @@ model AgentDefinition {
 @doc("The prompt agent definition")
 model PromptAgentDefinition extends AgentDefinition {
   kind: AgentKind.prompt;
+  ...PromptAgentDefinitionProperties;
+}
 
+@doc("A prompt agent definition that runs on a registered Foundry Local Agent service.")
+model PromptEdgeAgentDefinition extends AgentDefinition {
+  kind: AgentKind.prompt_edge;
+  ...PromptAgentDefinitionProperties;
+}
+
+model PromptAgentDefinitionProperties {
   @doc("The model deployment to use for this agent.")
   `model`: string;
 
@@ -996,9 +1006,7 @@ model AgentCard {
 /** The status of an agent session. */
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 union AgentSessionStatus {
@@ -1034,9 +1042,7 @@ union AgentSessionStatus {
 /** The type of version indicator used to determine the agent version backing a session. */
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 union VersionIndicatorType {
@@ -1050,9 +1056,7 @@ union VersionIndicatorType {
 @doc("Version indicator determining which agent version backs the session.")
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 @discriminator("type")
@@ -1064,9 +1068,7 @@ model VersionIndicator {
 /** Version indicator that references a specific agent version by name. */
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 model VersionRefIndicator extends VersionIndicator {
@@ -1083,9 +1085,7 @@ model VersionRefIndicator extends VersionIndicator {
 @doc("An agent session providing a long-lived compute sandbox for hosted agent invocations.")
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 model AgentSessionResource {
@@ -1120,9 +1120,7 @@ model AgentSessionResource {
 @doc("Request to create a new agent session.")
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 model CreateAgentSessionRequest {
@@ -1139,9 +1137,7 @@ model CreateAgentSessionRequest {
 @doc("Paged result for session list operations.")
 @extension(
   "x-ms-foundry-meta",
-  #{
-    required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview],
-  }
+  #{ required_previews: #[FoundryFeaturesOptInKeys.agent_endpoint_v1_preview] }
 )
 @removed(Versions.v1)
 model SessionListResult {


### PR DESCRIPTION
## Summary

- add the prompt-edge agent kind discriminator to the Foundry data-plane contract
- add the prompt-shaped agent definition
- update generated OpenAPI artifacts

No routes or ARM resources are changed.