### PR TITLE
[Cognitive Services] Add context cache container ID to deployments

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -3089,6 +3089,12 @@ model DeploymentProperties {
   `model`?: DeploymentModel;
 
   /**
+   * The resource ID of the context cache container associated with this deployment.
+   */
+  @added(Versions.v2026_03_15_preview)
+  contextCacheContainerId?: string;
+
+  /**
    * Speculative decoding settings for the deployment. This configuration applies to Fireworks model formats.
    */
   @added(Versions.v2026_05_15_preview)

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-03-15-preview/cognitiveservices.json
@@ -14895,6 +14895,10 @@
           "$ref": "#/definitions/DeploymentModel",
           "description": "Properties of Cognitive Services account deployment model."
         },
+        "contextCacheContainerId": {
+          "type": "string",
+          "description": "The resource ID of the context cache container associated with this deployment."
+        },
         "scaleSettings": {
           "$ref": "#/definitions/DeploymentScaleSettings",
           "description": "Properties of Cognitive Services account deployment model. (Deprecated, please use Deployment.sku instead.)"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-05-15-preview/cognitiveservices.json
@@ -14901,6 +14901,10 @@
           "$ref": "#/definitions/DeploymentModel",
           "description": "Properties of Cognitive Services account deployment model."
         },
+        "contextCacheContainerId": {
+          "type": "string",
+          "description": "The resource ID of the context cache container associated with this deployment."
+        },
         "speculativeDecoding": {
           "$ref": "#/definitions/DeploymentSpeculativeDecoding",
           "description": "Speculative decoding settings for the deployment. This configuration applies to Fireworks model formats."

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-05-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-05-01/cognitiveservices.json
@@ -12732,6 +12732,10 @@
           "$ref": "#/definitions/DeploymentModel",
           "description": "Properties of Cognitive Services account deployment model."
         },
+        "contextCacheContainerId": {
+          "type": "string",
+          "description": "The resource ID of the context cache container associated with this deployment."
+        },
         "scaleSettings": {
           "$ref": "#/definitions/DeploymentScaleSettings",
           "description": "Properties of Cognitive Services account deployment model. (Deprecated, please use Deployment.sku instead.)"

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/cognitiveservices.json
@@ -12768,6 +12768,10 @@
           "$ref": "#/definitions/DeploymentModel",
           "description": "Properties of Cognitive Services account deployment model."
         },
+        "contextCacheContainerId": {
+          "type": "string",
+          "description": "The resource ID of the context cache container associated with this deployment."
+        },
         "scaleSettings": {
           "$ref": "#/definitions/DeploymentScaleSettings",
           "description": "Properties of Cognitive Services account deployment model. (Deprecated, please use Deployment.sku instead.)"


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [ ] New resource provider.
- [ ] New API version for an existing resource provider.
- [ ] Update existing version for a new feature.
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing OpenAPI spec to TypeSpec spec.
- [x] Other, please clarify:
  - Align the Cognitive Services management specification with existing RP behavior by exposing the optional `properties.contextCacheContainerId` deployment property starting in `2026-03-15-preview`.

## Changes

- Add `contextCacheContainerId` to TypeSpec `DeploymentProperties` with `@added(Versions.v2026_03_15_preview)`.
- Regenerate Swagger for all applicable API versions: `2026-03-15-preview`, `2026-05-01`, `2026-05-15-preview`, and `2026-07-01`.
- This is an optional additive property and does not change existing request requirements.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [ ] I have reviewed the Resource Provider guidelines, ARM resource provider contract, and REST guidelines.
- [ ] A release plan has been created. SDK and Azure CLI follow-up will be handled separately by the owning teams.

## Validation

- TypeSpec compilation
- Prettier formatting checks
- OAV semantic validation for each regenerated Swagger file