### PR TITLE
Preserve Cost Management Java enum names

### DIFF
--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
@@ -556,27 +556,27 @@ model ExportRunReplacement extends Azure.ResourceManager.CommonTypes.Resource {
 // Preserve Java enum constant names from the previous SDK.
 @@clientName(
   CostDetailsMetricType.ActualCostCostDetailsMetricType,
-  "ActualCost",
+  "ACTUAL_COST",
   "java"
 );
 @@clientName(
   CostDetailsMetricType.AmortizedCostCostDetailsMetricType,
-  "AmortizedCost",
+  "AMORTIZED_COST",
   "java"
 );
 @@clientName(
   CostDetailsStatusType.CompletedCostDetailsStatusType,
-  "Completed",
+  "COMPLETED",
   "java"
 );
 @@clientName(
   CostDetailsStatusType.NoDataFoundCostDetailsStatusType,
-  "NoDataFound",
+  "NO_DATA_FOUND",
   "java"
 );
 @@clientName(
   CostDetailsStatusType.FailedCostDetailsStatusType,
-  "Failed",
+  "FAILED",
   "java"
 );
-@@clientName(CostDetailsDataFormat.CsvCostDetailsDataFormat, "Csv", "java");
+@@clientName(CostDetailsDataFormat.CsvCostDetailsDataFormat, "CSV", "java");

--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/client.tsp
@@ -552,3 +552,31 @@ model ExportRunReplacement extends Azure.ResourceManager.CommonTypes.Resource {
 // to free the original names for non-nullable [Obsolete] backward-compat shims.
 @@clientName(BudgetProperties.category, "BudgetCategory", "csharp");
 @@clientName(BudgetProperties.timeGrain, "BudgetTimeGrain", "csharp");
+
+// Preserve Java enum constant names from the previous SDK.
+@@clientName(
+  CostDetailsMetricType.ActualCostCostDetailsMetricType,
+  "ActualCost",
+  "java"
+);
+@@clientName(
+  CostDetailsMetricType.AmortizedCostCostDetailsMetricType,
+  "AmortizedCost",
+  "java"
+);
+@@clientName(
+  CostDetailsStatusType.CompletedCostDetailsStatusType,
+  "Completed",
+  "java"
+);
+@@clientName(
+  CostDetailsStatusType.NoDataFoundCostDetailsStatusType,
+  "NoDataFound",
+  "java"
+);
+@@clientName(
+  CostDetailsStatusType.FailedCostDetailsStatusType,
+  "Failed",
+  "java"
+);
+@@clientName(CostDetailsDataFormat.CsvCostDetailsDataFormat, "Csv", "java");


### PR DESCRIPTION
Preserves the existing Java enum constant names for Cost Management during the TypeSpec migration.

The TypeSpec union member names include type-name suffixes, which otherwise generate breaking Java constants such as `ACTUAL_COST_COST_DETAILS_METRIC_TYPE`. Java-scoped `@@clientName` customizations retain:

- `ACTUAL_COST`
- `AMORTIZED_COST`
- `COMPLETED`
- `NO_DATA_FOUND`
- `FAILED`
- `CSV`

Related SDK PR: https://github.com/Azure/azure-sdk-for-java/pull/50098
