### PR TITLE
Remove Go module major version suffixes

### DIFF
--- a/specification/appconfiguration/data-plane/AppConfiguration/tspconfig.yaml
+++ b/specification/appconfiguration/data-plane/AppConfiguration/tspconfig.yaml
@@ -39,7 +39,7 @@ options:
     generate-tests: false
     generate-samples: false
   "@azure-tools/typespec-go":
-    containing-module: "github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/v2"
+    containing-module: "github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig"
     service-dir: "sdk/data"
     emitter-output-dir: "{output-dir}/{service-dir}/azappconfig/internal/generated"
     slice-elements-byval: true

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/tspconfig.yaml
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/tspconfig.yaml
@@ -40,7 +40,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/appconfiguration"
     emitter-output-dir: "{output-dir}/{service-dir}/armappconfiguration"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armappconfiguration/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armappconfiguration"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/attestation/resource-manager/Microsoft.Attestation/Attestation/tspconfig.yaml
+++ b/specification/attestation/resource-manager/Microsoft.Attestation/Attestation/tspconfig.yaml
@@ -31,7 +31,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/attestation"
     emitter-output-dir: "{output-dir}/{service-dir}/armattestation"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armattestation/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armattestation"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/tspconfig.yaml
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/tspconfig.yaml
@@ -33,7 +33,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/authorization"
     emitter-output-dir: "{output-dir}/{service-dir}/armauthorization"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armauthorization/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armauthorization"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/azurefleet/resource-manager/Microsoft.AzureFleet/AzureFleet/tspconfig.yaml
+++ b/specification/azurefleet/resource-manager/Microsoft.AzureFleet/AzureFleet/tspconfig.yaml
@@ -30,7 +30,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/computefleet"
     emitter-output-dir: "{output-dir}/{service-dir}/armcomputefleet"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcomputefleet/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcomputefleet"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/tspconfig.yaml
+++ b/specification/azurestackhci/resource-manager/Microsoft.AzureStackHCI/StackHCI/tspconfig.yaml
@@ -8,7 +8,7 @@ options:
     arm-types-dir: "{project-root}/../../../../common-types/resource-management"
   "@azure-tools/typespec-go":
     service-dir: sdk/resourcemanager/azurestackhci
-    module: github.com/Azure/azure-sdk-for-go/{service-dir}/armazurestackhci/v3
+    module: github.com/Azure/azure-sdk-for-go/{service-dir}/armazurestackhci
     fix-const-stuttering: true
     generate-samples: true
     generate-fakes: true

--- a/specification/batch/resource-manager/Microsoft.Batch/Batch/tspconfig.yaml
+++ b/specification/batch/resource-manager/Microsoft.Batch/Batch/tspconfig.yaml
@@ -36,7 +36,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/batch"
     emitter-output-dir: "{output-dir}/{service-dir}/armbatch"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armbatch/v4"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armbatch"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/billing/resource-manager/Microsoft.Billing/Billing/tspconfig.yaml
+++ b/specification/billing/resource-manager/Microsoft.Billing/Billing/tspconfig.yaml
@@ -35,7 +35,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/billing"
     emitter-output-dir: "{output-dir}/{service-dir}/armbilling"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armbilling/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armbilling"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/billingbenefits/resource-manager/Microsoft.BillingBenefits/BillingBenefits/tspconfig.yaml
+++ b/specification/billingbenefits/resource-manager/Microsoft.BillingBenefits/BillingBenefits/tspconfig.yaml
@@ -39,7 +39,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/billingbenefits"
     emitter-output-dir: "{output-dir}/{service-dir}/armbillingbenefits"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armbillingbenefits/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armbillingbenefits"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/tspconfig.yaml
+++ b/specification/cdn/resource-manager/Microsoft.Cdn/Cdn/tspconfig.yaml
@@ -41,7 +41,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/cdn"
     emitter-output-dir: "{output-dir}/{service-dir}/armcdn"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcdn/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcdn"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/tspconfig.yaml
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/tspconfig.yaml
@@ -27,7 +27,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/chaos"
     emitter-output-dir: "{output-dir}/{service-dir}/armchaos"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armchaos/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armchaos"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/cognitiveservices/CognitiveServices.Management/tspconfig.yaml
