### PR TITLE
Add Ubuntu2604 OSSKU to the 2026-06 preview API

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/CommonModels.tsp
@@ -295,6 +295,12 @@ union OSSKU {
    */
   @added(Versions.v2026_03_01)
   AzureContainerLinux: "AzureContainerLinux",
+
+  /**
+   * Use Ubuntu2604 as the OS for node images. For limitations and supported Kubernetes versions, see https://aka.ms/aks/supported-ubuntu-versions
+   */
+  @added(Versions.v2026_06_02_preview)
+  Ubuntu2604: "Ubuntu2604",
 }
 
 /**

--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/preview/2026-06-02-preview/managedClusters.json
@@ -15383,7 +15383,8 @@
         "Windows2025",
         "WindowsAnnual",
         "Ubuntu2404",
-        "AzureContainerLinux"
+        "AzureContainerLinux",
+        "Ubuntu2604"
       ],
       "x-ms-enum": {
         "name": "OSSKU",
@@ -15453,6 +15454,11 @@
             "name": "AzureContainerLinux",
             "value": "AzureContainerLinux",
             "description": "Use Azure Container Linux as the OS for node images. Azure Container Linux is a container-optimized, security-focused Linux OS built on Azure Linux, with an immutable filesystem. ACL is derived from the Flatcar Container Linux project, building on Flatcar's proven container-first, immutable design, while adding Azure Linux packages, servicing, and deep integration with the Azure and AKS lifecycle. For more information, see https://aka.ms/azurecontainerlinux"
+          },
+          {
+            "name": "Ubuntu2604",
+            "value": "Ubuntu2604",
+            "description": "Use Ubuntu2604 as the OS for node images. For limitations and supported Kubernetes versions, see https://aka.ms/aks/supported-ubuntu-versions"
           }
         ]
       }


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [ ] New resource provider.
- [ ] New API version for an existing resource provider.
- [x] Update existing version for a new feature.
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing OpenAPI spec to TypeSpec spec.
- [ ] Other.

Adds `Ubuntu2604` to the extensible `OSSKU` union starting with API version `2026-06-02-preview` and regenerates the corresponding OpenAPI specification. The stable `2026-06-01` specification remains unchanged.

Work item: https://dev.azure.com/msazure/CloudNativeCompute/_workitems/edit/39161303/

## Due diligence checklist

- [x] I confirm this PR modifies Azure Resource Manager specifications and not data-plane specifications.
- [ ] I have reviewed the Resource Provider and REST API guidelines.
- [ ] A release plan has been created.

## Validation

- TypeSpec compilation completed successfully.
- TypeSpec formatting check passed.
- Confirmed `Ubuntu2604` is generated only in `preview/2026-06-02-preview/managedClusters.json`.
- Confirmed `stable/2026-06-01/managedClusters.json` is unchanged.