### PR TITLE
Fix Arc deployment SKU enum

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/ArcDeployment.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/ArcDeployment.tsp
@@ -60,14 +60,9 @@ interface ArcDeployments {
   /**
    * Creates an Arc deployment associated with the Cognitive Services account.
    */
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-put-operation-response-codes" "Arc deployment PUT is create-only; updates are supported through PATCH."
   create is ArmResourceCreateOrReplaceAsync<
     ArcDeployment,
-    LroHeaders = ArcDeploymentCreateLroHeaders,
-    Response = ArmResourceCreatedResponse<
-      ArcDeployment,
-      ArcDeploymentCreateLroHeaders
-    >
+    LroHeaders = ArcDeploymentCreateLroHeaders
   >;
 
   /**

--- a/specification/cognitiveservices/CognitiveServices.Management/ArcDeployment.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/ArcDeployment.tsp
@@ -425,11 +425,24 @@ model ArcDeploymentListResult {
  * SKU for an Arc deployment.
  */
 @added(Versions.v2026_07_15_preview)
+union ArcDeploymentSkuName {
+  string,
+
+  /**
+   * Arc SKU.
+   */
+  Arc: "Arc",
+}
+
+/**
+ * SKU for an Arc deployment.
+ */
+@added(Versions.v2026_07_15_preview)
 model ArcDeploymentSku {
   /**
    * The name of the Arc deployment SKU. Must be Arc.
    */
-  name: "Arc";
+  name: ArcDeploymentSkuName;
 }
 
 /**

--- a/specification/cognitiveservices/CognitiveServices.Management/ArcDeployment.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/ArcDeployment.tsp
@@ -58,9 +58,9 @@ interface ArcDeployments {
   get is ArmResourceRead<ArcDeployment>;
 
   /**
-   * Creates an Arc deployment associated with the Cognitive Services account.
+   * Creates or updates an Arc deployment associated with the Cognitive Services account.
    */
-  create is ArmResourceCreateOrReplaceAsync<
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<
     ArcDeployment,
     LroHeaders = ArcDeploymentCreateLroHeaders
   >;
@@ -476,7 +476,7 @@ model ArcDeploymentVllmParameters {
   "Properties of the Cognitive Services Arc deployment."
 );
 @@doc(
-  ArcDeployments.create::parameters.resource,
+  ArcDeployments.createOrUpdate::parameters.resource,
   "The Arc deployment properties."
 );
 @@doc(

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/CreateOrUpdateArcDeployment.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/CreateOrUpdateArcDeployment.json
@@ -1,6 +1,6 @@
 {
-  "operationId": "ArcDeployments_Create",
-  "title": "CreateArcDeployment",
+  "operationId": "ArcDeployments_CreateOrUpdate",
+  "title": "CreateOrUpdateArcDeployment",
   "parameters": {
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "resourceGroupName",
@@ -37,6 +37,42 @@
     }
   },
   "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/arcDeployments/phi-3-arc",
+        "name": "phi-3-arc",
+        "type": "Microsoft.CognitiveServices/accounts/arcDeployments",
+        "properties": {
+          "model": {
+            "format": "OpenAI",
+            "name": "phi-3-mini"
+          },
+          "extensionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Kubernetes/connectedClusters/edge-cluster/providers/Microsoft.KubernetesConfiguration/extensions/inference-operator",
+          "runtime": "onnx-genai",
+          "compute": "cpu",
+          "replicas": 2,
+          "resources": {
+            "requests": {
+              "cpu": "8",
+              "memory": "16Gi"
+            },
+            "limits": {
+              "cpu": "8",
+              "memory": "16Gi"
+            }
+          },
+          "nodeSelector": {
+            "agentpool": "cpu"
+          },
+          "provisioningState": "Succeeded",
+          "deploymentState": "Running",
+          "raiPolicyName": "Microsoft.DefaultV2"
+        },
+        "sku": {
+          "name": "Arc"
+        }
+      }
+    },
     "201": {
       "headers": {
         "azure-asyncoperation": "http://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000010?api-version=2026-07-15-preview",

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/CreateOrUpdateArcDeploymentWithTemplate.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-07-15-preview/CreateOrUpdateArcDeploymentWithTemplate.json
@@ -1,6 +1,6 @@
 {
-  "operationId": "ArcDeployments_Create",
-  "title": "CreateArcDeploymentWithTemplate",
+  "operationId": "ArcDeployments_CreateOrUpdate",
+  "title": "CreateOrUpdateArcDeploymentWithTemplate",
   "parameters": {
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "resourceGroupName",
@@ -33,6 +33,44 @@
     }
   },
   "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/arcDeployments/qwen-template-arc",
+        "name": "qwen-template-arc",
+        "type": "Microsoft.CognitiveServices/accounts/arcDeployments",
+        "properties": {
+          "model": {
+            "format": "OpenAI",
+            "name": "qwen3"
+          },
+          "extensionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Kubernetes/connectedClusters/edge-cluster/providers/Microsoft.KubernetesConfiguration/extensions/inference-operator",
+          "runtime": "vllm",
+          "compute": "gpu",
+          "replicas": 2,
+          "resources": {
+            "limits": {
+              "gpu": 5
+            }
+          },
+          "nodeSelector": {
+            "agentpool": "a100"
+          },
+          "deploymentTemplate": "azureml://registries/azureml-openai-oss/deploymenttemplates/vllm-qwen--qwen3-5-0-8b/versions/1",
+          "vllmParameters": {
+            "tensorParallelSize": 2,
+            "maxModelLen": 8192,
+            "gpuMemoryUtilization": 0.9,
+            "enforceEager": false
+          },
+          "provisioningState": "Succeeded",
+          "deploymentState": "Running",
+          "raiPolicyName": "Microsoft.DefaultV2"
+        },
+        "sku": {
+          "name": "Arc"
+        }
+      }
+    },
     "201": {
       "headers": {
         "azure-asyncoperation": "http://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000011?api-version=2026-07-15-preview",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
@@ -2121,11 +2121,11 @@
         }
       },
       "put": {
-        "operationId": "ArcDeployments_Create",
+        "operationId": "ArcDeployments_CreateOrUpdate",
         "tags": [
           "ArcDeployments"
         ],
-        "description": "Creates an Arc deployment associated with the Cognitive Services account.",
+        "description": "Creates or updates an Arc deployment associated with the Cognitive Services account.",
         "parameters": [
           {
             "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
@@ -2196,11 +2196,11 @@
           }
         },
         "x-ms-examples": {
-          "CreateArcDeployment": {
-            "$ref": "./examples/CreateArcDeployment.json"
+          "CreateOrUpdateArcDeployment": {
+            "$ref": "./examples/CreateOrUpdateArcDeployment.json"
           },
-          "CreateArcDeploymentWithTemplate": {
-            "$ref": "./examples/CreateArcDeploymentWithTemplate.json"
+          "CreateOrUpdateArcDeploymentWithTemplate": {
+            "$ref": "./examples/CreateOrUpdateArcDeploymentWithTemplate.json"
           }
         },
         "x-ms-long-running-operation-options": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
@@ -13183,19 +13183,31 @@
       "description": "SKU for an Arc deployment.",
       "properties": {
         "name": {
-          "type": "string",
-          "description": "The name of the Arc deployment SKU. Must be Arc.",
-          "enum": [
-            "Arc"
-          ],
-          "x-ms-enum": {
-            "modelAsString": false
-          }
+          "$ref": "#/definitions/ArcDeploymentSkuName",
+          "description": "The name of the Arc deployment SKU. Must be Arc."
         }
       },
       "required": [
         "name"
       ]
+    },
+    "ArcDeploymentSkuName": {
+      "type": "string",
+      "description": "SKU for an Arc deployment.",
+      "enum": [
+        "Arc"
+      ],
+      "x-ms-enum": {
+        "name": "ArcDeploymentSkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Arc",
+            "value": "Arc",
+            "description": "Arc SKU."
+          }
+        ]
+      }
     },
     "ArcDeploymentUpdate": {
       "type": "object",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/cognitiveservices.json
@@ -2165,6 +2165,12 @@
           }
         ],
         "responses": {
+          "200": {
+            "description": "Resource 'ArcDeployment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ArcDeployment"
+            }
+          },
           "201": {
             "description": "Resource 'ArcDeployment' create operation succeeded",
             "schema": {

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateOrUpdateArcDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateOrUpdateArcDeployment.json
@@ -1,6 +1,6 @@
 {
-  "operationId": "ArcDeployments_Create",
-  "title": "CreateArcDeployment",
+  "operationId": "ArcDeployments_CreateOrUpdate",
+  "title": "CreateOrUpdateArcDeployment",
   "parameters": {
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "resourceGroupName",
@@ -37,6 +37,42 @@
     }
   },
   "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/arcDeployments/phi-3-arc",
+        "name": "phi-3-arc",
+        "type": "Microsoft.CognitiveServices/accounts/arcDeployments",
+        "properties": {
+          "model": {
+            "format": "OpenAI",
+            "name": "phi-3-mini"
+          },
+          "extensionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Kubernetes/connectedClusters/edge-cluster/providers/Microsoft.KubernetesConfiguration/extensions/inference-operator",
+          "runtime": "onnx-genai",
+          "compute": "cpu",
+          "replicas": 2,
+          "resources": {
+            "requests": {
+              "cpu": "8",
+              "memory": "16Gi"
+            },
+            "limits": {
+              "cpu": "8",
+              "memory": "16Gi"
+            }
+          },
+          "nodeSelector": {
+            "agentpool": "cpu"
+          },
+          "provisioningState": "Succeeded",
+          "deploymentState": "Running",
+          "raiPolicyName": "Microsoft.DefaultV2"
+        },
+        "sku": {
+          "name": "Arc"
+        }
+      }
+    },
     "201": {
       "headers": {
         "azure-asyncoperation": "http://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000010?api-version=2026-07-15-preview",

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateOrUpdateArcDeploymentWithTemplate.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-07-15-preview/examples/CreateOrUpdateArcDeploymentWithTemplate.json
@@ -1,6 +1,6 @@
 {
-  "operationId": "ArcDeployments_Create",
-  "title": "CreateArcDeploymentWithTemplate",
+  "operationId": "ArcDeployments_CreateOrUpdate",
+  "title": "CreateOrUpdateArcDeploymentWithTemplate",
   "parameters": {
     "subscriptionId": "00000000-0000-0000-0000-000000000000",
     "resourceGroupName": "resourceGroupName",
@@ -33,6 +33,44 @@
     }
   },
   "responses": {
+    "200": {
+      "body": {
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/arcDeployments/qwen-template-arc",
+        "name": "qwen-template-arc",
+        "type": "Microsoft.CognitiveServices/accounts/arcDeployments",
+        "properties": {
+          "model": {
+            "format": "OpenAI",
+            "name": "qwen3"
+          },
+          "extensionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Kubernetes/connectedClusters/edge-cluster/providers/Microsoft.KubernetesConfiguration/extensions/inference-operator",
+          "runtime": "vllm",
+          "compute": "gpu",
+          "replicas": 2,
+          "resources": {
+            "limits": {
+              "gpu": 5
+            }
+          },
+          "nodeSelector": {
+            "agentpool": "a100"
+          },
+          "deploymentTemplate": "azureml://registries/azureml-openai-oss/deploymenttemplates/vllm-qwen--qwen3-5-0-8b/versions/1",
+          "vllmParameters": {
+            "tensorParallelSize": 2,
+            "maxModelLen": 8192,
+            "gpuMemoryUtilization": 0.9,
+            "enforceEager": false
+          },
+          "provisioningState": "Succeeded",
+          "deploymentState": "Running",
+          "raiPolicyName": "Microsoft.DefaultV2"
+        },
+        "sku": {
+          "name": "Arc"
+        }
+      }
+    },
     "201": {
       "headers": {
         "azure-asyncoperation": "http://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000011?api-version=2026-07-15-preview",

--- a/specification/cognitiveservices/resource-manager/readme.md
+++ b/specification/cognitiveservices/resource-manager/readme.md
@@ -168,14 +168,6 @@ suppressions:
       - $.definitions.ArcDeploymentProperties.properties.nodeSelector
       - $.definitions.ArcDeploymentProperties.properties.capabilities
       - $.definitions.ArcDeploymentUpdateProperties.properties.nodeSelector
-  - code: PutResponseCodes
-    reason: The Arc deployment PUT is create-only; updates are supported through PATCH, so the operation intentionally returns 201 + default without 200. This matches the arm-put-operation-response-codes suppression in the TypeSpec source.
-    where:
-      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/arcDeployments/{deploymentName}"].put
-  - code: ProvisioningStateSpecifiedForLROPut
-    reason: The Arc deployment PUT is a create-only long-running operation that returns 201. provisioningState is present in ArcDeploymentProperties (read-only) and returned in the GET and final LRO result. This matches the create-only PUT design and the arm-put-operation-response-codes suppression in the TypeSpec source.
-    where:
-      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/arcDeployments/{deploymentName}"].put
 ```
 
 ### Tag: package-2026-07-01


### PR DESCRIPTION
Fixes the ArcDeploymentSku.name extensible enum shape requested in Azure/azure-rest-api-specs#44334 review discussion.\n\nChanges:\n- Adds ArcDeploymentSkuName extensible union in TypeSpec.\n- Updates ArcDeploymentSku.name to reference the named union.\n- Regenerates 2026-07-15-preview Cognitive Services swagger so x-ms-enum has name ArcDeploymentSkuName and modelAsString: true.\n\nValidation run locally:\n- TypeSpec compile for specification\\cognitiveservices\\CognitiveServices.Management\n- Prettier check for ArcDeployment.tsp with TypeSpec plugin\n- oav validate-spec for 2026-07-15-preview cognitiveservices.json