### PR TITLE
Multi-Turn Synthetic Data: Add conversation_params 

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -33930,6 +33930,30 @@
         ],
         "description": "Represents the parameters for conversation simulation item generation."
       },
+      "ConversationGenerationParams": {
+        "type": "object",
+        "properties": {
+          "model_deployment_name": {
+            "type": "string",
+            "description": "The name of the model deployment used to run the multi-turn conversation simulation. This is distinct from the `model_deployment_name` on `item_generation_params`, which generates the seed scenarios. When omitted, the simulation falls back to the seed-generation model."
+          },
+          "num_conversations": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row."
+          },
+          "max_turns": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20,
+            "description": "Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies."
+          }
+        },
+        "description": "Conversation-simulation controls for a conversation-level synthetic run, carried on the synthetic data generation data source as a sibling of `item_generation_params`. These parameterize the downstream multi-turn simulation: the model that runs the simulation and how many conversations/turns to produce. All fields are optional; when omitted, service defaults apply."
+      },
       "ConversationIdTraceSource": {
         "type": "object",
         "required": [
@@ -33958,26 +33982,6 @@
           }
         ],
         "description": "A trace source that selects traces by conversation IDs."
-      },
-      "ConversationSimulationParams": {
-        "type": "object",
-        "properties": {
-          "num_conversations": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 5,
-            "description": "Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row."
-          },
-          "max_turns": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 20,
-            "description": "Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies."
-          }
-        },
-        "description": "Conversation-simulation controls carried alongside synthetic data generation for conversation-level runs. Both fields are optional; when omitted, service defaults apply (one conversation per seed row and the shipped max-turns default)."
       },
       "CosmosDBIndex": {
         "type": "object",
@@ -81217,6 +81221,10 @@
           "input_messages": {
             "$ref": "#/components/schemas/OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate",
             "description": "Input messages template configuration applicable only if target is of type 'azure_ai_model'"
+          },
+          "conversation_generation_params": {
+            "$ref": "#/components/schemas/ConversationGenerationParams",
+            "description": "Optional conversation-simulation controls, supplied as a sibling of `item_generation_params`. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation."
           }
         },
         "allOf": [
@@ -81270,10 +81278,6 @@
               "$ref": "#/components/schemas/OpenAI.EvalJsonlFileIdSource"
             },
             "description": "The optional seed data content source files for data generation."
-          },
-          "conversation_params": {
-            "$ref": "#/components/schemas/ConversationSimulationParams",
-            "description": "Optional conversation-simulation controls. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -33959,6 +33959,26 @@
         ],
         "description": "A trace source that selects traces by conversation IDs."
       },
