### PR TITLE
Add pagination ($skiptoken) to RestorableDroppedDatabases List (2026-08-01-preview)

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/RestorableDroppedDatabase.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/RestorableDroppedDatabase.tsp
@@ -9,6 +9,7 @@ using TypeSpec.Rest;
 using Azure.ResourceManager;
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
 
 namespace Microsoft.Sql;
 /**
@@ -70,7 +71,24 @@ interface RestorableDroppedDatabases {
   /**
    * Gets a list of restorable dropped databases.
    */
-  listByServer is ArmResourceListByParent<RestorableDroppedDatabase>;
+  listByServer is ArmResourceListByParent<
+    RestorableDroppedDatabase,
+    Parameters = {
+      /**
+       * An opaque token that identifies a starting point in the collection.
+       */
+      @query("$skiptoken")
+      @added(Versions.v2026_08_01_preview)
+      $skiptoken?: string;
+
+      /**
+       * The number of elements to return from the collection.
+       */
+      @query("$top")
+      @added(Versions.v2026_08_01_preview)
+      $top?: int64;
+    }
+  >;
 }
 
 @@doc(RestorableDroppedDatabase.name, "");

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/RestorableDroppedDatabase.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/RestorableDroppedDatabase.tsp
@@ -80,13 +80,6 @@ interface RestorableDroppedDatabases {
       @query("$skiptoken")
       @added(Versions.v2026_08_01_preview)
       $skiptoken?: string;
-
-      /**
-       * The number of elements to return from the collection.
-       */
-      @query("$top")
-      @added(Versions.v2026_08_01_preview)
-      $top?: int64;
     }
   >;
 }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/RestorableDroppedDatabase.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/RestorableDroppedDatabase.tsp
@@ -80,6 +80,13 @@ interface RestorableDroppedDatabases {
       @query("$skiptoken")
       @added(Versions.v2026_08_01_preview)
       $skiptoken?: string;
+
+      /**
+       * The number of elements to return from the collection.
+       */
+      @query("$top")
+      @added(Versions.v2026_08_01_preview)
+      $top?: int64;
     }
   >;
 }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2026-08-01-preview/ListRestorableDroppedDatabasesByServerWithOdata.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2026-08-01-preview/ListRestorableDroppedDatabasesByServerWithOdata.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "Default-SQL-SouthEastAsia",
+    "serverName": "testsvr",
+    "api-version": "2026-08-01-preview",
+    "$top": 25,
+    "$skipToken": "eyJuYW1lIjoidGVzdERiMCwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "sku": {
+              "name": "GP_Gen4_1",
+              "tier": "GeneralPurpose"
+            },
+            "location": "southeastasia",
+            "properties": {
+              "databaseName": "testDb1",
+              "maxSizeBytes": 321,
+              "creationDate": "2015-02-03T04:05:06Z",
+              "deletionDate": "2018-01-01T00:00:00Z",
+              "backupStorageRedundancy": "Geo"
+            },
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases/testDb1,131592384000000000",
+            "name": "testDb1,131592384000000000",
+            "type": "Microsoft.Sql/servers/restorableDroppedDatabases"
+          }
+        ],
+        "nextLink": "https://myreferrer.example/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases?api-version=2026-08-01-preview&$top=25&$skipToken=eyJuYW1lIjoidGVzdERiMSwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
+      }
+    }
+  },
+  "operationId": "RestorableDroppedDatabases_ListByServer",
+  "title": "Gets a list of restorable dropped databases with OData filtering."
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2026-08-01-preview/ListRestorableDroppedDatabasesByServerWithOdata.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2026-08-01-preview/ListRestorableDroppedDatabasesByServerWithOdata.json
@@ -4,6 +4,7 @@
     "resourceGroupName": "Default-SQL-SouthEastAsia",
     "serverName": "testsvr",
     "api-version": "2026-08-01-preview",
+    "$top": 25,
     "$skipToken": "eyJuYW1lIjoidGVzdERiMCwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
   },
   "responses": {
@@ -28,7 +29,7 @@
             "type": "Microsoft.Sql/servers/restorableDroppedDatabases"
           }
         ],
-        "nextLink": "https://myreferrer.example/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases?api-version=2026-08-01-preview&$skipToken=eyJuYW1lIjoidGVzdERiMSwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
+        "nextLink": "https://myreferrer.example/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases?api-version=2026-08-01-preview&$top=25&$skipToken=eyJuYW1lIjoidGVzdERiMSwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
       }
     }
   },

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2026-08-01-preview/ListRestorableDroppedDatabasesByServerWithOdata.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/examples/2026-08-01-preview/ListRestorableDroppedDatabasesByServerWithOdata.json
@@ -4,7 +4,6 @@
     "resourceGroupName": "Default-SQL-SouthEastAsia",
     "serverName": "testsvr",
     "api-version": "2026-08-01-preview",
-    "$top": 25,
     "$skipToken": "eyJuYW1lIjoidGVzdERiMCwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
   },
   "responses": {
@@ -29,7 +28,7 @@
             "type": "Microsoft.Sql/servers/restorableDroppedDatabases"
           }
         ],
