### PR TITLE
Revert "Revert "Update the typespec for blob-auditing APIs to support parameter for selective fields auditing feature.""

### DIFF
--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/models.tsp
@@ -4437,6 +4437,15 @@ model ServerBlobAuditingPolicyProperties {
   isManagedIdentityInUse?: boolean;
 
   /**
+   * Specifies the required fields to include in audit events (optional).
+   * Each item must be a valid audit_event field name.
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  requiredFields?: string[];
+
+  /**
    * Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.
    */
   state: BlobAuditingPolicyState;
@@ -4573,6 +4582,15 @@ model DatabaseBlobAuditingPolicyProperties {
    * Specifies whether Managed Identity is used to access blob storage
    */
   isManagedIdentityInUse?: boolean;
+
+  /**
+   * Specifies the required fields to include in audit events (optional).
+   * Each item must be a valid audit_event field name.
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  requiredFields?: string[];
 
   /**
    * Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.
@@ -4716,6 +4734,15 @@ model ExtendedDatabaseBlobAuditingPolicyProperties {
    * Specifies whether Managed Identity is used to access blob storage
    */
   isManagedIdentityInUse?: boolean;
+
+  /**
+   * Specifies the required fields to include in audit events (optional).
+   * Each item must be a valid audit_event field name.
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  requiredFields?: string[];
 
   /**
    * Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.
@@ -4874,6 +4901,15 @@ model ExtendedServerBlobAuditingPolicyProperties {
    * Specifies whether Managed Identity is used to access blob storage
    */
   isManagedIdentityInUse?: boolean;
+
+  /**
+   * Specifies the required fields to include in audit events (optional).
+   * Each item must be a valid audit_event field name.
+   * Can only be specified when isAzureMonitorTargetEnabled is true.
+   * For the complete list of valid field names, see the audit_event table schema documentation.
+   */
+  @added(Versions.v2026_08_01_preview)
+  requiredFields?: string[];
 
   /**
    * Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required.

--- a/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/blobAuditing.json
+++ b/specification/sql/resource-manager/Microsoft.Sql/SQL/preview/2026-08-01-preview/blobAuditing.json
@@ -991,6 +991,13 @@
           "type": "boolean",
           "description": "Specifies whether Managed Identity is used to access blob storage"
         },
+        "requiredFields": {
+          "type": "array",
+          "description": "Specifies the required fields to include in audit events (optional).\nEach item must be a valid audit_event field name.\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation.",
+          "items": {
+            "type": "string"
+          }
+        },
         "state": {
           "$ref": "./common.json#/definitions/BlobAuditingPolicyState",
           "description": "Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
@@ -1091,6 +1098,13 @@
         "isManagedIdentityInUse": {
           "type": "boolean",
           "description": "Specifies whether Managed Identity is used to access blob storage"
+        },
+        "requiredFields": {
+          "type": "array",
+          "description": "Specifies the required fields to include in audit events (optional).\nEach item must be a valid audit_event field name.\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation.",
+          "items": {
+            "type": "string"
+          }
         },
         "state": {
           "$ref": "./common.json#/definitions/BlobAuditingPolicyState",
@@ -1197,6 +1211,13 @@
           "type": "boolean",
           "description": "Specifies whether Managed Identity is used to access blob storage"
         },
+        "requiredFields": {
+          "type": "array",
+          "description": "Specifies the required fields to include in audit events (optional).\nEach item must be a valid audit_event field name.\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation.",
+          "items": {
+            "type": "string"
+          }
+        },
         "state": {
           "$ref": "./common.json#/definitions/BlobAuditingPolicyState",
           "description": "Specifies the state of the audit. If state is Enabled, storageEndpoint or isAzureMonitorTargetEnabled are required."
@@ -1297,6 +1318,13 @@
         "isManagedIdentityInUse": {
           "type": "boolean",
           "description": "Specifies whether Managed Identity is used to access blob storage"
+        },
+        "requiredFields": {
+          "type": "array",
+          "description": "Specifies the required fields to include in audit events (optional).\nEach item must be a valid audit_event field name.\nCan only be specified when isAzureMonitorTargetEnabled is true.\nFor the complete list of valid field names, see the audit_event table schema documentation.",
+          "items": {
+            "type": "string"
+          }
         },
         "state": {
           "$ref": "./common.json#/definitions/BlobAuditingPolicyState",


### PR DESCRIPTION
Reverts Azure/azure-rest-api-specs#45475

Original PR with approval https://github.com/Azure/azure-rest-api-specs/pull/45361

Accidentally reverted in https://github.com/Azure/azure-rest-api-specs/pull/45475 as another PR that was merged around the same time needed reverting