### PR TITLE
Attestation: keep /certs and OpenID metadata endpoints unversioned

### DIFF
--- a/specification/attestation/data-plane/Attestation/examples/2025-06-01/Get_MetadataConfiguration.json
+++ b/specification/attestation/data-plane/Attestation/examples/2025-06-01/Get_MetadataConfiguration.json
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "api-version": "2025-06-01",
     "instanceUrl": "https://instance.attest.azure.net"
   },
   "responses": {

--- a/specification/attestation/data-plane/Attestation/routes.tsp
+++ b/specification/attestation/data-plane/Attestation/routes.tsp
@@ -235,16 +235,16 @@ interface SigningCertificates {
    * Retrieves metadata signing certificates in use by the attestation service
    */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API - must use current operation signature for backward compatibility"
+  #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Unversioned discovery endpoint - clients call /certs before negotiating an API version, and every prior API version declares no parameters on this route"
   @summary("Retrieves the attestation signing keys in use by the attestation service")
   @route("/certs")
   @get
-  get is Azure.Core.Foundations.Operation<
-    {},
-    JsonWebKeySet & {
-      @header
-      contentType: SigningCertificatesContentType;
-    }
-  >;
+  get():
+    | (JsonWebKeySet & {
+        @header
+        contentType: SigningCertificatesContentType;
+      })
+    | Azure.Core.Foundations.ErrorResponse;
 }
 
 interface MetadataConfiguration {
@@ -253,8 +253,9 @@ interface MetadataConfiguration {
    * service
    */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API - must use current operation signature for backward compatibility"
+  #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Unversioned discovery endpoint - clients call the OpenID metadata document before negotiating an API version, and every prior API version declares no parameters on this route"
   @summary("Retrieves the OpenID Configuration data for the Azure Attestation Service")
   @route("/.well-known/openid-configuration")
   @get
-  get is Azure.Core.Foundations.Operation<{}, OpenIDConfigurationResponse>;
+  get(): OpenIDConfigurationResponse | Azure.Core.Foundations.ErrorResponse;
 }

--- a/specification/attestation/data-plane/Attestation/routes.tsp
+++ b/specification/attestation/data-plane/Attestation/routes.tsp
@@ -235,7 +235,6 @@ interface SigningCertificates {
    * Retrieves metadata signing certificates in use by the attestation service
    */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API - must use current operation signature for backward compatibility"
-  #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Unversioned discovery endpoint - clients call /certs before negotiating an API version, and every prior API version declares no parameters on this route"
   @summary("Retrieves the attestation signing keys in use by the attestation service")
   @route("/certs")
   @get
@@ -253,7 +252,6 @@ interface MetadataConfiguration {
    * service
    */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API - must use current operation signature for backward compatibility"
-  #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Unversioned discovery endpoint - clients call the OpenID metadata document before negotiating an API version, and every prior API version declares no parameters on this route"
   @summary("Retrieves the OpenID Configuration data for the Azure Attestation Service")
   @route("/.well-known/openid-configuration")
   @get

--- a/specification/attestation/data-plane/Attestation/routes.tsp
+++ b/specification/attestation/data-plane/Attestation/routes.tsp
@@ -235,6 +235,7 @@ interface SigningCertificates {
    * Retrieves metadata signing certificates in use by the attestation service
    */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API - must use current operation signature for backward compatibility"
+  #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Unversioned discovery endpoint - clients call /certs before negotiating an API version, and every prior API version declares no parameters on this route"
   @summary("Retrieves the attestation signing keys in use by the attestation service")
   @route("/certs")
   @get
@@ -252,6 +253,7 @@ interface MetadataConfiguration {
    * service
    */
   #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Existing API - must use current operation signature for backward compatibility"
+  #suppress "@azure-tools/typespec-azure-core/operation-missing-api-version" "Unversioned discovery endpoint - clients call the OpenID metadata document before negotiating an API version, and every prior API version declares no parameters on this route"
   @summary("Retrieves the OpenID Configuration data for the Azure Attestation Service")
   @route("/.well-known/openid-configuration")
   @get

--- a/specification/attestation/data-plane/Attestation/stable/2025-06-01/attestation.json
+++ b/specification/attestation/data-plane/Attestation/stable/2025-06-01/attestation.json
@@ -57,11 +57,7 @@
         "operationId": "MetadataConfiguration_Get",
         "summary": "Retrieves the OpenID Configuration data for the Azure Attestation Service",
         "description": "Retrieves metadata about the attestation signing keys in use by the attestation\nservice",
-        "parameters": [
-          {
-            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "The request has succeeded.",
@@ -495,11 +491,7 @@
           "application/jwk+json",
           "application/json"
         ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter"
-          }
-        ],
+        "parameters": [],
         "responses": {
           "200": {
             "description": "The request has succeeded.",

--- a/specification/attestation/data-plane/Attestation/stable/2025-06-01/examples/Get_MetadataConfiguration.json
+++ b/specification/attestation/data-plane/Attestation/stable/2025-06-01/examples/Get_MetadataConfiguration.json
@@ -1,6 +1,5 @@
 {
   "parameters": {
-    "api-version": "2025-06-01",
     "instanceUrl": "https://instance.attest.azure.net"
   },
   "responses": {


### PR DESCRIPTION
## Summary

Restores `/certs` and `/.well-known/openid-configuration` to being **unversioned**, matching the behavior of every previously published Attestation API version.

## Problem

The TypeSpec migration declared both discovery endpoints using `Azure.Core.Foundations.Operation<>`, which injects a required `api-version` query parameter. That was an incidental side effect of the wrapper, not an intentional contract change.

As a result, generated clients began sending:

```
GET https://<instance>.attest.azure.net/certs?api-version=2025-06-01
```

where previously they sent:

```
GET https://<instance>.attest.azure.net/certs
```

This surfaced as a recording mismatch in the .NET SDK migration (Azure/azure-sdk-for-net#61741), but it affects every language generated from this TypeSpec.

## Evidence that unversioned is correct

`/certs` declares **zero** parameters in all four previously published versions, while `/policies/{attestationType}` declares `ApiVersionParameter` in those same documents:

| API version | `/certs` params |
| --- | --- |
| 2018-09-01-preview | 0 |
| 2020-10-01 | 0 |
| 2022-08-01 | 0 |
| 2022-09-01-preview | 0 |
| 2025-06-01 (pre-fix) | 1 |

The service registers both routes with an empty api-version alongside the versioned values, so the unversioned form is explicitly supported. These are discovery endpoints - clients call them to learn what the service supports, before negotiating an API version.

## Change

Declares the two operations explicitly rather than via `Azure.Core.Foundations.Operation<>`, **retaining the `default` error response** so error modeling is unchanged, and suppresses `operation-missing-api-version` with a rationale.

## Emitted swagger diff

Limited to removing the `api-version` parameter from the two routes. `200` and `default` responses are unchanged:

```diff
-        "parameters": [
-          { "$ref": "#/parameters/Azure.Core.Foundations.ApiVersionParameter" }
-        ],
+        "parameters": [],
```

Final emitted contract now matches 2020-10-01 and 2022-08-01 exactly:

| route | params | responses |
| --- | --- | --- |
| `/certs` | (none) | 200, default |
| `/.well-known/openid-configuration` | (none) | 200, default |
| `/policies/{attestationType}` | api-version | 200, default |

`tsp compile` completes with no warnings.

## Validation

- TypeSpec compiles cleanly (0 warnings)
- Emitted swagger diff reviewed and limited to the intended change
- Fix verified against the .NET SDK test suite: 20/20 passing on net8.0 and net10.0, with zero public API surface diff and no re-recording required