+++ b/specification/cognitiveservices/CognitiveServices.Management/tspconfig.yaml
@@ -45,7 +45,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/cognitiveservices"
     emitter-output-dir: "{output-dir}/{service-dir}/armcognitiveservices"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcognitiveservices/v4"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcognitiveservices"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/communication/Communication.Management/tspconfig.yaml
+++ b/specification/communication/Communication.Management/tspconfig.yaml
@@ -42,7 +42,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/communication"
     emitter-output-dir: "{output-dir}/{service-dir}/armcommunication"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcommunication/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcommunication"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
+++ b/specification/compute/resource-manager/Microsoft.Compute/Compute/tspconfig.yaml
@@ -19,7 +19,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/compute"
     emitter-output-dir: "{output-dir}/{service-dir}/armcompute"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcompute/v8"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcompute"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/confluent/resource-manager/Microsoft.Confluent/Confluent/tspconfig.yaml
+++ b/specification/confluent/resource-manager/Microsoft.Confluent/Confluent/tspconfig.yaml
@@ -33,7 +33,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/confluent"
     emitter-output-dir: "{output-dir}/{service-dir}/armconfluent"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armconfluent/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armconfluent"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/consumption/resource-manager/Microsoft.Consumption/Consumption/tspconfig.yaml
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/Consumption/tspconfig.yaml
@@ -31,7 +31,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/consumption"
     emitter-output-dir: "{output-dir}/{service-dir}/armconsumption"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armconsumption/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armconsumption"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/Registry/tspconfig.yaml
+++ b/specification/containerregistry/resource-manager/Microsoft.ContainerRegistry/Registry/tspconfig.yaml
@@ -44,7 +44,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/containerregistry"
     emitter-output-dir: "{output-dir}/{service-dir}/armcontainerregistry"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontainerregistry/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontainerregistry"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/tspconfig.yaml
@@ -33,7 +33,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/containerservice"
     emitter-output-dir: "{output-dir}/{service-dir}/armcontainerservice"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontainerservice/v9"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontainerservice"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/tspconfig.yaml
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/fleet/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/containerservicefleet"
     emitter-output-dir: "{output-dir}/{service-dir}/armcontainerservicefleet"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontainerservicefleet/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontainerservicefleet"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/tspconfig.yaml
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/DocumentDB/tspconfig.yaml
@@ -45,7 +45,7 @@ options:
       DatabaseAccountGetPropertiesDatabaseAccountOfferType: DatabaseAccountOfferType
     api-version: "2026-03-15"
   "@azure-tools/typespec-go":
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcosmos/v4"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcosmos"
     service-dir: "sdk/resourcemanager/cosmos"
     emitter-output-dir: "{output-dir}/{service-dir}/armcosmos"
     generate-fakes: true

--- a/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/tspconfig.yaml
+++ b/specification/cost-management/resource-manager/Microsoft.CostManagement/CostManagement/tspconfig.yaml
@@ -34,7 +34,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/costmanagement"
     emitter-output-dir: "{output-dir}/{service-dir}/armcostmanagement"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcostmanagement/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcostmanagement"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/dashboard/resource-manager/Microsoft.Dashboard/Dashboard/tspconfig.yaml
+++ b/specification/dashboard/resource-manager/Microsoft.Dashboard/Dashboard/tspconfig.yaml
@@ -33,7 +33,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/dashboard"
     emitter-output-dir: "{output-dir}/{service-dir}/armdashboard"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdashboard/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdashboard"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/databox/resource-manager/Microsoft.DataBox/DataBox/tspconfig.yaml
