### PR TITLE
Add deprecation notice for Workflow Agents

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -29838,8 +29838,8 @@
             "enum": [
               "prompt",
               "hosted",
-              "external",
-              "workflow"
+              "workflow",
+              "external"
             ]
           }
         ]

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -84388,7 +84388,7 @@
             "$ref": "#/components/schemas/AgentDefinition"
           }
         ],
-        "description": "The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. \nIf you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,\nsee the [Migration guide](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide).",
+        "description": "The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. \nIf you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,\nsee the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).",
         "x-ms-foundry-meta": {
           "required_previews": [
             "WorkflowAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -29838,8 +29838,8 @@
             "enum": [
               "prompt",
               "hosted",
-              "workflow",
-              "external"
+              "external",
+              "workflow"
             ]
           }
         ]
@@ -84389,6 +84389,7 @@
           }
         ],
         "description": "The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. \nIf you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,\nsee the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).",
+        "deprecated": true,
         "x-ms-foundry-meta": {
           "required_previews": [
             "WorkflowAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -84388,7 +84388,7 @@
             "$ref": "#/components/schemas/AgentDefinition"
           }
         ],
-        "description": "The workflow agent definition.",
+        "description": "The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. \nIf you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,\nsee the [Migration guide](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide).",
         "x-ms-foundry-meta": {
           "required_previews": [
             "WorkflowAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -40376,8 +40376,8 @@ components:
           enum:
             - prompt
             - hosted
-            - workflow
             - external
+            - workflow
     AgentObject:
       type: object
       required:
@@ -79777,6 +79777,7 @@ components:
         The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. 
         If you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,
         see the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).
+      deprecated: true
       x-ms-foundry-meta:
         required_previews:
           - WorkflowAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -40376,8 +40376,8 @@ components:
           enum:
             - prompt
             - hosted
-            - external
             - workflow
+            - external
     AgentObject:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -79776,7 +79776,7 @@ components:
       description: |-
         The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. 
         If you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,
-        see the [Migration guide](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide).
+        see the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).
       x-ms-foundry-meta:
         required_previews:
           - WorkflowAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -79773,7 +79773,10 @@ components:
           description: The CSDL YAML definition of the workflow.
       allOf:
         - $ref: '#/components/schemas/AgentDefinition'
-      description: The workflow agent definition.
+      description: |-
+        The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. 
+        If you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,
+        see the [Migration guide](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide).
       x-ms-foundry-meta:
         required_previews:
           - WorkflowAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -33067,8 +33067,8 @@
             "enum": [
               "prompt",
               "hosted",
-              "workflow",
               "external",
+              "workflow",
               "container_app"
             ]
           }
@@ -89147,6 +89147,7 @@
           }
         ],
         "description": "The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. \nIf you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,\nsee the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).",
+        "deprecated": true,
         "x-ms-foundry-meta": {
           "required_previews": [
             "WorkflowAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -89146,7 +89146,7 @@
             "$ref": "#/components/schemas/AgentDefinition"
           }
         ],
-        "description": "The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. \nIf you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,\nsee the [Migration guide](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide).",
+        "description": "The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. \nIf you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,\nsee the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).",
         "x-ms-foundry-meta": {
           "required_previews": [
             "WorkflowAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -33067,8 +33067,8 @@
             "enum": [
               "prompt",
               "hosted",
-              "external",
               "workflow",
+              "external",
               "container_app"
             ]
           }

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -89146,7 +89146,7 @@
             "$ref": "#/components/schemas/AgentDefinition"
           }
         ],
-        "description": "The workflow agent definition.",
+        "description": "The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. \nIf you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,\nsee the [Migration guide](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide).",
         "x-ms-foundry-meta": {
           "required_previews": [
             "WorkflowAgents=V1Preview"

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -83043,7 +83043,7 @@ components:
       description: |-
         The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. 
         If you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,
-        see the [Migration guide](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide).
+        see the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).
       x-ms-foundry-meta:
         required_previews:
           - WorkflowAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -83040,7 +83040,10 @@ components:
           description: The CSDL YAML definition of the workflow.
       allOf:
         - $ref: '#/components/schemas/AgentDefinition'
-      description: The workflow agent definition.
+      description: |-
+        The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. 
+        If you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,
+        see the [Migration guide](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide).
       x-ms-foundry-meta:
         required_previews:
           - WorkflowAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -42543,8 +42543,8 @@ components:
           enum:
             - prompt
             - hosted
-            - workflow
             - external
+            - workflow
             - container_app
     AgentObject:
       type: object
@@ -83044,6 +83044,7 @@ components:
         The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. 
         If you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,
         see the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).
+      deprecated: true
       x-ms-foundry-meta:
         required_previews:
           - WorkflowAgents=V1Preview

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -42543,8 +42543,8 @@ components:
           enum:
             - prompt
             - hosted
-            - external
             - workflow
+            - external
             - container_app
     AgentObject:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -279,7 +279,7 @@ union AgentKind {
   hosted: "hosted",
   external: "external",
   
-  #deprecated "Deprecated. Use Microsoft Agent Framework instead"
+  #deprecated "deprecated"
   workflow: "workflow",
 
   @removed(Versions.v1)
@@ -366,7 +366,7 @@ model PromptAgentDefinitionTextOptions {
 * If you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,
 * see the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).
 */
-#deprecated "Deprecated. Use Microsoft Agent Framework instead"
+#deprecated "deprecated"
 @extension(
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.workflow_agents_v1_preview] }

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -362,7 +362,7 @@ model PromptAgentDefinitionTextOptions {
 /**
 * The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. 
 * If you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,
-* see the [Migration guide](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide).
+* see the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).
 */
 @extension(
   "x-ms-foundry-meta",

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -277,10 +277,8 @@ union AgentKind {
   string,
   prompt: "prompt",
   hosted: "hosted",
-  external: "external",
-  
-  #deprecated "deprecated"
   workflow: "workflow",
+  external: "external",
 
   @removed(Versions.v1)
   container_app: "container_app",

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -277,8 +277,10 @@ union AgentKind {
   string,
   prompt: "prompt",
   hosted: "hosted",
-  workflow: "workflow",
   external: "external",
+  
+  #deprecated "Deprecated. Use Microsoft Agent Framework instead"
+  workflow: "workflow",
 
   @removed(Versions.v1)
   container_app: "container_app",
@@ -364,6 +366,7 @@ model PromptAgentDefinitionTextOptions {
 * If you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,
 * see the [Migration guide](https://learn.microsoft.com/azure/foundry/agents/concepts/workflow#migration-guide).
 */
+#deprecated "Deprecated. Use Microsoft Agent Framework instead"
 @extension(
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.workflow_agents_v1_preview] }

--- a/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/agents/models.tsp
@@ -359,7 +359,11 @@ model PromptAgentDefinitionTextOptions {
   format?: OpenAI.TextResponseFormatConfiguration;
 }
 
-@doc("The workflow agent definition.")
+/**
+* The workflow agent definition. Microsoft Foundry is retiring workflows on December 1, 2026. 
+* If you're looking to build new workflows, use Microsoft Agent Framework. To migrate existing workflows,
+* see the [Migration guide](https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide).
+*/
 @extension(
   "x-ms-foundry-meta",
   #{ required_previews: #[AgentDefinitionOptInKeys.workflow_agents_v1_preview] }


### PR DESCRIPTION
The same notice already appears here: https://learn.microsoft.com/en-us/azure/foundry/agents/concepts/workflow#migration-guide