+      "ConversationSimulationParams": {
+        "type": "object",
+        "properties": {
+          "num_conversations": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row."
+          },
+          "max_turns": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20,
+            "description": "Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies."
+          }
+        },
+        "description": "Conversation-simulation controls carried alongside synthetic data generation for conversation-level runs. Both fields are optional; when omitted, service defaults apply (one conversation per seed row and the shipped max-turns default)."
+      },
       "CosmosDBIndex": {
         "type": "object",
         "required": [
@@ -81250,6 +81270,10 @@
               "$ref": "#/components/schemas/OpenAI.EvalJsonlFileIdSource"
             },
             "description": "The optional seed data content source files for data generation."
+          },
+          "conversation_params": {
+            "$ref": "#/components/schemas/ConversationSimulationParams",
+            "description": "Optional conversation-simulation controls. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -43260,6 +43260,25 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for conversation simulation item generation.
+    ConversationGenerationParams:
+      type: object
+      properties:
+        model_deployment_name:
+          type: string
+          description: The name of the model deployment used to run the multi-turn conversation simulation. This is distinct from the `model_deployment_name` on `item_generation_params`, which generates the seed scenarios. When omitted, the simulation falls back to the seed-generation model.
+        num_conversations:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 5
+          description: Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row.
+        max_turns:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 20
+          description: Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies.
+      description: 'Conversation-simulation controls for a conversation-level synthetic run, carried on the synthetic data generation data source as a sibling of `item_generation_params`. These parameterize the downstream multi-turn simulation: the model that runs the simulation and how many conversations/turns to produce. All fields are optional; when omitted, service defaults apply.'
     ConversationIdTraceSource:
       type: object
       required:
@@ -43279,22 +43298,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/TraceSource'
       description: A trace source that selects traces by conversation IDs.
-    ConversationSimulationParams:
-      type: object
-      properties:
-        num_conversations:
-          type: integer
-          format: int32
-          minimum: 1
-          maximum: 5
-          description: Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row.
-        max_turns:
-          type: integer
-          format: int32
-          minimum: 1
-          maximum: 20
-          description: Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies.
-      description: Conversation-simulation controls carried alongside synthetic data generation for conversation-level runs. Both fields are optional; when omitted, service defaults apply (one conversation per seed row and the shipped max-turns default).
     CosmosDBIndex:
       type: object
       required:
@@ -77583,6 +77586,9 @@ components:
         input_messages:
           $ref: '#/components/schemas/OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate'
           description: Input messages template configuration applicable only if target is of type 'azure_ai_model'
+        conversation_generation_params:
+          $ref: '#/components/schemas/ConversationGenerationParams'
+          description: Optional conversation-simulation controls, supplied as a sibling of `item_generation_params`. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation.
       allOf:
         - $ref: '#/components/schemas/EvalRunDataSource'
       description: Represents a data source for evaluation runs that evaluates based on generated synthetic data for testing purposes.
@@ -77621,9 +77627,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.EvalJsonlFileIdSource'
           description: The optional seed data content source files for data generation.
-        conversation_params:
-          $ref: '#/components/schemas/ConversationSimulationParams'
-          description: Optional conversation-simulation controls. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation.
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for synthetic data generation item generation.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -43279,6 +43279,22 @@ components:
       allOf:
         - $ref: '#/components/schemas/TraceSource'
       description: A trace source that selects traces by conversation IDs.
+    ConversationSimulationParams:
+      type: object
+      properties:
+        num_conversations:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 5
+          description: Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row.
+        max_turns:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 20
+          description: Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies.
+      description: Conversation-simulation controls carried alongside synthetic data generation for conversation-level runs. Both fields are optional; when omitted, service defaults apply (one conversation per seed row and the shipped max-turns default).
     CosmosDBIndex:
       type: object
       required:
@@ -77605,6 +77621,9 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.EvalJsonlFileIdSource'
           description: The optional seed data content source files for data generation.
+        conversation_params:
+          $ref: '#/components/schemas/ConversationSimulationParams'
+          description: Optional conversation-simulation controls. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation.
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for synthetic data generation item generation.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -37337,6 +37337,30 @@
         ],
         "description": "Represents the parameters for conversation simulation item generation."
       },
+      "ConversationGenerationParams": {
+        "type": "object",
+        "properties": {
+          "model_deployment_name": {
+            "type": "string",
+            "description": "The name of the model deployment used to run the multi-turn conversation simulation. This is distinct from the `model_deployment_name` on `item_generation_params`, which generates the seed scenarios. When omitted, the simulation falls back to the seed-generation model."
+          },
+          "num_conversations": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row."
+          },
+          "max_turns": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20,
+            "description": "Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies."
+          }
+        },
+        "description": "Conversation-simulation controls for a conversation-level synthetic run, carried on the synthetic data generation data source as a sibling of `item_generation_params`. These parameterize the downstream multi-turn simulation: the model that runs the simulation and how many conversations/turns to produce. All fields are optional; when omitted, service defaults apply."
+      },
       "ConversationIdTraceSource": {
         "type": "object",
         "required": [
@@ -37365,26 +37389,6 @@
           }
         ],
         "description": "A trace source that selects traces by conversation IDs."
-      },
-      "ConversationSimulationParams": {
-        "type": "object",
-        "properties": {
-          "num_conversations": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 5,
-            "description": "Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row."
-          },
-          "max_turns": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 1,
-            "maximum": 20,
-            "description": "Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies."
-          }
-        },
-        "description": "Conversation-simulation controls carried alongside synthetic data generation for conversation-level runs. Both fields are optional; when omitted, service defaults apply (one conversation per seed row and the shipped max-turns default)."
       },
       "CosmosDBIndex": {
         "type": "object",
@@ -85771,6 +85775,10 @@
           "input_messages": {
             "$ref": "#/components/schemas/OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate",
             "description": "Input messages template configuration applicable only if target is of type 'azure_ai_model'"
+          },
+          "conversation_generation_params": {
+            "$ref": "#/components/schemas/ConversationGenerationParams",
+            "description": "Optional conversation-simulation controls, supplied as a sibling of `item_generation_params`. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation."
           }
         },
         "allOf": [
@@ -85824,10 +85832,6 @@
               "$ref": "#/components/schemas/OpenAI.EvalJsonlFileIdSource"
             },
             "description": "The optional seed data content source files for data generation."