+++ b/specification/databox/resource-manager/Microsoft.DataBox/DataBox/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/databox"
     emitter-output-dir: "{output-dir}/{service-dir}/armdatabox"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdatabox/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdatabox"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/tspconfig.yaml
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/tspconfig.yaml
@@ -35,7 +35,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/datafactory"
     emitter-output-dir: "{output-dir}/{service-dir}/armdatafactory"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdatafactory/v11"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdatafactory"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/tspconfig.yaml
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/tspconfig.yaml
@@ -32,7 +32,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/dataprotection"
     emitter-output-dir: "{output-dir}/{service-dir}/armdataprotection"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdataprotection/v4"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdataprotection"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/devcenter/resource-manager/Microsoft.DevCenter/DevCenter/tspconfig.yaml
+++ b/specification/devcenter/resource-manager/Microsoft.DevCenter/DevCenter/tspconfig.yaml
@@ -42,7 +42,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/devcenter"
     emitter-output-dir: "{output-dir}/{service-dir}/armdevcenter"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdevcenter/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdevcenter"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/deviceregistry/DeviceRegistry.Management/tspconfig.yaml
+++ b/specification/deviceregistry/DeviceRegistry.Management/tspconfig.yaml
@@ -35,7 +35,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/deviceregistry"
     emitter-output-dir: "{output-dir}/{service-dir}/armdeviceregistry"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdeviceregistry/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdeviceregistry"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/dnsresolver/resource-manager/Microsoft.Network/DnsResolver/tspconfig.yaml
+++ b/specification/dnsresolver/resource-manager/Microsoft.Network/DnsResolver/tspconfig.yaml
@@ -38,7 +38,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/dnsresolver"
     emitter-output-dir: "{output-dir}/{service-dir}/armdnsresolver"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdnsresolver/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdnsresolver"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/dynatrace/resource-manager/Dynatrace.Observability/DynatraceObservability/tspconfig.yaml
+++ b/specification/dynatrace/resource-manager/Dynatrace.Observability/DynatraceObservability/tspconfig.yaml
@@ -40,7 +40,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/dynatrace"
     emitter-output-dir: "{output-dir}/{service-dir}/armdynatrace"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdynatrace/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdynatrace"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/elastic/resource-manager/Microsoft.Elastic/Elastic/tspconfig.yaml
+++ b/specification/elastic/resource-manager/Microsoft.Elastic/Elastic/tspconfig.yaml
@@ -39,7 +39,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/elastic"
     emitter-output-dir: "{output-dir}/{service-dir}/armelastic"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armelastic/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armelastic"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/tspconfig.yaml
+++ b/specification/eventgrid/resource-manager/Microsoft.EventGrid/EventGrid/tspconfig.yaml
@@ -35,7 +35,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/eventgrid"
     emitter-output-dir: "{output-dir}/{service-dir}/armeventgrid"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armeventgrid/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armeventgrid"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/fist/resource-manager/Microsoft.IoTFirmwareDefense/IoTFirmwareDefense/tspconfig.yaml
+++ b/specification/fist/resource-manager/Microsoft.IoTFirmwareDefense/IoTFirmwareDefense/tspconfig.yaml
@@ -34,7 +34,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/iotfirmwaredefense"
     emitter-output-dir: "{output-dir}/{service-dir}/armiotfirmwaredefense"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armiotfirmwaredefense/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armiotfirmwaredefense"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/frontdoor/resource-manager/Microsoft.Network/FrontDoor/tspconfig.yaml
+++ b/specification/frontdoor/resource-manager/Microsoft.Network/FrontDoor/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/frontdoor"
     emitter-output-dir: "{output-dir}/{service-dir}/armfrontdoor"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armfrontdoor/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armfrontdoor"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/hardwaresecuritymodules/resource-manager/Microsoft.HardwareSecurityModules/HardwareSecurityModules/tspconfig.yaml
+++ b/specification/hardwaresecuritymodules/resource-manager/Microsoft.HardwareSecurityModules/HardwareSecurityModules/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/hardwaresecuritymodules"
     emitter-output-dir: "{output-dir}/{service-dir}/armhardwaresecuritymodules"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armhardwaresecuritymodules/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armhardwaresecuritymodules"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsight/tspconfig.yaml
