### PR TITLE
Fix Recovery Services region of choice documentation

### DIFF
--- a/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/client.tsp
+++ b/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/client.tsp
@@ -7,6 +7,11 @@ using Azure.ClientGenerator.Core;
 
 namespace Microsoft.RecoveryServices;
 
+@@doc(
+  RegionOfChoiceSettings,
+  "Region of choice settings at the vault level. This setting allows customers to configure backups for data sources from a different region."
+);
+
 @@clientLocation(getOperationStatus, Operations, "go");
 @@clientLocation(getOperationResult, Operations, "go");
 @@clientName(getOperationStatus, "OperationStatusGet", "go");

--- a/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/client.tsp
+++ b/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/client.tsp
@@ -7,11 +7,6 @@ using Azure.ClientGenerator.Core;
 
 namespace Microsoft.RecoveryServices;
 
-@@doc(
-  RegionOfChoiceSettings,
-  "Region of choice settings at the vault level. This setting allows customers to configure backups for data sources from a different region."
-);
-
 @@clientLocation(getOperationStatus, Operations, "go");
 @@clientLocation(getOperationResult, Operations, "go");
 @@clientName(getOperationStatus, "OperationStatusGet", "go");

--- a/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/models.tsp
+++ b/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/models.tsp
@@ -1838,8 +1838,8 @@ model DeletedVaultUndeleteInput {
 );
 
 /**
- * Region of choice settings at the vault level.
- * This setting allows customers to configure backups for data sources from a different region.
+ * Region of choice settings at vault level.
+ * This setting allows customers to configure backups for datasources from different region.
  */
 @added(Versions.v2026_07_01)
 model RegionOfChoiceSettings {

--- a/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/models.tsp
+++ b/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/models.tsp
@@ -1838,8 +1838,8 @@ model DeletedVaultUndeleteInput {
 );
 
 /**
- * Region of choice settings at vault level.
- * This setting allows customers to configure backups for datasources from different region.
+ * Region of choice settings at the vault level.
+ * This setting allows customers to configure backups for data sources from a different region.
  */
 @added(Versions.v2026_07_01)
 model RegionOfChoiceSettings {

--- a/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/tspconfig.yaml
+++ b/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/tspconfig.yaml
@@ -21,7 +21,6 @@ options:
     namespace: "com.azure.resourcemanager.recoveryservices"
     service-name: "RecoveryServices" # human-readable service name, whitespace allowed
     flavor: azure
-    customization-class: customization/src/main/java/RecoveryServicesCustomization.java
   "@azure-tools/typespec-ts":
     compatibility-lro: true
     emitter-output-dir: "{output-dir}/{service-dir}/arm-recoveryservices"

--- a/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/tspconfig.yaml
+++ b/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/RecoveryServices/tspconfig.yaml
@@ -21,6 +21,7 @@ options:
     namespace: "com.azure.resourcemanager.recoveryservices"
     service-name: "RecoveryServices" # human-readable service name, whitespace allowed
     flavor: azure
+    customization-class: customization/src/main/java/RecoveryServicesCustomization.java
   "@azure-tools/typespec-ts":
     compatibility-lro: true
     emitter-output-dir: "{output-dir}/{service-dir}/arm-recoveryservices"


### PR DESCRIPTION
Corrects the C# SDK documentation generated for RegionOfChoiceSettings.\n\nRelated SDK PR: https://github.com/Azure/azure-sdk-for-net/pull/62034