### PR TITLE
fix(fleet): stop UpdateGroup.name description leaking memberSelector into earlier API versions

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-03-15-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-03-15-preview/fleets.json
@@ -1772,7 +1772,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-06-15-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-06-15-preview/fleets.json
@@ -1970,7 +1970,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-08-15-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2023-08-15-preview/fleets.json
@@ -2393,7 +2393,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2024-02-02-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2024-02-02-preview/fleets.json
@@ -2567,7 +2567,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2024-05-02-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2024-05-02-preview/fleets.json
@@ -3034,7 +3034,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-04-01-preview/fleets.json
@@ -3848,7 +3848,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-08-01-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2025-08-01-preview/fleets.json
@@ -4949,7 +4949,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2026-02-01-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2026-02-01-preview/fleets.json
@@ -4856,7 +4856,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2026-03-02-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2026-03-02-preview/fleets.json
@@ -5549,7 +5549,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2026-06-02-preview/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/preview/2026-06-02-preview/fleets.json
@@ -5736,7 +5736,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
@@ -5753,7 +5753,7 @@
         },
         "memberSelector": {
           "$ref": "#/definitions/MemberSelector",
-          "description": "Select the members of the group.\n  * If specified, label-based selection will override group name based selection.\n  * If not specified, group name based selection will be used.",
+          "description": "Select the members of the group.\n  * If specified, label-based selection will override group name based selection,\n    and Name is only used as an identifier.\n  * If not specified, group name based selection will be used, and Name must match a\n    group name of an existing fleet member.",
           "x-ms-mutability": [
             "read",
             "create"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/stable/2023-10-15/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/stable/2023-10-15/fleets.json
@@ -2277,7 +2277,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/stable/2024-04-01/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/stable/2024-04-01/fleets.json
@@ -2551,7 +2551,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/stable/2025-03-01/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/stable/2025-03-01/fleets.json
@@ -3331,7 +3331,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/stable/2026-06-01/fleets.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/stable/2026-06-01/fleets.json
@@ -4856,7 +4856,7 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Name of the group.\nIt serves as an identifier and must match a group name of an existing fleet member unless\nMemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.",
+          "description": "Name of the group.\nIt must match a group name of an existing fleet member.",
           "minLength": 1,
           "maxLength": 50,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/update/common.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/update/common.tsp
@@ -114,8 +114,7 @@ model ScheduledStartConfiguration {
 model UpdateGroup {
   @doc("""
     Name of the group.
-    It serves as an identifier and must match a group name of an existing fleet member unless
-    MemberSelector is specified. When MemberSelector is set, Name is only used as an identifier.
+    It must match a group name of an existing fleet member.
     """)
   @pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$")
   @minLength(1)
@@ -159,8 +158,10 @@ model UpdateGroup {
 
   @doc("""
     Select the members of the group.
-      * If specified, label-based selection will override group name based selection.
-      * If not specified, group name based selection will be used.
+      * If specified, label-based selection will override group name based selection,
+        and Name is only used as an identifier.
+      * If not specified, group name based selection will be used, and Name must match a
+        group name of an existing fleet member.
     """)
   @visibility(Lifecycle.Read, Lifecycle.Create)
   @added(Versions.v2026_06_02_preview)


### PR DESCRIPTION
(AI-generated)

Addresses review comment https://github.com/Azure/azure-rest-api-specs/pull/43386#discussion_r3739104117.

## Problem
The shared `UpdateGroup.name` `@doc` in `update/common.tsp` was rewritten to describe `MemberSelector` behavior. Since it is not version-gated, regeneration pushed that text into 13 previously-released API versions — including `stable/2026-06-01` (current GA), where `memberSelector` does not exist (`@added(Versions.v2026_06_02_preview)`).

## Fix
- Reverted the shared `UpdateGroup.name` `@doc` to its pre-PR text ("Name of the group. It must match a group name of an existing fleet member.").
- Documented the `Name` / `memberSelector` interaction on the version-gated `memberSelector` `@doc` block instead, so the capability is only described where it exists.
- Regenerated all `fleets.json` via `tsp compile` (no hand-editing).

## Result
- All 14 versions: `UpdateGroup.name` description reverted.
- `memberSelector.description` updated only in `2026-06-02-preview` (the sole version defining it).