+++ b/specification/hdinsight/resource-manager/Microsoft.HDInsight/HDInsight/tspconfig.yaml
@@ -35,7 +35,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/hdinsight"
     emitter-output-dir: "{output-dir}/{service-dir}/armhdinsight"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armhdinsight/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armhdinsight"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/healthbot/resource-manager/Microsoft.HealthBot/HealthBot/tspconfig.yaml
+++ b/specification/healthbot/resource-manager/Microsoft.HealthBot/HealthBot/tspconfig.yaml
@@ -36,7 +36,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/healthbot"
     emitter-output-dir: "{output-dir}/{service-dir}/armhealthbot"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armhealthbot/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armhealthbot"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/help/resource-manager/Microsoft.Help/Help/tspconfig.yaml
+++ b/specification/help/resource-manager/Microsoft.Help/Help/tspconfig.yaml
@@ -40,7 +40,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/selfhelp"
     emitter-output-dir: "{output-dir}/{service-dir}/armselfhelp"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armselfhelp/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armselfhelp"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/hybridkubernetes/resource-manager/Microsoft.Kubernetes/HybridKubernetes/tspconfig.yaml
+++ b/specification/hybridkubernetes/resource-manager/Microsoft.Kubernetes/HybridKubernetes/tspconfig.yaml
@@ -40,7 +40,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/hybridkubernetes"
     emitter-output-dir: "{output-dir}/{service-dir}/armhybridkubernetes"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armhybridkubernetes/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armhybridkubernetes"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/keyvault/resource-manager/Microsoft.KeyVault/KeyVault/tspconfig.yaml
+++ b/specification/keyvault/resource-manager/Microsoft.KeyVault/KeyVault/tspconfig.yaml
@@ -52,7 +52,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/keyvault"
     emitter-output-dir: "{output-dir}/{service-dir}/armkeyvault"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armkeyvault/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armkeyvault"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/management/resource-manager/Microsoft.Management/ManagementGroups/tspconfig.yaml
+++ b/specification/management/resource-manager/Microsoft.Management/ManagementGroups/tspconfig.yaml
@@ -40,7 +40,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/managementgroups"
     emitter-output-dir: "{output-dir}/{service-dir}/armmanagementgroups"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armmanagementgroups/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armmanagementgroups"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/maps/resource-manager/Microsoft.Maps/Maps/tspconfig.yaml
+++ b/specification/maps/resource-manager/Microsoft.Maps/Maps/tspconfig.yaml
@@ -33,7 +33,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/maps"
     emitter-output-dir: "{output-dir}/{service-dir}/armmaps"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armmaps/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armmaps"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/marketplace/resource-manager/Microsoft.Marketplace/Marketplace/tspconfig.yaml
+++ b/specification/marketplace/resource-manager/Microsoft.Marketplace/Marketplace/tspconfig.yaml
@@ -34,7 +34,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/marketplace"
     emitter-output-dir: "{output-dir}/{service-dir}/armmarketplace"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armmarketplace/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armmarketplace"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/tspconfig.yaml
+++ b/specification/mysql/resource-manager/Microsoft.DBforMySQL/FlexibleServers/tspconfig.yaml
@@ -45,7 +45,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/mysql"
     emitter-output-dir: "{output-dir}/{service-dir}/armmysqlflexibleservers"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armmysqlflexibleservers/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armmysqlflexibleservers"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/tspconfig.yaml
+++ b/specification/netapp/resource-manager/Microsoft.NetApp/NetApp/tspconfig.yaml
@@ -45,7 +45,7 @@ options:
   "@azure-tools/typespec-go":
     emitter-output-dir: "{output-dir}/{service-dir}/armnetapp"
     service-dir: "sdk/resourcemanager/netapp"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armnetapp/v10"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armnetapp"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/networkfunction/resource-manager/Microsoft.NetworkFunction/TrafficCollector/tspconfig.yaml
