### PR TITLE
sql: add CustomMaintenanceOptions to models.tsp for 2026-08-01-preview

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
@@ -2024,6 +2024,7 @@ union DayOfWeek {
 /**
  * Custom maintenance options.
  */
+@added(Versions.v2026_08_01_preview)
 model CustomMaintenanceOptions {
   /**
    * Custom maintenance day of week.
@@ -5972,6 +5973,7 @@ model DatabaseProperties {
   /**
    * Custom maintenance options for the database.
    */
+  @added(Versions.v2026_08_01_preview)
   customMaintenanceOptions?: CustomMaintenanceOptions;
 
   /**
@@ -6384,6 +6386,7 @@ model DatabaseUpdateProperties {
   /**
    * Custom maintenance options for the database.
    */
+  @added(Versions.v2026_08_01_preview)
   customMaintenanceOptions?: CustomMaintenanceOptions;
 
   /**
@@ -8013,6 +8016,7 @@ model ElasticPoolProperties {
   /**
    * Custom maintenance options for the elastic pool.
    */
+  @added(Versions.v2026_08_01_preview)
   customMaintenanceOptions?: CustomMaintenanceOptions;
 
   /**
@@ -8127,6 +8131,7 @@ model ElasticPoolUpdateProperties {
   /**
    * Custom maintenance options for the elastic pool.
    */
+  @added(Versions.v2026_08_01_preview)
   customMaintenanceOptions?: CustomMaintenanceOptions;
 
   /**

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
@@ -2021,6 +2021,26 @@ union DayOfWeek {
   Saturday: "Saturday",
 }
 
+/**
+ * Custom maintenance options.
+ */
+model CustomMaintenanceOptions {
+  /**
+   * Custom maintenance day of week.
+   */
+  dayOfWeek?: DayOfWeek;
+
+  /**
+   * Custom maintenance start hour.
+   */
+  startHour?: int32;
+
+  /**
+   * Custom maintenance start minute.
+   */
+  startMinute?: int32;
+}
+
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
 union ManagedShortTermRetentionPolicyName {
   string,
@@ -5950,6 +5970,11 @@ model DatabaseProperties {
   maintenanceConfigurationId?: string;
 
   /**
+   * Custom maintenance options for the database.
+   */
+  customMaintenanceOptions?: CustomMaintenanceOptions;
+
+  /**
    * Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created.
    */
   isLedgerOn?: boolean;
@@ -6355,6 +6380,11 @@ model DatabaseUpdateProperties {
    * Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur.
    */
   maintenanceConfigurationId?: string;
+
+  /**
+   * Custom maintenance options for the database.
+   */
+  customMaintenanceOptions?: CustomMaintenanceOptions;
 
   /**
    * Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created.
@@ -7981,6 +8011,11 @@ model ElasticPoolProperties {
   maintenanceConfigurationId?: string;
 
   /**
+   * Custom maintenance options for the elastic pool.
+   */
+  customMaintenanceOptions?: CustomMaintenanceOptions;
+
+  /**
    * The number of secondary replicas associated with the Business Critical, Premium, or Hyperscale edition elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools.
    */
   highAvailabilityReplicaCount?: int32;
@@ -8088,6 +8123,11 @@ model ElasticPoolUpdateProperties {
    * Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur.
    */
   maintenanceConfigurationId?: string;
+
+  /**
+   * Custom maintenance options for the elastic pool.
+   */
+  customMaintenanceOptions?: CustomMaintenanceOptions;
 
   /**
    * The number of secondary replicas associated with the Business Critical, Premium, or Hyperscale edition elastic pool that are used to provide high availability. Applicable only to Hyperscale elastic pools.

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/common.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/common.json
@@ -1411,6 +1411,26 @@
         ]
       }
     },
+    "CustomMaintenanceOptions": {
+      "type": "object",
+      "description": "Custom maintenance options.",
+      "properties": {
+        "dayOfWeek": {
+          "$ref": "#/definitions/DayOfWeek",
+          "description": "Custom maintenance day of week."
+        },
+        "startHour": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Custom maintenance start hour."
+        },
+        "startMinute": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Custom maintenance start minute."
+        }
+      }
+    },
     "DNSRefreshOperationStatus": {
       "type": "string",
       "description": "The status of the DNS refresh operation.",

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/databases.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/databases.json
@@ -1486,6 +1486,10 @@
           "type": "string",
           "description": "Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur."
         },
+        "customMaintenanceOptions": {
+          "$ref": "./common.json#/definitions/CustomMaintenanceOptions",
+          "description": "Custom maintenance options for the database."
+        },
         "isLedgerOn": {
           "type": "boolean",
           "description": "Whether or not this database is a ledger database, which means all tables in the database are ledger tables. Note: the value of this property cannot be changed after the database has been created."
@@ -1805,6 +1809,10 @@
         "maintenanceConfigurationId": {
           "type": "string",
           "description": "Maintenance configuration id assigned to the database. This configuration defines the period when the maintenance updates will occur."
+        },
+        "customMaintenanceOptions": {
+          "$ref": "./common.json#/definitions/CustomMaintenanceOptions",
+          "description": "Custom maintenance options for the database."
         },
         "isLedgerOn": {
           "type": "boolean",

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/elasticPools.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/elasticPools.json
@@ -625,6 +625,10 @@
           "type": "string",
           "description": "Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur."
         },
+        "customMaintenanceOptions": {
+          "$ref": "./common.json#/definitions/CustomMaintenanceOptions",
+          "description": "Custom maintenance options for the elastic pool."
+        },
         "highAvailabilityReplicaCount": {
           "type": "integer",
           "format": "int32",
@@ -701,6 +705,10 @@
         "maintenanceConfigurationId": {
           "type": "string",
           "description": "Maintenance configuration id assigned to the elastic pool. This configuration defines the period when the maintenance updates will will occur."
+        },
+        "customMaintenanceOptions": {
+          "$ref": "./common.json#/definitions/CustomMaintenanceOptions",
+          "description": "Custom maintenance options for the elastic pool."
         },
         "highAvailabilityReplicaCount": {
           "type": "integer",


### PR DESCRIPTION
This PR adds the TypeSpec definition for CustomMaintenanceOptions in API version 2026-08-01-preview in models.tsp.The change includes the dayOfWeek, startHour, and startMinute properties for databases and elastic pools.

**Purpose**
This is proactive API review work to obtain API team approval for the new property before it is publicly exposed.

CustomMaintenanceOptions will remain hidden from Swagger in DsMain master until the team decides to make the API publicly available.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