-          },
-          "conversation_params": {
-            "$ref": "#/components/schemas/ConversationSimulationParams",
-            "description": "Optional conversation-simulation controls. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -37366,6 +37366,26 @@
         ],
         "description": "A trace source that selects traces by conversation IDs."
       },
+      "ConversationSimulationParams": {
+        "type": "object",
+        "properties": {
+          "num_conversations": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 5,
+            "description": "Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row."
+          },
+          "max_turns": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "maximum": 20,
+            "description": "Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies."
+          }
+        },
+        "description": "Conversation-simulation controls carried alongside synthetic data generation for conversation-level runs. Both fields are optional; when omitted, service defaults apply (one conversation per seed row and the shipped max-turns default)."
+      },
       "CosmosDBIndex": {
         "type": "object",
         "required": [
@@ -85804,6 +85824,10 @@
               "$ref": "#/components/schemas/OpenAI.EvalJsonlFileIdSource"
             },
             "description": "The optional seed data content source files for data generation."
+          },
+          "conversation_params": {
+            "$ref": "#/components/schemas/ConversationSimulationParams",
+            "description": "Optional conversation-simulation controls. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation."
           }
         },
         "allOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -45549,6 +45549,25 @@ components:
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for conversation simulation item generation.
+    ConversationGenerationParams:
+      type: object
+      properties:
+        model_deployment_name:
+          type: string
+          description: The name of the model deployment used to run the multi-turn conversation simulation. This is distinct from the `model_deployment_name` on `item_generation_params`, which generates the seed scenarios. When omitted, the simulation falls back to the seed-generation model.
+        num_conversations:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 5
+          description: Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row.
+        max_turns:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 20
+          description: Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies.
+      description: 'Conversation-simulation controls for a conversation-level synthetic run, carried on the synthetic data generation data source as a sibling of `item_generation_params`. These parameterize the downstream multi-turn simulation: the model that runs the simulation and how many conversations/turns to produce. All fields are optional; when omitted, service defaults apply.'
     ConversationIdTraceSource:
       type: object
       required:
@@ -45568,22 +45587,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/TraceSource'
       description: A trace source that selects traces by conversation IDs.
-    ConversationSimulationParams:
-      type: object
-      properties:
-        num_conversations:
-          type: integer
-          format: int32
-          minimum: 1
-          maximum: 5
-          description: Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row.
-        max_turns:
-          type: integer
-          format: int32
-          minimum: 1
-          maximum: 20
-          description: Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies.
-      description: Conversation-simulation controls carried alongside synthetic data generation for conversation-level runs. Both fields are optional; when omitted, service defaults apply (one conversation per seed row and the shipped max-turns default).
     CosmosDBIndex:
       type: object
       required:
@@ -80720,6 +80723,9 @@ components:
         input_messages:
           $ref: '#/components/schemas/OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate'
           description: Input messages template configuration applicable only if target is of type 'azure_ai_model'
+        conversation_generation_params:
+          $ref: '#/components/schemas/ConversationGenerationParams'
+          description: Optional conversation-simulation controls, supplied as a sibling of `item_generation_params`. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation.
       allOf:
         - $ref: '#/components/schemas/EvalRunDataSource'
       description: Represents a data source for evaluation runs that evaluates based on generated synthetic data for testing purposes.
@@ -80758,9 +80764,6 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.EvalJsonlFileIdSource'
           description: The optional seed data content source files for data generation.
-        conversation_params:
-          $ref: '#/components/schemas/ConversationSimulationParams'
-          description: Optional conversation-simulation controls. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation.
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for synthetic data generation item generation.

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -45568,6 +45568,22 @@ components:
       allOf:
         - $ref: '#/components/schemas/TraceSource'
       description: A trace source that selects traces by conversation IDs.