+++ b/specification/networkfunction/resource-manager/Microsoft.NetworkFunction/TrafficCollector/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/networkfunction"
     emitter-output-dir: "{output-dir}/{service-dir}/armnetworkfunction"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armnetworkfunction/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armnetworkfunction"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/newrelic/NewRelicObservability.Management/tspconfig.yaml
+++ b/specification/newrelic/NewRelicObservability.Management/tspconfig.yaml
@@ -42,7 +42,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/newrelic"
     emitter-output-dir: "{output-dir}/{service-dir}/armnewrelicobservability"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armnewrelicobservability/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armnewrelicobservability"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/nginx/resource-manager/Nginx.NginxPlus/NginxPlus/tspconfig.yaml
+++ b/specification/nginx/resource-manager/Nginx.NginxPlus/NginxPlus/tspconfig.yaml
@@ -36,7 +36,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/nginx"
     emitter-output-dir: "{output-dir}/{service-dir}/armnginx"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armnginx/v4"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armnginx"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/tspconfig.yaml
+++ b/specification/notificationhubs/resource-manager/Microsoft.NotificationHubs/NotificationHubs/tspconfig.yaml
@@ -31,7 +31,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/notificationhubs"
     emitter-output-dir: "{output-dir}/{service-dir}/armnotificationhubs"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armnotificationhubs/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armnotificationhubs"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
+++ b/specification/operationalinsights/resource-manager/Microsoft.OperationalInsights/OperationalInsights/tspconfig.yaml
@@ -43,7 +43,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/operationalinsights"
     emitter-output-dir: "{output-dir}/{service-dir}/armoperationalinsights"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armoperationalinsights/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armoperationalinsights"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/oracle/resource-manager/Oracle.Database/OracleDatabase/tspconfig.yaml
+++ b/specification/oracle/resource-manager/Oracle.Database/OracleDatabase/tspconfig.yaml
@@ -32,7 +32,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/oracledatabase"
     emitter-output-dir: "{output-dir}/{service-dir}/armoracledatabase"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armoracledatabase/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armoracledatabase"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/paloaltonetworks/resource-manager/PaloAltoNetworks.Cloudngfw/Cloudngfw/tspconfig.yaml
+++ b/specification/paloaltonetworks/resource-manager/PaloAltoNetworks.Cloudngfw/Cloudngfw/tspconfig.yaml
@@ -36,7 +36,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/paloaltonetworksngfw"
     emitter-output-dir: "{output-dir}/{service-dir}/armpanngfw"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpanngfw/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpanngfw"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/peering/resource-manager/Microsoft.Peering/Peering/tspconfig.yaml
+++ b/specification/peering/resource-manager/Microsoft.Peering/Peering/tspconfig.yaml
@@ -31,7 +31,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/peering"
     emitter-output-dir: "{output-dir}/{service-dir}/armpeering"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpeering/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpeering"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/postgresql/DBforPostgreSQL.Management/tspconfig.yaml
+++ b/specification/postgresql/DBforPostgreSQL.Management/tspconfig.yaml
@@ -36,7 +36,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/postgresql"
     emitter-output-dir: "{output-dir}/{service-dir}/armpostgresqlflexibleservers"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpostgresqlflexibleservers/v6"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpostgresqlflexibleservers"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/tspconfig.yaml
+++ b/specification/powerbidedicated/resource-manager/Microsoft.PowerBIdedicated/PowerBIDedicated/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/powerbidedicated"
     emitter-output-dir: "{output-dir}/{service-dir}/armpowerbidedicated"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpowerbidedicated/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpowerbidedicated"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/tspconfig.yaml
+++ b/specification/privatedns/resource-manager/Microsoft.Network/PrivateDns/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/privatedns"
     emitter-output-dir: "{output-dir}/{service-dir}/armprivatedns"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armprivatedns/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armprivatedns"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/providerhub/ProviderHub.Management/tspconfig.yaml
