### PR TITLE
Add A365 logging flag to Cognitive Services 2026-07-15-preview

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/client.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/client.tsp
@@ -1095,6 +1095,11 @@ op regenerateKeyCustom(
   "csharp"
 );
 @@clientName(
+  AccountProperties.a365LoggingEnabled,
+  "IsA365LoggingEnabled",
+  "csharp"
+);
+@@clientName(
   ManagedComputeDeploymentProvisioningDetails.lastOperationTimestamp,
   "LastOperationOn",
   "csharp"

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -1584,6 +1584,12 @@ model AccountProperties {
    */
   storedCompletionsDisabled?: boolean;
 
+  /**
+   * Specifies whether A365 logging is enabled. Defaults to true. Set to false to opt out.
+   */
+  @added(Versions.v2026_07_15_preview)
+  a365LoggingEnabled?: boolean;
+
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "The quota limit for AccountProperties"
   @visibility(Lifecycle.Read)
   quotaLimit?: QuotaLimit;

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
@@ -12004,6 +12004,10 @@
           "type": "boolean",
           "description": "The flag to disable stored completions."
         },
+        "a365LoggingEnabled": {
+          "type": "boolean",
+          "description": "Specifies whether A365 logging is enabled. Defaults to true. Set to false to opt out."
+        },
         "quotaLimit": {
           "$ref": "#/definitions/QuotaLimit",
           "readOnly": true


### PR DESCRIPTION
## Summary

- add the optional `a365LoggingEnabled` property to Cognitive Services account properties
- expose the property only in `2026-07-15-preview`
- apply the C# SDK name `IsA365LoggingEnabled`

## Validation

- `npx tsp compile .`
- `npx tsp compile client.tsp`
- `npx tsp format -c`

## Dependency

Stacked on #44334, which introduces the `2026-07-15-preview` API version.