+    ConversationSimulationParams:
+      type: object
+      properties:
+        num_conversations:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 5
+          description: Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row.
+        max_turns:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 20
+          description: Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies.
+      description: Conversation-simulation controls carried alongside synthetic data generation for conversation-level runs. Both fields are optional; when omitted, service defaults apply (one conversation per seed row and the shipped max-turns default).
     CosmosDBIndex:
       type: object
       required:
@@ -80742,6 +80758,9 @@ components:
           items:
             $ref: '#/components/schemas/OpenAI.EvalJsonlFileIdSource'
           description: The optional seed data content source files for data generation.
+        conversation_params:
+          $ref: '#/components/schemas/ConversationSimulationParams'
+          description: Optional conversation-simulation controls. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation.
       allOf:
         - $ref: '#/components/schemas/ItemGenerationParams'
       description: Represents the parameters for synthetic data generation item generation.

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
@@ -471,6 +471,9 @@ model SyntheticDataGenerationPreviewEvalRunDataSource
 
   /** Input messages template configuration applicable only if target is of type 'azure_ai_model' */
   input_messages?: OpenAI.CreateEvalResponsesRunDataSourceInputMessagesTemplate;
+
+  /** Optional conversation-simulation controls, supplied as a sibling of `item_generation_params`. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation. */
+  conversation_generation_params?: ConversationGenerationParams;
 }
 
 /** Represents the parameters for synthetic data generation item generation. */
@@ -497,13 +500,13 @@ model SyntheticDataGenerationPreviewItemGenerationParams
 
   /** The optional seed data content source files for data generation. */
   sources: OpenAI.EvalJsonlFileIdSource[];
-
-  /** Optional conversation-simulation controls. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation. */
-  conversation_params?: ConversationSimulationParams;
 }
 
-/** Conversation-simulation controls carried alongside synthetic data generation for conversation-level runs. Both fields are optional; when omitted, service defaults apply (one conversation per seed row and the shipped max-turns default). */
-model ConversationSimulationParams {
+/** Conversation-simulation controls for a conversation-level synthetic run, carried on the synthetic data generation data source as a sibling of `item_generation_params`. These parameterize the downstream multi-turn simulation: the model that runs the simulation and how many conversations/turns to produce. All fields are optional; when omitted, service defaults apply. */
+model ConversationGenerationParams {
+  /** The name of the model deployment used to run the multi-turn conversation simulation. This is distinct from the `model_deployment_name` on `item_generation_params`, which generates the seed scenarios. When omitted, the simulation falls back to the seed-generation model. */
+  model_deployment_name?: string;
+
   /** Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row. */
   @minValue(1)
   @maxValue(5)

--- a/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/openai/evaluations/models.tsp
@@ -497,6 +497,22 @@ model SyntheticDataGenerationPreviewItemGenerationParams
 
   /** The optional seed data content source files for data generation. */
   sources: OpenAI.EvalJsonlFileIdSource[];
+
+  /** Optional conversation-simulation controls. Only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation. */
+  conversation_params?: ConversationSimulationParams;
+}
+
+/** Conversation-simulation controls carried alongside synthetic data generation for conversation-level runs. Both fields are optional; when omitted, service defaults apply (one conversation per seed row and the shipped max-turns default). */
+model ConversationSimulationParams {
+  /** Number of simulated conversations to generate per synthetic seed scenario. When omitted, defaults to one conversation per seed row. */
+  @minValue(1)
+  @maxValue(5)
+  num_conversations?: int32;
+
+  /** Maximum number of turns per simulated conversation. When omitted, the shipped simulation default applies. */
+  @minValue(1)
+  @maxValue(20)
+  max_turns?: int32;
 }
 
 /** Represents a data source for evaluation runs that are specific to Continuous Evaluation scenarios. */


### PR DESCRIPTION
…eration params

Adds an optional conversation_params block (num_conversations 1-5, max_turns 1-20) to SyntheticDataGenerationPreviewItemGenerationParams, mirroring the RAISvc C# ConversationSimulationParams contract. These conversation-simulation knobs are only meaningful for conversation-level synthetic runs, where the generated seed dataset feeds a downstream multi-turn simulation. Regenerated the v1 and virtual-public-preview openapi3 outputs (json + yaml).

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