+++ b/specification/providerhub/ProviderHub.Management/tspconfig.yaml
@@ -45,7 +45,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/providerhub"
     emitter-output-dir: "{output-dir}/{service-dir}/armproviderhub"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armproviderhub/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armproviderhub"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/purview/resource-manager/Microsoft.Purview/Purview/tspconfig.yaml
+++ b/specification/purview/resource-manager/Microsoft.Purview/Purview/tspconfig.yaml
@@ -33,7 +33,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/purview"
     emitter-output-dir: "{output-dir}/{service-dir}/armpurview"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpurview/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpurview"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/quota/resource-manager/Microsoft.Quota/Quota/tspconfig.yaml
+++ b/specification/quota/resource-manager/Microsoft.Quota/Quota/tspconfig.yaml
@@ -38,7 +38,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/quota"
     emitter-output-dir: "{output-dir}/{service-dir}/armquota"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armquota/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armquota"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/tspconfig.yaml
+++ b/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/tspconfig.yaml
@@ -31,7 +31,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/recoveryservices"
     emitter-output-dir: "{output-dir}/{service-dir}/armrecoveryservices"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armrecoveryservices/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armrecoveryservices"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/tspconfig.yaml
+++ b/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/RecoveryServicesBackup/tspconfig.yaml
@@ -39,7 +39,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/recoveryservices"
     emitter-output-dir: "{output-dir}/{service-dir}/armrecoveryservicesbackup"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armrecoveryservicesbackup/v5"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armrecoveryservicesbackup"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/tspconfig.yaml
+++ b/specification/recoveryservicessiterecovery/resource-manager/Microsoft.RecoveryServices/SiteRecovery/tspconfig.yaml
@@ -39,7 +39,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/recoveryservices"
     emitter-output-dir: "{output-dir}/{service-dir}/armrecoveryservicessiterecovery"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armrecoveryservicessiterecovery/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armrecoveryservicessiterecovery"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/redis/resource-manager/Microsoft.Cache/Redis/tspconfig.yaml
+++ b/specification/redis/resource-manager/Microsoft.Cache/Redis/tspconfig.yaml
@@ -49,7 +49,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/redis"
     emitter-output-dir: "{output-dir}/{service-dir}/armredis"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armredis/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armredis"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/tspconfig.yaml
+++ b/specification/redisenterprise/resource-manager/Microsoft.Cache/RedisEnterprise/tspconfig.yaml
@@ -34,7 +34,7 @@ options:
     float32-as-double: false
     flavor: azure
   "@azure-tools/typespec-go":
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armredisenterprise/v4"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armredisenterprise"
     service-dir: "sdk/resourcemanager/redisenterprise"
     emitter-output-dir: "{output-dir}/{service-dir}/armredisenterprise"
     fix-const-stuttering: false

--- a/specification/resources/resource-manager/Microsoft.Authorization/policy/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Authorization/policy/tspconfig.yaml
@@ -36,7 +36,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/resources"
     emitter-output-dir: "{output-dir}/{service-dir}/armpolicy"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpolicy/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armpolicy"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/resources/resource-manager/Microsoft.Resources/deploymentStacks/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Resources/deploymentStacks/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/resources"
     emitter-output-dir: "{output-dir}/{service-dir}/armdeploymentstacks"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdeploymentstacks/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armdeploymentstacks"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/search/resource-manager/Microsoft.Search/Search/tspconfig.yaml
+++ b/specification/search/resource-manager/Microsoft.Search/Search/tspconfig.yaml
@@ -46,7 +46,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/search"
     emitter-output-dir: "{output-dir}/{service-dir}/armsearch"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armsearch/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armsearch"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/serialconsole/resource-manager/Microsoft.SerialConsole/SerialConsole/tspconfig.yaml
+++ b/specification/serialconsole/resource-manager/Microsoft.SerialConsole/SerialConsole/tspconfig.yaml
@@ -30,7 +30,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/serialconsole"
     emitter-output-dir: "{output-dir}/{service-dir}/armserialconsole"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armserialconsole/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armserialconsole"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/tspconfig.yaml