-        "nextLink": "https://myreferrer.example/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases?api-version=2026-08-01-preview&$top=25&$skipToken=eyJuYW1lIjoidGVzdERiMSwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
+        "nextLink": "https://myreferrer.example/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases?api-version=2026-08-01-preview&$skipToken=eyJuYW1lIjoidGVzdERiMSwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
       }
     }
   },

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/examples/ListRestorableDroppedDatabasesByServerWithOdata.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/examples/ListRestorableDroppedDatabasesByServerWithOdata.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "resourceGroupName": "Default-SQL-SouthEastAsia",
+    "serverName": "testsvr",
+    "api-version": "2026-08-01-preview",
+    "$top": 25,
+    "$skipToken": "eyJuYW1lIjoidGVzdERiMCwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "sku": {
+              "name": "GP_Gen4_1",
+              "tier": "GeneralPurpose"
+            },
+            "location": "southeastasia",
+            "properties": {
+              "databaseName": "testDb1",
+              "maxSizeBytes": 321,
+              "creationDate": "2015-02-03T04:05:06Z",
+              "deletionDate": "2018-01-01T00:00:00Z",
+              "backupStorageRedundancy": "Geo"
+            },
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases/testDb1,131592384000000000",
+            "name": "testDb1,131592384000000000",
+            "type": "Microsoft.Sql/servers/restorableDroppedDatabases"
+          }
+        ],
+        "nextLink": "https://myreferrer.example/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases?api-version=2026-08-01-preview&$top=25&$skipToken=eyJuYW1lIjoidGVzdERiMSwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
+      }
+    }
+  },
+  "operationId": "RestorableDroppedDatabases_ListByServer",
+  "title": "Gets a list of restorable dropped databases with OData filtering."
+}

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/examples/ListRestorableDroppedDatabasesByServerWithOdata.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/examples/ListRestorableDroppedDatabasesByServerWithOdata.json
@@ -4,6 +4,7 @@
     "resourceGroupName": "Default-SQL-SouthEastAsia",
     "serverName": "testsvr",
     "api-version": "2026-08-01-preview",
+    "$top": 25,
     "$skipToken": "eyJuYW1lIjoidGVzdERiMCwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
   },
   "responses": {
@@ -28,7 +29,7 @@
             "type": "Microsoft.Sql/servers/restorableDroppedDatabases"
           }
         ],
-        "nextLink": "https://myreferrer.example/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases?api-version=2026-08-01-preview&$skipToken=eyJuYW1lIjoidGVzdERiMSwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
+        "nextLink": "https://myreferrer.example/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases?api-version=2026-08-01-preview&$top=25&$skipToken=eyJuYW1lIjoidGVzdERiMSwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
       }
     }
   },

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/examples/ListRestorableDroppedDatabasesByServerWithOdata.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/examples/ListRestorableDroppedDatabasesByServerWithOdata.json
@@ -4,7 +4,6 @@
     "resourceGroupName": "Default-SQL-SouthEastAsia",
     "serverName": "testsvr",
     "api-version": "2026-08-01-preview",
-    "$top": 25,
     "$skipToken": "eyJuYW1lIjoidGVzdERiMCwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
   },
   "responses": {
@@ -29,7 +28,7 @@
             "type": "Microsoft.Sql/servers/restorableDroppedDatabases"
           }
         ],
-        "nextLink": "https://myreferrer.example/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases?api-version=2026-08-01-preview&$top=25&$skipToken=eyJuYW1lIjoidGVzdERiMSwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
+        "nextLink": "https://myreferrer.example/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/Default-SQL-SouthEastAsia/providers/Microsoft.Sql/servers/testsvr/restorableDroppedDatabases?api-version=2026-08-01-preview&$skipToken=eyJuYW1lIjoidGVzdERiMSwxMzE1OTIzODQwMDAwMDAwMDAifQ%3D%3D"
       }
     }
   },

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/restorableDroppedDatabases.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/restorableDroppedDatabases.json
@@ -67,6 +67,21 @@
             "description": "The name of the server.",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "$skiptoken",
+            "in": "query",
+            "description": "An opaque token that identifies a starting point in the collection.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of elements to return from the collection.",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "responses": {
@@ -84,6 +99,9 @@
           }
         },
         "x-ms-examples": {
+          "Gets a list of restorable dropped databases with OData filtering.": {
+            "$ref": "./examples/ListRestorableDroppedDatabasesByServerWithOdata.json"
+          },
           "Gets a list of restorable dropped databases.": {
             "$ref": "./examples/ListRestorableDroppedDatabasesByServer.json"
           }

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/restorableDroppedDatabases.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/restorableDroppedDatabases.json
@@ -74,14 +74,6 @@
             "description": "An opaque token that identifies a starting point in the collection.",
             "required": false,
             "type": "string"
-          },
-          {
-            "name": "$top",
-            "in": "query",
-            "description": "The number of elements to return from the collection.",
-            "required": false,
-            "type": "integer",
-            "format": "int64"
           }
         ],
         "responses": {

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/restorableDroppedDatabases.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/restorableDroppedDatabases.json
@@ -74,6 +74,14 @@
             "description": "An opaque token that identifies a starting point in the collection.",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "The number of elements to return from the collection.",
+            "required": false,
+            "type": "integer",
+            "format": "int64"
           }
         ],
         "responses": {


### PR DESCRIPTION
Add pagination ($skiptoken) to RestorableDroppedDatabases List (2026-08-01-preview)

Adds $skipToken query parameter (version-gated with @added(2026-08-01-preview)) to the RestorableDroppedDatabases_ListByServer operation, a paginated OData example, and regenerated Swagger.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