+++ b/specification/servicefabric/resource-manager/Microsoft.ServiceFabric/ServiceFabric/tspconfig.yaml
@@ -36,7 +36,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/servicefabric"
     emitter-output-dir: "{output-dir}/{service-dir}/armservicefabric"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armservicefabric/v3"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armservicefabric"
     fix-const-stuttering: true
     generate-samples: true
     generate-fakes: true

--- a/specification/standbypool/resource-manager/Microsoft.StandbyPool/StandbyPool/tspconfig.yaml
+++ b/specification/standbypool/resource-manager/Microsoft.StandbyPool/StandbyPool/tspconfig.yaml
@@ -44,7 +44,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/standbypool"
     emitter-output-dir: "{output-dir}/{service-dir}/armstandbypool"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstandbypool/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstandbypool"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/storage/Storage.Management/tspconfig.yaml
+++ b/specification/storage/Storage.Management/tspconfig.yaml
@@ -45,7 +45,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/storage"
     emitter-output-dir: "{output-dir}/{service-dir}/armstorage"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstorage/v4"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstorage"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true

--- a/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/tspconfig.yaml
+++ b/specification/storagecache/resource-manager/Microsoft.StorageCache/StorageCache/tspconfig.yaml
@@ -40,7 +40,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/storagecache"
     emitter-output-dir: "{output-dir}/{service-dir}/armstoragecache"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstoragecache/v4"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstoragecache"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/storagemover/resource-manager/Microsoft.StorageMover/StorageMover/tspconfig.yaml
+++ b/specification/storagemover/resource-manager/Microsoft.StorageMover/StorageMover/tspconfig.yaml
@@ -37,7 +37,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/storagemover"
     emitter-output-dir: "{output-dir}/{service-dir}/armstoragemover"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstoragemover/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstoragemover"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/storagesync/resource-manager/Microsoft.StorageSync/StorageSync/tspconfig.yaml
+++ b/specification/storagesync/resource-manager/Microsoft.StorageSync/StorageSync/tspconfig.yaml
@@ -35,7 +35,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/storagesync"
     emitter-output-dir: "{output-dir}/{service-dir}/armstoragesync"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstoragesync/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armstoragesync"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/support/resource-manager/Microsoft.Support/Support/tspconfig.yaml
+++ b/specification/support/resource-manager/Microsoft.Support/Support/tspconfig.yaml
@@ -41,7 +41,7 @@ options:
     service-name: Support
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/support"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armsupport/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armsupport"
     emitter-output-dir: "{output-dir}/{service-dir}/armsupport"
     fix-const-stuttering: true
     flavor: "azure"

--- a/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/tspconfig.yaml
+++ b/specification/trafficmanager/resource-manager/Microsoft.Network/TrafficManager/tspconfig.yaml
@@ -45,7 +45,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/trafficmanager"
     emitter-output-dir: "{output-dir}/{service-dir}/armtrafficmanager"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armtrafficmanager/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armtrafficmanager"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/vmware/resource-manager/Microsoft.AVS/AVS/tspconfig.yaml
+++ b/specification/vmware/resource-manager/Microsoft.AVS/AVS/tspconfig.yaml
@@ -24,7 +24,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/avs"
     emitter-output-dir: "{output-dir}/{service-dir}/armavs"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armavs/v2"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armavs"
     fix-const-stuttering: true
     flavor: "azure"
     generate-samples: true

--- a/specification/web/resource-manager/Microsoft.Web/AppService/tspconfig.yaml
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/tspconfig.yaml
@@ -51,7 +51,7 @@ options:
   "@azure-tools/typespec-go":
     service-dir: "sdk/resourcemanager/appservice"
     emitter-output-dir: "{output-dir}/{service-dir}/armappservice"
-    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armappservice/v6"
+    module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armappservice"
     fix-const-stuttering: false
     flavor: "azure"
     generate-samples: true


### PR DESCRIPTION
## Summary
- remove major-version suffixes from Go emitter module paths in 76 TypeSpec configurations
- align the module paths with the canonical Go emitter configuration