### PR TITLE
Add Budget Policies preview API

### DIFF
--- a/specification/cognitiveservices/CognitiveServices.Management/BudgetPolicy.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/BudgetPolicy.tsp
@@ -1,0 +1,450 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "./models.tsp";
+import "./Account.tsp";
+
+using TypeSpec.Rest;
+using Azure.ResourceManager;
+using TypeSpec.Http;
+using TypeSpec.Versioning;
+
+namespace Microsoft.CognitiveServices;
+
+/**
+ * A budget policy owned by a Cognitive Services account.
+ */
+@added(Versions.v2026_08_31_preview)
+@parentResource(Account)
+model BudgetPolicy
+  is Azure.ResourceManager.ProxyResource<BudgetPolicyProperties> {
+  ...ResourceNameParameter<
+    Resource = BudgetPolicy,
+    KeyName = "budgetPolicyName",
+    SegmentName = "budgetPolicies",
+    NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$"
+  >;
+
+  /**
+   * The entity tag used for optimistic concurrency.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "The service returns etag on the budget policy resource envelope and uses it for conditional updates and deletes."
+  @visibility(Lifecycle.Read)
+  etag?: string;
+}
+
+/**
+ * The customer-authored settings of a budget policy.
+ */
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "Budget policies are synchronously persisted proxy resources and the service contract does not expose provisioningState."
+@added(Versions.v2026_08_31_preview)
+model BudgetPolicyProperties {
+  /**
+   * An optional human-readable name for the policy.
+   */
+  @maxLength(128)
+  displayName?: string;
+
+  /**
+   * The budget rules enforced by the policy.
+   */
+  @minItems(1)
+  @maxItems(50)
+  @identifiers(#["name"])
+  rules: BudgetRule[];
+}
+
+/**
+ * The properties that can be changed on a budget policy.
+ */
+@added(Versions.v2026_08_31_preview)
+model BudgetPolicyPatchProperties {
+  /**
+   * An optional human-readable name for the policy. Set this property to null to clear it.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "The service distinguishes an omitted displayName from an explicit null in PATCH so callers can clear the value."
+  @maxLength(128)
+  displayName?: string | null;
+
+  /**
+   * The complete replacement set of budget rules.
+   */
+  @minItems(1)
+  @maxItems(50)
+  @identifiers(#["name"])
+  rules?: BudgetRule[];
+}
+
+/**
+ * The request used to update a budget policy.
+ */
+@added(Versions.v2026_08_31_preview)
+model BudgetPolicyPatch {
+  /**
+   * The budget policy properties to update.
+   */
+  properties: BudgetPolicyPatchProperties;
+}
+
+/**
+ * A budget limit and the population to which it applies.
+ */
+@added(Versions.v2026_08_31_preview)
+model BudgetRule {
+  /**
+   * The stable rule identifier, unique within the policy without regard to case.
+   */
+  @key
+  @maxLength(64)
+  @pattern("^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$")
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  name: string;
+
+  /**
+   * The built-in dimension used to partition consumption. The initial preview supports exactly one dimension.
+   */
+  @minItems(1)
+  @maxItems(1)
+  @identifiers(#["type"])
+  counterKey: BudgetDimension[];
+
+  /**
+   * The unit used for the budget amount and absolute thresholds.
+   */
+  unit: BudgetUnit;
+
+  /**
+   * The maximum consumption allowed by this rule, expressed in the selected unit.
+   */
+  @minValueExclusive(0)
+  amount: float64;
+
+  /**
+   * The calendar-aligned UTC renewal period. This property is required for recurring rules and omitted for non-recurring rules.
+   */
+  period?: BudgetPeriod;
+
+  /**
+   * Whether the budget renews. The default is true.
+   */
+  recurring?: boolean = true;
+
+  /**
+   * Trusted request attributes and allowed values used to select matching requests.
+   */
+  match?: BudgetMatch;
+
+  /**
+   * The actions evaluated as consumption approaches the configured amount.
+   */
+  @minItems(1)
+  @maxItems(10)
+  @identifiers(#[])
+  thresholds: BudgetThreshold[];
+}
+
+/**
+ * Trusted request attributes and allowed values used to select matching requests.
+ */
+@added(Versions.v2026_08_31_preview)
+model BudgetMatch {
+  /**
+   * The stable Foundry agent IDs to match.
+   */
+  @encodedName("application/json", "foundry.caller.agent.id")
+  @minItems(1)
+  @maxItems(20)
+  agentIds?: BudgetMatchValue[];
+
+  /**
+   * The authenticated principal object IDs to match.
+   */
+  @encodedName("application/json", "foundry.caller.identity.oid")
+  @minItems(1)
+  @maxItems(20)
+  identityObjectIds?: BudgetMatchValue[];
+
+  /**
+   * The Foundry session IDs to match.
+   */
+  @encodedName("application/json", "foundry.caller.session.id")
+  @minItems(1)
+  @maxItems(20)
+  sessionIds?: BudgetMatchValue[];
+
+  /**
+   * The Foundry project resource IDs to match.
+   */
+  @encodedName("application/json", "foundry.caller.project.id")
+  @minItems(1)
+  @maxItems(20)
+  projectIds?: BudgetMatchValue[];
+}
+
+/**
+ * A non-empty value used to match a trusted request attribute.
+ */
+@added(Versions.v2026_08_31_preview)
+@minLength(1)
+scalar BudgetMatchValue extends string;
+
+/**
+ * A built-in request dimension used to partition budget consumption.
+ */
+@added(Versions.v2026_08_31_preview)
+model BudgetDimension {
+  /**
+   * The kind of request dimension.
+   */
+  @key
+  @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+  type: BudgetDimensionType;
+}
+
+/**
+ * The supported budget counter dimensions.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The service rejects unknown counter dimensions, so the public contract is intentionally closed."
+@added(Versions.v2026_08_31_preview)
+union BudgetDimensionType {
+  /**
+   * Consumption is partitioned by the stable Foundry agent ID.
+   */
+  Agent: "agent",
+
+  /**
+   * Consumption is partitioned by the authenticated principal object ID.
+   */
+  Identity: "identity",
+
+  /**
+   * Consumption is partitioned by the Foundry session ID.
+   */
+  Session: "session",
+
+  /**
+   * Consumption is partitioned by the Foundry project resource ID.
+   */
+  Project: "project",
+}
+
+/**
+ * The supported unit for budget amounts and thresholds.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The service rejects unknown budget units, so the public contract is intentionally closed."
+@added(Versions.v2026_08_31_preview)
+union BudgetUnit {
+  /**
+   * Estimated cost in United States dollars.
+   */
+  Usd: "usd",
+}
+
+/**
+ * The calendar-aligned UTC renewal periods for recurring budget rules.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The service rejects unknown renewal periods, so the public contract is intentionally closed."
+@added(Versions.v2026_08_31_preview)
+union BudgetPeriod {
+  /**
+   * Renews at the start of the next UTC minute.
+   */
+  Minute: "minute",
+
+  /**
+   * Renews at the start of the next UTC hour.
+   */
+  Hour: "hour",
+
+  /**
+   * Renews daily at 00:00 UTC.
+   */
+  Day: "day",
+
+  /**
+   * Renews Monday at 00:00 UTC.
+   */
+  Week: "week",
+
+  /**
+   * Renews on the first day of each month at 00:00 UTC.
+   */
+  Month: "month",
+
+  /**
+   * Renews January 1 at 00:00 UTC.
+   */
+  Year: "year",
+}
+
+/**
+ * An action evaluated when budget consumption reaches a threshold.
+ */
+@added(Versions.v2026_08_31_preview)
+model BudgetThreshold {
+  /**
+   * How the threshold value is interpreted.
+   */
+  type: BudgetThresholdType;
+
+  /**
+   * The threshold value. Percentage values range from 0 through 100, and absolute values cannot exceed the rule amount.
+   */
+  @minValue(0)
+  value: float64;
+
+  /**
+   * The action taken when the threshold is reached. The default is audit.
+   */
+  action?: BudgetThresholdAction = BudgetThresholdAction.Audit;
+}
+
+/**
+ * The supported threshold value interpretations.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The service rejects unknown threshold types, so the public contract is intentionally closed."
+@added(Versions.v2026_08_31_preview)
+union BudgetThresholdType {
+  /**
+   * The value is a percentage of the configured rule amount.
+   */
+  Percentage: "percentage",
+
+  /**
+   * The value is expressed in the rule's unit.
+   */
+  Absolute: "absolute",
+}
+
+/**
+ * The supported actions when a threshold is reached.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-closed-literal-union" "The service rejects unknown threshold actions, so the public contract is intentionally closed."
+@added(Versions.v2026_08_31_preview)
+union BudgetThresholdAction {
+  /**
+   * Records the threshold crossing without notifying the customer or blocking requests.
+   */
+  Audit: "audit",
+
+  /**
+   * Emits a customer-facing alert without blocking requests.
+   */
+  Alert: "alert",
+}
+
+/**
+ * A page of budget policies.
+ */
+@added(Versions.v2026_08_31_preview)
+model BudgetPolicyListResult {
+  /**
+   * The link used to get the next page of budget policies.
+   */
+  @nextLink
+  nextLink?: string;
+
+  /**
+   * The budget policies in this page.
+   */
+  @pageItems
+  @identifiers(#["name"])
+  value?: BudgetPolicy[];
+}
+
+/**
+ * Conditional request headers accepted when creating or replacing a budget policy.
+ */
+@added(Versions.v2026_08_31_preview)
+model BudgetPolicyCreateOrUpdateHeaders {
+  /**
+   * Proceeds only when the current entity tag matches this value.
+   */
+  @header("If-Match")
+  ifMatch?: string;
+
+  /**
+   * Proceeds only when the current entity tag does not match this value.
+   */
+  @header("If-None-Match")
+  ifNoneMatch?: string;
+}
+
+/**
+ * The conditional request header accepted when updating or deleting a budget policy.
+ */
+@added(Versions.v2026_08_31_preview)
+model BudgetPolicyIfMatchHeader {
+  /**
+   * Proceeds only when the current entity tag matches this value.
+   */
+  @header("If-Match")
+  ifMatch?: string;
+}
+
+/**
+ * The entity tag returned with a budget policy.
+ */
+@added(Versions.v2026_08_31_preview)
+model BudgetPolicyEtagHeader {
+  /**
+   * The current entity tag for the budget policy.
+   */
+  @header("ETag")
+  eTag: string;
+}
+
+/**
+ * Operations for managing budget policies owned by an account.
+ */
+@added(Versions.v2026_08_31_preview)
+@armResourceOperations
+interface BudgetPolicies {
+  /**
+   * Gets a budget policy.
+   */
+  get is ArmResourceRead<
+    BudgetPolicy,
+    Response = ArmResponse<BudgetPolicy> & BudgetPolicyEtagHeader
+  >;
+
+  /**
+   * Creates or replaces a budget policy.
+   */
+  createOrUpdate is ArmResourceCreateOrReplaceSync<
+    BudgetPolicy,
+    Parameters = BudgetPolicyCreateOrUpdateHeaders,
+    Response =
+      | (ArmResourceUpdatedResponse<BudgetPolicy> & BudgetPolicyEtagHeader)
+      | (ArmResourceCreatedSyncResponse<BudgetPolicy> & BudgetPolicyEtagHeader)
+  >;
+
+  /**
+   * Updates selected properties of a budget policy.
+   */
+  update is ArmCustomPatchSync<
+    BudgetPolicy,
+    BudgetPolicyPatch,
+    Parameters = BudgetPolicyIfMatchHeader,
+    Response = ArmResponse<BudgetPolicy> & BudgetPolicyEtagHeader
+  >;
+
+  /**
+   * Deletes a budget policy.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-delete-operation-response-codes" "The synchronous service endpoint returns 200 on successful deletion and does not return 204."
+  delete is ArmResourceDeleteSync<
+    BudgetPolicy,
+    Parameters = BudgetPolicyIfMatchHeader,
+    Response = ArmDeletedResponse
+  >;
+
+  /**
+   * Lists the budget policies owned by an account.
+   */
+  list is ArmResourceListByParent<
+    BudgetPolicy,
+    Response = BudgetPolicyListResult
+  >;
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountCapabilityHost/createOrUpdate.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountCapabilityHost/createOrUpdate.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHost": {
+      "properties": {
+        "customerSubnet": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet",
+        "enablePublicHostingEnvironment": true
+      }
+    },
+    "capabilityHostName": "capabilityHostName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "customerSubnet": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "enablePublicHostingEnvironment": true,
+          "provisioningState": "Succeeded",
+          "tags": {
+            "string": "string"
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "customerSubnet": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "enablePublicHostingEnvironment": true,
+          "provisioningState": "Succeeded",
+          "tags": {
+            "string": "string"
+          }
+        }
+      },
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "AccountCapabilityHosts_CreateOrUpdate",
+  "title": "CreateOrUpdate Account CapabilityHost."
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountCapabilityHost/delete.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountCapabilityHost/delete.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "AccountCapabilityHosts_Delete",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHostName": "capabilityHostName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Account CapabilityHost.",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "location_header_to_poll"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountCapabilityHost/get.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountCapabilityHost/get.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHostName": "capabilityHostName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "customerSubnet": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "enablePublicHostingEnvironment": true,
+          "provisioningState": "Succeeded",
+          "tags": {
+            "string": "string"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AccountCapabilityHosts_Get",
+  "title": "Get Account CapabilityHost."
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountCapabilityHost/list.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountCapabilityHost/list.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "capabilityHostName",
+            "type": "Microsoft.CognitiveServices/accounts/capabilityHosts",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/capabilityHosts/capabilityHostName",
+            "properties": {
+              "description": "string",
+              "customerSubnet": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+              "provisioningState": "Succeeded",
+              "tags": {
+                "string": "string"
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AccountCapabilityHosts_List",
+  "title": "List Account CapabilityHosts."
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountConnection/create.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountConnection/create.json
@@ -1,0 +1,34 @@
+{
+  "operationId": "AccountConnections_Create",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connection": {
+      "properties": {
+        "authType": "None",
+        "category": "ContainerRegistry",
+        "expiryTime": "2024-03-15T14:30:00Z",
+        "target": "[target url]"
+      }
+    },
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "CreateAccountConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "[target url]"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountConnection/delete.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountConnection/delete.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "AccountConnections_Delete",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeleteAccountConnection",
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountConnection/get.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountConnection/get.json
@@ -1,0 +1,26 @@
+{
+  "operationId": "AccountConnections_Get",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetAccountConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "[target url]"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountConnection/list.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountConnection/list.json
@@ -1,0 +1,41 @@
+{
+  "operationId": "AccountConnections_List",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "category": "ContainerRegistry",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "target": "[target url]"
+  },
+  "title": "ListAccountConnections",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "connection-1",
+            "type": "Microsoft.CognitiveServices/accounts/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/connections/connection-1",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "expiryTime": "2024-03-15T14:30:00Z",
+              "target": "[target url]"
+            }
+          },
+          {
+            "name": "connection-2",
+            "type": "Microsoft.CognitiveServices/accounts/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/connections/connection-2",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "target": "[target url]"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountConnection/update.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AccountConnection/update.json
@@ -1,0 +1,41 @@
+{
+  "operationId": "AccountConnections_Update",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connection": {
+      "properties": {
+        "authType": "AccessKey",
+        "category": "ADLSGen2",
+        "credentials": {
+          "accessKeyId": "some_string",
+          "secretAccessKey": "some_string"
+        },
+        "expiryTime": "2020-01-01T00:00:00Z",
+        "metadata": {},
+        "target": "some_string"
+      }
+    },
+    "connectionName": "connection-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "UpdateAccountConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/connections/connection-1",
+        "properties": {
+          "authType": "AccessKey",
+          "category": "ADLSGen2",
+          "expiryTime": "2020-01-01T00:00:00Z",
+          "metadata": {},
+          "target": "some_string"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AddRaiBlocklistItems.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AddRaiBlocklistItems.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "RaiBlocklistItems_BatchAdd",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistItems": [
+      {
+        "name": "myblocklistitem1",
+        "properties": {
+          "isRegex": true,
+          "pattern": "^[a-z0-9_-]{2,16}$"
+        }
+      },
+      {
+        "name": "myblocklistitem2",
+        "properties": {
+          "isRegex": false,
+          "pattern": "blockwords"
+        }
+      }
+    ],
+    "raiBlocklistName": "myblocklist",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "AddRaiBlocklistItems",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myblocklist",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "properties": {
+          "description": "Brief description of the blocklist"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/createOrUpdate.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/createOrUpdate.json
@@ -1,0 +1,74 @@
+{
+  "operationId": "AgentApplications_CreateOrUpdate",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "body": {
+      "properties": {
+        "description": "Sample agent application for customer support",
+        "displayName": "Customer Support Agent",
+        "tags": {
+          "environment": "production",
+          "team": "ai-platform"
+        }
+      }
+    },
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create or Update Account Agent Application.",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agent-app-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1",
+        "properties": {
+          "description": "Sample agent application for customer support",
+          "displayName": "Customer Support Agent",
+          "provisioningState": "Succeeded",
+          "tags": {
+            "environment": "production",
+            "team": "ai-platform"
+          }
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "agent-app-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1",
+        "properties": {
+          "description": "Sample agent application for customer support",
+          "displayName": "Customer Support Agent",
+          "provisioningState": "Creating",
+          "tags": {
+            "environment": "production",
+            "team": "ai-platform"
+          }
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/delete.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/delete.json
@@ -1,0 +1,21 @@
+{
+  "operationId": "AgentApplications_Delete",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Account Agent Application.",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-08-31-preview",
+        "Retry-After": "10"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/disable.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/disable.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "AgentApplications_Disable",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Disable Agent Application.",
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/enable.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/enable.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "AgentApplications_Enable",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Enable Agent Application.",
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/get.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/get.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "AgentApplications_Get",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get Account Agent Application.",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agent-app-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1",
+        "properties": {
+          "description": "Sample agent application for customer support",
+          "displayName": "Customer Support Agent",
+          "tags": {
+            "environment": "production",
+            "team": "ai-platform"
+          }
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/list.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/list.json
@@ -1,0 +1,51 @@
+{
+  "operationId": "AgentApplications_List",
+  "parameters": {
+    "$skipToken": "string",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "count": 30,
+    "names": [
+      "agent-app-1",
+      "agent-app-2"
+    ],
+    "orderBy": "name",
+    "orderByAsc": true,
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "searchText": "test",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Account Agent Applications.",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "string",
+        "value": [
+          {
+            "name": "agent-app-1",
+            "type": "Microsoft.CognitiveServices/accounts/projects/applications",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1",
+            "properties": {
+              "description": "Sample agent application for customer support",
+              "displayName": "Customer Support Agent",
+              "tags": {
+                "environment": "production",
+                "team": "ai-platform"
+              }
+            },
+            "systemData": {
+              "createdAt": "2024-09-29T12:34:56.999Z",
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/listAgents.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentApplication/listAgents.json
@@ -1,0 +1,56 @@
+{
+  "operationId": "AgentApplications_ListAgents",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Agents for Agent Application.",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "CustomerSupportAgent",
+            "type": "Microsoft.CognitiveServices/accounts/projects/applications/agents",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agents/agent-001",
+            "properties": {
+              "agentId": "agent-001",
+              "agentName": "CustomerSupportAgent"
+            },
+            "systemData": {
+              "createdAt": "2024-09-29T12:34:56.999Z",
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "TechnicalSupportAgent",
+            "type": "Microsoft.CognitiveServices/accounts/projects/applications/agents",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agents/agent-002",
+            "properties": {
+              "agentId": "agent-002",
+              "agentName": "TechnicalSupportAgent"
+            },
+            "systemData": {
+              "createdAt": "2024-09-29T12:34:56.999Z",
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/createOrUpdate.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/createOrUpdate.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "body": {
+      "properties": {
+        "agents": [
+          {
+            "agentId": "agent-123",
+            "agentName": "support-agent",
+            "agentVersion": "1.0.0"
+          }
+        ],
+        "deploymentType": "Managed",
+        "displayName": "Production Deployment",
+        "protocols": [
+          {
+            "version": "1.0",
+            "protocol": "Agent"
+          }
+        ],
+        "state": "Starting"
+      }
+    },
+    "deploymentName": "deployment-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deployment-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications/agentDeployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agentDeployments/deployment-1",
+        "properties": {
+          "agents": [
+            {
+              "agentId": "agent-123",
+              "agentName": "support-agent",
+              "agentVersion": "1.0.0"
+            }
+          ],
+          "deploymentId": "550e8400-e29b-41d4-a716-446655440001",
+          "deploymentType": "Managed",
+          "displayName": "Production Deployment",
+          "protocols": [
+            {
+              "version": "1.0",
+              "protocol": "Agent"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "state": "Running"
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "deployment-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications/agentDeployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agentDeployments/deployment-1",
+        "properties": {
+          "agents": [
+            {
+              "agentId": "agent-123",
+              "agentName": "support-agent",
+              "agentVersion": "1.0.0"
+            }
+          ],
+          "deploymentId": "550e8400-e29b-41d4-a716-446655440001",
+          "deploymentType": "Managed",
+          "displayName": "Production Deployment",
+          "protocols": [
+            {
+              "version": "1.0",
+              "protocol": "Agent"
+            }
+          ],
+          "provisioningState": "Creating",
+          "state": "Starting"
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/operationresults/00000000-1111-2222-3333-444444444444?api-version=2026-08-31-preview"
+      }
+    }
+  },
+  "operationId": "AgentDeployments_CreateOrUpdate",
+  "title": "Create or Update Agent Deployment."
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/delete.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/delete.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "AgentDeployments_Delete",
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "deploymentName": "deployment-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Agent Deployment.",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-08-31-preview",
+        "Retry-After": "10"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/get.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/get.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "deploymentName": "deployment-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deployment-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications/agentDeployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agentDeployments/deployment-1",
+        "properties": {
+          "agents": [
+            {
+              "agentId": "agent-123",
+              "agentName": "support-agent",
+              "agentVersion": "1.0.0"
+            }
+          ],
+          "deploymentId": "550e8400-e29b-41d4-a716-446655440001",
+          "deploymentType": "Managed",
+          "displayName": "Production Deployment",
+          "protocols": [
+            {
+              "version": "1.0",
+              "protocol": "Agent"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "state": "Running"
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AgentDeployments_Get",
+  "title": "Get Agent Deployment."
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/list.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/list.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "deployment-1",
+            "type": "Microsoft.CognitiveServices/accounts/projects/applications/agentDeployments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agentDeployments/deployment-1",
+            "properties": {
+              "agents": [
+                {
+                  "agentId": "agent-123",
+                  "agentName": "support-agent",
+                  "agentVersion": "1.0.0"
+                }
+              ],
+              "deploymentId": "550e8400-e29b-41d4-a716-446655440001",
+              "deploymentType": "Managed",
+              "displayName": "Production Deployment",
+              "protocols": [
+                {
+                  "version": "1.0",
+                  "protocol": "Agent"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "state": "Running"
+            },
+            "systemData": {
+              "createdAt": "2024-09-29T12:34:56.999Z",
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AgentDeployments_List",
+  "title": "List Agent Deployments."
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/start.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/start.json
@@ -1,0 +1,16 @@
+{
+  "operationId": "AgentDeployments_Start",
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "deploymentName": "deployment-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Start Agent Deployment.",
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/stop.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/AgentDeployment/stop.json
@@ -1,0 +1,16 @@
+{
+  "operationId": "AgentDeployments_Stop",
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "deploymentName": "deployment-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Stop Agent Deployment.",
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CalculateModelCapacity.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CalculateModelCapacity.json
@@ -1,0 +1,48 @@
+{
+  "operationId": "calculateModelCapacity",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "parameters": {
+      "model": {
+        "name": "gpt-4",
+        "format": "OpenAI",
+        "version": "0613"
+      },
+      "skuName": "ProvisionedManaged",
+      "workloads": [
+        {
+          "requestParameters": {
+            "avgGeneratedTokens": 50,
+            "avgPromptTokens": 30
+          },
+          "requestPerMinute": 10
+        },
+        {
+          "requestParameters": {
+            "avgGeneratedTokens": 20,
+            "avgPromptTokens": 60
+          },
+          "requestPerMinute": 20
+        }
+      ]
+    },
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Calculate Model Capacity",
+  "responses": {
+    "200": {
+      "body": {
+        "estimatedCapacity": {
+          "deployableValue": 400,
+          "value": 346
+        },
+        "model": {
+          "name": "gpt-4",
+          "format": "OpenAI",
+          "version": "0613"
+        },
+        "skuName": "ProvisionedManaged"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CheckDomainAvailability.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CheckDomainAvailability.json
@@ -1,0 +1,23 @@
+{
+  "operationId": "CheckDomainAvailability",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "westus",
+    "parameters": {
+      "type": "Microsoft.CognitiveServices/accounts",
+      "subdomainName": "contosodemoapp1"
+    },
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Check SKU Availability",
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.CognitiveServices/accounts",
+        "isSubdomainAvailable": false,
+        "reason": "Sub domain name 'contosodemoapp1' is not valid",
+        "subdomainName": "contosodemoapp1"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CheckSkuAvailability.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CheckSkuAvailability.json
@@ -1,0 +1,30 @@
+{
+  "operationId": "CheckSkuAvailability",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "westus",
+    "parameters": {
+      "type": "Microsoft.CognitiveServices/accounts",
+      "kind": "Face",
+      "skus": [
+        "S0"
+      ]
+    },
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Check SKU Availability",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.CognitiveServices/accounts",
+            "kind": "Face",
+            "skuAvailable": true,
+            "skuName": "S0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateAccount.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateAccount.json
@@ -1,0 +1,142 @@
+{
+  "operationId": "Accounts_Create",
+  "parameters": {
+    "account": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "kind": "Emotion",
+      "location": "West US",
+      "properties": {
+        "encryption": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": {
+            "keyName": "KeyName",
+            "keyVaultUri": "https://pltfrmscrts-use-pc-dev.vault.azure.net/",
+            "keyVersion": "891CF236-D241-4738-9462-D506AF493DFA"
+          }
+        },
+        "userOwnedStorage": [
+          {
+            "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
+        ]
+      },
+      "sku": {
+        "name": "S0"
+      }
+    },
+    "accountName": "testCreate1",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Account",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T08%3A00%3A05.445595Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": {
+              "keyName": "FakeKeyName",
+              "keyVaultUri": "https://pltfrmscrts-use-pc-dev.vault.azure.net/",
+              "keyVersion": "891CF236-D241-4738-9462-D506AF493DFA"
+            }
+          },
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded",
+          "userOwnedStorage": [
+            {
+              "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+            }
+          ]
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": {
+              "keyName": "FakeKeyName",
+              "keyVaultUri": "https://pltfrmscrts-use-pc-dev.vault.azure.net/",
+              "keyVersion": "891CF236-D241-4738-9462-D506AF493DFA"
+            }
+          },
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded",
+          "userOwnedStorage": [
+            {
+              "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+            }
+          ]
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": {
+              "keyName": "FakeKeyName",
+              "keyVaultUri": "https://pltfrmscrts-use-pc-dev.vault.azure.net/",
+              "keyVersion": "891CF236-D241-4738-9462-D506AF493DFA"
+            }
+          },
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded",
+          "userOwnedStorage": [
+            {
+              "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+            }
+          ]
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateAccountMin.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateAccountMin.json
@@ -1,0 +1,89 @@
+{
+  "operationId": "Accounts_Create",
+  "parameters": {
+    "account": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "kind": "CognitiveServices",
+      "location": "West US",
+      "properties": {},
+      "sku": {
+        "name": "S0"
+      }
+    },
+    "accountName": "testCreate1",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Account Min",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T08%3A00%3A05.445595Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateOrUpdateBudgetPolicy.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateOrUpdateBudgetPolicy.json
@@ -1,0 +1,140 @@
+{
+  "operationId": "BudgetPolicies_CreateOrUpdate",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "budgetPolicyName": "monthly-project-budget",
+    "resource": {
+      "properties": {
+        "displayName": "Monthly project budget",
+        "rules": [
+          {
+            "name": "project-spend",
+            "counterKey": [
+              {
+                "type": "project"
+              }
+            ],
+            "unit": "usd",
+            "amount": 200,
+            "period": "month",
+            "recurring": true,
+            "match": {
+              "foundry.caller.project.id": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+              ]
+            },
+            "thresholds": [
+              {
+                "type": "percentage",
+                "value": 80,
+                "action": "alert"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Create or replace a budget policy",
+  "responses": {
+    "200": {
+      "headers": {
+        "ETag": "\"00000000-0000-0000-0000-000000000002\""
+      },
+      "body": {
+        "name": "monthly-project-budget",
+        "type": "Microsoft.CognitiveServices/accounts/budgetPolicies",
+        "etag": "\"00000000-0000-0000-0000-000000000002\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget",
+        "properties": {
+          "displayName": "Monthly project budget",
+          "rules": [
+            {
+              "name": "project-spend",
+              "counterKey": [
+                {
+                  "type": "project"
+                }
+              ],
+              "unit": "usd",
+              "amount": 200,
+              "period": "month",
+              "recurring": true,
+              "match": {
+                "foundry.caller.project.id": [
+                  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+                ]
+              },
+              "thresholds": [
+                {
+                  "type": "percentage",
+                  "value": 80,
+                  "action": "alert"
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2026-08-13T18:00:00Z",
+          "createdBy": "00000000-0000-0000-0000-000000000001",
+          "createdByType": "User",
+          "lastModifiedAt": "2026-08-13T18:30:00Z",
+          "lastModifiedBy": "00000000-0000-0000-0000-000000000001",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "ETag": "\"00000000-0000-0000-0000-000000000001\""
+      },
+      "body": {
+        "name": "monthly-project-budget",
+        "type": "Microsoft.CognitiveServices/accounts/budgetPolicies",
+        "etag": "\"00000000-0000-0000-0000-000000000001\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget",
+        "properties": {
+          "displayName": "Monthly project budget",
+          "rules": [
+            {
+              "name": "project-spend",
+              "counterKey": [
+                {
+                  "type": "project"
+                }
+              ],
+              "unit": "usd",
+              "amount": 200,
+              "period": "month",
+              "recurring": true,
+              "match": {
+                "foundry.caller.project.id": [
+                  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+                ]
+              },
+              "thresholds": [
+                {
+                  "type": "percentage",
+                  "value": 80,
+                  "action": "alert"
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2026-08-13T18:00:00Z",
+          "createdBy": "00000000-0000-0000-0000-000000000001",
+          "createdByType": "User",
+          "lastModifiedAt": "2026-08-13T18:00:00Z",
+          "lastModifiedBy": "00000000-0000-0000-0000-000000000001",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateOrUpdateQuotaTier.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateOrUpdateQuotaTier.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "QuotaTiers_CreateOrUpdate",
+  "parameters": {
+    "default": "default",
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tier": {
+      "properties": {
+        "tierUpgradePolicy": "NoAutoUpgrade"
+      }
+    }
+  },
+  "title": "Update the quota tier resource for a subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/quotaTiers",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/quotaTiers/default",
+        "properties": {
+          "assignmentDate": "2025-06-09T18:13:29.389Z",
+          "currentTierName": "Free-Tier",
+          "tierUpgradePolicy": "NoAutoUpgrade"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/quotaTiers",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/quotaTiers/default",
+        "properties": {
+          "assignmentDate": "2025-06-09T18:13:29.389Z",
+          "currentTierName": "Free-Tier",
+          "tierUpgradePolicy": "NoAutoUpgrade"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateProject.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateProject.json
@@ -1,0 +1,98 @@
+{
+  "operationId": "Projects_Create",
+  "parameters": {
+    "accountName": "testCreate1",
+    "api-version": "2026-08-31-preview",
+    "project": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "West US",
+      "properties": {
+        "description": "Description of this project",
+        "displayName": "p1"
+      }
+    },
+    "projectName": "testProject1",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Project",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T08%3A00%3A05.445595Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "description": "Description of this project",
+          "displayName": "p1",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "description": "Description of this project",
+          "displayName": "p1",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "description": "Description of this project",
+          "displayName": "p1",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateProjectMin.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateProjectMin.json
@@ -1,0 +1,89 @@
+{
+  "operationId": "Projects_Create",
+  "parameters": {
+    "accountName": "testCreate1",
+    "api-version": "2026-08-31-preview",
+    "project": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "West US",
+      "properties": {}
+    },
+    "projectName": "testProject1",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Project Min",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T08%3A00%3A05.445595Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateSharedCommitmentPlan.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateSharedCommitmentPlan.json
@@ -1,0 +1,69 @@
+{
+  "operationId": "CommitmentPlans_CreateOrUpdatePlan",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlan": {
+      "kind": "SpeechServices",
+      "location": "West US",
+      "properties": {
+        "autoRenew": true,
+        "current": {
+          "tier": "T1"
+        },
+        "hostingModel": "Web",
+        "planType": "STT"
+      },
+      "sku": {
+        "name": "S0"
+      }
+    },
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Commitment Plan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+        "kind": "SpeechServices",
+        "location": "West US",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "STT",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+        "kind": "SpeechServices",
+        "location": "West US",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "STT",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateSharedCommitmentPlanAssociation.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/CreateSharedCommitmentPlanAssociation.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "CommitmentPlans_CreateOrUpdateAssociation",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "association": {
+      "properties": {
+        "accountId": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName"
+      }
+    },
+    "commitmentPlanAssociationName": "commitmentPlanAssociationName",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PutCommitmentPlan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanAssociationName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans/accountAssociations",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName/accountAssociations/commitmentPlanAssociationName",
+        "properties": {
+          "accountId": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "commitmentPlanAssociationName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans/accountAssociations",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName/accountAssociations/commitmentPlanAssociationName",
+        "properties": {
+          "accountId": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteAccount.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteAccount.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "Accounts_Delete",
+  "parameters": {
+    "accountName": "PropTest01",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Account",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteBudgetPolicy.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteBudgetPolicy.json
@@ -1,0 +1,14 @@
+{
+  "operationId": "BudgetPolicies_Delete",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "budgetPolicyName": "monthly-project-budget",
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Delete a budget policy",
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteCommitmentPlan.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteCommitmentPlan.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "CommitmentPlans_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeleteCommitmentPlan",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteDeployment.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteDeployment.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "Deployments_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeleteDeployment",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteEncryptionScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteEncryptionScope.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "EncryptionScopes_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "encryptionScopeName": "encryptionScopeName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteEncryptionScope",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeletePrivateEndpointConnection.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeletePrivateEndpointConnection.json
@@ -1,0 +1,21 @@
+{
+  "operationId": "PrivateEndpointConnections_Delete",
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-08-31-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeletePrivateEndpointConnection",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteProject.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteProject.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "Projects_Delete",
+  "parameters": {
+    "accountName": "PropTest01",
+    "api-version": "2026-08-31-preview",
+    "projectName": "myProject",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Project",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiBlocklist.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiBlocklist.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "RaiBlocklists_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiBlocklist",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiBlocklistItem.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiBlocklistItem.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "RaiBlocklistItems_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiBlocklistItem",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiBlocklistItems.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiBlocklistItems.json
@@ -1,0 +1,18 @@
+{
+  "operationId": "RaiBlocklistItems_BatchDelete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistItemsNames": [
+      "myblocklistitem1",
+      "myblocklistitem2"
+    ],
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiBlocklistItems",
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiExternalSafetyProvider.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiExternalSafetyProvider.json
@@ -1,0 +1,17 @@
+{
+  "operationId": "RaiExternalSafetyProvider_Delete",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "safetyProviderName": "safetyProviderName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiTopic",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiPolicy.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiPolicy.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "RaiPolicies_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiPolicy",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiToolLabel.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiToolLabel.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "RaiToolLabels_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiToolConnectionName": "Web_Search",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiToolLabel",
+  "responses": {
+    "202": {
+      "description": "Accepted -- delete operation started.",
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "description": "No Content -- RAI Tool Label does not exist."
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiTopic.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteRaiTopic.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "RaiTopics_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiTopicName": "raiTopicName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiTopic",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteSharedCommitmentPlan.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteSharedCommitmentPlan.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "CommitmentPlans_DeletePlan",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Commitment Plan",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteSharedCommitmentPlanAssociation.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteSharedCommitmentPlanAssociation.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "CommitmentPlans_DeleteAssociation",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanAssociationName": "commitmentPlanAssociationName",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeleteCommitmentPlan",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteSubscriptionRaiPolicy.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/DeleteSubscriptionRaiPolicy.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "SubscriptionRaiPolicy_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiPolicy",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetAccount.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetAccount.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "Accounts_Get",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get Account",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myAccount",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T04%3A42%3A19.7067387Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/myAccount",
+        "kind": "Emotion",
+        "location": "westus",
+        "properties": {
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "F0"
+        },
+        "tags": {
+          "ExpiredDate": "2017/09/01",
+          "Owner": "felixwa"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetBudgetPolicy.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetBudgetPolicy.json
@@ -1,0 +1,61 @@
+{
+  "operationId": "BudgetPolicies_Get",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "budgetPolicyName": "monthly-project-budget",
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get a budget policy",
+  "responses": {
+    "200": {
+      "headers": {
+        "ETag": "\"00000000-0000-0000-0000-000000000001\""
+      },
+      "body": {
+        "name": "monthly-project-budget",
+        "type": "Microsoft.CognitiveServices/accounts/budgetPolicies",
+        "etag": "\"00000000-0000-0000-0000-000000000001\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget",
+        "properties": {
+          "displayName": "Monthly project budget",
+          "rules": [
+            {
+              "name": "project-spend",
+              "counterKey": [
+                {
+                  "type": "project"
+                }
+              ],
+              "unit": "usd",
+              "amount": 200,
+              "period": "month",
+              "recurring": true,
+              "match": {
+                "foundry.caller.project.id": [
+                  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+                ]
+              },
+              "thresholds": [
+                {
+                  "type": "percentage",
+                  "value": 80,
+                  "action": "alert"
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2026-08-13T18:00:00Z",
+          "createdBy": "00000000-0000-0000-0000-000000000001",
+          "createdByType": "User",
+          "lastModifiedAt": "2026-08-13T18:00:00Z",
+          "lastModifiedBy": "00000000-0000-0000-0000-000000000001",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetCommitmentPlan.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetCommitmentPlan.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "CommitmentPlans_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetCommitmentPlan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/accounts/commitmentPlans",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/commitmentPlans/commitmentPlanName",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "Speech2Text"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetDefenderForAISetting.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetDefenderForAISetting.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "DefenderForAISettings_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "defenderForAISettingName": "Default",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetDefenderForAISetting",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default",
+        "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/defenderForAISettings/Default",
+        "properties": {
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2022-04-03T04:41:33.937Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-04-03T04:41:33.937Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetDeletedAccount.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetDeletedAccount.json
@@ -1,0 +1,34 @@
+{
+  "operationId": "DeletedAccounts_Get",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "location": "westus",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get Account",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myAccount",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T04%3A42%3A19.7067387Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/resourceGroups/myResourceGroup/deletedAccounts/myAccount",
+        "kind": "Emotion",
+        "location": "westus",
+        "properties": {
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "F0"
+        },
+        "tags": {
+          "ExpiredDate": "2017/09/01",
+          "Owner": "felixwa"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetDeployment.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetDeployment.json
@@ -1,0 +1,34 @@
+{
+  "operationId": "Deployments_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetDeployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Running",
+          "model": {
+            "name": "ada",
+            "format": "OpenAI",
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "serviceTier": "Default"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetEncryptionScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetEncryptionScope.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "EncryptionScopes_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "encryptionScopeName": "encryptionScopeName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetEncryptionScope",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "encryptionScopeName",
+        "type": "Microsoft.CognitiveServices/accounts/encryptionScopes",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/encryptionScopes/encryptionScopeName",
+        "properties": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": {
+            "identityClientId": "00000000-0000-0000-0000-000000000000",
+            "keyName": "DevKeyWestUS2",
+            "keyVaultUri": "https://devkvwestus2.vault.azure.net/",
+            "keyVersion": "9f85549d7bf14ff4bf178c10d3bdca95"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2023-06-08T06:35:08.0662558Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2023-06-08T06:35:08.0662558Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetNetworkSecurityPerimeterConfigurations.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetNetworkSecurityPerimeterConfigurations.json
@@ -1,0 +1,48 @@
+{
+  "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "nspConfigurationName": "NSPConfigurationName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetNetworkSecurityPerimeterConfigurations",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "networkSecurityPerimeterConfigurationName",
+        "type": "Microsoft.CognitiveServices/accounts/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/networkSecurityPerimeterConfigurations/config1",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Network/networkSecurityPerimeters/perimeter",
+            "location": "East US",
+            "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+          },
+          "profile": {
+            "name": "profileName",
+            "accessRules": [
+              {
+                "name": "ruleName",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8",
+                    "152.4.6.0/24"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": 1
+          },
+          "provisioningState": "Succeeded",
+          "resourceAssociation": {
+            "name": "associationName",
+            "accessMode": "Enforced"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetOperations.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetOperations.json
@@ -1,0 +1,45 @@
+{
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview"
+  },
+  "title": "Get Operations",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.CognitiveServices/accounts/read",
+            "display": {
+              "description": "Reads API accounts.",
+              "operation": "Read API Account",
+              "provider": "Microsoft Cognitive Services",
+              "resource": "Cognitive Services API Account"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.CognitiveServices/accounts/write",
+            "display": {
+              "description": "Writes API Accounts.",
+              "operation": "Write API Account",
+              "provider": "Microsoft Cognitive Services",
+              "resource": "Cognitive Services API Account"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.CognitiveServices/accounts/delete",
+            "display": {
+              "description": "Deletes API accounts",
+              "operation": "Delete API Account",
+              "provider": "Microsoft Cognitive Services",
+              "resource": "Cognitive Services API Account"
+            },
+            "origin": "user,system"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetPrivateEndpointConnection.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetPrivateEndpointConnection.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "PrivateEndpointConnections_Get",
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-08-31-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetPrivateEndpointConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.CognitiveServices/accounts/privateEndpointConnections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.CognitiveServices/accounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetProject.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetProject.json
@@ -1,0 +1,36 @@
+{
+  "operationId": "Projects_Get",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "projectName": "myProject",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get Project",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myProject",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T04%3A42%3A19.7067387Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/myAccount/projects/myProject",
+        "location": "westus",
+        "properties": {
+          "description": "This is my project",
+          "displayName": "myProject",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://customSubDomainName.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://customSubDomainName.openai.azure.com/"
+          },
+          "isDefault": false,
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "ExpiredDate": "2017/09/01",
+          "Owner": "felixwa"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetQuotaTier.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetQuotaTier.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "QuotaTiers_Get",
+  "parameters": {
+    "default": "default",
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get the Quota Tier information for a subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/quotaTiers",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/quotaTiers/default",
+        "properties": {
+          "assignmentDate": "2025-06-09T18:13:29.389Z",
+          "currentTierName": "Free-Tier",
+          "tierUpgradeEligibilityInfo": {
+            "nextTierName": "Tier-1",
+            "upgradeApplicableDate": "2025-06-15T18:13:29.389Z",
+            "upgradeAvailabilityStatus": "Available"
+          },
+          "tierUpgradePolicy": "OnceUpgradeIsAvailable"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiBlocklist.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiBlocklist.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "RaiBlocklists_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiBlocklist",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "This is a sample blocklist"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiBlocklistItem.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiBlocklistItem.json
@@ -1,0 +1,24 @@
+{
+  "operationId": "RaiBlocklistItems_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiBlocklistItem",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiContentFilter.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiContentFilter.json
@@ -1,0 +1,24 @@
+{
+  "operationId": "RaiContentFilters_Get",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "filterName": "IndirectAttack",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiContentFilters",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "IndirectAttack",
+        "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/IndirectAttack",
+        "properties": {
+          "name": "Indirect Attack",
+          "isMultiLevelFilter": false,
+          "source": "Prompt"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiExternalSafetyProvider.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiExternalSafetyProvider.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "RaiExternalSafetyProvider_Get",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "safetyProviderName": "safetyProviderName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiExternalSafetyProvider",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "safetyProviderName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/safetyProviderName",
+        "properties": {
+          "createdAt": "2025-07-01T00:00:00Z",
+          "keyVaultUri": "https://example.vault.azure.net",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "managedIdentity": "00000000-0000-0000-0000-000000000000",
+          "mode": "sync",
+          "providerId": "00000000-0000-0000-0000-000000000000",
+          "providerName": "safetyProviderName",
+          "secretName": "mySecretName",
+          "url": "https://example.webhook.endpoint"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiPolicy.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiPolicy.json
@@ -1,0 +1,107 @@
+{
+  "operationId": "RaiPolicies_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "effective": true,
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiPolicy",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiToolLabel.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiToolLabel.json
@@ -1,0 +1,44 @@
+{
+  "operationId": "RaiToolLabels_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiToolConnectionName": "ToolLabelName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiToolLabel",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiToolLabelName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiIfcToolLabels/raiIfcToolLabelName",
+        "properties": {
+          "accountScope": {
+            "labelValues": {
+              "confidentiality": "low",
+              "dataDirection": "egress"
+            }
+          },
+          "projectScopes": [
+            {
+              "labelValues": {
+                "confidentiality": "low",
+                "dataDirection": "egress"
+              },
+              "project": "ProjectA"
+            },
+            {
+              "labelValues": {
+                "confidentiality": "high",
+                "dataDirection": "egress"
+              },
+              "project": "ProjectB"
+            }
+          ],
+          "toolConnectionName": "SampleToolLabel"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiTopic.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetRaiTopic.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "RaiTopics_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiTopicName": "raiTopicName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiTopic",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiTopicName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiTopics/raiTopicName",
+        "properties": {
+          "description": "This is a sample topic.",
+          "createdAt": "2025-07-01T00:00:00Z",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "sampleBlobUrl": "https://example.blob.core.windows.net/sampleblob",
+          "status": "Succeeded",
+          "topicId": "00000000-0000-0000-0000-000000000000",
+          "topicName": "raiTopicName"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetSharedCommitmentPlan.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetSharedCommitmentPlan.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "CommitmentPlans_GetPlan",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get Commitment Plan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+        "kind": "SpeechServices",
+        "location": "West US",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "STT",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetSharedCommitmentPlanAssociation.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetSharedCommitmentPlanAssociation.json
@@ -1,0 +1,23 @@
+{
+  "operationId": "CommitmentPlans_GetAssociation",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanAssociationName": "commitmentPlanAssociationName",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetCommitmentPlan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanAssociationName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans/accountAssociations",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName/accountAssociations/commitmentPlanAssociationName",
+        "properties": {
+          "accountId": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetSkus.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetSkus.json
@@ -1,0 +1,2166 @@
+{
+  "operationId": "ResourceSkus_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "f1c637e4-72ec-4f89-8d2b-0f933c036002"
+  },
+  "title": "Regenerate Keys",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "F0",
+            "kind": "Bing.Speech",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Bing.Speech",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "SpeechTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "SpeechTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "SpeechTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "SpeechTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "SpeechTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "TextTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S5",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S6",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S7",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S8",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "Bing.Autosuggest.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "Bing.CustomSearch",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "Bing.SpellCheck.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Bing.EntitySearch",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "Bing.EntitySearch",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "SpeakerRecognition",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "SpeakerRecognition",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "CustomSpeech",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S2",
+            "kind": "CustomSpeech",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "CustomVision.Training",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "CustomVision.Training",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "CustomVision.Prediction",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "CustomVision.Prediction",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetSubscriptionRaiPolicy.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetSubscriptionRaiPolicy.json
@@ -1,0 +1,107 @@
+{
+  "operationId": "SubscriptionRaiPolicy_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "effective": true,
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiPolicy",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetUsages.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetUsages.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "Accounts_ListUsages",
+  "parameters": {
+    "accountName": "TestUsage02",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
+  },
+  "title": "Get Usages",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Face.Transactions",
+              "value": "Face.Transactions"
+            },
+            "currentValue": 3,
+            "limit": 30000,
+            "nextResetTime": "2018-03-28T09:33:51Z",
+            "quotaPeriod": "30.00:00:00",
+            "status": "Included",
+            "unit": "Count",
+            "scopeType": "Regional",
+            "scopeId": "eastus"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetUsagesClassicScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetUsagesClassicScope.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "Accounts_ListUsages",
+  "parameters": {
+    "accountName": "TestUsage02",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
+  },
+  "title": "Get Usages Classic Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Face.Transactions",
+              "value": "Face.Transactions"
+            },
+            "currentValue": 2,
+            "limit": 20000,
+            "nextResetTime": "2018-03-28T09:33:51Z",
+            "quotaPeriod": "30.00:00:00",
+            "status": "Included",
+            "unit": "Count",
+            "scopeType": "Classic"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetUsagesDataZoneScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetUsagesDataZoneScope.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "Accounts_ListUsages",
+  "parameters": {
+    "accountName": "TestUsage02",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
+  },
+  "title": "Get Usages DataZone Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Face.Transactions",
+              "value": "Face.Transactions"
+            },
+            "currentValue": 4,
+            "limit": 40000,
+            "nextResetTime": "2018-03-28T09:33:51Z",
+            "quotaPeriod": "30.00:00:00",
+            "status": "Included",
+            "unit": "Count",
+            "scopeType": "DataZone",
+            "scopeId": "US"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetUsagesGlobalScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/GetUsagesGlobalScope.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "Accounts_ListUsages",
+  "parameters": {
+    "accountName": "TestUsage02",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
+  },
+  "title": "Get Usages Global Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Face.Transactions",
+              "value": "Face.Transactions"
+            },
+            "currentValue": 5,
+            "limit": 50000,
+            "nextResetTime": "2018-03-28T09:33:51Z",
+            "quotaPeriod": "30.00:00:00",
+            "status": "Included",
+            "unit": "Count",
+            "scopeType": "Global",
+            "scopeId": "Global"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListAccountModels.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListAccountModels.json
@@ -1,0 +1,189 @@
+{
+  "operationId": "Accounts_ListModels",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "location": "location",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List AccountModels",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ada.1",
+            "format": "OpenAI",
+            "baseModel": {
+              "name": "ada",
+              "format": "OpenAI",
+              "version": "1"
+            },
+            "capabilities": {
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false"
+            },
+            "deprecation": {
+              "deprecationStatus": "Planned",
+              "fineTune": "2024-01-01T00:00:00Z",
+              "inference": "2024-01-01T00:00:00Z"
+            },
+            "isDefaultVersion": false,
+            "lifecycleStatus": "Legacy",
+            "maxCapacity": 10,
+            "systemData": {
+              "createdAt": "2021-10-07T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2021-10-07T00:00:00Z",
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": "Application"
+            },
+            "version": "1"
+          },
+          {
+            "name": "dall-e-3",
+            "format": "OpenAI",
+            "capabilities": {
+              "imageGenerations": "true",
+              "inference": "true"
+            },
+            "deprecation": {
+              "deprecationStatus": "Tentative",
+              "inference": "2025-06-30T00:00:00Z"
+            },
+            "isDefaultVersion": true,
+            "lifecycleStatus": "GenerallyAvailable",
+            "maxCapacity": 2,
+            "modelCatalogAssetId": "azureml://registries/azure-openai/models/dall-e-3/versions/3.0",
+            "systemData": {
+              "createdAt": "2023-08-11T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2023-08-11T00:00:00Z",
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": "Application"
+            },
+            "version": "3.0"
+          },
+          {
+            "name": "gpt-35-turbo",
+            "format": "OpenAI",
+            "capabilities": {
+              "chatCompletion": "true",
+              "completion": "true",
+              "fineTune": "false",
+              "scaleType": "Manual,Standard"
+            },
+            "deprecation": {
+              "deprecationStatus": "Planned",
+              "inference": "2025-04-30T00:00:00Z"
+            },
+            "isDefaultVersion": false,
+            "lifecycleStatus": "Deprecated",
+            "maxCapacity": 9,
+            "systemData": {
+              "createdAt": "2023-03-09T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2023-07-06T00:00:00Z",
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": "Application"
+            },
+            "version": "0301"
+          },
+          {
+            "name": "gpt-4o",
+            "format": "OpenAI",
+            "capabilities": {
+              "chat": "true",
+              "completion": "true",
+              "fineTune": "false",
+              "inference": "true",
+              "vision": "true"
+            },
+            "deprecation": {
+              "deprecationStatus": "Tentative",
+              "inference": "2025-09-15T00:00:00Z"
+            },
+            "lifecycleStatus": "Deprecating",
+            "maxCapacity": 50,
+            "modelCatalogAssetId": "azureml://registries/azure-openai/models/gpt-4o/versions/2024-05-13",
+            "replacementConfig": {
+              "autoUpgradeStartDate": "2025-03-26T07:00:00Z",
+              "targetModelName": "gpt-4.1",
+              "targetModelVersion": "2025-04-14",
+              "upgradeOnExpiryLeadTimeDays": 7
+            },
+            "systemData": {
+              "createdAt": "2024-05-13T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2024-12-15T00:00:00Z",
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": "Application"
+            },
+            "version": "2024-05-13"
+          },
+          {
+            "name": "Llama-3.2-90B-Vision-Instruct",
+            "format": "Meta",
+            "capabilities": {
+              "chatCompletion": "true"
+            },
+            "deprecation": {
+              "deprecationStatus": "Tentative",
+              "inference": "2099-12-31T00:00:00Z"
+            },
+            "isDefaultVersion": false,
+            "lifecycleStatus": "Stable",
+            "maxCapacity": 3,
+            "modelCatalogAssetId": "azureml://registries/azureml-meta/models/Llama-3.2-90B-Vision-Instruct/versions/2",
+            "systemData": {
+              "createdAt": "2024-10-01T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2025-04-16T04:45:33.9367873Z",
+              "lastModifiedBy": "MaaSModelConverter",
+              "lastModifiedByType": "Application"
+            },
+            "version": "2"
+          },
+          {
+            "name": "gpt-4o",
+            "format": "OpenAI",
+            "capabilities": {
+              "chat": "true",
+              "completion": "true",
+              "fineTune": "false",
+              "functionCalling": "true",
+              "inference": "true",
+              "vision": "true"
+            },
+            "finetuneCapabilities": {
+              "chat": "true",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "true",
+              "scaleType": "Manual"
+            },
+            "lifecycleStatus": "GenerallyAvailable",
+            "maxCapacity": 50,
+            "modelCatalogAssetId": "azureml://registries/azure-openai/models/gpt-4o/versions/2024-08-06",
+            "systemData": {
+              "createdAt": "2024-08-06T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2024-11-01T00:00:00Z",
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": "Application"
+            },
+            "version": "2024-08-06"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListAccountsByResourceGroup.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListAccountsByResourceGroup.json
@@ -1,0 +1,52 @@
+{
+  "operationId": "Accounts_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Accounts by Resource Group",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myAccount",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-04-10T04%3A42%3A19.7067387Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/myAccount",
+            "kind": "Emotion",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "F0"
+            },
+            "tags": {
+              "ExpiredDate": "2017/09/01",
+              "Owner": "felixwa"
+            }
+          },
+          {
+            "name": "TestPropertyWU2",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-04-07T04%3A32%3A38.9187216Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/TestPropertyWU2",
+            "kind": "Face",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/face/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListAccountsBySubscription.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListAccountsBySubscription.json
@@ -1,0 +1,79 @@
+{
+  "operationId": "Accounts_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Accounts by Subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "bingSearch",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-27T11%3A19%3A08.762494Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch",
+            "kind": "Bing.Search",
+            "location": "global",
+            "properties": {
+              "endpoint": "https://api.cognitive.microsoft.com/bing/v5.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S1"
+            }
+          },
+          {
+            "name": "CrisProd",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-31T08%3A57%3A07.4499566Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/CrisProd",
+            "kind": "CRIS",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/sts/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            },
+            "tags": {
+              "can't delete it successfully": "v-yunjin"
+            }
+          },
+          {
+            "name": "rayrptest0308",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-27T11%3A15%3A23.5232645Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/rayrptest0308",
+            "kind": "Face",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/face/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          },
+          {
+            "name": "raytest02",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-04-04T02%3A07%3A07.3957572Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/raytest02",
+            "kind": "Emotion",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListBlocklistItems.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListBlocklistItems.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "RaiBlocklistItems_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListBlocklistItems",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "raiBlocklistItemName",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+            "properties": {
+              "isRegex": false,
+              "pattern": "Pattern To Block"
+            }
+          },
+          {
+            "name": "raiBlocklistItemName2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName2",
+            "properties": {
+              "isRegex": false,
+              "pattern": "Another Pattern To Block"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListBlocklists.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListBlocklists.json
@@ -1,0 +1,25 @@
+{
+  "operationId": "RaiBlocklists_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListBlocklists",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "raiBlocklistName",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName",
+            "properties": {
+              "description": "This is a sample blocklist"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListBudgetPolicies.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListBudgetPolicies.json
@@ -1,0 +1,61 @@
+{
+  "operationId": "BudgetPolicies_List",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "List budget policies",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "monthly-project-budget",
+            "type": "Microsoft.CognitiveServices/accounts/budgetPolicies",
+            "etag": "\"00000000-0000-0000-0000-000000000001\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget",
+            "properties": {
+              "displayName": "Monthly project budget",
+              "rules": [
+                {
+                  "name": "project-spend",
+                  "counterKey": [
+                    {
+                      "type": "project"
+                    }
+                  ],
+                  "unit": "usd",
+                  "amount": 200,
+                  "period": "month",
+                  "recurring": true,
+                  "match": {
+                    "foundry.caller.project.id": [
+                      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+                    ]
+                  },
+                  "thresholds": [
+                    {
+                      "type": "percentage",
+                      "value": 80,
+                      "action": "alert"
+                    }
+                  ]
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2026-08-13T18:00:00Z",
+              "createdBy": "00000000-0000-0000-0000-000000000001",
+              "createdByType": "User",
+              "lastModifiedAt": "2026-08-13T18:00:00Z",
+              "lastModifiedBy": "00000000-0000-0000-0000-000000000001",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListCommitmentPlans.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListCommitmentPlans.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "CommitmentPlans_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ListCommitmentPlans",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "commitmentPlanName",
+            "type": "Microsoft.CognitiveServices/accounts/commitmentPlans",
+            "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/commitmentPlans/commitmentPlanName",
+            "properties": {
+              "autoRenew": true,
+              "current": {
+                "tier": "T1"
+              },
+              "hostingModel": "Web",
+              "planType": "Speech2Text"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListCommitmentTiers.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListCommitmentTiers.json
@@ -1,0 +1,30 @@
+{
+  "operationId": "CommitmentTiers_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "location",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ListCommitmentTiers",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "cost": {},
+            "hostingModel": "Web",
+            "kind": "TextAnalytics",
+            "planType": "TA",
+            "quota": {
+              "quantity": 1000000,
+              "unit": "Transaction"
+            },
+            "skuName": "S",
+            "tier": "T1"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListDefenderForAISetting.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListDefenderForAISetting.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "DefenderForAISettings_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListDefenderForAISetting",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Default",
+            "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+            "etag": "\"00000000-0000-0000-0000-000000000000\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/defenderForAISettings/Default",
+            "properties": {
+              "state": "Enabled"
+            },
+            "systemData": {
+              "createdAt": "2022-04-03T04:41:33.937Z",
+              "createdBy": "xxx@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-04-03T04:41:33.937Z",
+              "lastModifiedBy": "xxx@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListDeletedAccountsBySubscription.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListDeletedAccountsBySubscription.json
@@ -1,0 +1,79 @@
+{
+  "operationId": "DeletedAccounts_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Deleted Accounts by Subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "bingSearch",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-27T11%3A19%3A08.762494Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch",
+            "kind": "Bing.Search",
+            "location": "global",
+            "properties": {
+              "endpoint": "https://api.cognitive.microsoft.com/bing/v5.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S1"
+            }
+          },
+          {
+            "name": "CrisProd",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-31T08%3A57%3A07.4499566Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/CrisProd",
+            "kind": "CRIS",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/sts/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            },
+            "tags": {
+              "can't delete it successfully": "v-yunjin"
+            }
+          },
+          {
+            "name": "rayrptest0308",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-27T11%3A15%3A23.5232645Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/rayrptest0308",
+            "kind": "Face",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/face/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          },
+          {
+            "name": "raytest02",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-04-04T02%3A07%3A07.3957572Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/raytest02",
+            "kind": "Emotion",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListDeploymentSkus.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListDeploymentSkus.json
@@ -1,0 +1,36 @@
+{
+  "operationId": "Deployments_ListSkus",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListDeploymentSkus",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "capacity": {
+              "default": 100,
+              "allowedValues": [
+                100,
+                200
+              ],
+              "maximum": 1000,
+              "minimum": 100,
+              "step": 100
+            },
+            "resourceType": "Microsoft.CognitiveServices/accounts/deployments",
+            "sku": {
+              "name": "Standard",
+              "capacity": 1
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListDeployments.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListDeployments.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "Deployments_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ListDeployments",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "deploymentName",
+            "type": "Microsoft.CognitiveServices/accounts/deployments",
+            "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+            "properties": {
+              "deploymentState": "Running",
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "provisioningState": "Succeeded",
+              "serviceTier": "Default"
+            },
+            "sku": {
+              "name": "Standard",
+              "capacity": 1
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListEncryptionScopes.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListEncryptionScopes.json
@@ -1,0 +1,43 @@
+{
+  "operationId": "EncryptionScopes_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListEncryptionScopes",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "encryptionScopeName",
+            "type": "Microsoft.CognitiveServices/accounts/encryptionScopes",
+            "etag": "\"00000000-0000-0000-0000-000000000000\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/encryptionScopes/encryptionScopeName",
+            "properties": {
+              "keySource": "Microsoft.KeyVault",
+              "keyVaultProperties": {
+                "identityClientId": "00000000-0000-0000-0000-000000000000",
+                "keyName": "DevKeyWestUS2",
+                "keyVaultUri": "https://devkvwestus2.vault.azure.net/",
+                "keyVersion": "9f85549d7bf14ff4bf178c10d3bdca95"
+              },
+              "provisioningState": "Succeeded",
+              "state": "Enabled"
+            },
+            "systemData": {
+              "createdAt": "2023-06-08T06:35:08.0662558Z",
+              "createdBy": "xxx@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2023-06-08T06:35:08.0662558Z",
+              "lastModifiedBy": "xxx@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListKeys.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListKeys.json
@@ -1,0 +1,18 @@
+{
+  "operationId": "Accounts_ListKeys",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Keys",
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "KEY1",
+        "key2": "KEY2"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListLocationBasedModelCapacities.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListLocationBasedModelCapacities.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "LocationBasedModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListLocationBasedModelCapacities",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 300,
+              "availableFinetuneCapacity": 20,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "Standard",
+              "scopeId": "WestUS",
+              "scopeType": "Regional"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListLocationBasedModelCapacitiesClassicScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListLocationBasedModelCapacitiesClassicScope.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "LocationBasedModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListLocationBasedModelCapacities Classic Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 200,
+              "availableFinetuneCapacity": 15,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "Standard",
+              "scopeType": "Classic"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListLocationBasedModelCapacitiesDataZoneScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListLocationBasedModelCapacitiesDataZoneScope.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "LocationBasedModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListLocationBasedModelCapacities DataZone Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "DataZoneStandard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/DataZoneStandard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 400,
+              "availableFinetuneCapacity": 25,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "DataZoneStandard",
+              "scopeId": "US",
+              "scopeType": "DataZone"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListLocationBasedModelCapacitiesGlobalScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListLocationBasedModelCapacitiesGlobalScope.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "LocationBasedModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListLocationBasedModelCapacities Global Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "GlobalStandard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/GlobalStandard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 500,
+              "availableFinetuneCapacity": 30,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "GlobalStandard",
+              "scopeId": "Global",
+              "scopeType": "Global"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListLocationModels.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListLocationModels.json
@@ -1,0 +1,292 @@
+{
+  "operationId": "Models_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListLocationModels",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "kind": "OpenAI",
+            "model": {
+              "name": "ada",
+              "format": "OpenAI",
+              "capabilities": {
+                "FineTuneTokensMaxValue": "2000000000",
+                "FineTuneTokensMaxValuePerExample": "4096",
+                "completion": "true",
+                "inference": "false",
+                "scaleType": "Manual",
+                "search": "true"
+              },
+              "deprecation": {
+                "deprecationStatus": "Planned",
+                "fineTune": "2024-06-14T00:00:00Z",
+                "inference": "2024-06-14T00:00:00Z"
+              },
+              "lifecycleStatus": "Legacy",
+              "maxCapacity": 3,
+              "skus": [
+                {
+                  "name": "provisioned",
+                  "capacity": {
+                    "default": 100,
+                    "maximum": 1000,
+                    "minimum": 100,
+                    "step": 100
+                  },
+                  "usageName": "OpenAI.Provisioned.Class1"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2021-10-07T00:00:00Z",
+                "createdBy": "Microsoft",
+                "lastModifiedAt": "2021-10-07T00:00:00Z",
+                "lastModifiedBy": "Microsoft"
+              },
+              "version": "1"
+            },
+            "skuName": "S0"
+          },
+          {
+            "kind": "AIServices",
+            "model": {
+              "name": "dall-e-3",
+              "format": "OpenAI",
+              "capabilities": {
+                "imageGenerations": "true",
+                "inference": "true"
+              },
+              "deprecation": {
+                "deprecationStatus": "Tentative",
+                "inference": "2025-06-30T00:00:00Z"
+              },
+              "isDefaultVersion": true,
+              "lifecycleStatus": "GenerallyAvailable",
+              "maxCapacity": 2,
+              "modelCatalogAssetId": "azureml://registries/azure-openai/models/dall-e-3/versions/3.0",
+              "skus": [
+                {
+                  "name": "Provisioned",
+                  "capacity": {
+                    "default": 300,
+                    "maximum": 60000,
+                    "minimum": 300,
+                    "step": 100
+                  },
+                  "deprecationDate": "2025-09-30T00:00:00Z",
+                  "usageName": "OpenAI.Provisioned.Dalle"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2023-08-11T00:00:00Z",
+                "createdBy": "Microsoft",
+                "lastModifiedAt": "2023-08-11T00:00:00Z",
+                "lastModifiedBy": "Microsoft"
+              },
+              "version": "3.0"
+            },
+            "skuName": "S0"
+          },
+          {
+            "kind": "OpenAI",
+            "model": {
+              "name": "gpt-35-turbo",
+              "format": "OpenAI",
+              "capabilities": {
+                "chatCompletion": "true",
+                "completion": "true",
+                "maxTotalToken": "4096",
+                "scaleType": "Manual,Standard"
+              },
+              "deprecation": {
+                "deprecationStatus": "Planned",
+                "inference": "2025-04-30T00:00:00Z"
+              },
+              "isDefaultVersion": false,
+              "lifecycleStatus": "Deprecated",
+              "maxCapacity": 9,
+              "skus": [
+                {
+                  "name": "Standard",
+                  "capacity": {
+                    "default": 120,
+                    "maximum": 1000000
+                  },
+                  "deprecationDate": "2025-02-13T00:00:00Z",
+                  "usageName": "OpenAI.Standard.gpt-35-turbo"
+                },
+                {
+                  "name": "Provisioned",
+                  "capacity": {
+                    "default": 300,
+                    "maximum": 30000,
+                    "minimum": 300,
+                    "step": 100
+                  },
+                  "deprecationDate": "2025-05-15T00:00:00Z",
+                  "usageName": "OpenAI.Provisioned.gpt-35-turbo"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2023-03-09T00:00:00Z",
+                "createdBy": "Microsoft",
+                "createdByType": "Application",
+                "lastModifiedAt": "2023-07-06T00:00:00Z",
+                "lastModifiedBy": "Microsoft",
+                "lastModifiedByType": "Application"
+              },
+              "version": "0301"
+            },
+            "skuName": "S0"
+          },
+          {
+            "kind": "OpenAI",
+            "model": {
+              "name": "gpt-4o",
+              "format": "OpenAI",
+              "capabilities": {
+                "chat": "true",
+                "completion": "true",
+                "fineTune": "false",
+                "inference": "true",
+                "scaleType": "Manual,Provisioned",
+                "vision": "true"
+              },
+              "deprecation": {
+                "deprecationStatus": "Tentative",
+                "inference": "2025-09-15T00:00:00Z"
+              },
+              "lifecycleStatus": "Deprecating",
+              "maxCapacity": 50,
+              "modelCatalogAssetId": "azureml://registries/azure-openai/models/gpt-4o/versions/2024-05-13",
+              "replacementConfig": {
+                "autoUpgradeStartDate": "2025-03-26T07:00:00Z",
+                "targetModelName": "gpt-4.1",
+                "targetModelVersion": "2025-04-14",
+                "upgradeOnExpiryLeadTimeDays": 7
+              },
+              "skus": [
+                {
+                  "name": "provisioned",
+                  "capacity": {
+                    "default": 100,
+                    "maximum": 2000,
+                    "minimum": 50,
+                    "step": 50
+                  },
+                  "usageName": "OpenAI.Provisioned.GPT4o"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2024-05-13T00:00:00Z",
+                "createdBy": "Microsoft",
+                "lastModifiedAt": "2024-12-15T00:00:00Z",
+                "lastModifiedBy": "Microsoft"
+              },
+              "version": "2024-05-13"
+            },
+            "skuName": "S0"
+          },
+          {
+            "kind": "AIServices",
+            "model": {
+              "name": "Llama-3.2-90B-Vision-Instruct",
+              "format": "Meta",
+              "capabilities": {
+                "chatCompletion": "true"
+              },
+              "deprecation": {
+                "inference": "2099-12-31T00:00:00Z"
+              },
+              "isDefaultVersion": false,
+              "lifecycleStatus": "Stable",
+              "maxCapacity": 3,
+              "modelCatalogAssetId": "azureml://registries/azureml-meta/models/Llama-3.2-90B-Vision-Instruct/versions/2",
+              "skus": [
+                {
+                  "name": "GlobalStandard",
+                  "capacity": {
+                    "default": 1,
+                    "maximum": 1
+                  },
+                  "usageName": "AIServices.GlobalStandard.MaaS"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2024-10-01T00:00:00Z",
+                "createdBy": "Microsoft",
+                "createdByType": "Application",
+                "lastModifiedAt": "2025-04-16T04:45:33.9367873Z",
+                "lastModifiedBy": "MaaSModelConverter",
+                "lastModifiedByType": "Application"
+              },
+              "version": "2"
+            },
+            "skuName": "S0"
+          },
+          {
+            "kind": "OpenAI",
+            "model": {
+              "name": "gpt-4o",
+              "format": "OpenAI",
+              "capabilities": {
+                "chat": "true",
+                "completion": "true",
+                "fineTune": "false",
+                "functionCalling": "true",
+                "inference": "true",
+                "scaleType": "Manual,Standard,Provisioned",
+                "vision": "true"
+              },
+              "finetuneCapabilities": {
+                "chat": "true",
+                "completion": "true",
+                "fineTune": "true",
+                "inference": "true",
+                "scaleType": "Manual"
+              },
+              "lifecycleStatus": "GenerallyAvailable",
+              "maxCapacity": 50,
+              "modelCatalogAssetId": "azureml://registries/azure-openai/models/gpt-4o/versions/2024-08-06",
+              "skus": [
+                {
+                  "name": "Standard",
+                  "capacity": {
+                    "default": 10,
+                    "maximum": 100,
+                    "minimum": 1,
+                    "step": 1
+                  },
+                  "usageName": "OpenAI.Standard.GPT4o"
+                },
+                {
+                  "name": "provisioned",
+                  "capacity": {
+                    "default": 100,
+                    "maximum": 2000,
+                    "minimum": 50,
+                    "step": 50
+                  },
+                  "usageName": "OpenAI.Provisioned.GPT4o"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2024-08-06T00:00:00Z",
+                "createdBy": "Microsoft",
+                "lastModifiedAt": "2024-11-01T00:00:00Z",
+                "lastModifiedBy": "Microsoft"
+              },
+              "version": "2024-08-06"
+            },
+            "skuName": "S0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListModelCapacities.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListModelCapacities.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "ModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListModelCapacities",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 300,
+              "availableFinetuneCapacity": 20,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "Standard",
+              "scopeId": "WestUS",
+              "scopeType": "Regional"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListModelCapacitiesClassicScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListModelCapacitiesClassicScope.json
@@ -1,0 +1,36 @@
+{
+  "operationId": "ModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListModelCapacities Classic Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 200,
+              "availableFinetuneCapacity": 15,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "Standard",
+              "scopeType": "Classic"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListModelCapacitiesDataZoneScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListModelCapacitiesDataZoneScope.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "ModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListModelCapacities DataZone Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "DataZoneStandard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/DataZoneStandard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 400,
+              "availableFinetuneCapacity": 25,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "DataZoneStandard",
+              "scopeId": "US",
+              "scopeType": "DataZone"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListModelCapacitiesGlobalScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListModelCapacitiesGlobalScope.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "ModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListModelCapacities Global Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "GlobalStandard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/GlobalStandard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 500,
+              "availableFinetuneCapacity": 30,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "GlobalStandard",
+              "scopeId": "Global",
+              "scopeType": "Global"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListNetworkSecurityPerimeterConfigurations.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListNetworkSecurityPerimeterConfigurations.json
@@ -1,0 +1,51 @@
+{
+  "operationId": "NetworkSecurityPerimeterConfigurations_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListNetworkSecurityPerimeterConfigurations",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "networkSecurityPerimeterConfigurationName",
+            "type": "Microsoft.CognitiveServices/accounts/networkSecurityPerimeterConfigurations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/networkSecurityPerimeterConfigurations/config1",
+            "properties": {
+              "networkSecurityPerimeter": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Network/networkSecurityPerimeters/perimeter",
+                "location": "East US",
+                "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+              },
+              "profile": {
+                "name": "profileName",
+                "accessRules": [
+                  {
+                    "name": "ruleName",
+                    "properties": {
+                      "addressPrefixes": [
+                        "148.0.0.0/8",
+                        "152.4.6.0/24"
+                      ],
+                      "direction": "Inbound"
+                    }
+                  }
+                ],
+                "accessRulesVersion": 1
+              },
+              "provisioningState": "Succeeded",
+              "resourceAssociation": {
+                "name": "associationName",
+                "accessMode": "Enforced"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListPrivateEndpointConnections.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListPrivateEndpointConnections.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "PrivateEndpointConnections_List",
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetPrivateEndpointConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "{privateEndpointConnectionName}",
+            "type": "Microsoft.CognitiveServices/accounts/privateEndpointConnections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.CognitiveServices/accounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListPrivateLinkResources.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListPrivateLinkResources.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "PrivateLinkResources_List",
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ListPrivateLinkResources",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blob",
+            "type": "Microsoft.CognitiveServices/accounts/privateLinkResources",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res6977/providers/Microsoft.CognitiveServices/accounts/sto2527/privateLinkResources/account",
+            "properties": {
+              "groupId": "account",
+              "requiredMembers": [
+                "default"
+              ],
+              "requiredZoneNames": [
+                "privatelink.cognitiveservices.azure.com"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListProjects.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListProjects.json
@@ -1,0 +1,57 @@
+{
+  "operationId": "Projects_List",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Project",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myProject",
+            "type": "Microsoft.CognitiveServices/accounts/projects",
+            "etag": "W/\"datetime'2017-04-10T04%3A42%3A19.7067387Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/myAccount/projects/myProject",
+            "location": "westus",
+            "properties": {
+              "description": "This is my project 1",
+              "displayName": "myProject1",
+              "endpoints": {
+                "OpenAI Dall-E API": "https://customSubDomainName.openai.azure.com/",
+                "OpenAI Language Model Instance API": "https://customSubDomainName.openai.azure.com/"
+              },
+              "isDefault": true,
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "ExpiredDate": "2017/09/01",
+              "Owner": "felixwa"
+            }
+          },
+          {
+            "name": "myProject-2",
+            "type": "Microsoft.CognitiveServices/accounts/projects",
+            "etag": "W/\"datetime'2017-04-07T04%3A32%3A38.9187216Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/myAccount/projects/myProject-2",
+            "location": "westus",
+            "properties": {
+              "description": "This is my project 2",
+              "displayName": "myProject2",
+              "endpoints": {
+                "OpenAI Dall-E API": "https://customSubDomainName2.openai.azure.com/",
+                "OpenAI Language Model Instance API": "https://customSubDomainName2.openai.azure.com/"
+              },
+              "isDefault": false,
+              "provisioningState": "Succeeded"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListQuotaTiers.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListQuotaTiers.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "QuotaTiers_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List the Quota Tier for a subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.CognitiveServices/quotaTiers",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/quotaTiers/default",
+            "properties": {
+              "assignmentDate": "2025-06-09T18:13:29.389Z",
+              "currentTierName": "Free-Tier",
+              "tierUpgradeEligibilityInfo": {
+                "nextTierName": "Tier-1",
+                "upgradeApplicableDate": "2025-06-15T18:13:29.389Z",
+                "upgradeAvailabilityStatus": "Available"
+              },
+              "tierUpgradePolicy": "OnceUpgradeIsAvailable"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListRaiContentFilters.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListRaiContentFilters.json
@@ -1,0 +1,102 @@
+{
+  "operationId": "RaiContentFilters_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListRaiContentFilters",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Hate",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Hate",
+            "properties": {
+              "name": "Hate",
+              "isMultiLevelFilter": true
+            }
+          },
+          {
+            "name": "Sexual",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Sexual",
+            "properties": {
+              "name": "Sexual",
+              "isMultiLevelFilter": true
+            }
+          },
+          {
+            "name": "Violence",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Violence",
+            "properties": {
+              "name": "Violence",
+              "isMultiLevelFilter": true
+            }
+          },
+          {
+            "name": "Selfharm",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Selfharm",
+            "properties": {
+              "name": "Selfharm",
+              "isMultiLevelFilter": true
+            }
+          },
+          {
+            "name": "Jailbreak",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Jailbreak",
+            "properties": {
+              "name": "Jailbreak",
+              "isMultiLevelFilter": false,
+              "source": "Prompt"
+            }
+          },
+          {
+            "name": "ProtectedMaterialText",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/ProtectedMaterialText",
+            "properties": {
+              "name": "Protected Material Text",
+              "isMultiLevelFilter": false,
+              "source": "Completion"
+            }
+          },
+          {
+            "name": "ProtectedMaterialCode",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/ProtectedMaterialCode",
+            "properties": {
+              "name": "Protected Material Code",
+              "isMultiLevelFilter": false,
+              "source": "Completion"
+            }
+          },
+          {
+            "name": "Profanity",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Profanity",
+            "properties": {
+              "name": "Profanity",
+              "isMultiLevelFilter": false
+            }
+          },
+          {
+            "name": "IndirectAttack",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/IndirectAttack",
+            "properties": {
+              "name": "Indirect Attack",
+              "isMultiLevelFilter": false,
+              "source": "Prompt"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListRaiExternalSafetyProviders.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListRaiExternalSafetyProviders.json
@@ -1,0 +1,61 @@
+{
+  "operationId": "RaiExternalSafetyProviders_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListRaiExternalSafetyProviders",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "purview",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/purview",
+            "properties": {
+              "createdAt": "2025-07-01T00:00:00Z",
+              "keyVaultUri": "https://example.vault.azure.net",
+              "lastModifiedAt": "2025-07-02T00:00:00Z",
+              "managedIdentity": "00000000-0000-0000-0000-000000000000",
+              "mode": "sync",
+              "providerId": "00000000-0000-0000-0000-000000000000",
+              "providerName": "purview",
+              "secretName": "mySecretName",
+              "url": "https://example.webhook.endpoint"
+            }
+          },
+          {
+            "name": "microsoftDefenderForCloud",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/microsoftDefenderForCloud",
+            "properties": {
+              "createdAt": "2025-07-01T00:00:00Z",
+              "keyVaultUri": "https://example.vault.azure.net",
+              "lastModifiedAt": "2025-07-02T00:00:00Z",
+              "managedIdentity": "00000000-0000-0000-0000-000000000000",
+              "mode": "sync",
+              "providerId": "00000000-0000-0000-0000-000000000000",
+              "providerName": "microsoftDefenderForCloud",
+              "secretName": "mySecretName",
+              "url": "https://example.webhook.endpoint"
+            }
+          },
+          {
+            "name": "sampleSafetyProvider",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/sampleSafetyProvider",
+            "properties": {
+              "createdAt": "2025-07-01T00:00:00Z",
+              "keyVaultUri": "https://example.vault.azure.net",
+              "lastModifiedAt": "2025-07-02T00:00:00Z",
+              "managedIdentity": "00000000-0000-0000-0000-000000000000",
+              "mode": "sync",
+              "providerId": "00000000-0000-0000-0000-000000000000",
+              "providerName": "sampleSafetyProvider",
+              "secretName": "mySecretName",
+              "url": "https://example.webhook.endpoint"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListRaiPolicies.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListRaiPolicies.json
@@ -1,0 +1,108 @@
+{
+  "operationId": "RaiPolicies_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListRaiPolicies",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "raiPolicyName",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+            "properties": {
+              "basePolicyName": "Microsoft.Default",
+              "contentFilters": [
+                {
+                  "name": "Hate",
+                  "blocking": false,
+                  "enabled": false,
+                  "severityThreshold": "High",
+                  "source": "Prompt"
+                },
+                {
+                  "name": "Hate",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "Medium",
+                  "source": "Completion"
+                },
+                {
+                  "name": "Sexual",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "High",
+                  "source": "Prompt"
+                },
+                {
+                  "name": "Sexual",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "Medium",
+                  "source": "Completion"
+                },
+                {
+                  "name": "Selfharm",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "High",
+                  "source": "Prompt"
+                },
+                {
+                  "name": "Selfharm",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "Medium",
+                  "source": "Completion"
+                },
+                {
+                  "name": "Violence",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "Medium",
+                  "source": "Prompt"
+                },
+                {
+                  "name": "Violence",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "Medium",
+                  "source": "Completion"
+                },
+                {
+                  "name": "Jailbreak",
+                  "blocking": true,
+                  "enabled": true,
+                  "source": "Prompt"
+                },
+                {
+                  "name": "Protected Material Text",
+                  "blocking": true,
+                  "enabled": true,
+                  "source": "Completion"
+                },
+                {
+                  "name": "Protected Material Code",
+                  "blocking": true,
+                  "enabled": true,
+                  "source": "Completion"
+                },
+                {
+                  "name": "Profanity",
+                  "blocking": true,
+                  "enabled": true,
+                  "source": "Prompt"
+                }
+              ],
+              "mode": "Asynchronous_filter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListRaiToolLabels.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListRaiToolLabels.json
@@ -1,0 +1,44 @@
+{
+  "operationId": "RaiToolLabels_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListRaiToolLabels",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "raiIfcToolLabelName",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiIfcToolLabels/raiIfcToolLabelName",
+            "properties": {
+              "accountScope": {
+                "labelValues": {
+                  "confidentiality": "low"
+                }
+              },
+              "projectScopes": [
+                {
+                  "labelValues": {
+                    "confidentiality": "low"
+                  },
+                  "project": "hualiang-project"
+                },
+                {
+                  "labelValues": {
+                    "confidentiality": "low"
+                  },
+                  "project": "sahana-project"
+                }
+              ],
+              "toolConnectionName": "Web_Search"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListRaiTopics.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListRaiTopics.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "RaiTopics_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListRaiTopics",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "raiTopicName",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiTopics/raiTopicName",
+            "properties": {
+              "description": "This is a sample topic.",
+              "createdAt": "2025-07-01T00:00:00Z",
+              "lastModifiedAt": "2025-07-02T00:00:00Z",
+              "sampleBlobUrl": "https://example.blob.core.windows.net/sampleblob",
+              "status": "Succeeded",
+              "topicId": "00000000-0000-0000-0000-000000000000",
+              "topicName": "raiTopicName"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListSharedCommitmentPlanAssociations.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListSharedCommitmentPlanAssociations.json
@@ -1,0 +1,26 @@
+{
+  "operationId": "CommitmentPlans_ListAssociations",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ListCommitmentPlans",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "accountAssociationName",
+            "type": "Microsoft.CognitiveServices/commitmentPlans/accountAssociations",
+            "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName/accountAssociations/accountAssociationName",
+            "properties": {
+              "accountId": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListSharedCommitmentPlansByResourceGroup.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListSharedCommitmentPlansByResourceGroup.json
@@ -1,0 +1,36 @@
+{
+  "operationId": "CommitmentPlans_ListPlansByResourceGroup",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Commitment Plans by Resource Group",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "commitmentPlanName",
+            "type": "Microsoft.CognitiveServices/commitmentPlans",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+            "kind": "SpeechServices",
+            "location": "West US",
+            "properties": {
+              "autoRenew": true,
+              "current": {
+                "tier": "T1"
+              },
+              "hostingModel": "Web",
+              "planType": "STT",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListSharedCommitmentPlansBySubscription.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListSharedCommitmentPlansBySubscription.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "CommitmentPlans_ListPlansBySubscription",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Accounts by Subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "commitmentPlanName",
+            "type": "Microsoft.CognitiveServices/commitmentPlans",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+            "kind": "SpeechServices",
+            "location": "West US",
+            "properties": {
+              "autoRenew": true,
+              "current": {
+                "tier": "T1"
+              },
+              "hostingModel": "Web",
+              "planType": "STT",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListSkus.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListSkus.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "Accounts_ListSkus",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List SKUs",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "resourceType": "Microsoft.CognitiveServices/accounts",
+            "sku": {
+              "name": "F0",
+              "tier": "Free"
+            }
+          },
+          {
+            "resourceType": "Microsoft.CognitiveServices/accounts",
+            "sku": {
+              "name": "S0",
+              "tier": "Standard"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListUsages.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListUsages.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "Usages_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get Usages",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Cognitive Services total account limit",
+              "value": "AccountCount"
+            },
+            "currentValue": 3,
+            "limit": 200,
+            "unit": "Count",
+            "scopeType": "Regional",
+            "scopeId": "westus"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListUsagesClassicScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListUsagesClassicScope.json
@@ -1,0 +1,27 @@
+{
+  "operationId": "Usages_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get Usages Classic Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Cognitive Services total account limit",
+              "value": "AccountCount"
+            },
+            "currentValue": 2,
+            "limit": 100,
+            "unit": "Count",
+            "scopeType": "Classic"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListUsagesDataZoneScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListUsagesDataZoneScope.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "Usages_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get Usages DataZone Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Cognitive Services total account limit",
+              "value": "AccountCount"
+            },
+            "currentValue": 4,
+            "limit": 300,
+            "unit": "Count",
+            "scopeType": "DataZone",
+            "scopeId": "US"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListUsagesGlobalScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ListUsagesGlobalScope.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "Usages_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get Usages Global Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Cognitive Services total account limit",
+              "value": "AccountCount"
+            },
+            "currentValue": 5,
+            "limit": 500,
+            "unit": "Count",
+            "scopeType": "Global",
+            "scopeId": "Global"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/createOrUpdateManagedNetworkV2.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/createOrUpdateManagedNetworkV2.json
@@ -1,0 +1,59 @@
+{
+  "operationId": "ManagedNetworkSettings_Put",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "body": {
+      "properties": {
+        "managedNetwork": {
+          "firewallSku": "Standard",
+          "isolationMode": "AllowOnlyApprovedOutbound",
+          "outboundRules": {
+            "rule_name_1": {
+              "type": "FQDN",
+              "category": "UserDefined",
+              "destination": "destination_endpoint"
+            }
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Put ManagedNetworkSettings",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/accounts/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "status": "Active"
+              }
+            },
+            "provisioningState": "Succeeded"
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/createOrUpdateRuleV2.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/createOrUpdateRuleV2.json
@@ -1,0 +1,41 @@
+{
+  "operationId": "OutboundRule_CreateOrUpdate",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "body": {
+      "properties": {
+        "type": "FQDN",
+        "category": "UserDefined",
+        "destination": "destination_endpoint",
+        "status": "Active"
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule_name_1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "CreateOrUpdate OutboundRule",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "accounts/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_endpoint",
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/deleteManagedNetworkV2.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/deleteManagedNetworkV2.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "ManagedNetworkSettings_Delete",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete ManagedNetworkSettings",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-03-15-preview",
+        "Retry-After": "10"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/deleteRuleV2.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/deleteRuleV2.json
@@ -1,0 +1,21 @@
+{
+  "operationId": "OutboundRule_Delete",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule-name",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete OutboundRule",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-08-31-preview",
+        "Retry-After": "10"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/getManagedNetworkV2.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/getManagedNetworkV2.json
@@ -1,0 +1,39 @@
+{
+  "operationId": "ManagedNetworkSettings_Get",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get ManagedNetworkSettings",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/accounts/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "status": "Active"
+              }
+            },
+            "provisioningState": "Succeeded"
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/getRuleV2.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/getRuleV2.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "OutboundRule_Get",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "name_of_the_fqdn_rule",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get OutboundRule",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "accounts/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_of_the_fqdn_rule",
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/listManagedNetworkV2.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/listManagedNetworkV2.json
@@ -1,0 +1,43 @@
+{
+  "operationId": "ManagedNetworkSettings_List",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List ManagedNetworkSettings",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.CognitiveServices/accounts/managedNetworks",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default",
+            "properties": {
+              "managedNetwork": {
+                "firewallPublicIpAddress": "22.22.131.49",
+                "firewallSku": "Standard",
+                "isolationMode": "AllowOnlyApprovedOutbound",
+                "networkId": "00000000-1111-2222-3333-444444444444",
+                "outboundRules": {
+                  "rule_name_1": {
+                    "type": "FQDN",
+                    "category": "UserDefined",
+                    "destination": "destination_endpoint",
+                    "status": "Active"
+                  }
+                },
+                "provisioningState": "Succeeded"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/listRuleV2.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/listRuleV2.json
@@ -1,0 +1,44 @@
+{
+  "operationId": "OutboundRule_List",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List OutboundRules",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule_name_1",
+            "type": "accounts/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default/outboundRules/rule_name_1",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "errorInformation": "Error message",
+              "status": "Inactive"
+            }
+          },
+          {
+            "name": "rule_name_2",
+            "type": "accounts/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default/outboundRules/rule_name_2",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "errorInformation": "Error message",
+              "status": "Inactive"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/patchManagedNetworkV2.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/patchManagedNetworkV2.json
@@ -1,0 +1,59 @@
+{
+  "operationId": "ManagedNetworkSettings_Patch",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "body": {
+      "properties": {
+        "managedNetwork": {
+          "firewallSku": "Standard",
+          "isolationMode": "AllowOnlyApprovedOutbound",
+          "outboundRules": {
+            "rule_name_1": {
+              "type": "FQDN",
+              "category": "UserDefined",
+              "destination": "destination_endpoint"
+            }
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Patch ManagedNetworkSettings",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/accounts/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "status": "Active"
+              }
+            },
+            "provisioningState": "Succeeded"
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/postOutboundRulesV2.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/postOutboundRulesV2.json
@@ -1,0 +1,49 @@
+{
+  "operationId": "OutboundRules_Post",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "body": {
+      "properties": {
+        "firewallSku": "Standard",
+        "isolationMode": "AllowOnlyApprovedOutbound",
+        "outboundRules": {
+          "rule_name_1": {
+            "type": "FQDN",
+            "category": "UserDefined",
+            "destination": "destination_endpoint"
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Post OutboundRules",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule_name_1",
+            "type": "accounts/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default/outboundRules/rule_name_1",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "status": "Active"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/provisionManagedNetwork.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ManagedNetwork/provisionManagedNetwork.json
@@ -1,0 +1,24 @@
+{
+  "operationId": "ManagedNetworkProvisions_ProvisionManagedNetwork",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "body": {},
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Provision ManagedNetwork",
+  "responses": {
+    "200": {
+      "body": {
+        "status": "Active"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "location_url_to_poll_for_status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PauseDeployment.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PauseDeployment.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "Deployments_Pause",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PauseDeployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Paused",
+          "model": {
+            "name": "gpt-4",
+            "format": "OpenAI",
+            "version": "0613"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectCapabilityHost/createOrUpdate.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectCapabilityHost/createOrUpdate.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHost": {
+      "properties": {
+        "aiServicesConnections": [
+          "aoai_connection"
+        ],
+        "storageConnections": [
+          "blob_connection"
+        ],
+        "threadStorageConnections": [
+          "aca_connection"
+        ],
+        "vectorStoreConnections": [
+          "acs_connection"
+        ]
+      }
+    },
+    "capabilityHostName": "capabilityHostName",
+    "projectName": "project-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/projects/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "aiServicesConnections": [
+            "aoai_connection"
+          ],
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "blob_connection"
+          ],
+          "threadStorageConnections": [
+            "aca_connection"
+          ],
+          "vectorStoreConnections": [
+            "acs_connection"
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/projects/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "aiServicesConnections": [
+            "aoai_connection"
+          ],
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "blob_connection"
+          ],
+          "threadStorageConnections": [
+            "aca_connection"
+          ],
+          "vectorStoreConnections": [
+            "acs_connection"
+          ]
+        }
+      },
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ProjectCapabilityHosts_CreateOrUpdate",
+  "title": "CreateOrUpdate Project CapabilityHost."
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectCapabilityHost/delete.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectCapabilityHost/delete.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "ProjectCapabilityHosts_Delete",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHostName": "capabilityHostName",
+    "projectName": "project-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Project CapabilityHost.",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "location_header_to_poll"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectCapabilityHost/get.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectCapabilityHost/get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHostName": "capabilityHostName",
+    "projectName": "project-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/projects/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "aiServicesConnections": [
+            "aoai_connection"
+          ],
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "blob_connection"
+          ],
+          "threadStorageConnections": [
+            "aca_connection"
+          ],
+          "vectorStoreConnections": [
+            "acs_connection"
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ProjectCapabilityHosts_Get",
+  "title": "Get Project CapabilityHost."
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectCapabilityHost/list.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectCapabilityHost/list.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "projectName": "project-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "capabilityHostName",
+            "type": "Microsoft.CognitiveServices/accounts/projects/capabilityHosts",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/capabilityHosts/capabilityHostName",
+            "properties": {
+              "aiServicesConnections": [
+                "aoai_connection"
+              ],
+              "provisioningState": "Succeeded",
+              "storageConnections": [
+                "blob_connection"
+              ],
+              "threadStorageConnections": [
+                "aca_connection"
+              ],
+              "vectorStoreConnections": [
+                "acs_connection"
+              ]
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ProjectCapabilityHosts_List",
+  "title": "List Project CapabilityHosts."
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectConnection/create.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectConnection/create.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "ProjectConnections_Create",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connection": {
+      "properties": {
+        "authType": "None",
+        "category": "ContainerRegistry",
+        "expiryTime": "2024-03-15T14:30:00Z",
+        "target": "[target url]"
+      }
+    },
+    "connectionName": "connection-1",
+    "projectName": "project-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "CreateProjectConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "[target url]"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectConnection/delete.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectConnection/delete.json
@@ -1,0 +1,16 @@
+{
+  "operationId": "ProjectConnections_Delete",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connectionName": "connection-1",
+    "projectName": "project-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeleteProjectConnection",
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectConnection/get.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectConnection/get.json
@@ -1,0 +1,27 @@
+{
+  "operationId": "ProjectConnections_Get",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connectionName": "connection-1",
+    "projectName": "project-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetProjectConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "[target url]"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectConnection/list.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectConnection/list.json
@@ -1,0 +1,42 @@
+{
+  "operationId": "ProjectConnections_List",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "category": "ContainerRegistry",
+    "projectName": "project-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "target": "[target url]"
+  },
+  "title": "ListProjectConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "connection-1",
+            "type": "Microsoft.CognitiveServices/accounts/projects/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/connections/connection-1",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "expiryTime": "2024-03-15T14:30:00Z",
+              "target": "[target url]"
+            }
+          },
+          {
+            "name": "connection-2",
+            "type": "Microsoft.CognitiveServices/accounts/projects/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/connections/connection-2",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "target": "[target url]"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectConnection/update.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ProjectConnection/update.json
@@ -1,0 +1,42 @@
+{
+  "operationId": "ProjectConnections_Update",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connection": {
+      "properties": {
+        "authType": "AccessKey",
+        "category": "ADLSGen2",
+        "credentials": {
+          "accessKeyId": "some_string",
+          "secretAccessKey": "some_string"
+        },
+        "expiryTime": "2020-01-01T00:00:00Z",
+        "metadata": {},
+        "target": "some_string"
+      }
+    },
+    "connectionName": "connection-1",
+    "projectName": "project-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "UpdateProjectConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/connections/connection-1",
+        "properties": {
+          "authType": "AccessKey",
+          "category": "ADLSGen2",
+          "expiryTime": "2020-01-01T00:00:00Z",
+          "metadata": {},
+          "target": "some_string"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PurgeDeletedAccount.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PurgeDeletedAccount.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "DeletedAccounts_Purge",
+  "parameters": {
+    "accountName": "PropTest01",
+    "api-version": "2026-08-31-preview",
+    "location": "westus",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Account",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutCommitmentPlan.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutCommitmentPlan.json
@@ -1,0 +1,53 @@
+{
+  "operationId": "CommitmentPlans_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "commitmentPlan": {
+      "properties": {
+        "autoRenew": true,
+        "current": {
+          "tier": "T1"
+        },
+        "hostingModel": "Web",
+        "planType": "Speech2Text"
+      }
+    },
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PutCommitmentPlan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/accounts/commitmentPlans",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/commitmentPlans/commitmentPlanName",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "Speech2Text"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/accounts/commitmentPlans",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/commitmentPlans/commitmentPlanName",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "Speech2Text"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutDefenderForAISetting.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutDefenderForAISetting.json
@@ -1,0 +1,56 @@
+{
+  "operationId": "DefenderForAISettings_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "defenderForAISettingName": "Default",
+    "defenderForAISettings": {
+      "properties": {
+        "state": "Enabled"
+      }
+    },
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutDefenderForAISetting",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default",
+        "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/defenderForAISettings/Default",
+        "properties": {
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2022-04-03T04:41:33.937Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-04-03T04:41:33.937Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "Default",
+        "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/defenderForAISettings/Default",
+        "properties": {
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2022-04-03T04:41:33.937Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-04-03T04:41:33.937Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutDeployment.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutDeployment.json
@@ -1,0 +1,70 @@
+{
+  "operationId": "Deployments_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deployment": {
+      "properties": {
+        "deploymentState": "Running",
+        "model": {
+          "name": "ada",
+          "format": "OpenAI",
+          "version": "1"
+        },
+        "serviceTier": "Priority"
+      },
+      "sku": {
+        "name": "Standard",
+        "capacity": 1
+      }
+    },
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PutDeployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Running",
+          "model": {
+            "name": "ada",
+            "format": "OpenAI",
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "serviceTier": "Priority"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Running",
+          "model": {
+            "name": "ada",
+            "format": "OpenAI",
+            "version": "1"
+          },
+          "provisioningState": "Accepted",
+          "serviceTier": "Priority"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutEncryptionScope.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutEncryptionScope.json
@@ -1,0 +1,79 @@
+{
+  "operationId": "EncryptionScopes_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "encryptionScope": {
+      "properties": {
+        "keySource": "Microsoft.KeyVault",
+        "keyVaultProperties": {
+          "identityClientId": "00000000-0000-0000-0000-000000000000",
+          "keyName": "DevKeyWestUS2",
+          "keyVaultUri": "https://devkvwestus2.vault.azure.net/",
+          "keyVersion": "9f85549d7bf14ff4bf178c10d3bdca95"
+        },
+        "state": "Enabled"
+      }
+    },
+    "encryptionScopeName": "encryptionScopeName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutEncryptionScope",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "encryptionScopeName",
+        "type": "Microsoft.CognitiveServices/accounts/encryptionScopes",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/encryptionScopes/encryptionScopeName",
+        "properties": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": {
+            "identityClientId": "00000000-0000-0000-0000-000000000000",
+            "keyName": "DevKeyWestUS2",
+            "keyVaultUri": "https://devkvwestus2.vault.azure.net/",
+            "keyVersion": "9f85549d7bf14ff4bf178c10d3bdca95"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2023-06-08T06:35:08.0662558Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2023-06-08T06:35:08.0662558Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "encryptionScopeName",
+        "type": "Microsoft.CognitiveServices/accounts/encryptionScopes",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/encryptionScopes/encryptionScopeName",
+        "properties": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": {
+            "identityClientId": "00000000-0000-0000-0000-000000000000",
+            "keyName": "DevKeyWestUS2",
+            "keyVaultUri": "https://devkvwestus2.vault.azure.net/",
+            "keyVersion": "9f85549d7bf14ff4bf178c10d3bdca95"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2023-06-08T06:35:08.0662558Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2023-06-08T06:35:08.0662558Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutPrivateEndpointConnection.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutPrivateEndpointConnection.json
@@ -1,0 +1,56 @@
+{
+  "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-08-31-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "properties": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "Auto-Approved",
+          "status": "Approved"
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PutPrivateEndpointConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.CognitiveServices/accounts/privateEndpointConnections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.CognitiveServices/accounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          }
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.CognitiveServices/accounts/privateEndpointConnections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.CognitiveServices/accounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiBlocklist.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiBlocklist.json
@@ -1,0 +1,36 @@
+{
+  "operationId": "RaiBlocklists_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklist": {
+      "properties": {
+        "description": "Basic blocklist description"
+      }
+    },
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiBlocklist",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "Basic blocklist description"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "raiBlocklistName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "Basic blocklist description"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiBlocklistItem.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiBlocklistItem.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "RaiBlocklistItems_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistItem": {
+      "properties": {
+        "isRegex": false,
+        "pattern": "Pattern To Block"
+      }
+    },
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiBlocklistItem",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiExternalSafetyProvider.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiExternalSafetyProvider.json
@@ -1,0 +1,53 @@
+{
+  "operationId": "RaiExternalSafetyProvider_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "safetyProvider": {
+      "properties": {
+        "keyVaultUri": "https://example.vault.azure.net",
+        "managedIdentity": "00000000-0000-0000-0000-000000000000",
+        "mode": "sync",
+        "providerId": "00000000-0000-0000-0000-000000000000",
+        "providerName": "safetyProviderName",
+        "secretName": "mySecretName",
+        "url": "https://example.webhook.endpoint"
+      }
+    },
+    "safetyProviderName": "safetyProviderName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiExternalSafetyProvider",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "safetyProviderName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/safetyProviderName",
+        "properties": {
+          "createdAt": "2025-07-01T00:00:00Z",
+          "keyVaultUri": "https://example.vault.azure.net",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "managedIdentity": "00000000-0000-0000-0000-000000000000",
+          "mode": "sync",
+          "providerId": "00000000-0000-0000-0000-000000000000",
+          "providerName": "safetyProviderName",
+          "secretName": "mySecretName",
+          "url": "https://example.webhook.endpoint"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "safetyProviderName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/safetyProviderName",
+        "properties": {
+          "createdAt": "2025-07-01T00:00:00Z",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "mode": "sync",
+          "providerId": "00000000-0000-0000-0000-000000000000",
+          "providerName": "safetyProviderName",
+          "url": "https://example.webhook.endpoint"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiPolicy.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiPolicy.json
@@ -1,0 +1,285 @@
+{
+  "operationId": "RaiPolicies_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiPolicy": {
+      "properties": {
+        "basePolicyName": "Microsoft.Default",
+        "contentFilters": [
+          {
+            "name": "Hate",
+            "blocking": false,
+            "enabled": false,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Hate",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Sexual",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Sexual",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Selfharm",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Selfharm",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Violence",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Prompt"
+          },
+          {
+            "name": "Violence",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Jailbreak",
+            "blocking": true,
+            "enabled": true,
+            "source": "Prompt"
+          },
+          {
+            "name": "Protected Material Text",
+            "blocking": true,
+            "enabled": true,
+            "source": "Completion"
+          },
+          {
+            "name": "Protected Material Code",
+            "blocking": true,
+            "enabled": true,
+            "source": "Completion"
+          },
+          {
+            "name": "Profanity",
+            "blocking": true,
+            "enabled": true,
+            "source": "Prompt"
+          }
+        ],
+        "mode": "Asynchronous_filter"
+      }
+    },
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiPolicy",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiToolLabel.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiToolLabel.json
@@ -1,0 +1,95 @@
+{
+  "operationId": "RaiToolLabels_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiToolConnectionName": "Web_Search",
+    "raiToolLabel": {
+      "properties": {
+        "accountScope": {
+          "labelValues": {
+            "confidentiality": "low"
+          }
+        },
+        "projectScopes": [
+          {
+            "labelValues": {
+              "confidentiality": "low"
+            },
+            "project": "test-project"
+          },
+          {
+            "labelValues": {
+              "confidentiality": "low"
+            },
+            "project": "sample-project"
+          }
+        ],
+        "toolConnectionName": "Web_Search"
+      }
+    },
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiToolLabel",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Web_Search",
+        "type": "Microsoft.CognitiveServices/accounts/raiToolLabels",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiToolLabels/Web_Search",
+        "properties": {
+          "accountScope": {
+            "labelValues": {
+              "confidentiality": "low"
+            }
+          },
+          "projectScopes": [
+            {
+              "labelValues": {
+                "confidentiality": "low"
+              },
+              "project": "test-project"
+            },
+            {
+              "labelValues": {
+                "confidentiality": "low"
+              },
+              "project": "sample-project"
+            }
+          ],
+          "toolConnectionName": "Web_Search"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "Web_Search",
+        "type": "Microsoft.CognitiveServices/accounts/raiToolLabels",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiToolLabels/Web_Search",
+        "properties": {
+          "accountScope": {
+            "labelValues": {
+              "confidentiality": "low"
+            }
+          },
+          "projectScopes": [
+            {
+              "labelValues": {
+                "confidentiality": "low"
+              },
+              "project": "test-project"
+            },
+            {
+              "labelValues": {
+                "confidentiality": "low"
+              },
+              "project": "sample-project"
+            }
+          ],
+          "toolConnectionName": "Web_Search"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiTopic.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutRaiTopic.json
@@ -1,0 +1,50 @@
+{
+  "operationId": "RaiTopics_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiTopic": {
+      "properties": {
+        "description": "This is a sample topic.",
+        "sampleBlobUrl": "https://example.blob.core.windows.net/sampleblob",
+        "topicName": "raiTopicName"
+      }
+    },
+    "raiTopicName": "raiTopicName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiTopic",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiTopicName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiTopics/raiTopicName",
+        "properties": {
+          "description": "This is a sample topic.",
+          "createdAt": "2025-07-01T00:00:00Z",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "sampleBlobUrl": "https://example.blob.core.windows.net/sampleblob",
+          "status": "Training",
+          "topicId": "00000000-0000-0000-0000-000000000000",
+          "topicName": "raiTopicName"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "raiTopicName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiTopics/raiTopicName",
+        "properties": {
+          "description": "This is a sample topic.",
+          "createdAt": "2025-07-01T00:00:00Z",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "sampleBlobUrl": "https://example.blob.core.windows.net/sampleblob",
+          "status": "Training",
+          "topicId": "00000000-0000-0000-0000-000000000000",
+          "topicName": "raiTopicName"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutSubscriptionRaiPolicy.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/PutSubscriptionRaiPolicy.json
@@ -1,0 +1,285 @@
+{
+  "operationId": "SubscriptionRaiPolicy_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiPolicy": {
+      "properties": {
+        "basePolicyName": "Microsoft.Default",
+        "contentFilters": [
+          {
+            "name": "Hate",
+            "blocking": false,
+            "enabled": false,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Hate",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Sexual",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Sexual",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Selfharm",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Selfharm",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Violence",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Prompt"
+          },
+          {
+            "name": "Violence",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Jailbreak",
+            "blocking": true,
+            "enabled": true,
+            "source": "Prompt"
+          },
+          {
+            "name": "Protected Material Text",
+            "blocking": true,
+            "enabled": true,
+            "source": "Completion"
+          },
+          {
+            "name": "Protected Material Code",
+            "blocking": true,
+            "enabled": true,
+            "source": "Completion"
+          },
+          {
+            "name": "Profanity",
+            "blocking": true,
+            "enabled": true,
+            "source": "Prompt"
+          }
+        ],
+        "mode": "Asynchronous_filter"
+      }
+    },
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiPolicy",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ReconcileNetworkSecurityPerimeterConfigurations.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ReconcileNetworkSecurityPerimeterConfigurations.json
@@ -1,0 +1,53 @@
+{
+  "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "nspConfigurationName": "NSPConfigurationName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ReconcileNetworkSecurityPerimeterConfigurations",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "networkSecurityPerimeterConfigurationName",
+        "type": "Microsoft.CognitiveServices/accounts/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/networkSecurityPerimeterConfigurations/config1",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Network/networkSecurityPerimeters/perimeter",
+            "location": "East US",
+            "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+          },
+          "profile": {
+            "name": "profileName",
+            "accessRules": [
+              {
+                "name": "ruleName",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8",
+                    "152.4.6.0/24"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": 1
+          },
+          "provisioningState": "Succeeded",
+          "resourceAssociation": {
+            "name": "associationName",
+            "accessMode": "Enforced"
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/RegenerateKey.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/RegenerateKey.json
@@ -1,0 +1,21 @@
+{
+  "operationId": "Accounts_RegenerateKey",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "parameters": {
+      "keyName": "Key2"
+    },
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Regenerate Keys",
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "KEY1",
+        "key2": "KEY2"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ResumeDeployment.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/ResumeDeployment.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "Deployments_Resume",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ResumeDeployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Running",
+          "model": {
+            "name": "gpt-4",
+            "format": "OpenAI",
+            "version": "0613"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/TestRaiExternalSafetyProvider.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/TestRaiExternalSafetyProvider.json
@@ -1,0 +1,62 @@
+{
+  "operationId": "TestRaiExternalSafetyProvider_CreateOrUpdate",
+  "parameters": {
+    "accountName": "myCognitiveAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "safetyProvider": {
+      "properties": {
+        "keyVaultUri": "https://contoso-vault.vault.azure.net/",
+        "managedIdentity": "f3b9c2e7-4aad-4b1f-9d9c-9e9b1e9b1f9b",
+        "mode": "sync",
+        "providerId": "00000000-0000-0000-0000-000000000000",
+        "providerName": "safetyProviderName",
+        "secretName": "safety-provider-secret",
+        "url": "https://example-safety-provider.contoso.com/webhook"
+      }
+    },
+    "safetyProviderName": "mySafetyProvider",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "TestRaiExternalSafetyProvider",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mySafetyProvider",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/mySafetyProvider",
+        "properties": {
+          "keyVaultUri": "https://contoso-vault.vault.azure.net/",
+          "managedIdentity": "f3b9c2e7-4aad-4b1f-9d9c-9e9b1e9b1f9b",
+          "mode": "sync",
+          "providerId": "00000000-0000-0000-0000-000000000000",
+          "providerName": "safetyProviderName",
+          "secretName": "safety-provider-secret",
+          "url": "https://example-safety-provider.contoso.com/webhook"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "mySafetyProvider",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/mySafetyProvider",
+        "properties": {
+          "keyVaultUri": "https://contoso-vault.vault.azure.net/",
+          "managedIdentity": "f3b9c2e7-4aad-4b1f-9d9c-9e9b1e9b1f9b",
+          "mode": "sync",
+          "providerId": "00000000-0000-0000-0000-000000000000",
+          "providerName": "safetyProviderName",
+          "secretName": "safety-provider-secret",
+          "url": "https://example-safety-provider.contoso.com/webhook"
+        }
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "BadRequest",
+          "message": "The request is invalid."
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateAccount.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateAccount.json
@@ -1,0 +1,60 @@
+{
+  "operationId": "Accounts_Update",
+  "parameters": {
+    "account": {
+      "location": "global",
+      "sku": {
+        "name": "S2"
+      }
+    },
+    "accountName": "bingSearch",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "bvttest",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Update Account",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "bingSearch",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A46%3A21.5618831Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch",
+        "kind": "Bing.Search",
+        "location": "global",
+        "properties": {
+          "endpoint": "https://api.cognitive.microsoft.com/bing/v5.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S2"
+        }
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/global/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-06-01",
+        "azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "body": {
+        "name": "bingSearch",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A46%3A21.5618831Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch",
+        "kind": "Bing.Search",
+        "location": "global",
+        "properties": {
+          "endpoint": "https://api.cognitive.microsoft.com/bing/v5.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S2"
+        }
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/global/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-06-01",
+        "azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateAccountWithBudgetPolicyIds.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateAccountWithBudgetPolicyIds.json
@@ -1,0 +1,43 @@
+{
+  "operationId": "Accounts_Update",
+  "parameters": {
+    "account": {
+      "properties": {
+        "budgetPolicyIds": [
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget"
+        ]
+      }
+    },
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Attach a budget policy to an account",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "foundryAccount",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "\"00000000-0000-0000-0000-000000000002\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount",
+        "kind": "AIServices",
+        "location": "eastus",
+        "properties": {
+          "budgetPolicyIds": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget"
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000003?api-version=2026-08-31-preview"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateBudgetPolicy.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateBudgetPolicy.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "BudgetPolicies_Update",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "budgetPolicyName": "monthly-project-budget",
+    "properties": {
+      "properties": {
+        "displayName": "Monthly project budget - updated"
+      }
+    },
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Update selected budget policy properties",
+  "responses": {
+    "200": {
+      "headers": {
+        "ETag": "\"00000000-0000-0000-0000-000000000002\""
+      },
+      "body": {
+        "name": "monthly-project-budget",
+        "type": "Microsoft.CognitiveServices/accounts/budgetPolicies",
+        "etag": "\"00000000-0000-0000-0000-000000000002\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget",
+        "properties": {
+          "displayName": "Monthly project budget - updated",
+          "rules": [
+            {
+              "name": "project-spend",
+              "counterKey": [
+                {
+                  "type": "project"
+                }
+              ],
+              "unit": "usd",
+              "amount": 200,
+              "period": "month",
+              "recurring": true,
+              "match": {
+                "foundry.caller.project.id": [
+                  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+                ]
+              },
+              "thresholds": [
+                {
+                  "type": "percentage",
+                  "value": 80,
+                  "action": "alert"
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2026-08-13T18:00:00Z",
+          "createdBy": "00000000-0000-0000-0000-000000000001",
+          "createdByType": "User",
+          "lastModifiedAt": "2026-08-13T18:30:00Z",
+          "lastModifiedBy": "00000000-0000-0000-0000-000000000001",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateDefenderForAISetting.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateDefenderForAISetting.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "DefenderForAISettings_Update",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "defenderForAISettingName": "Default",
+    "defenderForAISettings": {
+      "properties": {
+        "state": "Enabled"
+      }
+    },
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "UpdateDefenderForAISetting",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default",
+        "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/defenderForAISettings/Default",
+        "properties": {
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2022-04-03T04:41:33.937Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-04-03T04:41:33.937Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateDeployment.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateDeployment.json
@@ -1,0 +1,45 @@
+{
+  "operationId": "Deployments_Update",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deployment": {
+      "sku": {
+        "name": "Standard",
+        "capacity": 1
+      }
+    },
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "UpdateDeployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Paused",
+          "model": {
+            "name": "ada",
+            "format": "OpenAI",
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "serviceTier": "Priority"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateDeploymentWithBudgetPolicyIds.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateDeploymentWithBudgetPolicyIds.json
@@ -1,0 +1,47 @@
+{
+  "operationId": "Deployments_Update",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "deployment": {
+      "properties": {
+        "budgetPolicyIds": [
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget"
+        ]
+      }
+    },
+    "deploymentName": "customer-support-model",
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Attach a budget policy to a deployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "customer-support-model",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/deployments/customer-support-model",
+        "properties": {
+          "budgetPolicyIds": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget"
+          ],
+          "model": {
+            "format": "OpenAI",
+            "name": "gpt-4.1",
+            "version": "2025-04-14"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "capacity": 1,
+          "name": "GlobalStandard"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000004?api-version=2026-08-31-preview"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateProjects.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateProjects.json
@@ -1,0 +1,65 @@
+{
+  "operationId": "Projects_Update",
+  "parameters": {
+    "accountName": "bingSearch",
+    "api-version": "2026-08-31-preview",
+    "project": {
+      "location": "global",
+      "properties": {
+        "description": "new description."
+      }
+    },
+    "projectName": "projectName",
+    "resourceGroupName": "bvttest",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Update Project",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "projectName",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A46%3A21.5618831Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch/projects/projectName",
+        "location": "global",
+        "properties": {
+          "description": "new description.",
+          "displayName": "myProject",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://customSubDomainName.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://customSubDomainName.openai.azure.com/"
+          },
+          "isDefault": false,
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/global/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-06-01",
+        "azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "body": {
+        "name": "projectName",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A46%3A21.5618831Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch/projects/projectName",
+        "location": "global",
+        "properties": {
+          "description": "new description.",
+          "displayName": "myProject",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://customSubDomainName.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://customSubDomainName.openai.azure.com/"
+          },
+          "isDefault": false,
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/global/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-06-01",
+        "azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateQuotaTier.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateQuotaTier.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "QuotaTiers_Update",
+  "parameters": {
+    "default": "default",
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tier": {
+      "properties": {
+        "tierUpgradePolicy": "NoAutoUpgrade"
+      }
+    }
+  },
+  "title": "Update the quota tier resource for a subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/quotaTiers",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/quotaTiers/default",
+        "properties": {
+          "assignmentDate": "2025-06-09T18:13:29.389Z",
+          "currentTierName": "Free-Tier",
+          "tierUpgradePolicy": "NoAutoUpgrade"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateSharedCommitmentPlan.json
+++ b/specification/cognitiveservices/CognitiveServices.Management/examples/2026-08-31-preview/UpdateSharedCommitmentPlan.json
@@ -1,0 +1,46 @@
+{
+  "operationId": "CommitmentPlans_UpdatePlan",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlan": {
+      "tags": {
+        "name": "value"
+      }
+    },
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Commitment Plan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+        "kind": "SpeechServices",
+        "location": "West US",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "STT",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        },
+        "tags": {
+          "name": "value"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/CognitiveServices.Management/main.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/main.tsp
@@ -43,6 +43,7 @@ import "./ManagedComputeUsages.tsp";
 import "./Compute.tsp";
 import "./Workbench.tsp";
 import "./ManagedComputeCapacity.tsp";
+import "./BudgetPolicy.tsp";
 import "./routes.tsp";
 import "./client.tsp";
 
@@ -104,6 +105,12 @@ enum Versions {
    * The 2026-07-01 API version.
    */
   v2026_07_01: "2026-07-01",
+
+  /**
+   * The 2026-08-31-preview API version.
+   */
+  @Azure.Core.previewVersion
+  v2026_08_31_preview: "2026-08-31-preview",
 }
 
 interface Operations extends Azure.ResourceManager.Operations {}

--- a/specification/cognitiveservices/CognitiveServices.Management/models.tsp
+++ b/specification/cognitiveservices/CognitiveServices.Management/models.tsp
@@ -1666,6 +1666,17 @@ model AccountProperties {
    * Specifies the projects, by project name, that are associated with this resource.
    */
   associatedProjects?: string[];
+
+  /**
+   * The full resource IDs of budget policies directly attached to this account.
+   */
+  @added(Versions.v2026_08_31_preview)
+  @maxItems(20)
+  budgetPolicyIds?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.CognitiveServices/accounts/budgetPolicies";
+    }
+  ]>[];
 }
 
 /**
@@ -3170,6 +3181,17 @@ model DeploymentProperties {
    * Routing configuration for the model-router deployment. This property is only applicable when the deployed model is 'model-router' version 2025-11-18 or later. Allows you to select the models subset for routing and the routing mode (balanced, quality, cost) for routing across all supported models or the model subset.
    */
   routing?: DeploymentRouting;
+
+  /**
+   * The full resource IDs of budget policies directly attached to this deployment.
+   */
+  @added(Versions.v2026_08_31_preview)
+  @maxItems(20)
+  budgetPolicyIds?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.CognitiveServices/accounts/budgetPolicies";
+    }
+  ]>[];
 }
 
 /**

--- a/specification/cognitiveservices/CognitiveServices.Management/service.yaml
+++ b/specification/cognitiveservices/CognitiveServices.Management/service.yaml
@@ -95,3 +95,7 @@ versions:
     source: typespec
     swagger-files:
       - ../resource-manager/Microsoft.CognitiveServices/stable/2026-07-01/cognitiveservices.json
+  - version: 2026-08-31-preview
+    source: typespec
+    swagger-files:
+      - ../resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/cognitiveservices.json

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/cognitiveservices.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/cognitiveservices.json
@@ -1,0 +1,18046 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "CognitiveServicesManagementClient",
+    "version": "2026-08-31-preview",
+    "description": "Cognitive Services Management Client",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "CognitiveServicesAccounts"
+    },
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "PrivateLinkResources"
+    },
+    {
+      "name": "TestRaiExternalSafetyProvider"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "Deployments"
+    },
+    {
+      "name": "CommitmentPlans"
+    },
+    {
+      "name": "CognitiveServicesCommitmentPlans"
+    },
+    {
+      "name": "EncryptionScopes"
+    },
+    {
+      "name": "RaiPolicies"
+    },
+    {
+      "name": "SubscriptionRaiPolicy"
+    },
+    {
+      "name": "RaiBlocklists"
+    },
+    {
+      "name": "RaiTopics"
+    },
+    {
+      "name": "RaiExternalSafetyProvider"
+    },
+    {
+      "name": "RaiToolLabels"
+    },
+    {
+      "name": "RaiContentFilters"
+    },
+    {
+      "name": "NetworkSecurityPerimeterConfigurations"
+    },
+    {
+      "name": "DefenderForAISettings"
+    },
+    {
+      "name": "CognitiveServicesProjects"
+    },
+    {
+      "name": "AccountConnectionResource"
+    },
+    {
+      "name": "ProjectConnectionResource"
+    },
+    {
+      "name": "AccountCapabilityHost"
+    },
+    {
+      "name": "ProjectCapabilityHost"
+    },
+    {
+      "name": "QuotaTier"
+    },
+    {
+      "name": "ManagedNetwork"
+    },
+    {
+      "name": "AgentApplication"
+    },
+    {
+      "name": "AgentDeployment"
+    },
+    {
+      "name": "BudgetPolicies"
+    },
+    {
+      "name": "Skus"
+    },
+    {
+      "name": "Usages"
+    },
+    {
+      "name": "CommitmentTiers"
+    },
+    {
+      "name": "Models"
+    },
+    {
+      "name": "ModelCapacities"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.CognitiveServices/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "Lists all the available Cognitive Services account operations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Operations": {
+            "$ref": "./examples/GetOperations.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/accounts": {
+      "get": {
+        "operationId": "Accounts_List",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AccountListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Accounts by Subscription": {
+            "$ref": "./examples/ListAccountsBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/calculateModelCapacity": {
+      "post": {
+        "operationId": "calculateModelCapacity",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Model capacity calculator.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CalculateModelCapacityParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CalculateModelCapacityResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Calculate Model Capacity": {
+            "$ref": "./examples/CalculateModelCapacity.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/checkDomainAvailability": {
+      "post": {
+        "operationId": "CheckDomainAvailability",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Check whether a domain is available.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckDomainAvailabilityParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DomainAvailability"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Check SKU Availability": {
+            "$ref": "./examples/CheckDomainAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/commitmentPlans": {
+      "get": {
+        "operationId": "CommitmentPlans_ListPlansBySubscription",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Accounts by Subscription": {
+            "$ref": "./examples/ListSharedCommitmentPlansBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/deletedAccounts": {
+      "get": {
+        "operationId": "DeletedAccounts_List",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AccountListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Deleted Accounts by Subscription": {
+            "$ref": "./examples/ListDeletedAccountsBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/checkSkuAvailability": {
+      "post": {
+        "operationId": "CheckSkuAvailability",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Check available SKUs.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The request body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CheckSkuAvailabilityParameter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/SkuAvailabilityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Check SKU Availability": {
+            "$ref": "./examples/CheckSkuAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/commitmentTiers": {
+      "get": {
+        "operationId": "CommitmentTiers_List",
+        "tags": [
+          "CommitmentTiers"
+        ],
+        "description": "List Commitment Tiers.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentTierListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListCommitmentTiers": {
+            "$ref": "./examples/ListCommitmentTiers.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/modelCapacities": {
+      "get": {
+        "operationId": "LocationBasedModelCapacities_List",
+        "tags": [
+          "ModelCapacities"
+        ],
+        "description": "List Location Based ModelCapacities.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "modelFormat",
+            "in": "query",
+            "description": "The format of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "modelName",
+            "in": "query",
+            "description": "The name of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "modelVersion",
+            "in": "query",
+            "description": "The version of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ModelCapacityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListLocationBasedModelCapacities": {
+            "$ref": "./examples/ListLocationBasedModelCapacities.json"
+          },
+          "ListLocationBasedModelCapacities Classic Scope": {
+            "$ref": "./examples/ListLocationBasedModelCapacitiesClassicScope.json"
+          },
+          "ListLocationBasedModelCapacities DataZone Scope": {
+            "$ref": "./examples/ListLocationBasedModelCapacitiesDataZoneScope.json"
+          },
+          "ListLocationBasedModelCapacities Global Scope": {
+            "$ref": "./examples/ListLocationBasedModelCapacitiesGlobalScope.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/models": {
+      "get": {
+        "operationId": "Models_List",
+        "tags": [
+          "Models"
+        ],
+        "description": "List Models.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ModelListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListLocationModels": {
+            "$ref": "./examples/ListLocationModels.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/raiContentFilters": {
+      "get": {
+        "operationId": "RaiContentFilters_List",
+        "tags": [
+          "RaiContentFilters"
+        ],
+        "description": "List Content Filters types.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RaiContentFilterListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListRaiContentFilters": {
+            "$ref": "./examples/ListRaiContentFilters.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/raiContentFilters/{filterName}": {
+      "get": {
+        "operationId": "RaiContentFilters_Get",
+        "tags": [
+          "RaiContentFilters"
+        ],
+        "description": "Get Content Filters by Name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "filterName",
+            "in": "path",
+            "description": "The name of the RAI Content Filter.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiContentFilter"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetRaiContentFilters": {
+            "$ref": "./examples/GetRaiContentFilter.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/resourceGroups/{resourceGroupName}/deletedAccounts/{accountName}": {
+      "get": {
+        "operationId": "DeletedAccounts_Get",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Returns a Cognitive Services account specified by the parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Account": {
+            "$ref": "./examples/GetDeletedAccount.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DeletedAccounts_Purge",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Deletes a Cognitive Services account from the resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Account": {
+            "$ref": "./examples/PurgeDeletedAccount.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/locations/{location}/usages": {
+      "get": {
+        "operationId": "Usages_List",
+        "tags": [
+          "Usages"
+        ],
+        "description": "Get usages for the requested subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/LocationParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "An OData filter expression that describes a subset of usages to return. The supported parameter is name.value (name of the metric, can have an or of multiple names).",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/UsageListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Usages": {
+            "$ref": "./examples/ListUsages.json"
+          },
+          "Get Usages Classic Scope": {
+            "$ref": "./examples/ListUsagesClassicScope.json"
+          },
+          "Get Usages DataZone Scope": {
+            "$ref": "./examples/ListUsagesDataZoneScope.json"
+          },
+          "Get Usages Global Scope": {
+            "$ref": "./examples/ListUsagesGlobalScope.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/modelCapacities": {
+      "get": {
+        "operationId": "ModelCapacities_List",
+        "tags": [
+          "ModelCapacities"
+        ],
+        "description": "List ModelCapacities.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "modelFormat",
+            "in": "query",
+            "description": "The format of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "modelName",
+            "in": "query",
+            "description": "The name of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "modelVersion",
+            "in": "query",
+            "description": "The version of the Model",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ModelCapacityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListModelCapacities": {
+            "$ref": "./examples/ListModelCapacities.json"
+          },
+          "ListModelCapacities Classic Scope": {
+            "$ref": "./examples/ListModelCapacitiesClassicScope.json"
+          },
+          "ListModelCapacities DataZone Scope": {
+            "$ref": "./examples/ListModelCapacitiesDataZoneScope.json"
+          },
+          "ListModelCapacities Global Scope": {
+            "$ref": "./examples/ListModelCapacitiesGlobalScope.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/quotaTiers": {
+      "get": {
+        "operationId": "QuotaTiers_ListBySubscription",
+        "tags": [
+          "QuotaTier"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/QuotaTierListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List the Quota Tier for a subscription": {
+            "$ref": "./examples/ListQuotaTiers.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/quotaTiers/{default}": {
+      "get": {
+        "operationId": "QuotaTiers_Get",
+        "tags": [
+          "QuotaTier"
+        ],
+        "summary": "Gets the Quota Tier for a subscription",
+        "description": "Gets the Quota Tier information for the given subscription. QuotaTiers is a subscription wide resource type. It holds current tier information.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "default",
+            "in": "path",
+            "description": "Default parameter. Leave the value as default.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get the Quota Tier information for a subscription": {
+            "$ref": "./examples/GetQuotaTier.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "QuotaTiers_CreateOrUpdate",
+        "tags": [
+          "QuotaTier"
+        ],
+        "summary": "Updates the Quota Tier resource for a subscription.",
+        "description": "Update the Quota Tier information for the given subscription. QuotaTiers is a subscription wide resource type. It holds current tier information.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "default",
+            "in": "path",
+            "description": "Default parameter. Leave the value as default.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "tier",
+            "in": "body",
+            "description": "The parameters to provide for the quota tier resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'QuotaTier' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          },
+          "201": {
+            "description": "Resource 'QuotaTier' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update the quota tier resource for a subscription": {
+            "$ref": "./examples/CreateOrUpdateQuotaTier.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "QuotaTiers_Update",
+        "tags": [
+          "QuotaTier"
+        ],
+        "summary": "Updates the Quota Tier resource for a subscription. The only properties that can be updated are  \"tierUpgradePolicy\"",
+        "description": "Update the Quota Tier information for the given subscription. QuotaTiers is a subscription wide resource type. It holds current tier information.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "default",
+            "in": "path",
+            "description": "Default parameter. Leave the value as default.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "tier",
+            "in": "body",
+            "description": "The parameters to provide for the quota tier resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/QuotaTier"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update the quota tier resource for a subscription": {
+            "$ref": "./examples/UpdateQuotaTier.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders": {
+      "get": {
+        "operationId": "RaiExternalSafetyProviders_List",
+        "tags": [
+          "RaiExternalSafetyProvider"
+        ],
+        "description": "Gets the safety providers associated with the subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListRaiExternalSafetyProviders": {
+            "$ref": "./examples/ListRaiExternalSafetyProviders.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/{safetyProviderName}": {
+      "get": {
+        "operationId": "RaiExternalSafetyProvider_Get",
+        "tags": [
+          "RaiExternalSafetyProvider"
+        ],
+        "description": "Gets the specified external safety provider associated with the Subscription",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "safetyProviderName",
+            "in": "path",
+            "description": "The name of the Rai External Safety Provider associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetRaiExternalSafetyProvider": {
+            "$ref": "./examples/GetRaiExternalSafetyProvider.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiExternalSafetyProvider_CreateOrUpdate",
+        "tags": [
+          "RaiExternalSafetyProvider"
+        ],
+        "description": "Create the rai safety provider associated with the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "safetyProviderName",
+            "in": "path",
+            "description": "The name of the Rai External Safety Provider associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "safetyProvider",
+            "in": "body",
+            "description": "Properties describing the rai external safety provider.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiExternalSafetyProviderSchema' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiExternalSafetyProviderSchema' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutRaiExternalSafetyProvider": {
+            "$ref": "./examples/PutRaiExternalSafetyProvider.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiExternalSafetyProvider_Delete",
+        "tags": [
+          "RaiExternalSafetyProvider"
+        ],
+        "description": "Deletes the specified custom topic associated with the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "safetyProviderName",
+            "in": "path",
+            "description": "The name of the Rai External Safety Provider associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteRaiTopic": {
+            "$ref": "./examples/DeleteRaiExternalSafetyProvider.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/raiPolicy/{raiPolicyName}": {
+      "get": {
+        "operationId": "SubscriptionRaiPolicy_Get",
+        "tags": [
+          "SubscriptionRaiPolicy"
+        ],
+        "description": "Gets the specified Content Filters associated with the Subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetRaiPolicy": {
+            "$ref": "./examples/GetSubscriptionRaiPolicy.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "SubscriptionRaiPolicy_CreateOrUpdate",
+        "tags": [
+          "SubscriptionRaiPolicy"
+        ],
+        "description": "Update the state of specified Content Filters associated with the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiPolicy",
+            "in": "body",
+            "description": "Properties describing the Content Filters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutRaiPolicy": {
+            "$ref": "./examples/PutSubscriptionRaiPolicy.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "SubscriptionRaiPolicy_Delete",
+        "tags": [
+          "SubscriptionRaiPolicy"
+        ],
+        "description": "Deletes the specified Content Filters associated with the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteRaiPolicy": {
+            "$ref": "./examples/DeleteSubscriptionRaiPolicy.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CognitiveServices/skus": {
+      "get": {
+        "operationId": "ResourceSkus_List",
+        "tags": [
+          "Skus",
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Gets the list of Microsoft.CognitiveServices SKUs available for your Subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ResourceSkuListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Regenerate Keys": {
+            "$ref": "./examples/GetSkus.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts": {
+      "get": {
+        "operationId": "Accounts_ListByResourceGroup",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AccountListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Accounts by Resource Group": {
+            "$ref": "./examples/ListAccountsByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}": {
+      "get": {
+        "operationId": "Accounts_Get",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Returns a Cognitive Services account specified by the parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Account": {
+            "$ref": "./examples/GetAccount.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Accounts_Create",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Create Cognitive Services Account. Accounts is a resource group wide resource type. It holds the keys for developer to access intelligent APIs. It's also the resource type for billing.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "account",
+            "in": "body",
+            "description": "The parameters to provide for the created account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Account' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "201": {
+            "description": "Resource 'Account' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create Account": {
+            "$ref": "./examples/CreateAccount.json"
+          },
+          "Create Account Min": {
+            "$ref": "./examples/CreateAccountMin.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Account"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Accounts_Update",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Updates a Cognitive Services account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "account",
+            "in": "body",
+            "description": "The parameters to provide for the created account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/Account"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Attach a budget policy to an account": {
+            "$ref": "./examples/UpdateAccountWithBudgetPolicyIds.json"
+          },
+          "Update Account": {
+            "$ref": "./examples/UpdateAccount.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Account"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Accounts_Delete",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Deletes a Cognitive Services account from the resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Account": {
+            "$ref": "./examples/DeleteAccount.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/budgetPolicies": {
+      "get": {
+        "operationId": "BudgetPolicies_List",
+        "tags": [
+          "BudgetPolicies"
+        ],
+        "description": "Lists the budget policies owned by an account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/BudgetPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List budget policies": {
+            "$ref": "./examples/ListBudgetPolicies.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/budgetPolicies/{budgetPolicyName}": {
+      "get": {
+        "operationId": "BudgetPolicies_Get",
+        "tags": [
+          "BudgetPolicies"
+        ],
+        "description": "Gets a budget policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "budgetPolicyName",
+            "in": "path",
+            "description": "The name of the BudgetPolicy",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/BudgetPolicy"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The current entity tag for the budget policy."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a budget policy": {
+            "$ref": "./examples/GetBudgetPolicy.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "BudgetPolicies_CreateOrUpdate",
+        "tags": [
+          "BudgetPolicies"
+        ],
+        "description": "Creates or replaces a budget policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "budgetPolicyName",
+            "in": "path",
+            "description": "The name of the BudgetPolicy",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$"
+          },
+          {
+            "$ref": "#/parameters/BudgetPolicyCreateOrUpdateHeaders.ifMatch"
+          },
+          {
+            "$ref": "#/parameters/BudgetPolicyCreateOrUpdateHeaders.ifNoneMatch"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BudgetPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/BudgetPolicy"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The current entity tag for the budget policy."
+              }
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/BudgetPolicy"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The current entity tag for the budget policy."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or replace a budget policy": {
+            "$ref": "./examples/CreateOrUpdateBudgetPolicy.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "BudgetPolicies_Update",
+        "tags": [
+          "BudgetPolicies"
+        ],
+        "description": "Updates selected properties of a budget policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "budgetPolicyName",
+            "in": "path",
+            "description": "The name of the BudgetPolicy",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$"
+          },
+          {
+            "$ref": "#/parameters/BudgetPolicyIfMatchHeader"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BudgetPolicyPatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/BudgetPolicy"
+            },
+            "headers": {
+              "ETag": {
+                "type": "string",
+                "description": "The current entity tag for the budget policy."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update selected budget policy properties": {
+            "$ref": "./examples/UpdateBudgetPolicy.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "BudgetPolicies_Delete",
+        "tags": [
+          "BudgetPolicies"
+        ],
+        "description": "Deletes a budget policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "budgetPolicyName",
+            "in": "path",
+            "description": "The name of the BudgetPolicy",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$"
+          },
+          {
+            "$ref": "#/parameters/BudgetPolicyIfMatchHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a budget policy": {
+            "$ref": "./examples/DeleteBudgetPolicy.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/capabilityHosts": {
+      "get": {
+        "operationId": "AccountCapabilityHosts_List",
+        "tags": [
+          "AccountCapabilityHost"
+        ],
+        "summary": "List capabilityHost.",
+        "description": "List capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CapabilityHostResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Account CapabilityHosts.": {
+            "$ref": "./examples/AccountCapabilityHost/list.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/capabilityHosts/{capabilityHostName}": {
+      "get": {
+        "operationId": "AccountCapabilityHosts_Get",
+        "tags": [
+          "AccountCapabilityHost"
+        ],
+        "summary": "Get account capabilityHost.",
+        "description": "Get account capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CapabilityHost"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Account CapabilityHost.": {
+            "$ref": "./examples/AccountCapabilityHost/get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AccountCapabilityHosts_CreateOrUpdate",
+        "tags": [
+          "AccountCapabilityHost"
+        ],
+        "summary": "Create or update account capabilityHost.",
+        "description": "Create or update account capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          },
+          {
+            "name": "capabilityHost",
+            "in": "body",
+            "description": "CapabilityHost definition.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CapabilityHost"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CapabilityHost"
+            }
+          },
+          "201": {
+            "description": "Resource 'CapabilityHost' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CapabilityHost"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Account CapabilityHost.": {
+            "$ref": "./examples/AccountCapabilityHost/createOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "original-uri",
+          "final-state-schema": "#/definitions/CapabilityHost"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AccountCapabilityHosts_Delete",
+        "tags": [
+          "AccountCapabilityHost"
+        ],
+        "summary": "Delete account capabilityHost.",
+        "description": "Delete account capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Account CapabilityHost.": {
+            "$ref": "./examples/AccountCapabilityHost/delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/commitmentPlans": {
+      "get": {
+        "operationId": "CommitmentPlans_List",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Gets the commitmentPlans associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListCommitmentPlans": {
+            "$ref": "./examples/ListCommitmentPlans.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/commitmentPlans/{commitmentPlanName}": {
+      "get": {
+        "operationId": "CommitmentPlans_Get",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Gets the specified commitmentPlans associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetCommitmentPlan": {
+            "$ref": "./examples/GetCommitmentPlan.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "CommitmentPlans_CreateOrUpdate",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Update the state of specified commitmentPlans associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "commitmentPlan",
+            "in": "body",
+            "description": "The commitmentPlan properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CommitmentPlan' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "201": {
+            "description": "Resource 'CommitmentPlan' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutCommitmentPlan": {
+            "$ref": "./examples/PutCommitmentPlan.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "CommitmentPlans_Delete",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Deletes the specified commitmentPlan associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteCommitmentPlan": {
+            "$ref": "./examples/DeleteCommitmentPlan.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/connections": {
+      "get": {
+        "operationId": "AccountConnections_List",
+        "tags": [
+          "AccountConnectionResource"
+        ],
+        "summary": "Lists all the available  Cognitive Services account connections under the specified account.",
+        "description": "Lists all the available  Cognitive Services account connections under the specified account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "description": "Target of the connection.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "description": "Category of the connection.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "includeAll",
+            "in": "query",
+            "description": "query parameter that indicates if get connection call should return both connections and datastores",
+            "required": false,
+            "type": "boolean",
+            "default": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListAccountConnections": {
+            "$ref": "./examples/AccountConnection/list.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/connections/{connectionName}": {
+      "get": {
+        "operationId": "AccountConnections_Get",
+        "tags": [
+          "AccountConnectionResource"
+        ],
+        "summary": "Lists Cognitive Services account connection by name.",
+        "description": "Lists Cognitive Services account connection by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetAccountConnection": {
+            "$ref": "./examples/AccountConnection/get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AccountConnections_Create",
+        "tags": [
+          "AccountConnectionResource"
+        ],
+        "summary": "Create or update Cognitive Services account connection under the specified account.",
+        "description": "Create or update Cognitive Services account connection under the specified account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "connection",
+            "in": "body",
+            "description": "The object for creating or updating a new account connection",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectionPropertiesV2BasicResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateAccountConnection": {
+            "$ref": "./examples/AccountConnection/create.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "AccountConnections_Update",
+        "tags": [
+          "AccountConnectionResource"
+        ],
+        "summary": "Update Cognitive Services account connection under the specified account.",
+        "description": "Update Cognitive Services account connection under the specified account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "connection",
+            "in": "body",
+            "description": "Parameters for account connection update.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ConnectionUpdateContent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateAccountConnection": {
+            "$ref": "./examples/AccountConnection/update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "AccountConnections_Delete",
+        "tags": [
+          "AccountConnectionResource"
+        ],
+        "summary": "Delete Cognitive Services account connection by name.",
+        "description": "Delete Cognitive Services account connection by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteAccountConnection": {
+            "$ref": "./examples/AccountConnection/delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/defenderForAISettings": {
+      "get": {
+        "operationId": "DefenderForAISettings_List",
+        "tags": [
+          "DefenderForAISettings"
+        ],
+        "description": "Lists the Defender for AI settings.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISettingResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListDefenderForAISetting": {
+            "$ref": "./examples/ListDefenderForAISetting.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/defenderForAISettings/{defenderForAISettingName}": {
+      "get": {
+        "operationId": "DefenderForAISettings_Get",
+        "tags": [
+          "DefenderForAISettings"
+        ],
+        "description": "Gets the specified Defender for AI setting by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "defenderForAISettingName",
+            "in": "path",
+            "description": "The name of the defender for AI setting.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetDefenderForAISetting": {
+            "$ref": "./examples/GetDefenderForAISetting.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DefenderForAISettings_CreateOrUpdate",
+        "tags": [
+          "DefenderForAISettings"
+        ],
+        "description": "Creates or Updates the specified Defender for AI setting.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "defenderForAISettingName",
+            "in": "path",
+            "description": "The name of the defender for AI setting.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "defenderForAISettings",
+            "in": "body",
+            "description": "Properties describing the Defender for AI setting.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DefenderForAISetting' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          },
+          "201": {
+            "description": "Resource 'DefenderForAISetting' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutDefenderForAISetting": {
+            "$ref": "./examples/PutDefenderForAISetting.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "DefenderForAISettings_Update",
+        "tags": [
+          "DefenderForAISettings"
+        ],
+        "description": "Updates the specified Defender for AI setting.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "defenderForAISettingName",
+            "in": "path",
+            "description": "The name of the defender for AI setting.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "defenderForAISettings",
+            "in": "body",
+            "description": "Properties describing the Defender for AI setting.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DefenderForAISetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateDefenderForAISetting": {
+            "$ref": "./examples/UpdateDefenderForAISetting.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments": {
+      "get": {
+        "operationId": "Deployments_List",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Gets the deployments associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/DeploymentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListDeployments": {
+            "$ref": "./examples/ListDeployments.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}": {
+      "get": {
+        "operationId": "Deployments_Get",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Gets the specified deployments associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetDeployment": {
+            "$ref": "./examples/GetDeployment.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Deployments_CreateOrUpdate",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Update the state of specified deployments associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deployment",
+            "in": "body",
+            "description": "The deployment properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Deployment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "201": {
+            "description": "Resource 'Deployment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutDeployment": {
+            "$ref": "./examples/PutDeployment.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Deployment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Deployments_Update",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Update specified deployments associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "deployment",
+            "in": "body",
+            "description": "The deployment properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PatchResourceTagsAndSku"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Attach a budget policy to a deployment": {
+            "$ref": "./examples/UpdateDeploymentWithBudgetPolicyIds.json"
+          },
+          "UpdateDeployment": {
+            "$ref": "./examples/UpdateDeployment.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Deployment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Deployments_Delete",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Deletes the specified deployment associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteDeployment": {
+            "$ref": "./examples/DeleteDeployment.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}/pause": {
+      "post": {
+        "operationId": "Deployments_Pause",
+        "tags": [
+          "Deployments"
+        ],
+        "summary": "Pause a deployment",
+        "description": "Pauses inferencing on a deployment by setting the deploymentState to 'Paused' (see #/definitions/DeploymentProperties/properties/deploymentState). Only Standard, DataZoneStandard, and GlobalStandard SKUs support this operation. Inference requests to the paused deployment endpoint will receive HTTP 423 (Locked). This operation is idempotent.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PauseDeployment": {
+            "$ref": "./examples/PauseDeployment.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}/resume": {
+      "post": {
+        "operationId": "Deployments_Resume",
+        "tags": [
+          "Deployments"
+        ],
+        "summary": "Resume a deployment",
+        "description": "Resumes inferencing on a previously paused deployment by setting the deploymentState to 'Running' (see #/definitions/DeploymentProperties/properties/deploymentState). This operation is idempotent and can be safely called on already running deployments.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Deployment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ResumeDeployment": {
+            "$ref": "./examples/ResumeDeployment.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/deployments/{deploymentName}/skus": {
+      "get": {
+        "operationId": "Deployments_ListSkus",
+        "tags": [
+          "Deployments"
+        ],
+        "description": "Lists the specified deployments skus associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DeploymentSkuListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListDeploymentSkus": {
+            "$ref": "./examples/ListDeploymentSkus.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/encryptionScopes": {
+      "get": {
+        "operationId": "EncryptionScopes_List",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Gets the content filters associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScopeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListEncryptionScopes": {
+            "$ref": "./examples/ListEncryptionScopes.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/encryptionScopes/{encryptionScopeName}": {
+      "get": {
+        "operationId": "EncryptionScopes_Get",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Gets the specified EncryptionScope associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "encryptionScopeName",
+            "in": "path",
+            "description": "The name of the encryptionScope associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetEncryptionScope": {
+            "$ref": "./examples/GetEncryptionScope.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "EncryptionScopes_CreateOrUpdate",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Update the state of specified encryptionScope associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "encryptionScopeName",
+            "in": "path",
+            "description": "The name of the encryptionScope associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "encryptionScope",
+            "in": "body",
+            "description": "The encryptionScope properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'EncryptionScope' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          },
+          "201": {
+            "description": "Resource 'EncryptionScope' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/EncryptionScope"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutEncryptionScope": {
+            "$ref": "./examples/PutEncryptionScope.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "EncryptionScopes_Delete",
+        "tags": [
+          "EncryptionScopes"
+        ],
+        "description": "Deletes the specified encryptionScope associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "encryptionScopeName",
+            "in": "path",
+            "description": "The name of the encryptionScope associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteEncryptionScope": {
+            "$ref": "./examples/DeleteEncryptionScope.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/listKeys": {
+      "post": {
+        "operationId": "Accounts_ListKeys",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Lists the account keys for the specified Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApiKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Keys": {
+            "$ref": "./examples/ListKeys.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks": {
+      "get": {
+        "operationId": "ManagedNetworkSettings_List",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "List API for managed network settings of a cognitive services account.",
+        "description": "List API for managed network settings of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List ManagedNetworkSettings": {
+            "$ref": "./examples/ManagedNetwork/listManagedNetworkV2.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}": {
+      "get": {
+        "operationId": "ManagedNetworkSettings_Get",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "Get API for managed network settings of a cognitive services account.",
+        "description": "Get API for managed network settings of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get ManagedNetworkSettings": {
+            "$ref": "./examples/ManagedNetwork/getManagedNetworkV2.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ManagedNetworkSettings_Put",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "PUT API for managed network settings of a cognitive services account.",
+        "description": "PUT API for managed network settings of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The Managed Network Settings object of the account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ManagedNetworkSettingsPropertiesBasicResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Put ManagedNetworkSettings": {
+            "$ref": "./examples/ManagedNetwork/createOrUpdateManagedNetworkV2.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ManagedNetworkSettings_Patch",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "Patch API for managed network settings of a cognitive services account.",
+        "description": "Patch API for managed network settings of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The Managed Network Settings object of the account.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch ManagedNetworkSettings": {
+            "$ref": "./examples/ManagedNetwork/patchManagedNetworkV2.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ManagedNetworkSettings_Delete",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "Delete API for managed network settings of a cognitive services account.",
+        "description": "Delete API for managed network settings of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete ManagedNetworkSettings": {
+            "$ref": "./examples/ManagedNetwork/deleteManagedNetworkV2.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/batchOutboundRules": {
+      "post": {
+        "operationId": "OutboundRules_Post",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "The POST API for updating the outbound rules of the managed network associated with the cognitive services account.",
+        "description": "The POST API for updating the outbound rules of the managed network associated with the cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The Managed Network Settings object of the account.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkSettingsBasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OutboundRuleListResult"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Post OutboundRules": {
+            "$ref": "./examples/ManagedNetwork/postOutboundRulesV2.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/OutboundRuleListResult"
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/outboundRules": {
+      "get": {
+        "operationId": "OutboundRule_List",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "The GET API for retrieving the list of outbound rules of the managed network associated with the cognitive services account.",
+        "description": "The GET API for retrieving the list of outbound rules of the managed network associated with the cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/OutboundRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List OutboundRules": {
+            "$ref": "./examples/ManagedNetwork/listRuleV2.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/outboundRules/{ruleName}": {
+      "get": {
+        "operationId": "OutboundRule_Get",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "The GET API for retrieving a single outbound rule of the managed network associated with the cognitive services account.",
+        "description": "The GET API for retrieving a single outbound rule of the managed network associated with the cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "Name of the cognitive services account managed network outbound rule",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/OutboundRuleBasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get OutboundRule": {
+            "$ref": "./examples/ManagedNetwork/getRuleV2.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "OutboundRule_CreateOrUpdate",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "The PUT API for creating or updating a single outbound rule of the managed network associated with the cognitive services account.",
+        "description": "The PUT API for creating or updating a single outbound rule of the managed network associated with the cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "Name of the cognitive services account managed network outbound rule",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/OutboundRuleBasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'OutboundRuleBasicResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/OutboundRuleBasicResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate OutboundRule": {
+            "$ref": "./examples/ManagedNetwork/createOrUpdateRuleV2.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/OutboundRuleBasicResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "OutboundRule_Delete",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "The DELETE API for deleting a single outbound rule of the managed network associated with the cognitive services account.",
+        "description": "The DELETE API for deleting a single outbound rule of the managed network associated with the cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "ruleName",
+            "in": "path",
+            "description": "Name of the cognitive services account managed network outbound rule",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete OutboundRule": {
+            "$ref": "./examples/ManagedNetwork/deleteRuleV2.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/provision": {
+      "post": {
+        "operationId": "ManagedNetworkProvisions_ProvisionManagedNetwork",
+        "tags": [
+          "ManagedNetwork"
+        ],
+        "summary": "Provisions the managed network of a cognitive services account.",
+        "description": "Provisions the managed network of a cognitive services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "managedNetworkName",
+            "in": "path",
+            "description": "Name of the managedNetwork associated with the cognitive services account. Only 'default' is supported.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Managed Network Provisioning Options for a cognitive services account.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkProvisionOptions"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedNetworkProvisionStatus"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Provision ManagedNetwork": {
+            "$ref": "./examples/ManagedNetwork/provisionManagedNetwork.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ManagedNetworkProvisionStatus"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/models": {
+      "get": {
+        "operationId": "Accounts_ListModels",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "List available Models for the requested Cognitive Services account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccountModelListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List AccountModels": {
+            "$ref": "./examples/ListAccountModels.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/networkSecurityPerimeterConfigurations": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_List",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Gets a list of NSP configurations for an account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationList"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListNetworkSecurityPerimeterConfigurations": {
+            "$ref": "./examples/ListNetworkSecurityPerimeterConfigurations.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/networkSecurityPerimeterConfigurations/{nspConfigurationName}": {
+      "get": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Gets the specified NSP configurations for an account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "nspConfigurationName",
+            "in": "path",
+            "description": "The name of the NSP Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^.*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetNetworkSecurityPerimeterConfigurations": {
+            "$ref": "./examples/GetNetworkSecurityPerimeterConfigurations.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/networkSecurityPerimeterConfigurations/{nspConfigurationName}/reconcile": {
+      "post": {
+        "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+        "tags": [
+          "NetworkSecurityPerimeterConfigurations"
+        ],
+        "description": "Reconcile the NSP configuration for an account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "nspConfigurationName",
+            "in": "path",
+            "description": "The name of the NSP Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^.*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ReconcileNetworkSecurityPerimeterConfigurations": {
+            "$ref": "./examples/ReconcileNetworkSecurityPerimeterConfigurations.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/NetworkSecurityPerimeterConfiguration"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_List",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets the private endpoint connections associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetPrivateEndpointConnection": {
+            "$ref": "./examples/ListPrivateEndpointConnections.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "PrivateEndpointConnections_Get",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Gets the specified private endpoint connection associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetPrivateEndpointConnection": {
+            "$ref": "./examples/GetPrivateEndpointConnection.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Update the state of specified private endpoint connection associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The private endpoint connection properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutPrivateEndpointConnection": {
+            "$ref": "./examples/PutPrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PrivateEndpointConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "PrivateEndpointConnections_Delete",
+        "tags": [
+          "PrivateEndpointConnections"
+        ],
+        "description": "Deletes the specified private endpoint connection associated with the Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "The name of the private endpoint connection associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeletePrivateEndpointConnection": {
+            "$ref": "./examples/DeletePrivateEndpointConnection.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/privateLinkResources": {
+      "get": {
+        "operationId": "PrivateLinkResources_List",
+        "tags": [
+          "PrivateLinkResources"
+        ],
+        "description": "Gets the private link resources that need to be created for a Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListPrivateLinkResources": {
+            "$ref": "./examples/ListPrivateLinkResources.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects": {
+      "get": {
+        "operationId": "Projects_List",
+        "tags": [
+          "CognitiveServicesProjects"
+        ],
+        "description": "Returns all the projects in a Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ProjectListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Project": {
+            "$ref": "./examples/ListProjects.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}": {
+      "get": {
+        "operationId": "Projects_Get",
+        "tags": [
+          "CognitiveServicesProjects"
+        ],
+        "description": "Returns a Cognitive Services project specified by the parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Project": {
+            "$ref": "./examples/GetProject.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Projects_Create",
+        "tags": [
+          "CognitiveServicesProjects"
+        ],
+        "description": "Create Cognitive Services Account's Project. Project is a sub-resource of an account which give AI developer it's individual container to work on.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "project",
+            "in": "body",
+            "description": "The parameters to provide for the created project.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Project' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
+          },
+          "201": {
+            "description": "Resource 'Project' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            },
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create Project": {
+            "$ref": "./examples/CreateProject.json"
+          },
+          "Create Project Min": {
+            "$ref": "./examples/CreateProjectMin.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Project"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Projects_Update",
+        "tags": [
+          "CognitiveServicesProjects"
+        ],
+        "description": "Updates a Cognitive Services Project",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "project",
+            "in": "body",
+            "description": "The parameters to provide for the created project.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            }
+          },
+          "202": {
+            "description": "The request has been accepted for processing, but processing has not yet completed.",
+            "schema": {
+              "$ref": "#/definitions/Project"
+            },
+            "headers": {
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Project": {
+            "$ref": "./examples/UpdateProjects.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Project"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Projects_Delete",
+        "tags": [
+          "CognitiveServicesProjects"
+        ],
+        "description": "Deletes a Cognitive Services project from the resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Project": {
+            "$ref": "./examples/DeleteProject.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications": {
+      "get": {
+        "operationId": "AgentApplications_List",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Lists Agent Applications in the project.",
+        "description": "Lists Agent Applications in the project.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "Number of agent applications to be retrieved in a page of results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 30
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Number of agent applications to skip.",
+            "required": false,
+            "type": "integer",
+            "format": "int32"
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "Continuation token for pagination.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "names",
+            "in": "query",
+            "description": "Names of agent applications to retrieve.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "searchText",
+            "in": "query",
+            "description": "Search text for filtering agent applications.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "Field to order by.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderByAsc",
+            "in": "query",
+            "description": "Whether to order in ascending order.",
+            "required": false,
+            "type": "boolean",
+            "default": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentApplicationResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Account Agent Applications.": {
+            "$ref": "./examples/AgentApplication/list.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{name}": {
+      "get": {
+        "operationId": "AgentApplications_Get",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Gets an Agent Application by name.",
+        "description": "Gets an Agent Application by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentApplication"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Account Agent Application.": {
+            "$ref": "./examples/AgentApplication/get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AgentApplications_CreateOrUpdate",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Creates or updates an Agent Application (asynchronous).",
+        "description": "Creates or updates an Agent Application (asynchronous).",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Agent Application definition object.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AgentApplication"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentApplication"
+            }
+          },
+          "201": {
+            "description": "Resource 'AgentApplication' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AgentApplication"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "URI to poll for asynchronous operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Account Agent Application.": {
+            "$ref": "./examples/AgentApplication/createOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/AgentApplication"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AgentApplications_Delete",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Delete Agent Application.",
+        "description": "Delete Agent Application.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Account Agent Application.": {
+            "$ref": "./examples/AgentApplication/delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{appName}/agentDeployments": {
+      "get": {
+        "operationId": "AgentDeployments_List",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Lists Agent Deployments in the application.",
+        "description": "Lists Agent Deployments in the application.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "Number of agent deployments to be retrieved in a page of results.",
+            "required": false,
+            "type": "integer",
+            "format": "int32",
+            "default": 30
+          },
+          {
+            "name": "$skipToken",
+            "in": "query",
+            "description": "Continuation token for pagination.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "names",
+            "in": "query",
+            "description": "Names of agent deployments to retrieve.",
+            "required": false,
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "Field to order by.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "orderByAsc",
+            "in": "query",
+            "description": "Whether to order in ascending order.",
+            "required": false,
+            "type": "boolean",
+            "default": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentDeploymentResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Agent Deployments.": {
+            "$ref": "./examples/AgentDeployment/list.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{appName}/agentDeployments/{deploymentName}": {
+      "get": {
+        "operationId": "AgentDeployments_Get",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Gets an Agent Deployment by name.",
+        "description": "Gets an Agent Deployment by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentDeployment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Agent Deployment.": {
+            "$ref": "./examples/AgentDeployment/get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AgentDeployments_CreateOrUpdate",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Creates or updates an Agent Deployment (asynchronous).",
+        "description": "Creates or updates an Agent Deployment (asynchronous).",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "Agent Deployment definition object.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AgentDeployment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentDeployment"
+            }
+          },
+          "201": {
+            "description": "Resource 'AgentDeployment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AgentDeployment"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "URI to poll for asynchronous operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Agent Deployment.": {
+            "$ref": "./examples/AgentDeployment/createOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/AgentDeployment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AgentDeployments_Delete",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Delete Agent Deployment.",
+        "description": "Delete Agent Deployment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Agent Deployment.": {
+            "$ref": "./examples/AgentDeployment/delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{appName}/agentDeployments/{deploymentName}/start": {
+      "post": {
+        "operationId": "AgentDeployments_Start",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Starts an Agent Deployment.",
+        "description": "Starts an Agent Deployment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Start Agent Deployment.": {
+            "$ref": "./examples/AgentDeployment/start.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{appName}/agentDeployments/{deploymentName}/stop": {
+      "post": {
+        "operationId": "AgentDeployments_Stop",
+        "tags": [
+          "AgentDeployment"
+        ],
+        "summary": "Stops an Agent Deployment.",
+        "description": "Stops an Agent Deployment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "The name of the application associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "deploymentName",
+            "in": "path",
+            "description": "The name of the deployment associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Stop Agent Deployment.": {
+            "$ref": "./examples/AgentDeployment/stop.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{name}/disable": {
+      "post": {
+        "operationId": "AgentApplications_Disable",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Disables an Agent Application.",
+        "description": "Disables an Agent Application.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Disable Agent Application.": {
+            "$ref": "./examples/AgentApplication/disable.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{name}/enable": {
+      "post": {
+        "operationId": "AgentApplications_Enable",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Enables an Agent Application.",
+        "description": "Enables an Agent Application.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Enable Agent Application.": {
+            "$ref": "./examples/AgentApplication/enable.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/applications/{name}/listAgents": {
+      "post": {
+        "operationId": "AgentApplications_ListAgents",
+        "tags": [
+          "AgentApplication"
+        ],
+        "summary": "Lists agents for an Agent Application.",
+        "description": "Lists agents for an Agent Application.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name for the Agent Application.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AgentReferenceResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Agents for Agent Application.": {
+            "$ref": "./examples/AgentApplication/listAgents.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/capabilityHosts": {
+      "get": {
+        "operationId": "ProjectCapabilityHosts_List",
+        "tags": [
+          "ProjectCapabilityHost"
+        ],
+        "summary": "List capabilityHost.",
+        "description": "List capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProjectCapabilityHostResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Project CapabilityHosts.": {
+            "$ref": "./examples/ProjectCapabilityHost/list.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/capabilityHosts/{capabilityHostName}": {
+      "get": {
+        "operationId": "ProjectCapabilityHosts_Get",
+        "tags": [
+          "ProjectCapabilityHost"
+        ],
+        "summary": "Get project capabilityHost.",
+        "description": "Get project capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProjectCapabilityHost"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Project CapabilityHost.": {
+            "$ref": "./examples/ProjectCapabilityHost/get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ProjectCapabilityHosts_CreateOrUpdate",
+        "tags": [
+          "ProjectCapabilityHost"
+        ],
+        "summary": "Create or update project capabilityHost.",
+        "description": "Create or update project capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          },
+          {
+            "name": "capabilityHost",
+            "in": "body",
+            "description": "CapabilityHost definition.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ProjectCapabilityHost"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ProjectCapabilityHost"
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/ProjectCapabilityHost"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateOrUpdate Project CapabilityHost.": {
+            "$ref": "./examples/ProjectCapabilityHost/createOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "original-uri",
+          "final-state-schema": "#/definitions/ProjectCapabilityHost"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ProjectCapabilityHosts_Delete",
+        "tags": [
+          "ProjectCapabilityHost"
+        ],
+        "summary": "Delete project capabilityHost.",
+        "description": "Delete project capabilityHost.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "capabilityHostName",
+            "in": "path",
+            "description": "The name of the capability host associated with the Cognitive Services Resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{0,254}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "x-ms-async-operation-timeout": {
+                "type": "string",
+                "format": "duration",
+                "description": "Timeout for the client to use when polling the asynchronous operation."
+              }
+            }
+          },
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Project CapabilityHost.": {
+            "$ref": "./examples/ProjectCapabilityHost/delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/connections": {
+      "get": {
+        "operationId": "ProjectConnections_List",
+        "tags": [
+          "ProjectConnectionResource"
+        ],
+        "summary": "Lists all the available Cognitive Services project connections under the specified project.",
+        "description": "Lists all the available Cognitive Services project connections under the specified project.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "target",
+            "in": "query",
+            "description": "Target of the connection.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "description": "Category of the connection.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "includeAll",
+            "in": "query",
+            "description": "query parameter that indicates if get connection call should return both connections and datastores",
+            "required": false,
+            "type": "boolean",
+            "default": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResourceArmPaginatedResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListProjectConnection": {
+            "$ref": "./examples/ProjectConnection/list.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/connections/{connectionName}": {
+      "get": {
+        "operationId": "ProjectConnections_Get",
+        "tags": [
+          "ProjectConnectionResource"
+        ],
+        "summary": "Lists Cognitive Services project connection by name.",
+        "description": "Lists Cognitive Services project connection by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetProjectConnection": {
+            "$ref": "./examples/ProjectConnection/get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ProjectConnections_Create",
+        "tags": [
+          "ProjectConnectionResource"
+        ],
+        "summary": "Create or update Cognitive Services project connection under the specified project.",
+        "description": "Create or update Cognitive Services project connection under the specified project.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "connection",
+            "in": "body",
+            "description": "The object for creating or updating a new account connection",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectionPropertiesV2BasicResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "CreateProjectConnection": {
+            "$ref": "./examples/ProjectConnection/create.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "ProjectConnections_Update",
+        "tags": [
+          "ProjectConnectionResource"
+        ],
+        "summary": "Update Cognitive Services project connection under the specified project.",
+        "description": "Update Cognitive Services project connection under the specified project.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          },
+          {
+            "name": "connection",
+            "in": "body",
+            "description": "Parameters for account connection update.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ConnectionUpdateContent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "UpdateProjectConnection": {
+            "$ref": "./examples/ProjectConnection/update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ProjectConnections_Delete",
+        "tags": [
+          "ProjectConnectionResource"
+        ],
+        "summary": "Delete Cognitive Services project connection by name.",
+        "description": "Delete Cognitive Services project connection by name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "projectName",
+            "in": "path",
+            "description": "The name of Cognitive Services account's project.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "connectionName",
+            "in": "path",
+            "description": "Friendly name of the connection",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteProjectConnection": {
+            "$ref": "./examples/ProjectConnection/delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists": {
+      "get": {
+        "operationId": "RaiBlocklists_List",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Gets the custom blocklists associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RaiBlockListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListBlocklists": {
+            "$ref": "./examples/ListBlocklists.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}": {
+      "get": {
+        "operationId": "RaiBlocklists_Get",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Gets the specified custom blocklist associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklist"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetRaiBlocklist": {
+            "$ref": "./examples/GetRaiBlocklist.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiBlocklists_CreateOrUpdate",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Update the state of specified blocklist associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklist",
+            "in": "body",
+            "description": "Properties describing the custom blocklist.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklist"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiBlocklist' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklist"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiBlocklist' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklist"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutRaiBlocklist": {
+            "$ref": "./examples/PutRaiBlocklist.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiBlocklists_Delete",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Deletes the specified custom blocklist associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteRaiBlocklist": {
+            "$ref": "./examples/DeleteRaiBlocklist.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/addRaiBlocklistItems": {
+      "post": {
+        "operationId": "RaiBlocklistItems_BatchAdd",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Batch operation to add blocklist items.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItems",
+            "in": "body",
+            "description": "Properties describing the custom blocklist items.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItemsBulkAddRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklist"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AddRaiBlocklistItems": {
+            "$ref": "./examples/AddRaiBlocklistItems.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/deleteRaiBlocklistItems": {
+      "post": {
+        "operationId": "RaiBlocklistItems_BatchDelete",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Batch operation to delete blocklist items.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItemsNames",
+            "in": "body",
+            "description": "List of RAI Blocklist Items Names.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItemsBulkDeleteRequest"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteRaiBlocklistItems": {
+            "$ref": "./examples/DeleteRaiBlocklistItems.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/raiBlocklistItems": {
+      "get": {
+        "operationId": "RaiBlocklistItems_List",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Gets the blocklist items associated with the custom blocklist.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiBlockListItemsResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListBlocklistItems": {
+            "$ref": "./examples/ListBlocklistItems.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/raiBlocklistItems/{raiBlocklistItemName}": {
+      "get": {
+        "operationId": "RaiBlocklistItems_Get",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Gets the specified custom blocklist Item associated with the custom blocklist.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItemName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist Item associated with the custom blocklist",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItem"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetRaiBlocklistItem": {
+            "$ref": "./examples/GetRaiBlocklistItem.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiBlocklistItems_CreateOrUpdate",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Update the state of specified blocklist item associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItemName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist Item associated with the custom blocklist",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItem",
+            "in": "body",
+            "description": "Properties describing the custom blocklist.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItem"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiBlocklistItem' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItem"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiBlocklistItem' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiBlocklistItem"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutRaiBlocklistItem": {
+            "$ref": "./examples/PutRaiBlocklistItem.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiBlocklistItems_Delete",
+        "tags": [
+          "RaiBlocklists"
+        ],
+        "description": "Deletes the specified blocklist Item associated with the custom blocklist.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiBlocklistItemName",
+            "in": "path",
+            "description": "The name of the RaiBlocklist Item associated with the custom blocklist",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteRaiBlocklistItem": {
+            "$ref": "./examples/DeleteRaiBlocklistItem.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiPolicies": {
+      "get": {
+        "operationId": "RaiPolicies_List",
+        "tags": [
+          "RaiPolicies"
+        ],
+        "description": "Gets the content filters associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicyListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListRaiPolicies": {
+            "$ref": "./examples/ListRaiPolicies.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiPolicies/{raiPolicyName}": {
+      "get": {
+        "operationId": "RaiPolicies_Get",
+        "tags": [
+          "RaiPolicies"
+        ],
+        "description": "Gets the specified Content Filters associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetRaiPolicy": {
+            "$ref": "./examples/GetRaiPolicy.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiPolicies_CreateOrUpdate",
+        "tags": [
+          "RaiPolicies"
+        ],
+        "description": "Update the state of specified Content Filters associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiPolicy",
+            "in": "body",
+            "description": "Properties describing the Content Filters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiPolicy' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutRaiPolicy": {
+            "$ref": "./examples/PutRaiPolicy.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiPolicies_Delete",
+        "tags": [
+          "RaiPolicies"
+        ],
+        "description": "Deletes the specified Content Filters associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiPolicyName",
+            "in": "path",
+            "description": "The name of the RaiPolicy associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteRaiPolicy": {
+            "$ref": "./examples/DeleteRaiPolicy.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiToolLabels": {
+      "get": {
+        "operationId": "RaiToolLabels_List",
+        "tags": [
+          "RaiToolLabels"
+        ],
+        "description": "Lists all RAI Tool Labels associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiToolLabelResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListRaiToolLabels": {
+            "$ref": "./examples/ListRaiToolLabels.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiToolLabels/{raiToolConnectionName}": {
+      "get": {
+        "operationId": "RaiToolLabels_Get",
+        "tags": [
+          "RaiToolLabels"
+        ],
+        "description": "Gets the specified RAI Tool Label associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiToolConnectionName",
+            "in": "path",
+            "description": "The name of the Rai Tool Label",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiToolLabel"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetRaiToolLabel": {
+            "$ref": "./examples/GetRaiToolLabel.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiToolLabels_CreateOrUpdate",
+        "tags": [
+          "RaiToolLabels"
+        ],
+        "description": "Creates the RAI Tool Label associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiToolConnectionName",
+            "in": "path",
+            "description": "The name of the Rai Tool Label",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiToolLabel",
+            "in": "body",
+            "description": "Properties describing the RAI Tool Label.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiToolLabel"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiToolLabel' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiToolLabel"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiToolLabel' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiToolLabel"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutRaiToolLabel": {
+            "$ref": "./examples/PutRaiToolLabel.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiToolLabels_Delete",
+        "tags": [
+          "RaiToolLabels"
+        ],
+        "description": "Deletes the specified RAI Tool Label associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiToolConnectionName",
+            "in": "path",
+            "description": "The name of the Rai Tool Label",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteRaiToolLabel": {
+            "$ref": "./examples/DeleteRaiToolLabel.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raitopics": {
+      "get": {
+        "operationId": "RaiTopics_List",
+        "tags": [
+          "RaiTopics"
+        ],
+        "description": "Gets the custom topics associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiTopicResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListRaiTopics": {
+            "$ref": "./examples/ListRaiTopics.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raitopics/{raiTopicName}": {
+      "get": {
+        "operationId": "RaiTopics_Get",
+        "tags": [
+          "RaiTopics"
+        ],
+        "description": "Gets the specified custom topic associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiTopicName",
+            "in": "path",
+            "description": "The name of the Rai Topic associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetRaiTopic": {
+            "$ref": "./examples/GetRaiTopic.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "RaiTopics_CreateOrUpdate",
+        "tags": [
+          "RaiTopics"
+        ],
+        "description": "Create the rai topic associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiTopicName",
+            "in": "path",
+            "description": "The name of the Rai Topic associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiTopic",
+            "in": "body",
+            "description": "Properties describing the rai topic.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiTopic"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'RaiTopic' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiTopic"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiTopic' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiTopic"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutRaiTopic": {
+            "$ref": "./examples/PutRaiTopic.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "RaiTopics_Delete",
+        "tags": [
+          "RaiTopics"
+        ],
+        "description": "Deletes the specified custom topic associated with the Azure OpenAI account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "raiTopicName",
+            "in": "path",
+            "description": "The name of the Rai Topic associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteRaiTopic": {
+            "$ref": "./examples/DeleteRaiTopic.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/regenerateKey": {
+      "post": {
+        "operationId": "Accounts_RegenerateKey",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Regenerates the specified account key for the specified Cognitive Services account.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "regenerate key parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RegenerateKeyParameters"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApiKeys"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Regenerate Keys": {
+            "$ref": "./examples/RegenerateKey.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/skus": {
+      "get": {
+        "operationId": "Accounts_ListSkus",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "List available SKUs for the requested Cognitive Services account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AccountSkuListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List SKUs": {
+            "$ref": "./examples/ListSkus.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/testRaiExternalSafetyProvider/{safetyProviderName}": {
+      "put": {
+        "operationId": "TestRaiExternalSafetyProvider_CreateOrUpdate",
+        "tags": [
+          "TestRaiExternalSafetyProvider"
+        ],
+        "description": "Test the rai safety provider associated with the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "safetyProviderName",
+            "in": "path",
+            "description": "The name of the Rai External Safety Provider associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "safetyProvider",
+            "in": "body",
+            "description": "Properties describing the rai external safety provider.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          },
+          "201": {
+            "description": "Resource 'RaiExternalSafetyProviderSchema' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "TestRaiExternalSafetyProvider": {
+            "$ref": "./examples/TestRaiExternalSafetyProvider.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/usages": {
+      "get": {
+        "operationId": "Accounts_ListUsages",
+        "tags": [
+          "CognitiveServicesAccounts"
+        ],
+        "description": "Get usages for the requested Cognitive Services account",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "accountName",
+            "in": "path",
+            "description": "The name of Cognitive Services account.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "An OData filter expression that describes a subset of usages to return. The supported parameter is name.value (name of the metric, can have an or of multiple names).",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/UsageListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Usages": {
+            "$ref": "./examples/GetUsages.json"
+          },
+          "Get Usages Classic Scope": {
+            "$ref": "./examples/GetUsagesClassicScope.json"
+          },
+          "Get Usages DataZone Scope": {
+            "$ref": "./examples/GetUsagesDataZoneScope.json"
+          },
+          "Get Usages Global Scope": {
+            "$ref": "./examples/GetUsagesGlobalScope.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans": {
+      "get": {
+        "operationId": "CommitmentPlans_ListPlansByResourceGroup",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Returns all the resources of a particular type belonging to a resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Commitment Plans by Resource Group": {
+            "$ref": "./examples/ListSharedCommitmentPlansByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}": {
+      "get": {
+        "operationId": "CommitmentPlans_GetPlan",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Returns a Cognitive Services commitment plan specified by the parameters.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Commitment Plan": {
+            "$ref": "./examples/GetSharedCommitmentPlan.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "CommitmentPlans_CreateOrUpdatePlan",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Create Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlan",
+            "in": "body",
+            "description": "The parameters to provide for the created commitment plan.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CommitmentPlan' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "201": {
+            "description": "Resource 'CommitmentPlan' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create Commitment Plan": {
+            "$ref": "./examples/CreateSharedCommitmentPlan.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/CommitmentPlan"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "CommitmentPlans_UpdatePlan",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Create Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlan",
+            "in": "body",
+            "description": "The parameters to provide for the created commitment plan.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PatchResourceTagsAndSku"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlan"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create Commitment Plan": {
+            "$ref": "./examples/UpdateSharedCommitmentPlan.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/CommitmentPlan"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "CommitmentPlans_DeletePlan",
+        "tags": [
+          "CognitiveServicesCommitmentPlans"
+        ],
+        "description": "Deletes a Cognitive Services commitment plan from the resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Commitment Plan": {
+            "$ref": "./examples/DeleteSharedCommitmentPlan.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}/accountAssociations": {
+      "get": {
+        "operationId": "CommitmentPlans_ListAssociations",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Gets the associations of the Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanAccountAssociationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ListCommitmentPlans": {
+            "$ref": "./examples/ListSharedCommitmentPlanAssociations.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/commitmentPlans/{commitmentPlanName}/accountAssociations/{commitmentPlanAssociationName}": {
+      "get": {
+        "operationId": "CommitmentPlans_GetAssociation",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Gets the association of the Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanAssociationName",
+            "in": "path",
+            "description": "The name of the commitment plan association with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanAccountAssociation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GetCommitmentPlan": {
+            "$ref": "./examples/GetSharedCommitmentPlanAssociation.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "CommitmentPlans_CreateOrUpdateAssociation",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Create or update the association of the Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanAssociationName",
+            "in": "path",
+            "description": "The name of the commitment plan association with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "association",
+            "in": "body",
+            "description": "The commitmentPlan properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanAccountAssociation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'CommitmentPlanAccountAssociation' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanAccountAssociation"
+            }
+          },
+          "201": {
+            "description": "Resource 'CommitmentPlanAccountAssociation' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/CommitmentPlanAccountAssociation"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "PutCommitmentPlan": {
+            "$ref": "./examples/CreateSharedCommitmentPlanAssociation.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/CommitmentPlanAccountAssociation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "CommitmentPlans_DeleteAssociation",
+        "tags": [
+          "CommitmentPlans"
+        ],
+        "description": "Deletes the association of the Cognitive Services commitment plan.",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v3/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "commitmentPlanName",
+            "in": "path",
+            "description": "The name of the commitmentPlan associated with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          },
+          {
+            "name": "commitmentPlanAssociationName",
+            "in": "path",
+            "description": "The name of the commitment plan association with the Cognitive Services Account",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              },
+              "location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DeleteCommitmentPlan": {
+            "$ref": "./examples/DeleteSharedCommitmentPlanAssociation.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "AADAuthTypeConnectionProperties": {
+      "type": "object",
+      "description": "This connection type covers the AAD auth for any applicable Azure service",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "AAD"
+    },
+    "AbusePenalty": {
+      "type": "object",
+      "description": "The abuse penalty.",
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/AbusePenaltyAction",
+          "description": "The action of AbusePenalty."
+        },
+        "rateLimitPercentage": {
+          "type": "number",
+          "format": "float",
+          "description": "The percentage of rate limit."
+        },
+        "expiration": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The datetime of expiration of the AbusePenalty."
+        }
+      }
+    },
+    "AbusePenaltyAction": {
+      "type": "string",
+      "description": "The action of AbusePenalty.",
+      "enum": [
+        "Throttle",
+        "Block"
+      ],
+      "x-ms-enum": {
+        "name": "AbusePenaltyAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Throttle",
+            "value": "Throttle"
+          },
+          {
+            "name": "Block",
+            "value": "Block"
+          }
+        ]
+      }
+    },
+    "AccessKeyAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionAccessKey"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "AccessKey"
+    },
+    "Account": {
+      "type": "object",
+      "description": "Cognitive Services account is an Azure resource representing the provisioned account, it's type, location and SKU.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AccountProperties",
+          "description": "Properties of Cognitive Services account."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "Identity for the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AccountKeyAuthTypeConnectionProperties": {
+      "type": "object",
+      "description": "This connection type covers the account key connection for Azure storage",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionAccountKey",
+          "description": "Account key object for connection credential."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "AccountKey"
+    },
+    "AccountListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of accounts."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts and their properties.",
+          "items": {
+            "$ref": "#/definitions/Account"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "AccountModel": {
+      "type": "object",
+      "description": "Cognitive Services account Model.",
+      "properties": {
+        "baseModel": {
+          "$ref": "#/definitions/DeploymentModel",
+          "description": "Properties of Cognitive Services account deployment model."
+        },
+        "isDefaultVersion": {
+          "type": "boolean",
+          "description": "If the model is default version."
+        },
+        "skus": {
+          "type": "array",
+          "description": "The list of Model Sku.",
+          "items": {
+            "$ref": "#/definitions/ModelSku"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "maxCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The max capacity."
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "The capabilities.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "finetuneCapabilities": {
+          "type": "object",
+          "description": "The capabilities for finetune models.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "deprecation": {
+          "$ref": "#/definitions/ModelDeprecationInfo",
+          "description": "Cognitive Services account ModelDeprecationInfo."
+        },
+        "replacementConfig": {
+          "$ref": "#/definitions/ReplacementConfig",
+          "description": "Configuration for model replacement."
+        },
+        "modelCatalogAssetId": {
+          "type": "string",
+          "description": "Asset identifier for the model in the model catalog."
+        },
+        "lifecycleStatus": {
+          "$ref": "#/definitions/ModelLifecycleStatus",
+          "description": "Model lifecycle status."
+        },
+        "systemData": {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/systemData",
+          "description": "Metadata pertaining to creation and last modification of the resource.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DeploymentModel"
+        }
+      ]
+    },
+    "AccountModelListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Model."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts Model and their properties.",
+          "items": {
+            "$ref": "#/definitions/AccountModel"
+          },
+          "x-ms-identifiers": [
+            "name",
+            "format",
+            "version"
+          ]
+        }
+      }
+    },
+    "AccountProperties": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Gets the status of the cognitive services account at the time the operation was called.",
+          "readOnly": true
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "Endpoint of the created account.",
+          "readOnly": true
+        },
+        "internalId": {
+          "type": "string",
+          "description": "The internal identifier (deprecated, do not use this property).",
+          "readOnly": true
+        },
+        "capabilities": {
+          "type": "array",
+          "description": "Gets the capabilities of the cognitive services account. Each item indicates the capability of a specific feature. The values are read-only and for reference only.",
+          "items": {
+            "$ref": "#/definitions/SkuCapability"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "isMigrated": {
+          "type": "boolean",
+          "description": "If the resource is migrated from an existing key.",
+          "readOnly": true
+        },
+        "migrationToken": {
+          "type": "string",
+          "description": "Resource migration token."
+        },
+        "skuChangeInfo": {
+          "$ref": "#/definitions/SkuChangeInfo",
+          "description": "Sku change info of account.",
+          "readOnly": true
+        },
+        "customSubDomainName": {
+          "type": "string",
+          "description": "Optional subdomain name used for token-based authentication."
+        },
+        "networkAcls": {
+          "$ref": "#/definitions/NetworkRuleSet",
+          "description": "A collection of rules governing the accessibility from specific network locations."
+        },
+        "encryption": {
+          "$ref": "#/definitions/Encryption",
+          "description": "The encryption properties for this resource."
+        },
+        "userOwnedStorage": {
+          "type": "array",
+          "description": "The storage accounts for this resource.",
+          "items": {
+            "$ref": "#/definitions/UserOwnedStorage"
+          },
+          "x-ms-identifiers": [
+            "resourceId"
+          ]
+        },
+        "amlWorkspace": {
+          "$ref": "#/definitions/UserOwnedAmlWorkspace",
+          "description": "The user owned AML account properties."
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "The private endpoint connection associated with the Cognitive Services account.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Whether or not public endpoint access is allowed for this account."
+        },
+        "apiProperties": {
+          "$ref": "#/definitions/ApiProperties",
+          "description": "The api properties for special APIs."
+        },
+        "dateCreated": {
+          "type": "string",
+          "description": "Gets the date of cognitive services account creation.",
+          "readOnly": true
+        },
+        "callRateLimit": {
+          "$ref": "#/definitions/CallRateLimit",
+          "description": "The call rate limit Cognitive Services account.",
+          "readOnly": true
+        },
+        "dynamicThrottlingEnabled": {
+          "type": "boolean",
+          "description": "The flag to enable dynamic throttling."
+        },
+        "storedCompletionsDisabled": {
+          "type": "boolean",
+          "description": "The flag to disable stored completions."
+        },
+        "quotaLimit": {
+          "$ref": "#/definitions/QuotaLimit",
+          "readOnly": true
+        },
+        "restrictOutboundNetworkAccess": {
+          "type": "boolean"
+        },
+        "allowedFqdnList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "disableLocalAuth": {
+          "type": "boolean"
+        },
+        "endpoints": {
+          "type": "object",
+          "description": "Dictionary of <string>",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "restore": {
+          "type": "boolean",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "deletionDate": {
+          "type": "string",
+          "description": "The deletion date, only available for deleted account.",
+          "readOnly": true
+        },
+        "scheduledPurgeDate": {
+          "type": "string",
+          "description": "The scheduled purge date, only available for deleted account.",
+          "readOnly": true
+        },
+        "locations": {
+          "$ref": "#/definitions/MultiRegionSettings",
+          "description": "The multiregion settings of Cognitive Services account."
+        },
+        "commitmentPlanAssociations": {
+          "type": "array",
+          "description": "The commitment plan associations of Cognitive Services account.",
+          "items": {
+            "$ref": "#/definitions/CommitmentPlanAssociation"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "commitmentPlanId"
+          ]
+        },
+        "abusePenalty": {
+          "$ref": "#/definitions/AbusePenalty",
+          "description": "The abuse penalty.",
+          "readOnly": true
+        },
+        "raiMonitorConfig": {
+          "$ref": "#/definitions/RaiMonitorConfig",
+          "description": "Cognitive Services Rai Monitor Config."
+        },
+        "networkInjections": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkInjection"
+          }
+        },
+        "allowProjectManagement": {
+          "type": "boolean",
+          "description": "Specifies whether this resource support project management as child resources, used as containers for access management, data isolation and cost in AI Foundry."
+        },
+        "defaultProject": {
+          "type": "string",
+          "description": "Specifies the project, by project name, that is targeted when data plane endpoints are called without a project parameter."
+        },
+        "associatedProjects": {
+          "type": "array",
+          "description": "Specifies the projects, by project name, that are associated with this resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "budgetPolicyIds": {
+          "type": "array",
+          "description": "The full resource IDs of budget policies directly attached to this account.",
+          "maxItems": 20,
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.CognitiveServices/accounts/budgetPolicies"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "AccountSku": {
+      "type": "object",
+      "description": "Cognitive Services resource type and SKU.",
+      "properties": {
+        "resourceType": {
+          "type": "string",
+          "description": "Resource Namespace and Type"
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The SKU of Cognitive Services account."
+        }
+      }
+    },
+    "AccountSkuListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts and their properties.",
+          "items": {
+            "$ref": "#/definitions/AccountSku"
+          },
+          "x-ms-identifiers": [
+            "sku/name",
+            "resourceType"
+          ]
+        }
+      }
+    },
+    "ActionType": {
+      "type": "string",
+      "description": "Enum. Indicates the action type. \"Internal\" refers to actions that are for internal only APIs.",
+      "enum": [
+        "Internal"
+      ],
+      "x-ms-enum": {
+        "name": "ActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Internal",
+            "value": "Internal"
+          }
+        ]
+      }
+    },
+    "AgentApplication": {
+      "type": "object",
+      "description": "Agent Application resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AgenticApplicationProperties",
+          "description": "[Required] Additional attributes of the entity."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AgentApplicationResourceArmPaginatedResult": {
+      "type": "object",
+      "description": "A paginated list of Agent Application entities.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of Agent Application objects. If null, there are no additional pages.",
+          "x-nullable": true
+        },
+        "value": {
+          "type": "array",
+          "description": "An array of objects of type Agent Application.",
+          "items": {
+            "$ref": "#/definitions/AgentApplication"
+          }
+        }
+      }
+    },
+    "AgentCard": {
+      "type": "object",
+      "description": "Represents a detailed description of an agent, including its name, functionality, hosting information, supported interaction modes, and available skills.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the Agent (e.g., 'Recipe Agent').",
+          "x-nullable": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the Agent's function.",
+          "x-nullable": true
+        },
+        "url": {
+          "type": "string",
+          "description": "URL address where the Agent is hosted.",
+          "x-nullable": true
+        },
+        "provider": {
+          "$ref": "#/definitions/ProviderInfo",
+          "description": "Service provider information for the Agent.",
+          "x-nullable": true
+        },
+        "version": {
+          "type": "string",
+          "description": "Version of the Agent (format defined by provider, e.g., '1.0.0').",
+          "x-nullable": true
+        },
+        "documentationUrl": {
+          "type": "string",
+          "description": "URL for the Agent's documentation.",
+          "x-nullable": true
+        },
+        "defaultInputModes": {
+          "type": "array",
+          "description": "Default interaction modes supported by the Agent across all skills.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "defaultOutputModes": {
+          "type": "array",
+          "description": "Default output modes supported by the Agent across all skills.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "skills": {
+          "type": "array",
+          "description": "Collection of capability units the Agent can perform.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/Skill"
+          }
+        }
+      }
+    },
+    "AgentDeployment": {
+      "type": "object",
+      "description": "Agent Deployment resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AgentDeploymentProperties",
+          "description": "[Required] Additional attributes of the entity."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AgentDeploymentProperties": {
+      "type": "object",
+      "description": "Type representing an agent deployment as a management construct.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "Gets or sets the display name of the deployment.",
+          "x-nullable": true
+        },
+        "deploymentId": {
+          "type": "string",
+          "description": "Gets or sets the unique identifier of the deployment.",
+          "x-nullable": true
+        },
+        "state": {
+          "$ref": "#/definitions/AgentDeploymentState",
+          "description": "Gets or sets the current operational state of the deployment (and, intrinsically, of the comprising agents).",
+          "x-nullable": true
+        },
+        "protocols": {
+          "type": "array",
+          "description": "Gets or sets the supported protocol types and versions exposed by this deployment.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/AgentProtocolVersion"
+          }
+        },
+        "agents": {
+          "type": "array",
+          "description": "Returns a flat list of agent:version deployed in this deployment.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/VersionedAgentReference"
+          }
+        },
+        "deploymentType": {
+          "$ref": "#/definitions/AgentDeploymentType",
+          "description": "Gets or sets the type of deployment for the agent."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/AgentDeploymentProvisioningState",
+          "description": "Gets or sets the provisioning state of the agent deployment.",
+          "readOnly": true
+        }
+      },
+      "discriminator": "deploymentType",
+      "required": [
+        "deploymentType"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceBase"
+        }
+      ]
+    },
+    "AgentDeploymentProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of an agentic deployment, as an Azure resource.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "AgentDeploymentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The deployment was successfully completed."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The deployment failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The deployment was canceled."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "The deployment is being created."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The deployment is being updated."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The deployment is being deleted."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "AgentDeploymentResourceArmPaginatedResult": {
+      "type": "object",
+      "description": "A paginated list of Agent Deployment entities.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of Agent Deployment objects. If null, there are no additional pages.",
+          "x-nullable": true
+        },
+        "value": {
+          "type": "array",
+          "description": "An array of objects of type Agent Deployment.",
+          "items": {
+            "$ref": "#/definitions/AgentDeployment"
+          }
+        }
+      }
+    },
+    "AgentDeploymentState": {
+      "type": "string",
+      "description": "Current operational state of the agentic functionality represented by this deployment.",
+      "enum": [
+        "Starting",
+        "Running",
+        "Stopping",
+        "Stopped",
+        "Failed",
+        "Deleting",
+        "Deleted",
+        "Updating"
+      ],
+      "x-ms-enum": {
+        "name": "AgentDeploymentState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Starting",
+            "value": "Starting",
+            "description": "The deployment is starting."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The deployment started/is operational."
+          },
+          {
+            "name": "Stopping",
+            "value": "Stopping",
+            "description": "The deployment is being stopped."
+          },
+          {
+            "name": "Stopped",
+            "value": "Stopped",
+            "description": "The deployment was stopped."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The deployment failed."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The deployment is being deleted."
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "The deployment was deleted."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The deployment is being updated."
+          }
+        ]
+      }
+    },
+    "AgentDeploymentType": {
+      "type": "string",
+      "description": "Specifies the type of deployment for an agent, indicating how the underlying compute and network infrastructure is managed.",
+      "enum": [
+        "Managed",
+        "Hosted",
+        "Custom"
+      ],
+      "x-ms-enum": {
+        "name": "AgentDeploymentType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Managed",
+            "value": "Managed",
+            "description": "The underlying infra is managed by the platform in the deployer's subscription"
+          },
+          {
+            "name": "Hosted",
+            "value": "Hosted",
+            "description": "The underlying infra is owned by the platform"
+          },
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "The underlying infra is provisioned by the deployer (BYO)"
+          }
+        ]
+      }
+    },
+    "AgentProtocol": {
+      "type": "string",
+      "description": "Protocol used by the agent/exposed by a deployment.",
+      "enum": [
+        "Agent",
+        "A2A",
+        "Responses"
+      ],
+      "x-ms-enum": {
+        "name": "AgentProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Agent",
+            "value": "Agent",
+            "description": "Agent protocol (aka Active)"
+          },
+          {
+            "name": "A2A",
+            "value": "A2A",
+            "description": "Agent2Agent standard"
+          },
+          {
+            "name": "Responses",
+            "value": "Responses",
+            "description": "OpenAI-compatible"
+          }
+        ]
+      }
+    },
+    "AgentProtocolVersion": {
+      "type": "object",
+      "description": "Type modeling the protocol and version used by an agent/exposed by a deployment.",
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/AgentProtocol",
+          "description": "The protocol used by the agent/exposed by a deployment."
+        },
+        "version": {
+          "type": "string",
+          "description": "The version of the protocol.",
+          "x-nullable": true
+        }
+      }
+    },
+    "AgentReference": {
+      "type": "object",
+      "description": "Agent Reference resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AgentReferenceProperties",
+          "description": "[Required] Additional attributes of the entity."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AgentReferenceProperties": {
+      "type": "object",
+      "description": "Type modeling a reference to a version of an agent definition.",
+      "properties": {
+        "agentId": {
+          "type": "string",
+          "description": "Gets the agent's unique identifier within the organization (subscription).",
+          "x-nullable": true
+        },
+        "agentName": {
+          "type": "string",
+          "description": "Gets the agent's name (unique within the project/app).",
+          "x-nullable": true
+        }
+      }
+    },
+    "AgentReferenceResourceArmPaginatedResult": {
+      "type": "object",
+      "description": "A paginated list of Agent Reference entities.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of Agent Reference objects. If null, there are no additional pages.",
+          "x-nullable": true
+        },
+        "value": {
+          "type": "array",
+          "description": "An array of objects of type Agent Reference.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/AgentReference"
+          }
+        }
+      }
+    },
+    "AgenticApplicationProperties": {
+      "type": "object",
+      "description": "Resource type representing an agentic application as a management construct.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the application.",
+          "x-nullable": true
+        },
+        "baseUrl": {
+          "type": "string",
+          "description": "The application's dedicated invocation endpoint.",
+          "x-nullable": true
+        },
+        "agents": {
+          "type": "array",
+          "description": "The list of agent definitions comprising this application, returned as references to the objects under the parent project; use this to obtain a flat list of all agent-version pairs represented by this application.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/AgentReferenceProperties"
+          }
+        },
+        "agentIdentityBlueprint": {
+          "$ref": "#/definitions/AssignedIdentity",
+          "description": "The EntraId Agentic Blueprint of the application.",
+          "x-nullable": true
+        },
+        "defaultInstanceIdentity": {
+          "$ref": "#/definitions/AssignedIdentity",
+          "description": "The (default) agent instance identity of the application.",
+          "x-nullable": true
+        },
+        "authorizationPolicy": {
+          "$ref": "#/definitions/ApplicationAuthorizationPolicy",
+          "description": "Gets or sets the authorization policy associated with this agentic application instance.",
+          "x-nullable": true
+        },
+        "trafficRoutingPolicy": {
+          "$ref": "#/definitions/ApplicationTrafficRoutingPolicy",
+          "description": "Gets or sets the traffic routing policy for the application's deployments.",
+          "x-nullable": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/AgenticApplicationProvisioningState",
+          "description": "Provisioning state of the application.",
+          "readOnly": true
+        },
+        "isEnabled": {
+          "type": "boolean",
+          "description": "Enabledstate of the application.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceBase"
+        }
+      ]
+    },
+    "AgenticApplicationProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of an agentic application.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "AgenticApplicationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The application was successfully provisioned."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The application provisioning failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The application provisioning was canceled."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "The application is being created."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The application is being updated."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The application is being deleted."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ApiKeyAuthConnectionProperties": {
+      "type": "object",
+      "description": "This connection type covers the generic ApiKey auth connection categories, for examples:\nAzureOpenAI:\nCategory:= AzureOpenAI\nAuthType:= ApiKey (as type discriminator)\nCredentials:= {ApiKey} as .ApiKey\nTarget:= {ApiBase}\n\nCognitiveService:\nCategory:= CognitiveService\nAuthType:= ApiKey (as type discriminator)\nCredentials:= {SubscriptionKey} as ApiKey\nTarget:= ServiceRegion={serviceRegion}\n\nCognitiveSearch:\nCategory:= CognitiveSearch\nAuthType:= ApiKey (as type discriminator)\nCredentials:= {Key} as ApiKey\nTarget:= {Endpoint}\n\nUse Metadata property bag for ApiType, ApiVersion, Kind and other metadata fields",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionApiKey",
+          "description": "Api key object for connection credential."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "ApiKey"
+    },
+    "ApiKeys": {
+      "type": "object",
+      "description": "The access keys for the cognitive services account.",
+      "properties": {
+        "key1": {
+          "type": "string",
+          "description": "Gets the value of key 1."
+        },
+        "key2": {
+          "type": "string",
+          "description": "Gets the value of key 2."
+        }
+      }
+    },
+    "ApiProperties": {
+      "type": "object",
+      "description": "The api properties for special APIs.",
+      "properties": {
+        "qnaRuntimeEndpoint": {
+          "type": "string",
+          "description": "(QnAMaker Only) The runtime endpoint of QnAMaker."
+        },
+        "qnaAzureSearchEndpointKey": {
+          "type": "string",
+          "description": "(QnAMaker Only) The Azure Search endpoint key of QnAMaker."
+        },
+        "qnaAzureSearchEndpointId": {
+          "type": "string",
+          "description": "(QnAMaker Only) The Azure Search endpoint id of QnAMaker."
+        },
+        "statisticsEnabled": {
+          "type": "boolean",
+          "description": "(Bing Search Only) The flag to enable statistics of Bing Search."
+        },
+        "eventHubConnectionString": {
+          "type": "string",
+          "description": "(Personalization Only) The flag to enable statistics of Bing Search.",
+          "maxLength": 1000,
+          "pattern": "^( *)Endpoint=sb://(.*);( *)SharedAccessKeyName=(.*);( *)SharedAccessKey=(.*)$"
+        },
+        "storageAccountConnectionString": {
+          "type": "string",
+          "description": "(Personalization Only) The storage account connection string.",
+          "maxLength": 1000,
+          "pattern": "^(( *)DefaultEndpointsProtocol=(http|https)( *);( *))?AccountName=(.*)AccountKey=(.*)EndpointSuffix=(.*)$"
+        },
+        "aadClientId": {
+          "type": "string",
+          "description": "(Metrics Advisor Only) The Azure AD Client Id (Application Id).",
+          "maxLength": 500
+        },
+        "aadTenantId": {
+          "type": "string",
+          "description": "(Metrics Advisor Only) The Azure AD Tenant Id.",
+          "maxLength": 500
+        },
+        "superUser": {
+          "type": "string",
+          "description": "(Metrics Advisor Only) The super user of Metrics Advisor.",
+          "maxLength": 500
+        },
+        "websiteName": {
+          "type": "string",
+          "description": "(Metrics Advisor Only) The website name of Metrics Advisor.",
+          "maxLength": 500
+        }
+      },
+      "additionalProperties": {}
+    },
+    "ApplicationAuthorizationPolicy": {
+      "type": "object",
+      "description": "Represents a policy for authorizing applications based on specified authentication and authorization schemes.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/BuiltInAuthorizationScheme",
+          "description": "Authorization scheme type."
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "ApplicationTrafficRoutingPolicy": {
+      "type": "object",
+      "description": "Type representing an application traffic policy as a property of an agentic application.",
+      "properties": {
+        "protocol": {
+          "$ref": "#/definitions/TrafficRoutingProtocol",
+          "description": "Methodology used to route traffic to the application's deployments."
+        },
+        "rules": {
+          "type": "array",
+          "description": "Gets or sets the collection of traffic routing rules.",
+          "x-nullable": true,
+          "items": {
+            "$ref": "#/definitions/TrafficRoutingRule"
+          }
+        }
+      }
+    },
+    "AssignedIdentity": {
+      "type": "object",
+      "description": "Type representing an identity assignment",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/IdentityKind",
+          "description": "Specifies the kind of Entra identity described by this object."
+        },
+        "type": {
+          "$ref": "#/definitions/IdentityManagementType",
+          "description": "Enumeration of identity types, from the perspective of management."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The client ID of the identity."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID of the identity."
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The tenant ID of the identity."
+        },
+        "subject": {
+          "type": "string",
+          "description": "The subject of this identity assignment.",
+          "x-nullable": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/IdentityProvisioningState",
+          "description": "Represents the provisioning state of an identity resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "kind",
+        "type",
+        "clientId",
+        "principalId",
+        "tenantId"
+      ]
+    },
+    "Azure.Core.uuid": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Universally Unique Identifier"
+    },
+    "BillingMeterInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "meterId": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string"
+        }
+      }
+    },
+    "BudgetDimension": {
+      "type": "object",
+      "description": "A built-in request dimension used to partition budget consumption.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/BudgetDimensionType",
+          "description": "The kind of request dimension.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "BudgetDimensionType": {
+      "type": "string",
+      "description": "The supported budget counter dimensions.",
+      "enum": [
+        "agent",
+        "identity",
+        "session",
+        "project"
+      ],
+      "x-ms-enum": {
+        "name": "BudgetDimensionType",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Agent",
+            "value": "agent",
+            "description": "Consumption is partitioned by the stable Foundry agent ID."
+          },
+          {
+            "name": "Identity",
+            "value": "identity",
+            "description": "Consumption is partitioned by the authenticated principal object ID."
+          },
+          {
+            "name": "Session",
+            "value": "session",
+            "description": "Consumption is partitioned by the Foundry session ID."
+          },
+          {
+            "name": "Project",
+            "value": "project",
+            "description": "Consumption is partitioned by the Foundry project resource ID."
+          }
+        ]
+      }
+    },
+    "BudgetMatch": {
+      "type": "object",
+      "description": "Trusted request attributes and allowed values used to select matching requests.",
+      "properties": {
+        "foundry.caller.agent.id": {
+          "type": "array",
+          "description": "The stable Foundry agent IDs to match.",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "$ref": "#/definitions/BudgetMatchValue"
+          },
+          "x-ms-client-name": "agentIds"
+        },
+        "foundry.caller.identity.oid": {
+          "type": "array",
+          "description": "The authenticated principal object IDs to match.",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "$ref": "#/definitions/BudgetMatchValue"
+          },
+          "x-ms-client-name": "identityObjectIds"
+        },
+        "foundry.caller.session.id": {
+          "type": "array",
+          "description": "The Foundry session IDs to match.",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "$ref": "#/definitions/BudgetMatchValue"
+          },
+          "x-ms-client-name": "sessionIds"
+        },
+        "foundry.caller.project.id": {
+          "type": "array",
+          "description": "The Foundry project resource IDs to match.",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "$ref": "#/definitions/BudgetMatchValue"
+          },
+          "x-ms-client-name": "projectIds"
+        }
+      }
+    },
+    "BudgetMatchValue": {
+      "type": "string",
+      "description": "A non-empty value used to match a trusted request attribute.",
+      "minLength": 1
+    },
+    "BudgetPeriod": {
+      "type": "string",
+      "description": "The calendar-aligned UTC renewal periods for recurring budget rules.",
+      "enum": [
+        "minute",
+        "hour",
+        "day",
+        "week",
+        "month",
+        "year"
+      ],
+      "x-ms-enum": {
+        "name": "BudgetPeriod",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Minute",
+            "value": "minute",
+            "description": "Renews at the start of the next UTC minute."
+          },
+          {
+            "name": "Hour",
+            "value": "hour",
+            "description": "Renews at the start of the next UTC hour."
+          },
+          {
+            "name": "Day",
+            "value": "day",
+            "description": "Renews daily at 00:00 UTC."
+          },
+          {
+            "name": "Week",
+            "value": "week",
+            "description": "Renews Monday at 00:00 UTC."
+          },
+          {
+            "name": "Month",
+            "value": "month",
+            "description": "Renews on the first day of each month at 00:00 UTC."
+          },
+          {
+            "name": "Year",
+            "value": "year",
+            "description": "Renews January 1 at 00:00 UTC."
+          }
+        ]
+      }
+    },
+    "BudgetPolicy": {
+      "type": "object",
+      "description": "A budget policy owned by a Cognitive Services account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BudgetPolicyProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "etag": {
+          "type": "string",
+          "description": "The entity tag used for optimistic concurrency.",
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "BudgetPolicyEtagHeader": {
+      "type": "object",
+      "description": "The entity tag returned with a budget policy."
+    },
+    "BudgetPolicyListResult": {
+      "type": "object",
+      "description": "A page of budget policies.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of budget policies."
+        },
+        "value": {
+          "type": "array",
+          "description": "The budget policies in this page.",
+          "items": {
+            "$ref": "#/definitions/BudgetPolicy"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "BudgetPolicyPatch": {
+      "type": "object",
+      "description": "The request used to update a budget policy.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BudgetPolicyPatchProperties",
+          "description": "The budget policy properties to update."
+        }
+      },
+      "required": [
+        "properties"
+      ]
+    },
+    "BudgetPolicyPatchProperties": {
+      "type": "object",
+      "description": "The properties that can be changed on a budget policy.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "An optional human-readable name for the policy. Set this property to null to clear it.",
+          "maxLength": 128,
+          "x-nullable": true
+        },
+        "rules": {
+          "type": "array",
+          "description": "The complete replacement set of budget rules.",
+          "minItems": 1,
+          "maxItems": 50,
+          "items": {
+            "$ref": "#/definitions/BudgetRule"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "BudgetPolicyProperties": {
+      "type": "object",
+      "description": "The customer-authored settings of a budget policy.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "An optional human-readable name for the policy.",
+          "maxLength": 128
+        },
+        "rules": {
+          "type": "array",
+          "description": "The budget rules enforced by the policy.",
+          "minItems": 1,
+          "maxItems": 50,
+          "items": {
+            "$ref": "#/definitions/BudgetRule"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "rules"
+      ]
+    },
+    "BudgetRule": {
+      "type": "object",
+      "description": "A budget limit and the population to which it applies.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The stable rule identifier, unique within the policy without regard to case.",
+          "maxLength": 64,
+          "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_.-]{0,63}$",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "counterKey": {
+          "type": "array",
+          "description": "The built-in dimension used to partition consumption. The initial preview supports exactly one dimension.",
+          "minItems": 1,
+          "maxItems": 1,
+          "items": {
+            "$ref": "#/definitions/BudgetDimension"
+          },
+          "x-ms-identifiers": [
+            "type"
+          ]
+        },
+        "unit": {
+          "$ref": "#/definitions/BudgetUnit",
+          "description": "The unit used for the budget amount and absolute thresholds."
+        },
+        "amount": {
+          "type": "number",
+          "format": "double",
+          "description": "The maximum consumption allowed by this rule, expressed in the selected unit."
+        },
+        "period": {
+          "$ref": "#/definitions/BudgetPeriod",
+          "description": "The calendar-aligned UTC renewal period. This property is required for recurring rules and omitted for non-recurring rules."
+        },
+        "recurring": {
+          "type": "boolean",
+          "description": "Whether the budget renews. The default is true.",
+          "default": true
+        },
+        "match": {
+          "$ref": "#/definitions/BudgetMatch",
+          "description": "Trusted request attributes and allowed values used to select matching requests."
+        },
+        "thresholds": {
+          "type": "array",
+          "description": "The actions evaluated as consumption approaches the configured amount.",
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/definitions/BudgetThreshold"
+          },
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "name",
+        "counterKey",
+        "unit",
+        "amount",
+        "thresholds"
+      ]
+    },
+    "BudgetThreshold": {
+      "type": "object",
+      "description": "An action evaluated when budget consumption reaches a threshold.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/BudgetThresholdType",
+          "description": "How the threshold value is interpreted."
+        },
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "The threshold value. Percentage values range from 0 through 100, and absolute values cannot exceed the rule amount.",
+          "minimum": 0
+        },
+        "action": {
+          "type": "string",
+          "description": "The action taken when the threshold is reached. The default is audit.",
+          "default": "audit",
+          "enum": [
+            "audit",
+            "alert"
+          ],
+          "x-ms-enum": {
+            "name": "BudgetThresholdAction",
+            "modelAsString": false,
+            "values": [
+              {
+                "name": "Audit",
+                "value": "audit",
+                "description": "Records the threshold crossing without notifying the customer or blocking requests."
+              },
+              {
+                "name": "Alert",
+                "value": "alert",
+                "description": "Emits a customer-facing alert without blocking requests."
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "type",
+        "value"
+      ]
+    },
+    "BudgetThresholdAction": {
+      "type": "string",
+      "description": "The supported actions when a threshold is reached.",
+      "enum": [
+        "audit",
+        "alert"
+      ],
+      "x-ms-enum": {
+        "name": "BudgetThresholdAction",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Audit",
+            "value": "audit",
+            "description": "Records the threshold crossing without notifying the customer or blocking requests."
+          },
+          {
+            "name": "Alert",
+            "value": "alert",
+            "description": "Emits a customer-facing alert without blocking requests."
+          }
+        ]
+      }
+    },
+    "BudgetThresholdType": {
+      "type": "string",
+      "description": "The supported threshold value interpretations.",
+      "enum": [
+        "percentage",
+        "absolute"
+      ],
+      "x-ms-enum": {
+        "name": "BudgetThresholdType",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Percentage",
+            "value": "percentage",
+            "description": "The value is a percentage of the configured rule amount."
+          },
+          {
+            "name": "Absolute",
+            "value": "absolute",
+            "description": "The value is expressed in the rule's unit."
+          }
+        ]
+      }
+    },
+    "BudgetUnit": {
+      "type": "string",
+      "enum": [
+        "usd"
+      ],
+      "x-ms-enum": {
+        "modelAsString": false
+      },
+      "x-nullable": false
+    },
+    "BuiltInAuthorizationScheme": {
+      "type": "string",
+      "description": "Authorization scheme type.",
+      "enum": [
+        "Default",
+        "OrganizationScope",
+        "Channels",
+        "Custom"
+      ],
+      "x-ms-enum": {
+        "name": "BuiltInAuthorizationScheme",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Standard AzureML RBAC"
+          },
+          {
+            "name": "OrganizationScope",
+            "value": "OrganizationScope",
+            "description": "Claim-based, requires membership in the tenant"
+          },
+          {
+            "name": "Channels",
+            "value": "Channels",
+            "description": "Channels-specific (AzureBotService) authorization"
+          },
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "Custom scheme defined by the application author"
+          }
+        ]
+      }
+    },
+    "ByPassSelection": {
+      "type": "string",
+      "description": "Setting for trusted services.",
+      "enum": [
+        "None",
+        "AzureServices"
+      ],
+      "x-ms-enum": {
+        "name": "ByPassSelection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "AzureServices",
+            "value": "AzureServices"
+          }
+        ]
+      }
+    },
+    "CalculateModelCapacityParameter": {
+      "type": "object",
+      "description": "Calculate Model Capacity parameter.",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/DeploymentModel",
+          "description": "Properties of Cognitive Services account deployment model."
+        },
+        "skuName": {
+          "type": "string",
+          "description": "The name of SKU."
+        },
+        "workloads": {
+          "type": "array",
+          "description": "List of Model Capacity Calculator Workload.",
+          "items": {
+            "$ref": "#/definitions/ModelCapacityCalculatorWorkload"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "CalculateModelCapacityResult": {
+      "type": "object",
+      "description": "Calculate Model Capacity result.",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/DeploymentModel",
+          "description": "Properties of Cognitive Services account deployment model."
+        },
+        "skuName": {
+          "type": "string"
+        },
+        "estimatedCapacity": {
+          "$ref": "#/definitions/CalculateModelCapacityResultEstimatedCapacity",
+          "description": "Model Estimated Capacity."
+        }
+      }
+    },
+    "CalculateModelCapacityResultEstimatedCapacity": {
+      "type": "object",
+      "description": "Model Estimated Capacity.",
+      "properties": {
+        "value": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "deployableValue": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "CallRateLimit": {
+      "type": "object",
+      "description": "The call rate limit Cognitive Services account.",
+      "properties": {
+        "count": {
+          "type": "number",
+          "format": "float",
+          "description": "The count value of Call Rate Limit."
+        },
+        "renewalPeriod": {
+          "type": "number",
+          "format": "float",
+          "description": "The renewal period in seconds of Call Rate Limit."
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ThrottlingRule"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        }
+      }
+    },
+    "CapabilityHost": {
+      "type": "object",
+      "description": "Azure Resource Manager resource envelope.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CapabilityHostProperties",
+          "description": "[Required] Additional attributes of the entity."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CapabilityHostKind": {
+      "type": "string",
+      "enum": [
+        "Agents"
+      ],
+      "x-ms-enum": {
+        "name": "CapabilityHostKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Agents",
+            "value": "Agents"
+          }
+        ]
+      }
+    },
+    "CapabilityHostProperties": {
+      "type": "object",
+      "properties": {
+        "aiServicesConnections": {
+          "type": "array",
+          "description": "List of AI services connections.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "capabilityHostKind": {
+          "$ref": "#/definitions/CapabilityHostKind",
+          "description": "Kind of this capability host."
+        },
+        "customerSubnet": {
+          "type": "string",
+          "description": "Customer subnet info to help set up this capability host.",
+          "x-nullable": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/CapabilityHostProvisioningState",
+          "description": "Provisioning state for the CapabilityHost.",
+          "readOnly": true
+        },
+        "storageConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used as a storage resource.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "threadStorageConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used for Thread storage.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "vectorStoreConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used for vector database (e.g. CosmosDB).",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "enablePublicHostingEnvironment": {
+          "type": "boolean",
+          "description": "Whether public hosting environment is enabled for the capability host"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceBase"
+        }
+      ]
+    },
+    "CapabilityHostProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of capability host.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "CapabilityHostProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "CapabilityHostResourceArmPaginatedResult": {
+      "type": "object",
+      "description": "A paginated list of Capability Host entities.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of Capability Host objects. If null, there are no additional pages.",
+          "x-nullable": true
+        },
+        "value": {
+          "type": "array",
+          "description": "An array of objects of type Capability Host.",
+          "items": {
+            "$ref": "#/definitions/CapabilityHost"
+          }
+        }
+      }
+    },
+    "CapacityConfig": {
+      "type": "object",
+      "description": "The capacity configuration.",
+      "properties": {
+        "minimum": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum capacity."
+        },
+        "maximum": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum capacity."
+        },
+        "step": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimal incremental between allowed values for capacity."
+        },
+        "default": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The default capacity."
+        },
+        "allowedValues": {
+          "type": "array",
+          "description": "The array of allowed values for capacity.",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    },
+    "ChannelsBuiltInAuthorizationPolicy": {
+      "type": "object",
+      "description": "Represents a built-in authorization policy specific to Azure Bot Service/Channels authentication.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApplicationAuthorizationPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "Channels"
+    },
+    "CheckDomainAvailabilityParameter": {
+      "type": "object",
+      "description": "Check Domain availability parameter.",
+      "properties": {
+        "subdomainName": {
+          "type": "string",
+          "description": "The subdomain name to use."
+        },
+        "type": {
+          "type": "string",
+          "description": "The Type of the resource."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        }
+      },
+      "required": [
+        "subdomainName",
+        "type"
+      ]
+    },
+    "CheckSkuAvailabilityParameter": {
+      "type": "object",
+      "description": "Check SKU availability parameter.",
+      "properties": {
+        "skus": {
+          "type": "array",
+          "description": "The SKU of the resource.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "type": {
+          "type": "string",
+          "description": "The Type of the resource."
+        }
+      },
+      "required": [
+        "skus",
+        "kind",
+        "type"
+      ]
+    },
+    "CommitmentCost": {
+      "type": "object",
+      "description": "Cognitive Services account commitment cost.",
+      "properties": {
+        "commitmentMeterId": {
+          "type": "string",
+          "description": "Commitment meter Id."
+        },
+        "overageMeterId": {
+          "type": "string",
+          "description": "Overage meter Id."
+        }
+      }
+    },
+    "CommitmentPeriod": {
+      "type": "object",
+      "description": "Cognitive Services account commitment period.",
+      "properties": {
+        "tier": {
+          "type": "string",
+          "description": "Commitment period commitment tier."
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Commitment period commitment count."
+        },
+        "quota": {
+          "$ref": "#/definitions/CommitmentQuota",
+          "description": "Cognitive Services account commitment quota.",
+          "readOnly": true
+        },
+        "startDate": {
+          "type": "string",
+          "description": "Commitment period start date.",
+          "readOnly": true
+        },
+        "endDate": {
+          "type": "string",
+          "description": "Commitment period end date.",
+          "readOnly": true
+        }
+      }
+    },
+    "CommitmentPlan": {
+      "type": "object",
+      "description": "Cognitive Services account commitment plan.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CommitmentPlanProperties",
+          "description": "Properties of Cognitive Services account commitment plan."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CommitmentPlanAccountAssociation": {
+      "type": "object",
+      "description": "The commitment plan association.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CommitmentPlanAccountAssociationProperties",
+          "description": "Properties of Cognitive Services account commitment plan association.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "CommitmentPlanAccountAssociationListResult": {
+      "type": "object",
+      "description": "The list of cognitive services Commitment Plan Account Association operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Commitment Plan Account Association."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services Commitment Plan Account Association and their properties.",
+          "items": {
+            "$ref": "#/definitions/CommitmentPlanAccountAssociation"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      }
+    },
+    "CommitmentPlanAccountAssociationProperties": {
+      "type": "object",
+      "description": "The commitment plan account association properties.",
+      "properties": {
+        "accountId": {
+          "type": "string",
+          "description": "The Azure resource id of the account."
+        }
+      }
+    },
+    "CommitmentPlanAssociation": {
+      "type": "object",
+      "description": "The commitment plan association.",
+      "properties": {
+        "commitmentPlanId": {
+          "type": "string",
+          "description": "The Azure resource id of the commitment plan."
+        },
+        "commitmentPlanLocation": {
+          "type": "string",
+          "description": "The location of of the commitment plan."
+        }
+      }
+    },
+    "CommitmentPlanListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of CommitmentPlan."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts CommitmentPlan and their properties.",
+          "items": {
+            "$ref": "#/definitions/CommitmentPlan"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "CommitmentPlanProperties": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account commitment plan.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/CommitmentPlanProvisioningState",
+          "description": "Gets the status of the resource at the time the operation was called.",
+          "readOnly": true
+        },
+        "commitmentPlanGuid": {
+          "type": "string",
+          "description": "Commitment plan guid."
+        },
+        "hostingModel": {
+          "$ref": "#/definitions/HostingModel",
+          "description": "Account hosting model."
+        },
+        "planType": {
+          "type": "string",
+          "description": "Commitment plan type."
+        },
+        "current": {
+          "$ref": "#/definitions/CommitmentPeriod",
+          "description": "Cognitive Services account commitment period."
+        },
+        "autoRenew": {
+          "type": "boolean",
+          "description": "AutoRenew commitment plan."
+        },
+        "next": {
+          "$ref": "#/definitions/CommitmentPeriod",
+          "description": "Cognitive Services account commitment period."
+        },
+        "last": {
+          "$ref": "#/definitions/CommitmentPeriod",
+          "description": "Cognitive Services account commitment period.",
+          "readOnly": true
+        },
+        "provisioningIssues": {
+          "type": "array",
+          "description": "The list of ProvisioningIssue.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "CommitmentPlanProvisioningState": {
+      "type": "string",
+      "description": "Gets the status of the resource at the time the operation was called.",
+      "enum": [
+        "Accepted",
+        "Creating",
+        "Deleting",
+        "Moving",
+        "Failed",
+        "Succeeded",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "CommitmentPlanProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Moving",
+            "value": "Moving"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "CommitmentQuota": {
+      "type": "object",
+      "description": "Cognitive Services account commitment quota.",
+      "properties": {
+        "quantity": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Commitment quota quantity."
+        },
+        "unit": {
+          "type": "string",
+          "description": "Commitment quota unit."
+        }
+      }
+    },
+    "CommitmentTier": {
+      "type": "object",
+      "description": "Cognitive Services account commitment tier.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "skuName": {
+          "type": "string",
+          "description": "The name of the SKU. Ex - P3. It is typically a letter+number code"
+        },
+        "hostingModel": {
+          "$ref": "#/definitions/HostingModel",
+          "description": "Account hosting model."
+        },
+        "planType": {
+          "type": "string",
+          "description": "Commitment plan type."
+        },
+        "tier": {
+          "type": "string",
+          "description": "Commitment period commitment tier."
+        },
+        "maxCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Commitment period commitment max count."
+        },
+        "quota": {
+          "$ref": "#/definitions/CommitmentQuota",
+          "description": "Cognitive Services account commitment quota."
+        },
+        "cost": {
+          "$ref": "#/definitions/CommitmentCost",
+          "description": "Cognitive Services account commitment cost."
+        }
+      }
+    },
+    "CommitmentTierListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of CommitmentTier."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts CommitmentTier and their properties.",
+          "items": {
+            "$ref": "#/definitions/CommitmentTier"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "kind",
+            "tier",
+            "skuName",
+            "hostingModel",
+            "planType"
+          ]
+        }
+      }
+    },
+    "ConnectionAccessKey": {
+      "type": "object",
+      "properties": {
+        "accessKeyId": {
+          "type": "string"
+        },
+        "secretAccessKey": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "ConnectionAccountKey": {
+      "type": "object",
+      "description": "Account key object for connection credential.",
+      "properties": {
+        "key": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "ConnectionApiKey": {
+      "type": "object",
+      "description": "Api key object for connection credential.",
+      "properties": {
+        "key": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "ConnectionAuthType": {
+      "type": "string",
+      "description": "Authentication type of the connection target",
+      "enum": [
+        "PAT",
+        "ManagedIdentity",
+        "UsernamePassword",
+        "None",
+        "SAS",
+        "AccountKey",
+        "ServicePrincipal",
+        "AccessKey",
+        "ApiKey",
+        "CustomKeys",
+        "OAuth2",
+        "AAD",
+        "DelegatedSAS",
+        "ProjectManagedIdentity",
+        "AccountManagedIdentity",
+        "UserEntraToken",
+        "AgentUserImpersonation",
+        "AgenticIdentityToken",
+        "AgenticUser"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionAuthType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PAT",
+            "value": "PAT"
+          },
+          {
+            "name": "ManagedIdentity",
+            "value": "ManagedIdentity"
+          },
+          {
+            "name": "UsernamePassword",
+            "value": "UsernamePassword"
+          },
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "SAS",
+            "value": "SAS"
+          },
+          {
+            "name": "AccountKey",
+            "value": "AccountKey"
+          },
+          {
+            "name": "ServicePrincipal",
+            "value": "ServicePrincipal"
+          },
+          {
+            "name": "AccessKey",
+            "value": "AccessKey"
+          },
+          {
+            "name": "ApiKey",
+            "value": "ApiKey"
+          },
+          {
+            "name": "CustomKeys",
+            "value": "CustomKeys"
+          },
+          {
+            "name": "OAuth2",
+            "value": "OAuth2"
+          },
+          {
+            "name": "AAD",
+            "value": "AAD"
+          },
+          {
+            "name": "DelegatedSAS",
+            "value": "DelegatedSAS"
+          },
+          {
+            "name": "ProjectManagedIdentity",
+            "value": "ProjectManagedIdentity"
+          },
+          {
+            "name": "AccountManagedIdentity",
+            "value": "AccountManagedIdentity"
+          },
+          {
+            "name": "UserEntraToken",
+            "value": "UserEntraToken"
+          },
+          {
+            "name": "AgentUserImpersonation",
+            "value": "AgentUserImpersonation"
+          },
+          {
+            "name": "AgenticIdentityToken",
+            "value": "AgenticIdentityToken"
+          },
+          {
+            "name": "AgenticUser",
+            "value": "AgenticUser"
+          }
+        ]
+      }
+    },
+    "ConnectionCategory": {
+      "type": "string",
+      "description": "Category of the connection",
+      "enum": [
+        "PythonFeed",
+        "ContainerRegistry",
+        "Git",
+        "S3",
+        "Snowflake",
+        "AzureKeyVault",
+        "AzureSqlDb",
+        "AzureSynapseAnalytics",
+        "AzureMySqlDb",
+        "AzurePostgresDb",
+        "ADLSGen2",
+        "AzureContainerAppEnvironment",
+        "Redis",
+        "ApiKey",
+        "AzureOpenAI",
+        "AIServices",
+        "CognitiveSearch",
+        "CognitiveService",
+        "CustomKeys",
+        "AzureBlob",
+        "AzureStorageAccount",
+        "AzureOneLake",
+        "CosmosDb",
+        "CosmosDbMongoDbApi",
+        "AzureDataExplorer",
+        "AzureMariaDb",
+        "AzureDatabricksDeltaLake",
+        "AzureSqlMi",
+        "AzureTableStorage",
+        "AmazonRdsForOracle",
+        "AmazonRdsForSqlServer",
+        "AmazonRedshift",
+        "Db2",
+        "Drill",
+        "GoogleBigQuery",
+        "Greenplum",
+        "Hbase",
+        "Hive",
+        "Impala",
+        "Informix",
+        "MariaDb",
+        "MicrosoftAccess",
+        "MySql",
+        "Netezza",
+        "Oracle",
+        "Phoenix",
+        "PostgreSql",
+        "Presto",
+        "SapOpenHub",
+        "SapBw",
+        "SapHana",
+        "SapTable",
+        "Spark",
+        "SqlServer",
+        "Sybase",
+        "Teradata",
+        "Vertica",
+        "Pinecone",
+        "Databricks",
+        "Cassandra",
+        "Couchbase",
+        "MongoDbV2",
+        "MongoDbAtlas",
+        "AmazonS3Compatible",
+        "FileServer",
+        "FtpServer",
+        "GoogleCloudStorage",
+        "Hdfs",
+        "OracleCloudStorage",
+        "Sftp",
+        "GenericHttp",
+        "ODataRest",
+        "Odbc",
+        "GenericRest",
+        "RemoteTool",
+        "AmazonMws",
+        "Concur",
+        "Dynamics",
+        "DynamicsAx",
+        "DynamicsCrm",
+        "GoogleAdWords",
+        "Hubspot",
+        "Jira",
+        "Magento",
+        "Marketo",
+        "Office365",
+        "Eloqua",
+        "Responsys",
+        "OracleServiceCloud",
+        "PayPal",
+        "QuickBooks",
+        "Salesforce",
+        "SalesforceServiceCloud",
+        "SalesforceMarketingCloud",
+        "SapCloudForCustomer",
+        "SapEcc",
+        "ServiceNow",
+        "SharePointOnlineList",
+        "Shopify",
+        "Square",
+        "WebTable",
+        "Xero",
+        "Zoho",
+        "GenericContainerRegistry",
+        "Elasticsearch",
+        "AppInsights",
+        "AppConfig",
+        "OpenAI",
+        "Serp",
+        "BingLLMSearch",
+        "Serverless",
+        "ManagedOnlineEndpoint",
+        "ApiManagement",
+        "ModelGateway",
+        "GroundingWithBingSearch",
+        "GroundingWithCustomSearch",
+        "Sharepoint",
+        "MicrosoftFabric",
+        "PowerPlatformEnvironment",
+        "RemoteA2A"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionCategory",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "PythonFeed",
+            "value": "PythonFeed"
+          },
+          {
+            "name": "ContainerRegistry",
+            "value": "ContainerRegistry"
+          },
+          {
+            "name": "Git",
+            "value": "Git"
+          },
+          {
+            "name": "S3",
+            "value": "S3"
+          },
+          {
+            "name": "Snowflake",
+            "value": "Snowflake"
+          },
+          {
+            "name": "AzureKeyVault",
+            "value": "AzureKeyVault"
+          },
+          {
+            "name": "AzureSqlDb",
+            "value": "AzureSqlDb"
+          },
+          {
+            "name": "AzureSynapseAnalytics",
+            "value": "AzureSynapseAnalytics"
+          },
+          {
+            "name": "AzureMySqlDb",
+            "value": "AzureMySqlDb"
+          },
+          {
+            "name": "AzurePostgresDb",
+            "value": "AzurePostgresDb"
+          },
+          {
+            "name": "ADLSGen2",
+            "value": "ADLSGen2"
+          },
+          {
+            "name": "AzureContainerAppEnvironment",
+            "value": "AzureContainerAppEnvironment"
+          },
+          {
+            "name": "Redis",
+            "value": "Redis"
+          },
+          {
+            "name": "ApiKey",
+            "value": "ApiKey"
+          },
+          {
+            "name": "AzureOpenAI",
+            "value": "AzureOpenAI"
+          },
+          {
+            "name": "AIServices",
+            "value": "AIServices"
+          },
+          {
+            "name": "CognitiveSearch",
+            "value": "CognitiveSearch"
+          },
+          {
+            "name": "CognitiveService",
+            "value": "CognitiveService"
+          },
+          {
+            "name": "CustomKeys",
+            "value": "CustomKeys"
+          },
+          {
+            "name": "AzureBlob",
+            "value": "AzureBlob"
+          },
+          {
+            "name": "AzureStorageAccount",
+            "value": "AzureStorageAccount"
+          },
+          {
+            "name": "AzureOneLake",
+            "value": "AzureOneLake"
+          },
+          {
+            "name": "CosmosDb",
+            "value": "CosmosDb"
+          },
+          {
+            "name": "CosmosDbMongoDbApi",
+            "value": "CosmosDbMongoDbApi"
+          },
+          {
+            "name": "AzureDataExplorer",
+            "value": "AzureDataExplorer"
+          },
+          {
+            "name": "AzureMariaDb",
+            "value": "AzureMariaDb"
+          },
+          {
+            "name": "AzureDatabricksDeltaLake",
+            "value": "AzureDatabricksDeltaLake"
+          },
+          {
+            "name": "AzureSqlMi",
+            "value": "AzureSqlMi"
+          },
+          {
+            "name": "AzureTableStorage",
+            "value": "AzureTableStorage"
+          },
+          {
+            "name": "AmazonRdsForOracle",
+            "value": "AmazonRdsForOracle"
+          },
+          {
+            "name": "AmazonRdsForSqlServer",
+            "value": "AmazonRdsForSqlServer"
+          },
+          {
+            "name": "AmazonRedshift",
+            "value": "AmazonRedshift"
+          },
+          {
+            "name": "Db2",
+            "value": "Db2"
+          },
+          {
+            "name": "Drill",
+            "value": "Drill"
+          },
+          {
+            "name": "GoogleBigQuery",
+            "value": "GoogleBigQuery"
+          },
+          {
+            "name": "Greenplum",
+            "value": "Greenplum"
+          },
+          {
+            "name": "Hbase",
+            "value": "Hbase"
+          },
+          {
+            "name": "Hive",
+            "value": "Hive"
+          },
+          {
+            "name": "Impala",
+            "value": "Impala"
+          },
+          {
+            "name": "Informix",
+            "value": "Informix"
+          },
+          {
+            "name": "MariaDb",
+            "value": "MariaDb"
+          },
+          {
+            "name": "MicrosoftAccess",
+            "value": "MicrosoftAccess"
+          },
+          {
+            "name": "MySql",
+            "value": "MySql"
+          },
+          {
+            "name": "Netezza",
+            "value": "Netezza"
+          },
+          {
+            "name": "Oracle",
+            "value": "Oracle"
+          },
+          {
+            "name": "Phoenix",
+            "value": "Phoenix"
+          },
+          {
+            "name": "PostgreSql",
+            "value": "PostgreSql"
+          },
+          {
+            "name": "Presto",
+            "value": "Presto"
+          },
+          {
+            "name": "SapOpenHub",
+            "value": "SapOpenHub"
+          },
+          {
+            "name": "SapBw",
+            "value": "SapBw"
+          },
+          {
+            "name": "SapHana",
+            "value": "SapHana"
+          },
+          {
+            "name": "SapTable",
+            "value": "SapTable"
+          },
+          {
+            "name": "Spark",
+            "value": "Spark"
+          },
+          {
+            "name": "SqlServer",
+            "value": "SqlServer"
+          },
+          {
+            "name": "Sybase",
+            "value": "Sybase"
+          },
+          {
+            "name": "Teradata",
+            "value": "Teradata"
+          },
+          {
+            "name": "Vertica",
+            "value": "Vertica"
+          },
+          {
+            "name": "Pinecone",
+            "value": "Pinecone"
+          },
+          {
+            "name": "Databricks",
+            "value": "Databricks"
+          },
+          {
+            "name": "Cassandra",
+            "value": "Cassandra"
+          },
+          {
+            "name": "Couchbase",
+            "value": "Couchbase"
+          },
+          {
+            "name": "MongoDbV2",
+            "value": "MongoDbV2"
+          },
+          {
+            "name": "MongoDbAtlas",
+            "value": "MongoDbAtlas"
+          },
+          {
+            "name": "AmazonS3Compatible",
+            "value": "AmazonS3Compatible"
+          },
+          {
+            "name": "FileServer",
+            "value": "FileServer"
+          },
+          {
+            "name": "FtpServer",
+            "value": "FtpServer"
+          },
+          {
+            "name": "GoogleCloudStorage",
+            "value": "GoogleCloudStorage"
+          },
+          {
+            "name": "Hdfs",
+            "value": "Hdfs"
+          },
+          {
+            "name": "OracleCloudStorage",
+            "value": "OracleCloudStorage"
+          },
+          {
+            "name": "Sftp",
+            "value": "Sftp"
+          },
+          {
+            "name": "GenericHttp",
+            "value": "GenericHttp"
+          },
+          {
+            "name": "ODataRest",
+            "value": "ODataRest"
+          },
+          {
+            "name": "Odbc",
+            "value": "Odbc"
+          },
+          {
+            "name": "GenericRest",
+            "value": "GenericRest"
+          },
+          {
+            "name": "RemoteTool",
+            "value": "RemoteTool"
+          },
+          {
+            "name": "AmazonMws",
+            "value": "AmazonMws"
+          },
+          {
+            "name": "Concur",
+            "value": "Concur"
+          },
+          {
+            "name": "Dynamics",
+            "value": "Dynamics"
+          },
+          {
+            "name": "DynamicsAx",
+            "value": "DynamicsAx"
+          },
+          {
+            "name": "DynamicsCrm",
+            "value": "DynamicsCrm"
+          },
+          {
+            "name": "GoogleAdWords",
+            "value": "GoogleAdWords"
+          },
+          {
+            "name": "Hubspot",
+            "value": "Hubspot"
+          },
+          {
+            "name": "Jira",
+            "value": "Jira"
+          },
+          {
+            "name": "Magento",
+            "value": "Magento"
+          },
+          {
+            "name": "Marketo",
+            "value": "Marketo"
+          },
+          {
+            "name": "Office365",
+            "value": "Office365"
+          },
+          {
+            "name": "Eloqua",
+            "value": "Eloqua"
+          },
+          {
+            "name": "Responsys",
+            "value": "Responsys"
+          },
+          {
+            "name": "OracleServiceCloud",
+            "value": "OracleServiceCloud"
+          },
+          {
+            "name": "PayPal",
+            "value": "PayPal"
+          },
+          {
+            "name": "QuickBooks",
+            "value": "QuickBooks"
+          },
+          {
+            "name": "Salesforce",
+            "value": "Salesforce"
+          },
+          {
+            "name": "SalesforceServiceCloud",
+            "value": "SalesforceServiceCloud"
+          },
+          {
+            "name": "SalesforceMarketingCloud",
+            "value": "SalesforceMarketingCloud"
+          },
+          {
+            "name": "SapCloudForCustomer",
+            "value": "SapCloudForCustomer"
+          },
+          {
+            "name": "SapEcc",
+            "value": "SapEcc"
+          },
+          {
+            "name": "ServiceNow",
+            "value": "ServiceNow"
+          },
+          {
+            "name": "SharePointOnlineList",
+            "value": "SharePointOnlineList"
+          },
+          {
+            "name": "Shopify",
+            "value": "Shopify"
+          },
+          {
+            "name": "Square",
+            "value": "Square"
+          },
+          {
+            "name": "WebTable",
+            "value": "WebTable"
+          },
+          {
+            "name": "Xero",
+            "value": "Xero"
+          },
+          {
+            "name": "Zoho",
+            "value": "Zoho"
+          },
+          {
+            "name": "GenericContainerRegistry",
+            "value": "GenericContainerRegistry"
+          },
+          {
+            "name": "Elasticsearch",
+            "value": "Elasticsearch"
+          },
+          {
+            "name": "AppInsights",
+            "value": "AppInsights"
+          },
+          {
+            "name": "AppConfig",
+            "value": "AppConfig"
+          },
+          {
+            "name": "OpenAI",
+            "value": "OpenAI"
+          },
+          {
+            "name": "Serp",
+            "value": "Serp"
+          },
+          {
+            "name": "BingLLMSearch",
+            "value": "BingLLMSearch"
+          },
+          {
+            "name": "Serverless",
+            "value": "Serverless"
+          },
+          {
+            "name": "ManagedOnlineEndpoint",
+            "value": "ManagedOnlineEndpoint"
+          },
+          {
+            "name": "ApiManagement",
+            "value": "ApiManagement"
+          },
+          {
+            "name": "ModelGateway",
+            "value": "ModelGateway"
+          },
+          {
+            "name": "GroundingWithBingSearch",
+            "value": "GroundingWithBingSearch"
+          },
+          {
+            "name": "GroundingWithCustomSearch",
+            "value": "GroundingWithCustomSearch"
+          },
+          {
+            "name": "Sharepoint",
+            "value": "Sharepoint"
+          },
+          {
+            "name": "MicrosoftFabric",
+            "value": "MicrosoftFabric"
+          },
+          {
+            "name": "PowerPlatformEnvironment",
+            "value": "PowerPlatformEnvironment"
+          },
+          {
+            "name": "RemoteA2A",
+            "value": "RemoteA2A"
+          }
+        ]
+      }
+    },
+    "ConnectionGroup": {
+      "type": "string",
+      "description": "Group based on connection category",
+      "enum": [
+        "Azure",
+        "AzureAI",
+        "Database",
+        "NoSQL",
+        "File",
+        "GenericProtocol",
+        "ServicesAndApps"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectionGroup",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Azure",
+            "value": "Azure"
+          },
+          {
+            "name": "AzureAI",
+            "value": "AzureAI"
+          },
+          {
+            "name": "Database",
+            "value": "Database"
+          },
+          {
+            "name": "NoSQL",
+            "value": "NoSQL"
+          },
+          {
+            "name": "File",
+            "value": "File"
+          },
+          {
+            "name": "GenericProtocol",
+            "value": "GenericProtocol"
+          },
+          {
+            "name": "ServicesAndApps",
+            "value": "ServicesAndApps"
+          }
+        ]
+      }
+    },
+    "ConnectionManagedIdentity": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "resourceId": {
+          "type": "string"
+        }
+      }
+    },
+    "ConnectionOAuth2": {
+      "type": "object",
+      "description": "ClientId and ClientSecret are required. Other properties are optional\ndepending on each OAuth2 provider's implementation.",
+      "properties": {
+        "authUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Required by Concur connection category"
+        },
+        "clientId": {
+          "$ref": "#/definitions/Azure.Core.uuid",
+          "description": "Client id in the format of UUID"
+        },
+        "clientSecret": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        },
+        "developerToken": {
+          "type": "string",
+          "format": "password",
+          "description": "Required by GoogleAdWords connection category",
+          "x-ms-secret": true
+        },
+        "password": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        },
+        "refreshToken": {
+          "type": "string",
+          "format": "password",
+          "description": "Required by GoogleBigQuery, GoogleAdWords, Hubspot, QuickBooks, Square, Xero, Zoho\nwhere user needs to get RefreshToken offline",
+          "x-ms-secret": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "Required by QuickBooks and Xero connection categories"
+        },
+        "username": {
+          "type": "string",
+          "description": "Concur, ServiceNow auth server AccessToken grant type is 'Password'\nwhich requires UsernamePassword"
+        }
+      }
+    },
+    "ConnectionPersonalAccessToken": {
+      "type": "object",
+      "properties": {
+        "pat": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "ConnectionPropertiesV2": {
+      "type": "object",
+      "description": "Connection property base schema.",
+      "properties": {
+        "authType": {
+          "$ref": "#/definitions/ConnectionAuthType",
+          "description": "Authentication type of the connection target"
+        },
+        "category": {
+          "$ref": "#/definitions/ConnectionCategory",
+          "description": "Category of the connection"
+        },
+        "createdByWorkspaceArmId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+          "readOnly": true
+        },
+        "error": {
+          "type": "string",
+          "description": "Provides the error message if the connection fails"
+        },
+        "expiryTime": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "group": {
+          "$ref": "#/definitions/ConnectionGroup",
+          "description": "Group based on connection category",
+          "readOnly": true
+        },
+        "isSharedToAll": {
+          "type": "boolean"
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Store user metadata for this connection",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "peRequirement": {
+          "$ref": "#/definitions/ManagedPERequirement",
+          "description": "Specifies how private endpoints are used with this connection: 'Required', 'NotRequired', or 'NotApplicable'."
+        },
+        "peStatus": {
+          "$ref": "#/definitions/ManagedPEStatus",
+          "description": "Specifies the status of private endpoints for this connection: 'Inactive', 'Active', or 'NotApplicable'."
+        },
+        "sharedUserList": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "target": {
+          "type": "string",
+          "description": "The connection URL to be used."
+        },
+        "useWorkspaceManagedIdentity": {
+          "type": "boolean"
+        }
+      },
+      "discriminator": "authType",
+      "required": [
+        "authType"
+      ]
+    },
+    "ConnectionPropertiesV2BasicResource": {
+      "type": "object",
+      "description": "Connection base resource schema.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectionPropertiesV2",
+          "description": "Connection property base schema."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ConnectionPropertiesV2BasicResourceArmPaginatedResult": {
+      "type": "object",
+      "properties": {
+        "nextLink": {
+          "type": "string"
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ConnectionPropertiesV2BasicResource"
+          }
+        }
+      }
+    },
+    "ConnectionServicePrincipal": {
+      "type": "object",
+      "properties": {
+        "clientId": {
+          "type": "string"
+        },
+        "clientSecret": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        },
+        "tenantId": {
+          "type": "string"
+        }
+      }
+    },
+    "ConnectionSharedAccessSignature": {
+      "type": "object",
+      "properties": {
+        "sas": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "ConnectionUpdateContent": {
+      "type": "object",
+      "description": "The properties that the Cognitive services connection will be updated with.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectionPropertiesV2",
+          "description": "The properties that the Cognitive services connection will be updated with."
+        }
+      }
+    },
+    "ConnectionUsernamePassword": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "type": "string",
+          "format": "password",
+          "x-ms-secret": true
+        },
+        "securityToken": {
+          "type": "string",
+          "format": "password",
+          "description": "Optional, required by connections like SalesForce for extra security in addition to UsernamePassword",
+          "x-ms-secret": true
+        },
+        "username": {
+          "type": "string"
+        }
+      }
+    },
+    "ContentLevel": {
+      "type": "string",
+      "description": "Level at which content is filtered.",
+      "enum": [
+        "Low",
+        "Medium",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "ContentLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Low",
+            "value": "Low"
+          },
+          {
+            "name": "Medium",
+            "value": "Medium"
+          },
+          {
+            "name": "High",
+            "value": "High"
+          }
+        ]
+      }
+    },
+    "CreatedByType": {
+      "type": "string",
+      "description": "The type of identity that created the resource.",
+      "enum": [
+        "User",
+        "Application",
+        "ManagedIdentity",
+        "Key"
+      ],
+      "x-ms-enum": {
+        "name": "CreatedByType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "User",
+            "value": "User"
+          },
+          {
+            "name": "Application",
+            "value": "Application"
+          },
+          {
+            "name": "ManagedIdentity",
+            "value": "ManagedIdentity"
+          },
+          {
+            "name": "Key",
+            "value": "Key"
+          }
+        ]
+      }
+    },
+    "CustomBlocklistConfig": {
+      "type": "object",
+      "description": "Gets or sets the source to which filter applies.",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/RaiPolicyContentSource",
+          "description": "Content source to apply the Content Filters."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RaiBlocklistConfig"
+        }
+      ]
+    },
+    "CustomKeys": {
+      "type": "object",
+      "description": "Custom Keys credential object",
+      "properties": {
+        "keys": {
+          "type": "object",
+          "description": "Dictionary of <string>",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CustomKeysConnectionProperties": {
+      "type": "object",
+      "description": "Category:= CustomKeys\nAuthType:= CustomKeys (as type discriminator)\nCredentials:= {CustomKeys} as CustomKeys\nTarget:= {any value}\nUse Metadata property bag for ApiVersion and other metadata fields",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/CustomKeys",
+          "description": "Custom Keys credential object"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "CustomKeys"
+    },
+    "DefenderForAISetting": {
+      "type": "object",
+      "description": "The Defender for AI resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DefenderForAISettingProperties",
+          "description": "The Defender for AI resource properties.",
+          "x-ms-client-flatten": true
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DefenderForAISettingProperties": {
+      "type": "object",
+      "description": "The Defender for AI resource properties.",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/DefenderForAISettingState",
+          "description": "Defender for AI state on the AI resource."
+        }
+      }
+    },
+    "DefenderForAISettingResult": {
+      "type": "object",
+      "description": "The list of cognitive services Defender for AI Settings.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Defender for AI Settings."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of Defender for AI Settings.",
+          "items": {
+            "$ref": "#/definitions/DefenderForAISetting"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "DefenderForAISettingState": {
+      "type": "string",
+      "description": "Defender for AI state on the AI resource.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "DefenderForAISettingState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          }
+        ]
+      }
+    },
+    "Deployment": {
+      "type": "object",
+      "description": "Cognitive Services account deployment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DeploymentProperties",
+          "description": "Properties of Cognitive Services account deployment."
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DeploymentCapacitySettings": {
+      "type": "object",
+      "description": "Internal use only.",
+      "properties": {
+        "designatedCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The designated capacity.",
+          "minimum": 0
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The priority of this capacity setting.",
+          "minimum": 0
+        }
+      }
+    },
+    "DeploymentListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Deployment."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts Deployment and their properties.",
+          "items": {
+            "$ref": "#/definitions/Deployment"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "DeploymentModel": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account deployment model.",
+      "properties": {
+        "publisher": {
+          "type": "string",
+          "description": "Deployment model publisher."
+        },
+        "format": {
+          "type": "string",
+          "description": "Deployment model format."
+        },
+        "name": {
+          "type": "string",
+          "description": "Deployment model name."
+        },
+        "version": {
+          "type": "string",
+          "description": "Optional. Deployment model version. If version is not specified, a default version will be assigned. The default version is different for different models and might change when there is new version available for a model. Default version for a model could be found from list models API."
+        },
+        "source": {
+          "type": "string",
+          "description": "Optional. Deployment model source ARM resource ID."
+        },
+        "sourceAccount": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Optional. Source of the model, another Microsoft.CognitiveServices accounts ARM resource ID.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.CognitiveServices/accounts"
+              }
+            ]
+          }
+        },
+        "callRateLimit": {
+          "$ref": "#/definitions/CallRateLimit",
+          "description": "The call rate limit Cognitive Services account.",
+          "readOnly": true
+        }
+      }
+    },
+    "DeploymentModelVersionUpgradeOption": {
+      "type": "string",
+      "description": "Deployment model version upgrade option.",
+      "enum": [
+        "OnceNewDefaultVersionAvailable",
+        "OnceCurrentVersionExpired",
+        "NoAutoUpgrade"
+      ],
+      "x-ms-enum": {
+        "name": "DeploymentModelVersionUpgradeOption",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OnceNewDefaultVersionAvailable",
+            "value": "OnceNewDefaultVersionAvailable"
+          },
+          {
+            "name": "OnceCurrentVersionExpired",
+            "value": "OnceCurrentVersionExpired"
+          },
+          {
+            "name": "NoAutoUpgrade",
+            "value": "NoAutoUpgrade"
+          }
+        ]
+      }
+    },
+    "DeploymentProperties": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account deployment.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/DeploymentProvisioningState",
+          "description": "Gets the status of the resource at the time the operation was called.",
+          "readOnly": true
+        },
+        "model": {
+          "$ref": "#/definitions/DeploymentModel",
+          "description": "Properties of Cognitive Services account deployment model."
+        },
+        "scaleSettings": {
+          "$ref": "#/definitions/DeploymentScaleSettings",
+          "description": "Properties of Cognitive Services account deployment model. (Deprecated, please use Deployment.sku instead.)"
+        },
+        "capabilities": {
+          "type": "object",
+          "description": "The capabilities.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "raiPolicyName": {
+          "type": "string",
+          "description": "The name of RAI policy."
+        },
+        "callRateLimit": {
+          "$ref": "#/definitions/CallRateLimit",
+          "description": "The call rate limit Cognitive Services account.",
+          "readOnly": true
+        },
+        "rateLimits": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ThrottlingRule"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "key"
+          ]
+        },
+        "versionUpgradeOption": {
+          "$ref": "#/definitions/DeploymentModelVersionUpgradeOption",
+          "description": "Deployment model version upgrade option."
+        },
+        "dynamicThrottlingEnabled": {
+          "type": "boolean",
+          "description": "If the dynamic throttling is enabled.",
+          "readOnly": true
+        },
+        "currentCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The current capacity."
+        },
+        "capacitySettings": {
+          "$ref": "#/definitions/DeploymentCapacitySettings",
+          "description": "Internal use only."
+        },
+        "parentDeploymentName": {
+          "type": "string",
+          "description": "The name of parent deployment."
+        },
+        "spilloverDeploymentName": {
+          "type": "string",
+          "description": "Specifies the deployment name that should serve requests when the request would have otherwise been throttled due to reaching current deployment throughput limit."
+        },
+        "serviceTier": {
+          "$ref": "#/definitions/ServiceTier",
+          "description": "The service tier for the deployment. Determines the pricing and performance level for request processing. Use 'Default' for standard pricing or 'Priority' for higher-priority processing with premium pricing. Note: Pause operations are only supported on Standard, DataZoneStandard, and GlobalStandard SKUs.",
+          "x-nullable": true
+        },
+        "deploymentState": {
+          "$ref": "#/definitions/DeploymentState",
+          "description": "The state of the deployment. Controls whether the deployment is accepting inference requests. Use 'Running' for active deployments that process requests, or 'Paused' to temporarily stop inference while preserving the deployment configuration.",
+          "x-nullable": true
+        },
+        "routing": {
+          "$ref": "#/definitions/DeploymentRouting",
+          "description": "Routing configuration for the model-router deployment. This property is only applicable when the deployed model is 'model-router' version 2025-11-18 or later. Allows you to select the models subset for routing and the routing mode (balanced, quality, cost) for routing across all supported models or the model subset."
+        },
+        "budgetPolicyIds": {
+          "type": "array",
+          "description": "The full resource IDs of budget policies directly attached to this deployment.",
+          "maxItems": 20,
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.CognitiveServices/accounts/budgetPolicies"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "DeploymentProvisioningState": {
+      "type": "string",
+      "description": "Gets the status of the resource at the time the operation was called.",
+      "enum": [
+        "Accepted",
+        "Creating",
+        "Deleting",
+        "Moving",
+        "Failed",
+        "Succeeded",
+        "Disabled",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "DeploymentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Moving",
+            "value": "Moving"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "DeploymentRouting": {
+      "type": "object",
+      "description": "Routing configuration for the model-router deployment. Specifies how requests are routed across multiple models.",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "description": "The model-router routing mode that determines how requests are distributed across models.",
+          "default": "balanced",
+          "enum": [
+            "cost",
+            "balanced",
+            "quality"
+          ],
+          "x-ms-enum": {
+            "name": "RoutingMode",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Cost",
+                "value": "cost",
+                "description": "Route requests to minimize cost while meeting performance requirements."
+              },
+              {
+                "name": "Balanced",
+                "value": "balanced",
+                "description": "Balance cost and quality when routing requests across models."
+              },
+              {
+                "name": "Quality",
+                "value": "quality",
+                "description": "Route requests to maximize quality regardless of cost."
+              }
+            ]
+          }
+        },
+        "models": {
+          "type": "array",
+          "description": "Optional. The list of model-router supported models that the model router can use to route requests across. If not specified, the model router will route to all available models specified in the model-router version.",
+          "items": {
+            "$ref": "#/definitions/DeploymentModel"
+          },
+          "x-ms-identifiers": [
+            "name",
+            "version"
+          ]
+        }
+      }
+    },
+    "DeploymentScaleSettings": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account deployment model. (Deprecated, please use Deployment.sku instead.)",
+      "properties": {
+        "scaleType": {
+          "$ref": "#/definitions/DeploymentScaleType",
+          "description": "Deployment scale type."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Deployment capacity."
+        },
+        "activeCapacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Deployment active capacity. This value might be different from `capacity` if customer recently updated `capacity`.",
+          "readOnly": true
+        }
+      }
+    },
+    "DeploymentScaleType": {
+      "type": "string",
+      "description": "Deployment scale type.",
+      "enum": [
+        "Standard",
+        "Manual"
+      ],
+      "x-ms-enum": {
+        "name": "DeploymentScaleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard"
+          },
+          {
+            "name": "Manual",
+            "value": "Manual"
+          }
+        ]
+      }
+    },
+    "DeploymentSkuListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of deployment skus."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts deployment skus.",
+          "items": {
+            "$ref": "#/definitions/SkuResource"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "resourceType"
+          ]
+        }
+      }
+    },
+    "DeploymentState": {
+      "type": "string",
+      "description": "The state of the deployment. Controls whether the deployment is accepting inference requests. Use 'Running' for active deployments that process requests, or 'Paused' to temporarily stop inference while preserving the deployment configuration.",
+      "enum": [
+        "Running",
+        "Paused"
+      ],
+      "x-ms-enum": {
+        "name": "DeploymentState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "The deployment is running and accepting inference requests."
+          },
+          {
+            "name": "Paused",
+            "value": "Paused",
+            "description": "The deployment is paused and not accepting inference requests."
+          }
+        ]
+      }
+    },
+    "DeprecationStatus": {
+      "type": "string",
+      "description": "Indicates whether the deprecation date is a confirmed planned end-of-life date or an estimated deprecation date. When 'Planned', the deprecation date represents a confirmed and communicated model end-of-life date. When 'Tentative', the deprecation date is an estimated timeline that may be subject to change.",
+      "enum": [
+        "Planned",
+        "Tentative"
+      ],
+      "x-ms-enum": {
+        "name": "DeprecationStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Planned",
+            "value": "Planned"
+          },
+          {
+            "name": "Tentative",
+            "value": "Tentative"
+          }
+        ]
+      }
+    },
+    "DomainAvailability": {
+      "type": "object",
+      "description": "Domain availability.",
+      "properties": {
+        "isSubdomainAvailable": {
+          "type": "boolean",
+          "description": "Indicates the given SKU is available or not."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Reason why the SKU is not available."
+        },
+        "subdomainName": {
+          "type": "string",
+          "description": "The subdomain name to use."
+        },
+        "type": {
+          "type": "string",
+          "description": "The Type of the resource."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        }
+      }
+    },
+    "Encryption": {
+      "type": "object",
+      "description": "Properties to configure Encryption",
+      "properties": {
+        "keyVaultProperties": {
+          "$ref": "#/definitions/KeyVaultProperties",
+          "description": "Properties of KeyVault"
+        },
+        "keySource": {
+          "type": "string",
+          "description": "Enumerates the possible value of keySource for Encryption",
+          "default": "Microsoft.KeyVault",
+          "enum": [
+            "Microsoft.CognitiveServices",
+            "Microsoft.KeyVault"
+          ],
+          "x-ms-enum": {
+            "name": "KeySource",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Microsoft.CognitiveServices",
+                "value": "Microsoft.CognitiveServices"
+              },
+              {
+                "name": "Microsoft.KeyVault",
+                "value": "Microsoft.KeyVault"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "EncryptionScope": {
+      "type": "object",
+      "description": "Cognitive Services EncryptionScope",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EncryptionScopeProperties",
+          "description": "Properties of Cognitive Services EncryptionScope."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "EncryptionScopeListResult": {
+      "type": "object",
+      "description": "The list of cognitive services EncryptionScopes.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of EncryptionScope."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of EncryptionScope.",
+          "items": {
+            "$ref": "#/definitions/EncryptionScope"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "EncryptionScopeProperties": {
+      "type": "object",
+      "description": "Properties to EncryptionScope",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/EncryptionScopeProvisioningState",
+          "description": "Gets the status of the resource at the time the operation was called.",
+          "readOnly": true
+        },
+        "state": {
+          "$ref": "#/definitions/EncryptionScopeState",
+          "description": "The encryptionScope state."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Encryption"
+        }
+      ]
+    },
+    "EncryptionScopeProvisioningState": {
+      "type": "string",
+      "description": "Gets the status of the resource at the time the operation was called.",
+      "enum": [
+        "Accepted",
+        "Creating",
+        "Deleting",
+        "Moving",
+        "Failed",
+        "Succeeded",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "EncryptionScopeProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Moving",
+            "value": "Moving"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "EncryptionScopeState": {
+      "type": "string",
+      "description": "The encryptionScope state.",
+      "enum": [
+        "Disabled",
+        "Enabled"
+      ],
+      "x-ms-enum": {
+        "name": "EncryptionScopeState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          }
+        ]
+      }
+    },
+    "FirewallSku": {
+      "type": "string",
+      "description": "Firewall Sku used for FQDN Rules",
+      "enum": [
+        "Standard",
+        "Basic"
+      ],
+      "x-ms-enum": {
+        "name": "FirewallSku",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Standard",
+            "value": "Standard"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic"
+          }
+        ]
+      }
+    },
+    "FqdnOutboundRule": {
+      "type": "object",
+      "description": "FQDN Outbound Rule for the managed network of a cognitive services account.",
+      "properties": {
+        "destination": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OutboundRule"
+        }
+      ],
+      "x-ms-discriminator-value": "FQDN"
+    },
+    "HostedAgentDeployment": {
+      "type": "object",
+      "description": "Represents a hosted agent deployment where the underlying infrastructure is owned by the platform.",
+      "properties": {
+        "minReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the minimum number of replicas for this hosted deployment.",
+          "minimum": 0
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the maximum number of replicas for this hosted deployment.",
+          "minimum": 0
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AgentDeploymentProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Hosted"
+    },
+    "HostingModel": {
+      "type": "string",
+      "description": "Account hosting model.",
+      "enum": [
+        "Web",
+        "ConnectedContainer",
+        "DisconnectedContainer",
+        "ProvisionedWeb"
+      ],
+      "x-ms-enum": {
+        "name": "HostingModel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Web",
+            "value": "Web"
+          },
+          {
+            "name": "ConnectedContainer",
+            "value": "ConnectedContainer"
+          },
+          {
+            "name": "DisconnectedContainer",
+            "value": "DisconnectedContainer"
+          },
+          {
+            "name": "ProvisionedWeb",
+            "value": "ProvisionedWeb"
+          }
+        ]
+      }
+    },
+    "Identity": {
+      "type": "object",
+      "description": "Identity for the resource.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ResourceIdentityType",
+          "description": "The identity type."
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The tenant ID of resource.",
+          "readOnly": true
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID of resource identity.",
+          "readOnly": true
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The list of user assigned identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}",
+          "additionalProperties": {
+            "$ref": "#/definitions/UserAssignedIdentity"
+          }
+        }
+      }
+    },
+    "IdentityKind": {
+      "type": "string",
+      "description": "Specifies the kind of Entra identity described by this object.",
+      "enum": [
+        "AgentBlueprint",
+        "AgentInstance",
+        "AgenticUser",
+        "Managed",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "IdentityKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AgentBlueprint",
+            "value": "AgentBlueprint",
+            "description": "Represents a class identity, used for agentic applications."
+          },
+          {
+            "name": "AgentInstance",
+            "value": "AgentInstance",
+            "description": "Represents an instance identity."
+          },
+          {
+            "name": "AgenticUser",
+            "value": "AgenticUser",
+            "description": "Represents an agentic instance identity with user-like traits."
+          },
+          {
+            "name": "Managed",
+            "value": "Managed",
+            "description": "Represents a classic managed identity."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No identity."
+          }
+        ]
+      }
+    },
+    "IdentityManagementType": {
+      "type": "string",
+      "description": "Enumeration of identity types, from the perspective of management.",
+      "enum": [
+        "System",
+        "User",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "IdentityManagementType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "System",
+            "value": "System",
+            "description": "Platform-managed identity."
+          },
+          {
+            "name": "User",
+            "value": "User",
+            "description": "User-managed identity."
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "No identity."
+          }
+        ]
+      }
+    },
+    "IdentityProvisioningState": {
+      "type": "string",
+      "description": "Represents the provisioning state of an identity resource.",
+      "enum": [
+        "Creating",
+        "Updating",
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "IdentityProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Identity is being created."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Identity is being updated."
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Identity has been successfully provisioned."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Identity provisioning has failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Identity provisioning has been canceled."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Identity is being deleted."
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "IpRule": {
+      "type": "object",
+      "description": "A rule governing the accessibility from a specific ip address or ip range.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "An IPv4 address range in CIDR notation, such as '124.56.78.91' (simple IP address) or '124.56.78.0/24' (all addresses that start with 124.56.78)."
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "IsolationMode": {
+      "type": "string",
+      "description": "Isolation mode for the managed network of a cognitive services account.",
+      "enum": [
+        "Disabled",
+        "AllowInternetOutbound",
+        "AllowOnlyApprovedOutbound"
+      ],
+      "x-ms-enum": {
+        "name": "IsolationMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          },
+          {
+            "name": "AllowInternetOutbound",
+            "value": "AllowInternetOutbound"
+          },
+          {
+            "name": "AllowOnlyApprovedOutbound",
+            "value": "AllowOnlyApprovedOutbound"
+          }
+        ]
+      }
+    },
+    "KeyName": {
+      "type": "string",
+      "description": "key name to generate (Key1|Key2)",
+      "enum": [
+        "Key1",
+        "Key2"
+      ],
+      "x-ms-enum": {
+        "name": "KeyName",
+        "modelAsString": false
+      }
+    },
+    "KeySource": {
+      "type": "string",
+      "description": "Enumerates the possible value of keySource for Encryption",
+      "enum": [
+        "Microsoft.CognitiveServices",
+        "Microsoft.KeyVault"
+      ],
+      "x-ms-enum": {
+        "name": "KeySource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Microsoft.CognitiveServices",
+            "value": "Microsoft.CognitiveServices"
+          },
+          {
+            "name": "Microsoft.KeyVault",
+            "value": "Microsoft.KeyVault"
+          }
+        ]
+      }
+    },
+    "KeyVaultProperties": {
+      "type": "object",
+      "description": "Properties to configure keyVault Properties",
+      "properties": {
+        "keyName": {
+          "type": "string",
+          "description": "Name of the Key from KeyVault"
+        },
+        "keyVersion": {
+          "type": "string",
+          "description": "Version of the Key from KeyVault"
+        },
+        "keyVaultUri": {
+          "type": "string",
+          "description": "Uri of KeyVault"
+        },
+        "identityClientId": {
+          "type": "string"
+        }
+      }
+    },
+    "ManagedAgentDeployment": {
+      "type": "object",
+      "description": "Represents a managed agent deployment where the underlying infrastructure is managed by the platform in the deployer's subscription.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/AgentDeploymentProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Managed"
+    },
+    "ManagedIdentityAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionManagedIdentity"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "ManagedIdentity"
+    },
+    "ManagedNetworkKind": {
+      "type": "string",
+      "description": "The Kind of the managed network. Users can switch from V1 to V2 for granular access controls, but cannot switch back to V1 once V2 is enabled.",
+      "enum": [
+        "V1",
+        "V2"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedNetworkKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "V1",
+            "value": "V1"
+          },
+          {
+            "name": "V2",
+            "value": "V2"
+          }
+        ]
+      }
+    },
+    "ManagedNetworkListResult": {
+      "type": "object",
+      "description": "List of managed networks of a cognitive services account.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page constructed using the continuationToken.  If null, there are no additional pages."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of managed network settings of an account. Since this list may be incomplete, the nextLink field should be used to request the next list of cognitive services accounts.",
+          "items": {
+            "$ref": "#/definitions/ManagedNetworkSettingsPropertiesBasicResource"
+          }
+        }
+      }
+    },
+    "ManagedNetworkProvisionOptions": {
+      "type": "object",
+      "description": "Managed Network Provisioning options for managed network of a cognitive services account."
+    },
+    "ManagedNetworkProvisionStatus": {
+      "type": "object",
+      "description": "Status of the Provisioning for the managed network of a cognitive services account.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/ManagedNetworkStatus",
+          "description": "Status for the managed network of a cognitive services account."
+        }
+      }
+    },
+    "ManagedNetworkProvisioningState": {
+      "type": "string",
+      "enum": [
+        "Deferred",
+        "Updating",
+        "Succeeded",
+        "Failed",
+        "Deleting",
+        "Deleted"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedNetworkProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Deferred",
+            "value": "Deferred"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "ManagedNetworkSettings": {
+      "type": "object",
+      "description": "Managed Network settings for a cognitive services account.",
+      "properties": {
+        "isolationMode": {
+          "$ref": "#/definitions/IsolationMode",
+          "description": "Isolation mode for the managed network of a cognitive services account."
+        },
+        "networkId": {
+          "type": "string",
+          "readOnly": true
+        },
+        "outboundRules": {
+          "type": "object",
+          "description": "Dictionary of <OutboundRule>",
+          "x-nullable": true,
+          "additionalProperties": {
+            "$ref": "#/definitions/OutboundRule"
+          }
+        },
+        "status": {
+          "$ref": "#/definitions/ManagedNetworkProvisionStatus",
+          "description": "Status of the Provisioning for the managed network of a cognitive services account."
+        },
+        "firewallSku": {
+          "$ref": "#/definitions/FirewallSku",
+          "description": "Firewall Sku used for FQDN Rules"
+        },
+        "managedNetworkKind": {
+          "$ref": "#/definitions/ManagedNetworkKind",
+          "description": "The Kind of the managed network. Users can switch from V1 to V2 for granular access controls, but cannot switch back to V1 once V2 is enabled."
+        },
+        "firewallPublicIpAddress": {
+          "type": "string",
+          "description": "Public IP address assigned to the Azure Firewall.",
+          "x-nullable": true,
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ManagedNetworkProvisioningState",
+          "description": "The provisioning state of the managed network settings.",
+          "readOnly": true
+        }
+      }
+    },
+    "ManagedNetworkSettingsBasicResource": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedNetworkSettings",
+          "description": "Managed Network settings for a cognitive services account."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "ManagedNetworkSettingsEx": {
+      "type": "object",
+      "properties": {
+        "changeableIsolationModes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IsolationMode"
+          },
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ManagedNetworkSettings"
+        }
+      ]
+    },
+    "ManagedNetworkSettingsProperties": {
+      "type": "object",
+      "description": "The properties of the managed network settings of a cognitive services account.",
+      "properties": {
+        "managedNetwork": {
+          "$ref": "#/definitions/ManagedNetworkSettingsEx",
+          "description": "Managed Network settings for a cognitive services account."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ManagedNetworkProvisioningState",
+          "description": "The current deployment state of the managed network resource. The provisioningState is to indicate states for resource provisioning.",
+          "readOnly": true
+        }
+      }
+    },
+    "ManagedNetworkSettingsPropertiesBasicResource": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedNetworkSettingsProperties",
+          "description": "The properties of the managed network settings of a cognitive services account."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ManagedNetworkStatus": {
+      "type": "string",
+      "description": "Status for the managed network of a cognitive services account.",
+      "enum": [
+        "Inactive",
+        "Active"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedNetworkStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inactive",
+            "value": "Inactive"
+          },
+          {
+            "name": "Active",
+            "value": "Active"
+          }
+        ]
+      }
+    },
+    "ManagedPERequirement": {
+      "type": "string",
+      "enum": [
+        "Required",
+        "NotRequired",
+        "NotApplicable"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedPERequirement",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Required",
+            "value": "Required"
+          },
+          {
+            "name": "NotRequired",
+            "value": "NotRequired"
+          },
+          {
+            "name": "NotApplicable",
+            "value": "NotApplicable"
+          }
+        ]
+      }
+    },
+    "ManagedPEStatus": {
+      "type": "string",
+      "enum": [
+        "Inactive",
+        "Active",
+        "NotApplicable"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedPEStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inactive",
+            "value": "Inactive"
+          },
+          {
+            "name": "Active",
+            "value": "Active"
+          },
+          {
+            "name": "NotApplicable",
+            "value": "NotApplicable"
+          }
+        ]
+      }
+    },
+    "MetricName": {
+      "type": "object",
+      "description": "A metric name.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The name of the metric."
+        },
+        "localizedValue": {
+          "type": "string",
+          "description": "The friendly name of the metric."
+        }
+      }
+    },
+    "Model": {
+      "type": "object",
+      "description": "Cognitive Services Model.",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/AccountModel",
+          "description": "Cognitive Services account Model."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "skuName": {
+          "type": "string",
+          "description": "The name of SKU."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the model."
+        }
+      }
+    },
+    "ModelCapacityCalculatorWorkload": {
+      "type": "object",
+      "description": "Model Capacity Calculator Workload.",
+      "properties": {
+        "requestPerMinute": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Request per minute."
+        },
+        "requestParameters": {
+          "$ref": "#/definitions/ModelCapacityCalculatorWorkloadRequestParam",
+          "description": "Dictionary, Model Capacity Calculator Workload Parameters."
+        }
+      }
+    },
+    "ModelCapacityCalculatorWorkloadRequestParam": {
+      "type": "object",
+      "description": "Dictionary, Model Capacity Calculator Workload Parameters.",
+      "properties": {
+        "avgPromptTokens": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Average prompt tokens."
+        },
+        "avgGeneratedTokens": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Average generated tokens."
+        }
+      }
+    },
+    "ModelCapacityListResult": {
+      "type": "object",
+      "description": "The list of cognitive services accounts operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of ModelSkuCapacity."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts ModelSkuCapacity.",
+          "items": {
+            "$ref": "#/definitions/ModelCapacityListResultValueItem"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "model"
+          ]
+        }
+      }
+    },
+    "ModelCapacityListResultValueItem": {
+      "type": "object",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "The location of the Model Sku Capacity."
+        },
+        "properties": {
+          "$ref": "#/definitions/ModelSkuCapacityProperties",
+          "description": "Cognitive Services account ModelSkuCapacity."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ModelDeprecationInfo": {
+      "type": "object",
+      "description": "Cognitive Services account ModelDeprecationInfo.",
+      "properties": {
+        "fineTune": {
+          "type": "string",
+          "description": "The datetime of deprecation of the fineTune Model."
+        },
+        "inference": {
+          "type": "string",
+          "description": "The datetime of deprecation of the inference Model."
+        },
+        "deprecationStatus": {
+          "$ref": "#/definitions/DeprecationStatus",
+          "description": "Indicates whether the deprecation date is a confirmed planned end-of-life date or an estimated deprecation date. When 'Planned', the deprecation date represents a confirmed and communicated model end-of-life date. When 'Tentative', the deprecation date is an estimated timeline that may be subject to change."
+        }
+      }
+    },
+    "ModelLifecycleStatus": {
+      "type": "string",
+      "description": "Model lifecycle status.",
+      "enum": [
+        "Stable",
+        "Preview",
+        "GenerallyAvailable",
+        "Deprecating",
+        "Deprecated",
+        "Legacy"
+      ],
+      "x-ms-enum": {
+        "name": "ModelLifecycleStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Stable",
+            "value": "Stable",
+            "description": "Legacy state. Replaced with GenerallyAvailable going forward."
+          },
+          {
+            "name": "Preview",
+            "value": "Preview",
+            "description": "Model is in preview and may be subject to changes."
+          },
+          {
+            "name": "GenerallyAvailable",
+            "value": "GenerallyAvailable",
+            "description": "Model is generally available for production use."
+          },
+          {
+            "name": "Deprecating",
+            "value": "Deprecating",
+            "description": "Model is being deprecated and will be removed in the future. Only customers with existing deployments can create new deployments with this model."
+          },
+          {
+            "name": "Deprecated",
+            "value": "Deprecated",
+            "description": "Model has been deprecated, also known as retired, and is no longer supported. Inference calls to deployments of models in this lifecycle state will return 410 errors."
+          },
+          {
+            "name": "Legacy",
+            "value": "Legacy",
+            "description": "Model is a legacy version that is no longer recommended for use. Customers should migrate to newer models. Check replacementConfig for upgrade information."
+          }
+        ]
+      }
+    },
+    "ModelListResult": {
+      "type": "object",
+      "description": "The list of cognitive services models.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Model."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services accounts Model and their properties.",
+          "items": {
+            "$ref": "#/definitions/Model"
+          },
+          "x-ms-identifiers": [
+            "kind",
+            "skuName",
+            "/model/name",
+            "/model/format",
+            "/model/version"
+          ]
+        }
+      }
+    },
+    "ModelSku": {
+      "type": "object",
+      "description": "Describes an available Cognitive Services Model SKU.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the model SKU."
+        },
+        "usageName": {
+          "type": "string",
+          "description": "The usage name of the model SKU."
+        },
+        "deprecationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The datetime of deprecation of the model SKU."
+        },
+        "capacity": {
+          "$ref": "#/definitions/CapacityConfig",
+          "description": "The capacity configuration."
+        },
+        "rateLimits": {
+          "type": "array",
+          "description": "The list of rateLimit.",
+          "items": {
+            "$ref": "#/definitions/CallRateLimit"
+          },
+          "x-ms-identifiers": []
+        },
+        "cost": {
+          "type": "array",
+          "description": "The list of billing meter info.",
+          "items": {
+            "$ref": "#/definitions/BillingMeterInfo"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ModelSkuCapacityProperties": {
+      "type": "object",
+      "description": "Cognitive Services account ModelSkuCapacity.",
+      "properties": {
+        "model": {
+          "$ref": "#/definitions/DeploymentModel",
+          "description": "Properties of Cognitive Services account deployment model."
+        },
+        "skuName": {
+          "type": "string"
+        },
+        "availableCapacity": {
+          "type": "number",
+          "format": "float",
+          "description": "The available capacity for deployment with this model and sku."
+        },
+        "availableFinetuneCapacity": {
+          "type": "number",
+          "format": "float",
+          "description": "The available capacity for deployment with a fine-tune version of this model and sku."
+        },
+        "scopeId": {
+          "type": "string",
+          "description": "The scope identifier for model SKU capacity.",
+          "x-nullable": true
+        },
+        "scopeType": {
+          "$ref": "#/definitions/QuotaScopeType",
+          "description": "The scope type for model SKU capacity.",
+          "x-nullable": true
+        }
+      }
+    },
+    "MultiRegionSettings": {
+      "type": "object",
+      "description": "The multiregion settings Cognitive Services account.",
+      "properties": {
+        "routingMethod": {
+          "$ref": "#/definitions/RoutingMethods",
+          "description": "Multiregion routing methods."
+        },
+        "regions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RegionSetting"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "NetworkInjection": {
+      "type": "object",
+      "description": "Specifies in AI Foundry where virtual network injection occurs to secure scenarios like Agents entirely within the user's private network, eliminating public internet exposure while maintaining control over network configurations and resources.",
+      "properties": {
+        "scenario": {
+          "$ref": "#/definitions/ScenarioType",
+          "description": "Specifies what features in AI Foundry network injection applies to. Currently only supports 'agent' for agent scenarios. 'none' means no network injection."
+        },
+        "subnetArmId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Specify the subnet for which your Agent Client is injected into.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/virtualNetworks/subnets"
+              }
+            ]
+          }
+        },
+        "useMicrosoftManagedNetwork": {
+          "type": "boolean",
+          "description": "Boolean to enable Microsoft Managed Network for subnet delegation"
+        }
+      }
+    },
+    "NetworkRuleAction": {
+      "type": "string",
+      "description": "The default action when no rule from ipRules and from virtualNetworkRules match. This is only used after the bypass property has been evaluated.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkRuleAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny"
+          }
+        ]
+      }
+    },
+    "NetworkRuleSet": {
+      "type": "object",
+      "description": "A set of rules governing the network accessibility.",
+      "properties": {
+        "defaultAction": {
+          "$ref": "#/definitions/NetworkRuleAction",
+          "description": "The default action when no rule from ipRules and from virtualNetworkRules match. This is only used after the bypass property has been evaluated."
+        },
+        "bypass": {
+          "$ref": "#/definitions/ByPassSelection",
+          "description": "Setting for trusted services."
+        },
+        "ipRules": {
+          "type": "array",
+          "description": "The list of IP address rules.",
+          "items": {
+            "$ref": "#/definitions/IpRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "virtualNetworkRules": {
+          "type": "array",
+          "description": "The list of virtual network rules.",
+          "items": {
+            "$ref": "#/definitions/VirtualNetworkRule"
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeter": {
+      "type": "object",
+      "description": "Information about a linked Network Security Perimeter",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified identifier of the resource"
+        },
+        "perimeterGuid": {
+          "type": "string",
+          "description": "Guid of the resource"
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the resource"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterAccessRule": {
+      "type": "object",
+      "description": "Network Security Perimeter Access Rule",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Network Security Perimeter Access Rule Name"
+        },
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterAccessRuleProperties",
+          "description": "Properties of Network Security Perimeter Access Rule"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterAccessRuleProperties": {
+      "type": "object",
+      "description": "The Properties of Network Security Perimeter Rule",
+      "properties": {
+        "direction": {
+          "$ref": "#/definitions/NspAccessRuleDirection",
+          "description": "Direction of Access Rule"
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "Address prefixes for inbound rules",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subscriptions": {
+          "type": "array",
+          "description": "Subscriptions for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterAccessRulePropertiesSubscriptionsItem"
+          }
+        },
+        "networkSecurityPerimeters": {
+          "type": "array",
+          "description": "NetworkSecurityPerimeters for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeter"
+          }
+        },
+        "fullyQualifiedDomainNames": {
+          "type": "array",
+          "description": "Fully qualified domain name for outbound rules",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NetworkSecurityPerimeterAccessRulePropertiesSubscriptionsItem": {
+      "type": "object",
+      "description": "Subscription for inbound rule",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Fully qualified identifier of subscription"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfiguration": {
+      "type": "object",
+      "description": "NSP Configuration for an Cognitive Services account.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "NSP Configuration properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "NetworkSecurityPerimeterConfigurationAssociationInfo": {
+      "type": "object",
+      "description": "Network Security Perimeter Configuration Association Information",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource association"
+        },
+        "accessMode": {
+          "type": "string",
+          "description": "Access Mode of the resource association"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationList": {
+      "type": "object",
+      "description": "A list of NSP configurations for an Cognitive Services account.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Array of NSP configurations List Result for an Cognitive Services account.",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
+          },
+          "x-ms-identifiers": [
+            "id"
+          ]
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "Link to retrieve next page of results."
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationProperties": {
+      "type": "object",
+      "description": "The properties of an NSP Configuration.",
+      "properties": {
+        "provisioningState": {
+          "type": "string",
+          "description": "Provisioning state of NetworkSecurityPerimeter configuration",
+          "readOnly": true
+        },
+        "provisioningIssues": {
+          "type": "array",
+          "description": "List of Provisioning Issues",
+          "items": {
+            "$ref": "#/definitions/ProvisioningIssue"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "networkSecurityPerimeter": {
+          "$ref": "#/definitions/NetworkSecurityPerimeter",
+          "description": "Information about a linked Network Security Perimeter"
+        },
+        "resourceAssociation": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationAssociationInfo",
+          "description": "Network Security Perimeter Configuration Association Information"
+        },
+        "profile": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterProfileInfo",
+          "description": "Network Security Perimeter Profile Information"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterProfileInfo": {
+      "type": "object",
+      "description": "Network Security Perimeter Profile Information",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource profile"
+        },
+        "accessRulesVersion": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Access rules version of the resource profile"
+        },
+        "accessRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterAccessRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "diagnosticSettingsVersion": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Current diagnostic settings version"
+        },
+        "enabledLogCategories": {
+          "type": "array",
+          "description": "List of enabled log categories",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NoneAuthTypeConnectionProperties": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "None"
+    },
+    "NspAccessRuleDirection": {
+      "type": "string",
+      "description": "Direction of Access Rule",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "NspAccessRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound"
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound"
+          }
+        ]
+      }
+    },
+    "OAuth2AuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionOAuth2",
+          "description": "ClientId and ClientSecret are required. Other properties are optional\ndepending on each OAuth2 provider's implementation."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "OAuth2"
+    },
+    "OrganizationSharedBuiltInAuthorizationPolicy": {
+      "type": "object",
+      "description": "Built-in authorization policy scoped to organization/tenant.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApplicationAuthorizationPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "OrganizationScope"
+    },
+    "Origin": {
+      "type": "string",
+      "description": "The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is \"user,system\"",
+      "enum": [
+        "user",
+        "system",
+        "user,system"
+      ],
+      "x-ms-enum": {
+        "name": "Origin",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "user",
+            "value": "user"
+          },
+          {
+            "name": "system",
+            "value": "system"
+          },
+          {
+            "name": "user,system",
+            "value": "user,system"
+          }
+        ]
+      }
+    },
+    "OutboundRule": {
+      "type": "object",
+      "description": "Outbound Rule for the managed network of a cognitive services account.",
+      "properties": {
+        "category": {
+          "$ref": "#/definitions/RuleCategory",
+          "description": "Category of a managed network Outbound Rule of a cognitive services account."
+        },
+        "status": {
+          "$ref": "#/definitions/RuleStatus",
+          "description": "Type of a managed network Outbound Rule of a cognitive services account."
+        },
+        "type": {
+          "$ref": "#/definitions/RuleType",
+          "description": "Type of a managed network Outbound Rule of a cognitive services account."
+        },
+        "errorInformation": {
+          "type": "string",
+          "description": "Error information about an outbound rule of a cognitive services account if RuleStatus is failed.",
+          "readOnly": true
+        },
+        "parentRuleNames": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      },
+      "discriminator": "type",
+      "required": [
+        "type"
+      ]
+    },
+    "OutboundRuleBasicResource": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/OutboundRule",
+          "description": "Outbound Rule for the managed network of a cognitive services account."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "OutboundRuleListResult": {
+      "type": "object",
+      "description": "List of outbound rules for the managed network of a cognitive services account.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page constructed using the continuationToken.  If null, there are no additional pages."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of cognitive services accounts. Since this list may be incomplete, the nextLink field should be used to request the next list of cognitive services accounts.",
+          "items": {
+            "$ref": "#/definitions/OutboundRuleBasicResource"
+          }
+        }
+      }
+    },
+    "PATAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionPersonalAccessToken"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "PAT"
+    },
+    "PatchResourceTags": {
+      "type": "object",
+      "description": "The object being used to update tags of a resource, in general used for PATCH operations.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
+    "PatchResourceTagsAndSku": {
+      "type": "object",
+      "description": "The object being used to update tags and sku of a resource, in general used for PATCH operations.",
+      "properties": {
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PatchResourceTags"
+        }
+      ]
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "The Private Endpoint Connection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Resource properties."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "The location of the private endpoint connection"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "A list of private endpoint connections",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Array of private endpoint connections",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        }
+      }
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the PrivateEndpointConnectProperties.",
+      "properties": {
+        "privateEndpoint": {
+          "$ref": "../../../../../common-types/resource-management/v3/privatelinks.json#/definitions/PrivateEndpoint",
+          "description": "The resource of private end point."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "../../../../../common-types/resource-management/v3/privatelinks.json#/definitions/PrivateLinkServiceConnectionState",
+          "description": "A collection of information about the state of the connection between service consumer and provider."
+        },
+        "provisioningState": {
+          "$ref": "../../../../../common-types/resource-management/v3/privatelinks.json#/definitions/PrivateEndpointConnectionProvisioningState",
+          "description": "The provisioning state of the private endpoint connection resource.",
+          "readOnly": true
+        },
+        "groupIds": {
+          "type": "array",
+          "description": "The private link resource group ids.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ]
+    },
+    "PrivateEndpointOutboundRule": {
+      "type": "object",
+      "description": "Private Endpoint outbound rule for the managed network of a cognitive services account.",
+      "properties": {
+        "destination": {
+          "$ref": "#/definitions/PrivateEndpointOutboundRuleDestination",
+          "description": "Private Endpoint destination."
+        },
+        "fqdns": {
+          "type": "array",
+          "description": "List of FQDNs associated with the private endpoint outbound rule.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OutboundRule"
+        }
+      ],
+      "x-ms-discriminator-value": "PrivateEndpoint"
+    },
+    "PrivateEndpointOutboundRuleDestination": {
+      "type": "object",
+      "description": "Private Endpoint destination for an outbound rule.",
+      "properties": {
+        "serviceResourceId": {
+          "type": "string",
+          "description": "The Azure resource ID of the target private endpoint service."
+        },
+        "subresourceTarget": {
+          "type": "string",
+          "description": "The subresource of the target service to connect to."
+        }
+      }
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "A private link resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "Resource properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "PrivateLinkResourceListResult": {
+      "type": "object",
+      "description": "A list of private link resources",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Array of private link resources",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        }
+      }
+    },
+    "PrivateLinkResourceProperties": {
+      "type": "object",
+      "description": "Properties of a private link resource.",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The private link resource group id.",
+          "readOnly": true
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "The private link resource required member names.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "The private link resource Private link DNS zone name.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The private link resource display name.",
+          "readOnly": true
+        }
+      }
+    },
+    "Project": {
+      "type": "object",
+      "description": "Cognitive Services project is an Azure resource representing the provisioned account's project, it's type, location and SKU.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProjectProperties",
+          "description": "Properties of Cognitive Services project."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "location": {
+          "type": "string",
+          "description": "The geo-location where the resource lives",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "Identity for the resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ProjectCapabilityHost": {
+      "type": "object",
+      "description": "Azure Resource Manager resource envelope for Project CapabilityHost.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ProjectCapabilityHostProperties",
+          "description": "[Required] Additional attributes of the entity."
+        }
+      },
+      "required": [
+        "properties"
+      ],
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ProjectCapabilityHostProperties": {
+      "type": "object",
+      "properties": {
+        "aiServicesConnections": {
+          "type": "array",
+          "description": "List of AI services connections.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "vectorStoreConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used for vector database (e.g. CosmosDB).",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "storageConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used as a storage resource.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "threadStorageConnections": {
+          "type": "array",
+          "description": "List of connection names from those available in the account or project to be used for Thread storage.",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/CapabilityHostProvisioningState",
+          "description": "Provisioning state for the CapabilityHost.",
+          "readOnly": true
+        }
+      }
+    },
+    "ProjectCapabilityHostResourceArmPaginatedResult": {
+      "type": "object",
+      "description": "A paginated list of Project Capability Host entities.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link to the next page of Project Capability Host objects. If null, there are no additional pages.",
+          "x-nullable": true
+        },
+        "value": {
+          "type": "array",
+          "description": "An array of objects of type Project Capability Host.",
+          "items": {
+            "$ref": "#/definitions/ProjectCapabilityHost"
+          }
+        }
+      }
+    },
+    "ProjectListResult": {
+      "type": "object",
+      "description": "The list of cognitive services projects operation response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of projects."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Cognitive Services projects and their properties.",
+          "items": {
+            "$ref": "#/definitions/Project"
+          },
+          "readOnly": true
+        }
+      }
+    },
+    "ProjectProperties": {
+      "type": "object",
+      "description": "Properties of Cognitive Services Project'.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "Gets the status of the cognitive services project at the time the operation was called.",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the Cognitive Services Project."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the Cognitive Services Project."
+        },
+        "endpoints": {
+          "type": "object",
+          "description": "The list of endpoint for this Cognitive Services Project.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "isDefault": {
+          "type": "boolean",
+          "description": "Indicates whether the project is the default project for the account.",
+          "readOnly": true
+        }
+      }
+    },
+    "ProviderInfo": {
+      "type": "object",
+      "description": "Service provider information for the Agent",
+      "properties": {
+        "organization": {
+          "type": "string",
+          "description": "Organization name of the provider.",
+          "x-nullable": true
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of the provider.",
+          "x-nullable": true
+        }
+      }
+    },
+    "ProvisioningIssue": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the NSP provisioning issue"
+        },
+        "properties": {
+          "$ref": "#/definitions/ProvisioningIssueProperties",
+          "description": "Properties of Provisioning Issue"
+        }
+      }
+    },
+    "ProvisioningIssueProperties": {
+      "type": "object",
+      "description": "Properties of Provisioning Issue",
+      "properties": {
+        "issueType": {
+          "type": "string",
+          "description": "Type of Issue"
+        },
+        "severity": {
+          "type": "string",
+          "description": "Severity of the issue"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the issue"
+        },
+        "suggestedResourceIds": {
+          "type": "array",
+          "description": "IDs of resources that can be associated to the same perimeter to remediate the issue.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource."
+          }
+        },
+        "suggestedAccessRules": {
+          "type": "array",
+          "description": "Optional array, suggested access rules",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeterAccessRule"
+          }
+        }
+      }
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "Gets the status of the cognitive services account at the time the operation was called.",
+      "enum": [
+        "Accepted",
+        "Creating",
+        "Deleting",
+        "Moving",
+        "Failed",
+        "Succeeded",
+        "Canceled",
+        "ResolvingDNS"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Accepted",
+            "value": "Accepted"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Moving",
+            "value": "Moving"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled"
+          },
+          {
+            "name": "ResolvingDNS",
+            "value": "ResolvingDNS"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "Whether or not public endpoint access is allowed for this account.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled"
+          }
+        ]
+      }
+    },
+    "QuotaLimit": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "number",
+          "format": "float"
+        },
+        "renewalPeriod": {
+          "type": "number",
+          "format": "float"
+        },
+        "rules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ThrottlingRule"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        }
+      }
+    },
+    "QuotaScopeType": {
+      "type": "string",
+      "description": "The quota scope that determines the level at which the quota is applied.",
+      "enum": [
+        "Regional",
+        "Global",
+        "DataZone",
+        "Classic"
+      ],
+      "x-ms-enum": {
+        "name": "QuotaScopeType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Regional",
+            "value": "Regional"
+          },
+          {
+            "name": "Global",
+            "value": "Global"
+          },
+          {
+            "name": "DataZone",
+            "value": "DataZone"
+          },
+          {
+            "name": "Classic",
+            "value": "Classic"
+          }
+        ]
+      }
+    },
+    "QuotaTier": {
+      "type": "object",
+      "description": "The quota tier information for the subscription",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/QuotaTierProperties",
+          "description": "Properties of quota tier resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "QuotaTierListResult": {
+      "type": "object",
+      "description": "The list of Quota Tiers response.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of quota tiers."
+        },
+        "value": {
+          "type": "array",
+          "description": "Gets the list of Quota Tiers and their properties.",
+          "items": {
+            "$ref": "#/definitions/QuotaTier"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      }
+    },
+    "QuotaTierProperties": {
+      "type": "object",
+      "description": "Properties of Quota Tier resource'.",
+      "properties": {
+        "currentTierName": {
+          "type": "string",
+          "description": "Name of the current quota tier for the subscription.",
+          "readOnly": true
+        },
+        "tierUpgradePolicy": {
+          "$ref": "#/definitions/TierUpgradePolicy",
+          "description": "Gets the tier upgrade policy for the subscription."
+        },
+        "assignmentDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date on which the current tier was assigned to the subscription (UTC).",
+          "readOnly": true
+        },
+        "tierUpgradeEligibilityInfo": {
+          "$ref": "#/definitions/QuotaTierUpgradeEligibilityInfo",
+          "description": "Information about the quota tier upgrade eligibility for the subscription.",
+          "x-nullable": true,
+          "readOnly": true
+        }
+      }
+    },
+    "QuotaTierUpgradeEligibilityInfo": {
+      "type": "object",
+      "description": "Information about the quota tier upgrade eligibility for the subscription.",
+      "properties": {
+        "nextTierName": {
+          "type": "string",
+          "description": "Name of the next quota tier for the subscription.",
+          "x-nullable": true
+        },
+        "upgradeAvailabilityStatus": {
+          "$ref": "#/definitions/UpgradeAvailabilityStatus",
+          "description": "Specifies whether an upgrade to the next quota tier is available."
+        },
+        "upgradeApplicableDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date after which the current tier will be upgraded to the next tier if the TierUpgradePolicy is \"OnceUpgradeIsAvailable\" (UTC).",
+          "x-nullable": true
+        },
+        "upgradeUnavailabilityReason": {
+          "type": "string",
+          "description": "Reason in case the subscription is not eligible for upgrade to the next tier.",
+          "x-nullable": true
+        }
+      }
+    },
+    "QuotaUsageStatus": {
+      "type": "string",
+      "description": "Cognitive Services account quota usage status.",
+      "enum": [
+        "Included",
+        "Blocked",
+        "InOverage",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "QuotaUsageStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Included",
+            "value": "Included"
+          },
+          {
+            "name": "Blocked",
+            "value": "Blocked"
+          },
+          {
+            "name": "InOverage",
+            "value": "InOverage"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown"
+          }
+        ]
+      }
+    },
+    "RaiActionType": {
+      "type": "string",
+      "description": "The action types to apply to the content filters",
+      "enum": [
+        "None",
+        "BLOCKING",
+        "ANNOTATING",
+        "HITL",
+        "RETRY"
+      ],
+      "x-ms-enum": {
+        "name": "RaiActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "BLOCKING",
+            "value": "BLOCKING"
+          },
+          {
+            "name": "ANNOTATING",
+            "value": "ANNOTATING"
+          },
+          {
+            "name": "HITL",
+            "value": "HITL"
+          },
+          {
+            "name": "RETRY",
+            "value": "RETRY"
+          }
+        ]
+      }
+    },
+    "RaiBlockListItemsResult": {
+      "type": "object",
+      "description": "The list of cognitive services RAI Blocklist Items.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of RaiBlocklistItems."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiBlocklistItems.",
+          "items": {
+            "$ref": "#/definitions/RaiBlocklistItem"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiBlockListResult": {
+      "type": "object",
+      "description": "The list of cognitive services RAI Blocklists.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of RaiBlocklists."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiBlocklist.",
+          "items": {
+            "$ref": "#/definitions/RaiBlocklist"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiBlocklist": {
+      "type": "object",
+      "description": "Cognitive Services RaiBlocklist.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiBlocklistProperties",
+          "description": "Properties of Cognitive Services RaiBlocklist."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiBlocklistConfig": {
+      "type": "object",
+      "description": "Azure OpenAI blocklist config.",
+      "properties": {
+        "blocklistName": {
+          "type": "string",
+          "description": "Name of ContentFilter."
+        },
+        "blocking": {
+          "type": "boolean",
+          "description": "If blocking would occur."
+        }
+      }
+    },
+    "RaiBlocklistItem": {
+      "type": "object",
+      "description": "Cognitive Services RaiBlocklist Item.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiBlocklistItemProperties",
+          "description": "Properties of Cognitive Services RaiBlocklist Item."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiBlocklistItemBulkRequest": {
+      "type": "object",
+      "description": "The Cognitive Services RaiBlocklist Item request body.",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "properties": {
+          "$ref": "#/definitions/RaiBlocklistItemProperties",
+          "description": "Properties of Cognitive Services RaiBlocklist Item."
+        }
+      }
+    },
+    "RaiBlocklistItemProperties": {
+      "type": "object",
+      "description": "RAI Custom Blocklist Item properties.",
+      "properties": {
+        "pattern": {
+          "type": "string",
+          "description": "Pattern to match against."
+        },
+        "isRegex": {
+          "type": "boolean",
+          "description": "If the pattern is a regex pattern."
+        }
+      }
+    },
+    "RaiBlocklistItemsBulkAddRequest": {
+      "type": "array",
+      "description": "The list of Cognitive Services RaiBlocklist Items for batch add.",
+      "items": {
+        "$ref": "#/definitions/RaiBlocklistItemBulkRequest"
+      }
+    },
+    "RaiBlocklistItemsBulkDeleteRequest": {
+      "type": "array",
+      "description": "The list of Cognitive Services RaiBlocklist Items Names.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "RaiBlocklistProperties": {
+      "type": "object",
+      "description": "RAI Custom Blocklist properties.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description of the block list."
+        }
+      }
+    },
+    "RaiContentFilter": {
+      "type": "object",
+      "description": "Azure OpenAI Content Filter.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiContentFilterProperties",
+          "description": "Azure OpenAI Content Filter Properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiContentFilterListResult": {
+      "type": "object",
+      "description": "The list of Content Filters.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Content Filters."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiContentFilter.",
+          "items": {
+            "$ref": "#/definitions/RaiContentFilter"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiContentFilterProperties": {
+      "type": "object",
+      "description": "Azure OpenAI Content Filter Properties.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of Content Filter."
+        },
+        "isMultiLevelFilter": {
+          "type": "boolean",
+          "description": "If the Content Filter has multi severity levels(Low, Medium, or High)."
+        },
+        "source": {
+          "$ref": "#/definitions/RaiPolicyContentSource",
+          "description": "Content source to apply the Content Filters."
+        }
+      }
+    },
+    "RaiExternalSafetyProviderResult": {
+      "type": "object",
+      "description": "The list of cognitive services RAI External Safety Providers.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Rai External Safety Provider."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiExternalSafetyProvider.",
+          "items": {
+            "$ref": "#/definitions/RaiExternalSafetyProviderSchema"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiExternalSafetyProviderSchema": {
+      "type": "object",
+      "description": "Cognitive Services Rai External Safety provider Schema.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiExternalSafetyProviderSchemaProperties",
+          "description": "Properties of Cognitive Services Rai External Safety provider."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiExternalSafetyProviderSchemaProperties": {
+      "type": "object",
+      "description": "RAI External SafetyProvider schema properties.",
+      "properties": {
+        "providerId": {
+          "type": "string",
+          "description": "The unique identifier of the safety provider."
+        },
+        "providerName": {
+          "type": "string",
+          "description": "Name of the safety provider."
+        },
+        "mode": {
+          "type": "string",
+          "description": "Safety provider mode sync/async."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Webhook URL for the safety provider."
+        },
+        "secretName": {
+          "type": "string",
+          "description": "The name of the secret in Key Vault that contains the api key to access the webhook."
+        },
+        "managedIdentity": {
+          "type": "string",
+          "description": "The managed identity to access the Key Vault."
+        },
+        "keyVaultUri": {
+          "type": "string",
+          "format": "uri",
+          "description": "The Key Vault URI that contains the api key for safety provider urls."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation time of the safety provider.",
+          "readOnly": true
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last modified time of the safety provider.",
+          "readOnly": true
+        }
+      }
+    },
+    "RaiMonitorConfig": {
+      "type": "object",
+      "description": "Cognitive Services Rai Monitor Config.",
+      "properties": {
+        "adxStorageResourceId": {
+          "type": "string",
+          "description": "The storage resource Id."
+        },
+        "identityClientId": {
+          "type": "string",
+          "description": "The identity client Id to access the storage."
+        }
+      }
+    },
+    "RaiPolicy": {
+      "type": "object",
+      "description": "Cognitive Services RaiPolicy.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiPolicyProperties",
+          "description": "Properties of Cognitive Services RaiPolicy."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiPolicyContentFilter": {
+      "type": "object",
+      "description": "Azure OpenAI Content Filter.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of ContentFilter."
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "If the ContentFilter is enabled."
+        },
+        "severityThreshold": {
+          "$ref": "#/definitions/ContentLevel",
+          "description": "Level at which content is filtered."
+        },
+        "blocking": {
+          "type": "boolean",
+          "description": "If blocking would occur."
+        },
+        "source": {
+          "$ref": "#/definitions/RaiPolicyContentSource",
+          "description": "Content source to apply the Content Filters."
+        },
+        "action": {
+          "$ref": "#/definitions/RaiActionType",
+          "description": "The action types to apply to the content filters"
+        }
+      }
+    },
+    "RaiPolicyContentSource": {
+      "type": "string",
+      "description": "Content source to apply the Content Filters.",
+      "enum": [
+        "Prompt",
+        "Completion",
+        "PreToolCall",
+        "PostToolCall",
+        "PreRun",
+        "PostRun"
+      ],
+      "x-ms-enum": {
+        "name": "RaiPolicyContentSource",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Prompt",
+            "value": "Prompt"
+          },
+          {
+            "name": "Completion",
+            "value": "Completion"
+          },
+          {
+            "name": "PreToolCall",
+            "value": "PreToolCall"
+          },
+          {
+            "name": "PostToolCall",
+            "value": "PostToolCall"
+          },
+          {
+            "name": "PreRun",
+            "value": "PreRun"
+          },
+          {
+            "name": "PostRun",
+            "value": "PostRun"
+          }
+        ]
+      }
+    },
+    "RaiPolicyListResult": {
+      "type": "object",
+      "description": "The list of cognitive services RaiPolicies.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of RaiPolicy."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiPolicy.",
+          "items": {
+            "$ref": "#/definitions/RaiPolicy"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiPolicyMode": {
+      "type": "string",
+      "description": "Rai policy mode. The enum value mapping is as below: Default = 0, Deferred=1, Blocking=2, Asynchronous_filter =3. Please use 'Asynchronous_filter' after 2025-06-01. It is the same as 'Deferred' in previous version.",
+      "enum": [
+        "Default",
+        "Deferred",
+        "Blocking",
+        "Asynchronous_filter"
+      ],
+      "x-ms-enum": {
+        "name": "RaiPolicyMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default"
+          },
+          {
+            "name": "Deferred",
+            "value": "Deferred"
+          },
+          {
+            "name": "Blocking",
+            "value": "Blocking"
+          },
+          {
+            "name": "Asynchronous_filter",
+            "value": "Asynchronous_filter"
+          }
+        ]
+      }
+    },
+    "RaiPolicyProperties": {
+      "type": "object",
+      "description": "Azure OpenAI Content Filters properties.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/RaiPolicyType",
+          "description": "Content Filters policy type.",
+          "readOnly": true
+        },
+        "mode": {
+          "$ref": "#/definitions/RaiPolicyMode",
+          "description": "Rai policy mode. The enum value mapping is as below: Default = 0, Deferred=1, Blocking=2, Asynchronous_filter =3. Please use 'Asynchronous_filter' after 2025-06-01. It is the same as 'Deferred' in previous version."
+        },
+        "basePolicyName": {
+          "type": "string",
+          "description": "Name of Rai policy."
+        },
+        "contentFilters": {
+          "type": "array",
+          "description": "The list of Content Filters.",
+          "items": {
+            "$ref": "#/definitions/RaiPolicyContentFilter"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "customBlocklists": {
+          "type": "array",
+          "description": "The list of custom Blocklist.",
+          "items": {
+            "$ref": "#/definitions/CustomBlocklistConfig"
+          },
+          "x-ms-identifiers": []
+        },
+        "safetyProviders": {
+          "type": "array",
+          "description": "The list of Safety Providers.",
+          "items": {
+            "$ref": "#/definitions/SafetyProviderConfig"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "RaiPolicyType": {
+      "type": "string",
+      "description": "Content Filters policy type.",
+      "enum": [
+        "UserManaged",
+        "SystemManaged"
+      ],
+      "x-ms-enum": {
+        "name": "RaiPolicyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "UserManaged",
+            "value": "UserManaged"
+          },
+          {
+            "name": "SystemManaged",
+            "value": "SystemManaged"
+          }
+        ]
+      }
+    },
+    "RaiSafetyProviderConfig": {
+      "type": "object",
+      "description": "Azure OpenAI RAI safety provider config.",
+      "properties": {
+        "safetyProviderName": {
+          "type": "string",
+          "description": "Name of RAI Safety Provider."
+        },
+        "blocking": {
+          "type": "boolean",
+          "description": "If blocking would occur."
+        }
+      }
+    },
+    "RaiToolLabel": {
+      "type": "object",
+      "description": "Cognitive Services RAI Tool Label resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiToolLabelProperties",
+          "description": "Properties of the RAI Tool Label."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiToolLabelProperties": {
+      "type": "object",
+      "description": "RAI Tool Label properties.",
+      "properties": {
+        "toolConnectionName": {
+          "type": "string",
+          "description": "The unique tool connection name, e.g., 'Web_Search'."
+        },
+        "accountScope": {
+          "$ref": "#/definitions/RaiToolLabelPropertiesAccountScope",
+          "description": "Account-level tool label definition."
+        },
+        "projectScopes": {
+          "type": "array",
+          "description": "List of project-level tool label definitions.",
+          "items": {
+            "$ref": "#/definitions/RaiToolLabelPropertiesProjectScopesItem"
+          }
+        }
+      },
+      "required": [
+        "toolConnectionName"
+      ]
+    },
+    "RaiToolLabelPropertiesAccountScope": {
+      "type": "object",
+      "description": "Account-level tool label definition.",
+      "properties": {
+        "labelValues": {
+          "type": "object",
+          "description": "Dictionary of label key-value pairs for the account scope.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RaiToolLabelPropertiesProjectScopesItem": {
+      "type": "object",
+      "properties": {
+        "project": {
+          "type": "string",
+          "description": "Project name to which this scope applies."
+        },
+        "labelValues": {
+          "type": "object",
+          "description": "Dictionary of label key-value pairs for the project scope.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "project",
+        "labelValues"
+      ]
+    },
+    "RaiToolLabelResult": {
+      "type": "object",
+      "description": "The list of Cognitive Services RAI Tool Labels.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of RaiToolLabels."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RAI Tool Labels.",
+          "items": {
+            "$ref": "#/definitions/RaiToolLabel"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RaiTopic": {
+      "type": "object",
+      "description": "Cognitive Services Rai Topic.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RaiTopicProperties",
+          "description": "Properties of Cognitive Services Rai Topic."
+        },
+        "etag": {
+          "type": "string",
+          "description": "Resource Etag.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v3/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RaiTopicProperties": {
+      "type": "object",
+      "description": "RAI Custom Topic properties.",
+      "properties": {
+        "topicId": {
+          "type": "string",
+          "description": "The unique identifier of the custom topic."
+        },
+        "topicName": {
+          "type": "string",
+          "description": "The name of the custom topic."
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the custom topic."
+        },
+        "sampleBlobUrl": {
+          "type": "string",
+          "description": "Sample blob url for the custom topic."
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the custom topic."
+        },
+        "failedReason": {
+          "type": "string",
+          "description": "Failed reason if the status is Failed."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation time of the custom topic."
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Last modified time of the custom topic."
+        }
+      }
+    },
+    "RaiTopicResult": {
+      "type": "object",
+      "description": "The list of cognitive services RAI Topics.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of RaiTopics."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of RaiTopic.",
+          "items": {
+            "$ref": "#/definitions/RaiTopic"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "RegenerateKeyParameters": {
+      "type": "object",
+      "description": "Regenerate key parameters.",
+      "properties": {
+        "keyName": {
+          "$ref": "#/definitions/KeyName",
+          "description": "key name to generate (Key1|Key2)"
+        }
+      },
+      "required": [
+        "keyName"
+      ]
+    },
+    "RegionSetting": {
+      "type": "object",
+      "description": "The call rate limit Cognitive Services account.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the region."
+        },
+        "value": {
+          "type": "number",
+          "format": "float",
+          "description": "A value for priority or weighted routing methods."
+        },
+        "customsubdomain": {
+          "type": "string",
+          "description": "Maps the region to the regional custom subdomain."
+        }
+      }
+    },
+    "ReplacementConfig": {
+      "type": "object",
+      "description": "Configuration for model replacement.",
+      "properties": {
+        "targetModelName": {
+          "type": "string",
+          "description": "The name of the replacement model."
+        },
+        "targetModelVersion": {
+          "type": "string",
+          "description": "The version of the replacement model."
+        },
+        "autoUpgradeStartDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The date when automatic upgrade should start. This applies to deployments with the OnceNewDefaultVersionAvailable upgrade option."
+        },
+        "upgradeOnExpiryLeadTimeDays": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of days before deprecation date to trigger upgrade. This applies to deployments with the OnceCurrentVersionExpired upgrade option."
+        }
+      }
+    },
+    "RequestMatchPattern": {
+      "type": "object",
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "method": {
+          "type": "string"
+        }
+      }
+    },
+    "ResourceBase": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "The asset description text.",
+          "x-nullable": true
+        },
+        "tags": {
+          "type": "object",
+          "description": "Tag dictionary. Tags can be added, removed, and updated.",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ResourceIdentityType": {
+      "type": "string",
+      "description": "The identity type.",
+      "enum": [
+        "None",
+        "SystemAssigned",
+        "UserAssigned",
+        "SystemAssigned, UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceIdentityType",
+        "modelAsString": false
+      }
+    },
+    "ResourceSku": {
+      "type": "object",
+      "description": "Describes an available Cognitive Services SKU.",
+      "properties": {
+        "resourceType": {
+          "type": "string",
+          "description": "The type of resource the SKU applies to."
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of SKU."
+        },
+        "tier": {
+          "type": "string",
+          "description": "Specifies the tier of Cognitive Services account."
+        },
+        "kind": {
+          "type": "string",
+          "description": "The Kind of resources that are supported in this SKU."
+        },
+        "locations": {
+          "type": "array",
+          "description": "The set of locations that the SKU is available.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "restrictions": {
+          "type": "array",
+          "description": "The restrictions because of which SKU cannot be used. This is empty if there are no restrictions.",
+          "items": {
+            "$ref": "#/definitions/ResourceSkuRestrictions"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ResourceSkuListResult": {
+      "type": "object",
+      "description": "The Get Skus operation response.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ResourceSku items on this page",
+          "items": {
+            "$ref": "#/definitions/ResourceSku"
+          },
+          "x-ms-identifiers": [
+            "resourceType",
+            "name",
+            "kind"
+          ]
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ResourceSkuRestrictionInfo": {
+      "type": "object",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "description": "Locations where the SKU is restricted",
+          "items": {
+            "type": "string"
+          }
+        },
+        "zones": {
+          "type": "array",
+          "description": "List of availability zones where the SKU is restricted.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ResourceSkuRestrictions": {
+      "type": "object",
+      "description": "Describes restrictions of a SKU.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ResourceSkuRestrictionsType",
+          "description": "The type of restrictions."
+        },
+        "values": {
+          "type": "array",
+          "description": "The value of restrictions. If the restriction type is set to location. This would be different locations where the SKU is restricted.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "restrictionInfo": {
+          "$ref": "#/definitions/ResourceSkuRestrictionInfo",
+          "description": "The information about the restriction where the SKU cannot be used."
+        },
+        "reasonCode": {
+          "$ref": "#/definitions/ResourceSkuRestrictionsReasonCode",
+          "description": "The reason for restriction."
+        }
+      }
+    },
+    "ResourceSkuRestrictionsReasonCode": {
+      "type": "string",
+      "description": "The reason for restriction.",
+      "enum": [
+        "QuotaId",
+        "NotAvailableForSubscription"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceSkuRestrictionsReasonCode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "QuotaId",
+            "value": "QuotaId"
+          },
+          {
+            "name": "NotAvailableForSubscription",
+            "value": "NotAvailableForSubscription"
+          }
+        ]
+      }
+    },
+    "ResourceSkuRestrictionsType": {
+      "type": "string",
+      "description": "The type of restrictions.",
+      "enum": [
+        "Location",
+        "Zone"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceSkuRestrictionsType",
+        "modelAsString": false
+      }
+    },
+    "RoleBasedBuiltInAuthorizationPolicy": {
+      "type": "object",
+      "description": "Built-in role-based authorization policy.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ApplicationAuthorizationPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "Default"
+    },
+    "RoutingMethods": {
+      "type": "string",
+      "description": "Multiregion routing methods.",
+      "enum": [
+        "Priority",
+        "Weighted",
+        "Performance"
+      ],
+      "x-ms-enum": {
+        "name": "RoutingMethods",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Priority",
+            "value": "Priority"
+          },
+          {
+            "name": "Weighted",
+            "value": "Weighted"
+          },
+          {
+            "name": "Performance",
+            "value": "Performance"
+          }
+        ]
+      }
+    },
+    "RoutingMode": {
+      "type": "string",
+      "description": "The model-router routing mode that determines how requests are distributed across models.",
+      "enum": [
+        "cost",
+        "balanced",
+        "quality"
+      ],
+      "x-ms-enum": {
+        "name": "RoutingMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Cost",
+            "value": "cost",
+            "description": "Route requests to minimize cost while meeting performance requirements."
+          },
+          {
+            "name": "Balanced",
+            "value": "balanced",
+            "description": "Balance cost and quality when routing requests across models."
+          },
+          {
+            "name": "Quality",
+            "value": "quality",
+            "description": "Route requests to maximize quality regardless of cost."
+          }
+        ]
+      }
+    },
+    "RuleAction": {
+      "type": "string",
+      "description": "The action enum for a managed network outbound rule.",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "RuleAction",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny"
+          }
+        ]
+      }
+    },
+    "RuleCategory": {
+      "type": "string",
+      "description": "Category of a managed network Outbound Rule of a cognitive services account.",
+      "enum": [
+        "Required",
+        "Recommended",
+        "UserDefined",
+        "Dependency"
+      ],
+      "x-ms-enum": {
+        "name": "RuleCategory",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Required",
+            "value": "Required"
+          },
+          {
+            "name": "Recommended",
+            "value": "Recommended"
+          },
+          {
+            "name": "UserDefined",
+            "value": "UserDefined"
+          },
+          {
+            "name": "Dependency",
+            "value": "Dependency"
+          }
+        ]
+      }
+    },
+    "RuleStatus": {
+      "type": "string",
+      "description": "Type of a managed network Outbound Rule of a cognitive services account.",
+      "enum": [
+        "Inactive",
+        "Active",
+        "Provisioning",
+        "Deleting",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "RuleStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inactive",
+            "value": "Inactive"
+          },
+          {
+            "name": "Active",
+            "value": "Active"
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed"
+          }
+        ]
+      }
+    },
+    "RuleType": {
+      "type": "string",
+      "description": "Type of a managed network Outbound Rule of a cognitive services account.",
+      "enum": [
+        "FQDN",
+        "PrivateEndpoint",
+        "ServiceTag"
+      ],
+      "x-ms-enum": {
+        "name": "RuleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FQDN",
+            "value": "FQDN"
+          },
+          {
+            "name": "PrivateEndpoint",
+            "value": "PrivateEndpoint"
+          },
+          {
+            "name": "ServiceTag",
+            "value": "ServiceTag"
+          }
+        ]
+      }
+    },
+    "SASAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionSharedAccessSignature"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "SAS"
+    },
+    "SafetyProviderConfig": {
+      "type": "object",
+      "description": "Gets or sets the source to which safety providers applies.",
+      "properties": {
+        "source": {
+          "$ref": "#/definitions/RaiPolicyContentSource",
+          "description": "Content source to apply the Content Filters."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RaiSafetyProviderConfig"
+        }
+      ]
+    },
+    "ScenarioType": {
+      "type": "string",
+      "description": "Specifies what features in AI Foundry network injection applies to. Currently only supports 'agent' for agent scenarios. 'none' means no network injection.",
+      "enum": [
+        "none",
+        "agent"
+      ],
+      "x-ms-enum": {
+        "name": "ScenarioType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "none",
+            "value": "none"
+          },
+          {
+            "name": "agent",
+            "value": "agent"
+          }
+        ]
+      }
+    },
+    "ServicePrincipalAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionServicePrincipal"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "ServicePrincipal"
+    },
+    "ServiceTagOutboundRule": {
+      "type": "object",
+      "description": "Service Tag outbound rule for the managed network of a cognitive services account.",
+      "properties": {
+        "destination": {
+          "$ref": "#/definitions/ServiceTagOutboundRuleDestination",
+          "description": "Service Tag destination."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OutboundRule"
+        }
+      ],
+      "x-ms-discriminator-value": "ServiceTag"
+    },
+    "ServiceTagOutboundRuleDestination": {
+      "type": "object",
+      "description": "Service Tag destination for an outbound rule.",
+      "properties": {
+        "serviceTag": {
+          "type": "string",
+          "description": "Name of the Azure service tag to target."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Network protocol used by the service tag rule."
+        },
+        "portRanges": {
+          "type": "string",
+          "description": "Destination port ranges."
+        },
+        "action": {
+          "$ref": "#/definitions/RuleAction",
+          "description": "The action for the service tag outbound rule."
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "Optional address prefixes. If provided, the serviceTag property will be ignored.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ServiceTier": {
+      "type": "string",
+      "description": "The service tier for the deployment. Determines the pricing and performance level for request processing. Use 'Default' for standard pricing or 'Priority' for higher-priority processing with premium pricing. Note: Pause operations are only supported on Standard, DataZoneStandard, and GlobalStandard SKUs.",
+      "enum": [
+        "Default",
+        "Priority"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Default",
+            "value": "Default",
+            "description": "Default service tier meaning the request will be processed with the standard pricing and performance for the selected model."
+          },
+          {
+            "name": "Priority",
+            "value": "Priority",
+            "description": "Priority service tier meaning the request will be processed with higher pricing and performance for the selected model."
+          }
+        ]
+      }
+    },
+    "Skill": {
+      "type": "object",
+      "description": "Collection of capability units the Agent can perform",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for the skill.",
+          "x-nullable": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for the skill.",
+          "x-nullable": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Skill description.",
+          "x-nullable": true
+        },
+        "tags": {
+          "type": "array",
+          "description": "Tags describing the skill's capability category (e.g., 'cooking', 'customer support').",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "examples": {
+          "type": "array",
+          "description": "Example scenarios or prompts the skill can execute (e.g., 'I need a recipe for bread').",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "inputModes": {
+          "type": "array",
+          "description": "Input MIME types supported by the skill (if different from default).",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        },
+        "outputModes": {
+          "type": "array",
+          "description": "Output MIME types supported by the skill (if different from default).",
+          "x-nullable": true,
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Sku": {
+      "type": "object",
+      "description": "The resource model definition representing SKU",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SKU. Ex - P3. It is typically a letter+number code"
+        },
+        "tier": {
+          "$ref": "#/definitions/SkuTier",
+          "description": "This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT."
+        },
+        "size": {
+          "type": "string",
+          "description": "The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code."
+        },
+        "family": {
+          "type": "string",
+          "description": "If the service has different generations of hardware, for the same SKU, then that can be captured here."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not possible for the resource this may be omitted."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "SkuAvailability": {
+      "type": "object",
+      "description": "SKU availability.",
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The kind (type) of cognitive service account."
+        },
+        "type": {
+          "type": "string",
+          "description": "The Type of the resource."
+        },
+        "skuName": {
+          "type": "string",
+          "description": "The name of SKU."
+        },
+        "skuAvailable": {
+          "type": "boolean",
+          "description": "Indicates the given SKU is available or not."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Reason why the SKU is not available."
+        },
+        "message": {
+          "type": "string",
+          "description": "Additional error message."
+        }
+      }
+    },
+    "SkuAvailabilityListResult": {
+      "type": "object",
+      "description": "Check SKU availability result list.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Check SKU availability result list.",
+          "items": {
+            "$ref": "#/definitions/SkuAvailability"
+          },
+          "x-ms-identifiers": [
+            "skuName",
+            "type",
+            "kind"
+          ]
+        }
+      }
+    },
+    "SkuCapability": {
+      "type": "object",
+      "description": "SkuCapability indicates the capability of a certain feature.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the SkuCapability."
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the SkuCapability."
+        }
+      }
+    },
+    "SkuChangeInfo": {
+      "type": "object",
+      "description": "Sku change info of account.",
+      "properties": {
+        "countOfDowngrades": {
+          "type": "number",
+          "format": "float",
+          "description": "Gets the count of downgrades."
+        },
+        "countOfUpgradesAfterDowngrades": {
+          "type": "number",
+          "format": "float",
+          "description": "Gets the count of upgrades after downgrades."
+        },
+        "lastChangeDate": {
+          "type": "string",
+          "description": "Gets the last change date."
+        }
+      }
+    },
+    "SkuResource": {
+      "type": "object",
+      "description": "Properties of Cognitive Services account resource sku resource properties.",
+      "properties": {
+        "resourceType": {
+          "type": "string",
+          "description": "The resource type name."
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The resource model definition representing SKU"
+        },
+        "capacity": {
+          "$ref": "#/definitions/CapacityConfig",
+          "description": "The capacity configuration."
+        }
+      }
+    },
+    "SkuTier": {
+      "type": "string",
+      "description": "This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.",
+      "enum": [
+        "Free",
+        "Basic",
+        "Standard",
+        "Premium",
+        "Enterprise"
+      ],
+      "x-ms-enum": {
+        "name": "SkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Free",
+            "value": "Free"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard"
+          },
+          {
+            "name": "Premium",
+            "value": "Premium"
+          },
+          {
+            "name": "Enterprise",
+            "value": "Enterprise"
+          }
+        ]
+      }
+    },
+    "ThrottlingRule": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "renewalPeriod": {
+          "type": "number",
+          "format": "float"
+        },
+        "count": {
+          "type": "number",
+          "format": "float"
+        },
+        "minCount": {
+          "type": "number",
+          "format": "float"
+        },
+        "dynamicThrottlingEnabled": {
+          "type": "boolean"
+        },
+        "matchPatterns": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RequestMatchPattern"
+          },
+          "x-ms-identifiers": [
+            "path",
+            "method"
+          ]
+        }
+      }
+    },
+    "TierUpgradePolicy": {
+      "type": "string",
+      "description": "Gets the tier upgrade policy for the subscription.",
+      "enum": [
+        "OnceUpgradeIsAvailable",
+        "NoAutoUpgrade"
+      ],
+      "x-ms-enum": {
+        "name": "TierUpgradePolicy",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OnceUpgradeIsAvailable",
+            "value": "OnceUpgradeIsAvailable"
+          },
+          {
+            "name": "NoAutoUpgrade",
+            "value": "NoAutoUpgrade"
+          }
+        ]
+      }
+    },
+    "TrafficRoutingProtocol": {
+      "type": "string",
+      "description": "Traffic routing protocol, used to distribute an application's inbound traffic to its deployments.",
+      "enum": [
+        "FixedRatio"
+      ],
+      "x-ms-enum": {
+        "name": "TrafficRoutingProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FixedRatio",
+            "value": "FixedRatio",
+            "description": "Percentage based routing"
+          }
+        ]
+      }
+    },
+    "TrafficRoutingRule": {
+      "type": "object",
+      "description": "Represents a rule for routing traffic to a specific deployment.",
+      "properties": {
+        "ruleId": {
+          "type": "string",
+          "description": "The identifier of this traffic routing rule.",
+          "x-nullable": true
+        },
+        "description": {
+          "type": "string",
+          "description": "A user-provided description for this traffic routing rule.",
+          "x-nullable": true
+        },
+        "deploymentId": {
+          "type": "string",
+          "description": "The unique identifier of the deployment to which traffic is routed by this rule.",
+          "x-nullable": true
+        },
+        "trafficPercentage": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Gets or sets the percentage of traffic allocated to this instance."
+        }
+      }
+    },
+    "UnitType": {
+      "type": "string",
+      "description": "The unit of the metric.",
+      "enum": [
+        "Count",
+        "Bytes",
+        "Seconds",
+        "Percent",
+        "CountPerSecond",
+        "BytesPerSecond",
+        "Milliseconds"
+      ],
+      "x-ms-enum": {
+        "name": "UnitType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Count",
+            "value": "Count"
+          },
+          {
+            "name": "Bytes",
+            "value": "Bytes"
+          },
+          {
+            "name": "Seconds",
+            "value": "Seconds"
+          },
+          {
+            "name": "Percent",
+            "value": "Percent"
+          },
+          {
+            "name": "CountPerSecond",
+            "value": "CountPerSecond"
+          },
+          {
+            "name": "BytesPerSecond",
+            "value": "BytesPerSecond"
+          },
+          {
+            "name": "Milliseconds",
+            "value": "Milliseconds"
+          }
+        ]
+      }
+    },
+    "UpgradeAvailabilityStatus": {
+      "type": "string",
+      "description": "Specifies whether an upgrade to the next quota tier is available.",
+      "enum": [
+        "Available",
+        "NotAvailable"
+      ],
+      "x-ms-enum": {
+        "name": "UpgradeAvailabilityStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Available",
+            "value": "Available"
+          },
+          {
+            "name": "NotAvailable",
+            "value": "NotAvailable"
+          }
+        ]
+      }
+    },
+    "Usage": {
+      "type": "object",
+      "description": "The usage data for a usage request.",
+      "properties": {
+        "unit": {
+          "$ref": "#/definitions/UnitType",
+          "description": "The unit of the metric."
+        },
+        "name": {
+          "$ref": "#/definitions/MetricName",
+          "description": "The name information for the metric."
+        },
+        "quotaPeriod": {
+          "type": "string",
+          "description": "The quota period used to summarize the usage values."
+        },
+        "limit": {
+          "type": "number",
+          "format": "double",
+          "description": "Maximum value for this metric."
+        },
+        "currentValue": {
+          "type": "number",
+          "format": "double",
+          "description": "Current value for this metric."
+        },
+        "nextResetTime": {
+          "type": "string",
+          "description": "Next reset time for current quota."
+        },
+        "status": {
+          "$ref": "#/definitions/QuotaUsageStatus",
+          "description": "Cognitive Services account quota usage status."
+        },
+        "scopeType": {
+          "$ref": "#/definitions/QuotaScopeType",
+          "description": "The scope type of the quota usage.",
+          "x-nullable": true
+        },
+        "scopeId": {
+          "type": "string",
+          "description": "The scope identifier of the quota usage.",
+          "x-nullable": true
+        }
+      }
+    },
+    "UsageListResult": {
+      "type": "object",
+      "description": "The response to a list usage request.",
+      "properties": {
+        "nextLink": {
+          "type": "string",
+          "description": "The link used to get the next page of Usages."
+        },
+        "value": {
+          "type": "array",
+          "description": "The list of usages for Cognitive Service account.",
+          "items": {
+            "$ref": "#/definitions/Usage"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "description": "User-assigned managed identity.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "Azure Active Directory principal ID associated with this Identity.",
+          "readOnly": true
+        },
+        "clientId": {
+          "type": "string",
+          "description": "Client App Id associated with this identity.",
+          "readOnly": true
+        }
+      }
+    },
+    "UserOwnedAmlWorkspace": {
+      "type": "object",
+      "description": "The user owned AML account for Cognitive Services account.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "Full resource id of a AML account resource."
+        },
+        "identityClientId": {
+          "type": "string",
+          "description": "Identity Client id of a AML account resource."
+        }
+      }
+    },
+    "UserOwnedStorage": {
+      "type": "object",
+      "description": "The user owned storage for Cognitive Services account.",
+      "properties": {
+        "resourceId": {
+          "type": "string",
+          "description": "Full resource id of a Microsoft.Storage resource."
+        },
+        "identityClientId": {
+          "type": "string"
+        }
+      }
+    },
+    "UsernamePasswordAuthTypeConnectionProperties": {
+      "type": "object",
+      "properties": {
+        "credentials": {
+          "$ref": "#/definitions/ConnectionUsernamePassword"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ConnectionPropertiesV2"
+        }
+      ],
+      "x-ms-discriminator-value": "UsernamePassword"
+    },
+    "VersionedAgentReference": {
+      "type": "object",
+      "description": "Type modeling a reference to a version of an agent definition.",
+      "properties": {
+        "agentVersion": {
+          "type": "string",
+          "description": "Gets the agent's version (unique for each agent lineage).",
+          "x-nullable": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AgentReferenceProperties"
+        }
+      ]
+    },
+    "VirtualNetworkRule": {
+      "type": "object",
+      "description": "A rule governing the accessibility from a specific virtual network.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Full resource id of a vnet subnet, such as '/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/test-vnet/subnets/subnet1'."
+        },
+        "state": {
+          "type": "string",
+          "description": "Gets the state of virtual network rule."
+        },
+        "ignoreMissingVnetServiceEndpoint": {
+          "type": "boolean",
+          "description": "Ignore missing vnet service endpoint or not."
+        }
+      },
+      "required": [
+        "id"
+      ]
+    }
+  },
+  "parameters": {
+    "BudgetPolicyCreateOrUpdateHeaders.ifMatch": {
+      "name": "If-Match",
+      "in": "header",
+      "description": "Proceeds only when the current entity tag matches this value.",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "ifMatch"
+    },
+    "BudgetPolicyCreateOrUpdateHeaders.ifNoneMatch": {
+      "name": "If-None-Match",
+      "in": "header",
+      "description": "Proceeds only when the current entity tag does not match this value.",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "ifNoneMatch"
+    },
+    "BudgetPolicyIfMatchHeader": {
+      "name": "If-Match",
+      "in": "header",
+      "description": "Proceeds only when the current entity tag matches this value.",
+      "required": false,
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "x-ms-client-name": "ifMatch"
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountCapabilityHost/createOrUpdate.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountCapabilityHost/createOrUpdate.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHost": {
+      "properties": {
+        "customerSubnet": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubnet",
+        "enablePublicHostingEnvironment": true
+      }
+    },
+    "capabilityHostName": "capabilityHostName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "customerSubnet": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "enablePublicHostingEnvironment": true,
+          "provisioningState": "Succeeded",
+          "tags": {
+            "string": "string"
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "customerSubnet": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "enablePublicHostingEnvironment": true,
+          "provisioningState": "Succeeded",
+          "tags": {
+            "string": "string"
+          }
+        }
+      },
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "AccountCapabilityHosts_CreateOrUpdate",
+  "title": "CreateOrUpdate Account CapabilityHost."
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountCapabilityHost/delete.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountCapabilityHost/delete.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "AccountCapabilityHosts_Delete",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHostName": "capabilityHostName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Account CapabilityHost.",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "location_header_to_poll"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountCapabilityHost/get.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountCapabilityHost/get.json
@@ -1,0 +1,30 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHostName": "capabilityHostName",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "description": "string",
+          "customerSubnet": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+          "enablePublicHostingEnvironment": true,
+          "provisioningState": "Succeeded",
+          "tags": {
+            "string": "string"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AccountCapabilityHosts_Get",
+  "title": "Get Account CapabilityHost."
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountCapabilityHost/list.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountCapabilityHost/list.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "capabilityHostName",
+            "type": "Microsoft.CognitiveServices/accounts/capabilityHosts",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/capabilityHosts/capabilityHostName",
+            "properties": {
+              "description": "string",
+              "customerSubnet": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroups/providers/Microsoft.Network/virtualNetworks/myVnet/subnets/mySubne",
+              "provisioningState": "Succeeded",
+              "tags": {
+                "string": "string"
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AccountCapabilityHosts_List",
+  "title": "List Account CapabilityHosts."
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountConnection/create.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountConnection/create.json
@@ -1,0 +1,34 @@
+{
+  "operationId": "AccountConnections_Create",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connection": {
+      "properties": {
+        "authType": "None",
+        "category": "ContainerRegistry",
+        "expiryTime": "2024-03-15T14:30:00Z",
+        "target": "[target url]"
+      }
+    },
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "CreateAccountConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "[target url]"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountConnection/delete.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountConnection/delete.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "AccountConnections_Delete",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeleteAccountConnection",
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountConnection/get.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountConnection/get.json
@@ -1,0 +1,26 @@
+{
+  "operationId": "AccountConnections_Get",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connectionName": "connection-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetAccountConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "[target url]"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountConnection/list.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountConnection/list.json
@@ -1,0 +1,41 @@
+{
+  "operationId": "AccountConnections_List",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "category": "ContainerRegistry",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "target": "[target url]"
+  },
+  "title": "ListAccountConnections",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "connection-1",
+            "type": "Microsoft.CognitiveServices/accounts/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/connections/connection-1",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "expiryTime": "2024-03-15T14:30:00Z",
+              "target": "[target url]"
+            }
+          },
+          {
+            "name": "connection-2",
+            "type": "Microsoft.CognitiveServices/accounts/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/connections/connection-2",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "target": "[target url]"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountConnection/update.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AccountConnection/update.json
@@ -1,0 +1,41 @@
+{
+  "operationId": "AccountConnections_Update",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connection": {
+      "properties": {
+        "authType": "AccessKey",
+        "category": "ADLSGen2",
+        "credentials": {
+          "accessKeyId": "some_string",
+          "secretAccessKey": "some_string"
+        },
+        "expiryTime": "2020-01-01T00:00:00Z",
+        "metadata": {},
+        "target": "some_string"
+      }
+    },
+    "connectionName": "connection-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "UpdateAccountConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/connections/connection-1",
+        "properties": {
+          "authType": "AccessKey",
+          "category": "ADLSGen2",
+          "expiryTime": "2020-01-01T00:00:00Z",
+          "metadata": {},
+          "target": "some_string"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AddRaiBlocklistItems.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AddRaiBlocklistItems.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "RaiBlocklistItems_BatchAdd",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistItems": [
+      {
+        "name": "myblocklistitem1",
+        "properties": {
+          "isRegex": true,
+          "pattern": "^[a-z0-9_-]{2,16}$"
+        }
+      },
+      {
+        "name": "myblocklistitem2",
+        "properties": {
+          "isRegex": false,
+          "pattern": "blockwords"
+        }
+      }
+    ],
+    "raiBlocklistName": "myblocklist",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "AddRaiBlocklistItems",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myblocklist",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "properties": {
+          "description": "Brief description of the blocklist"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/createOrUpdate.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/createOrUpdate.json
@@ -1,0 +1,74 @@
+{
+  "operationId": "AgentApplications_CreateOrUpdate",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "body": {
+      "properties": {
+        "description": "Sample agent application for customer support",
+        "displayName": "Customer Support Agent",
+        "tags": {
+          "environment": "production",
+          "team": "ai-platform"
+        }
+      }
+    },
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create or Update Account Agent Application.",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agent-app-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1",
+        "properties": {
+          "description": "Sample agent application for customer support",
+          "displayName": "Customer Support Agent",
+          "provisioningState": "Succeeded",
+          "tags": {
+            "environment": "production",
+            "team": "ai-platform"
+          }
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "agent-app-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1",
+        "properties": {
+          "description": "Sample agent application for customer support",
+          "displayName": "Customer Support Agent",
+          "provisioningState": "Creating",
+          "tags": {
+            "environment": "production",
+            "team": "ai-platform"
+          }
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/delete.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/delete.json
@@ -1,0 +1,21 @@
+{
+  "operationId": "AgentApplications_Delete",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Account Agent Application.",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-08-31-preview",
+        "Retry-After": "10"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/disable.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/disable.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "AgentApplications_Disable",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Disable Agent Application.",
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/enable.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/enable.json
@@ -1,0 +1,15 @@
+{
+  "operationId": "AgentApplications_Enable",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Enable Agent Application.",
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/get.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/get.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "AgentApplications_Get",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get Account Agent Application.",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "agent-app-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1",
+        "properties": {
+          "description": "Sample agent application for customer support",
+          "displayName": "Customer Support Agent",
+          "tags": {
+            "environment": "production",
+            "team": "ai-platform"
+          }
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/list.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/list.json
@@ -1,0 +1,51 @@
+{
+  "operationId": "AgentApplications_List",
+  "parameters": {
+    "$skipToken": "string",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "count": 30,
+    "names": [
+      "agent-app-1",
+      "agent-app-2"
+    ],
+    "orderBy": "name",
+    "orderByAsc": true,
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "searchText": "test",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Account Agent Applications.",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": "string",
+        "value": [
+          {
+            "name": "agent-app-1",
+            "type": "Microsoft.CognitiveServices/accounts/projects/applications",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1",
+            "properties": {
+              "description": "Sample agent application for customer support",
+              "displayName": "Customer Support Agent",
+              "tags": {
+                "environment": "production",
+                "team": "ai-platform"
+              }
+            },
+            "systemData": {
+              "createdAt": "2024-09-29T12:34:56.999Z",
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/listAgents.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentApplication/listAgents.json
@@ -1,0 +1,56 @@
+{
+  "operationId": "AgentApplications_ListAgents",
+  "parameters": {
+    "name": "agent-app-1",
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Agents for Agent Application.",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "CustomerSupportAgent",
+            "type": "Microsoft.CognitiveServices/accounts/projects/applications/agents",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agents/agent-001",
+            "properties": {
+              "agentId": "agent-001",
+              "agentName": "CustomerSupportAgent"
+            },
+            "systemData": {
+              "createdAt": "2024-09-29T12:34:56.999Z",
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "TechnicalSupportAgent",
+            "type": "Microsoft.CognitiveServices/accounts/projects/applications/agents",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agents/agent-002",
+            "properties": {
+              "agentId": "agent-002",
+              "agentName": "TechnicalSupportAgent"
+            },
+            "systemData": {
+              "createdAt": "2024-09-29T12:34:56.999Z",
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/createOrUpdate.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/createOrUpdate.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "body": {
+      "properties": {
+        "agents": [
+          {
+            "agentId": "agent-123",
+            "agentName": "support-agent",
+            "agentVersion": "1.0.0"
+          }
+        ],
+        "deploymentType": "Managed",
+        "displayName": "Production Deployment",
+        "protocols": [
+          {
+            "version": "1.0",
+            "protocol": "Agent"
+          }
+        ],
+        "state": "Starting"
+      }
+    },
+    "deploymentName": "deployment-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deployment-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications/agentDeployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agentDeployments/deployment-1",
+        "properties": {
+          "agents": [
+            {
+              "agentId": "agent-123",
+              "agentName": "support-agent",
+              "agentVersion": "1.0.0"
+            }
+          ],
+          "deploymentId": "550e8400-e29b-41d4-a716-446655440001",
+          "deploymentType": "Managed",
+          "displayName": "Production Deployment",
+          "protocols": [
+            {
+              "version": "1.0",
+              "protocol": "Agent"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "state": "Running"
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "deployment-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications/agentDeployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agentDeployments/deployment-1",
+        "properties": {
+          "agents": [
+            {
+              "agentId": "agent-123",
+              "agentName": "support-agent",
+              "agentVersion": "1.0.0"
+            }
+          ],
+          "deploymentId": "550e8400-e29b-41d4-a716-446655440001",
+          "deploymentType": "Managed",
+          "displayName": "Production Deployment",
+          "protocols": [
+            {
+              "version": "1.0",
+              "protocol": "Agent"
+            }
+          ],
+          "provisioningState": "Creating",
+          "state": "Starting"
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/operationresults/00000000-1111-2222-3333-444444444444?api-version=2026-08-31-preview"
+      }
+    }
+  },
+  "operationId": "AgentDeployments_CreateOrUpdate",
+  "title": "Create or Update Agent Deployment."
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/delete.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/delete.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "AgentDeployments_Delete",
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "deploymentName": "deployment-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Agent Deployment.",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-08-31-preview",
+        "Retry-After": "10"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/get.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/get.json
@@ -1,0 +1,51 @@
+{
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "deploymentName": "deployment-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deployment-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/applications/agentDeployments",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agentDeployments/deployment-1",
+        "properties": {
+          "agents": [
+            {
+              "agentId": "agent-123",
+              "agentName": "support-agent",
+              "agentVersion": "1.0.0"
+            }
+          ],
+          "deploymentId": "550e8400-e29b-41d4-a716-446655440001",
+          "deploymentType": "Managed",
+          "displayName": "Production Deployment",
+          "protocols": [
+            {
+              "version": "1.0",
+              "protocol": "Agent"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "state": "Running"
+        },
+        "systemData": {
+          "createdAt": "2024-09-29T12:34:56.999Z",
+          "createdBy": "user@contoso.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+          "lastModifiedBy": "user@contoso.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AgentDeployments_Get",
+  "title": "Get Agent Deployment."
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/list.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/list.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "deployment-1",
+            "type": "Microsoft.CognitiveServices/accounts/projects/applications/agentDeployments",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/my-cognitive-services-account/projects/my-project/applications/agent-app-1/agentDeployments/deployment-1",
+            "properties": {
+              "agents": [
+                {
+                  "agentId": "agent-123",
+                  "agentName": "support-agent",
+                  "agentVersion": "1.0.0"
+                }
+              ],
+              "deploymentId": "550e8400-e29b-41d4-a716-446655440001",
+              "deploymentType": "Managed",
+              "displayName": "Production Deployment",
+              "protocols": [
+                {
+                  "version": "1.0",
+                  "protocol": "Agent"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "state": "Running"
+            },
+            "systemData": {
+              "createdAt": "2024-09-29T12:34:56.999Z",
+              "createdBy": "user@contoso.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-09-29T12:34:56.999Z",
+              "lastModifiedBy": "user@contoso.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AgentDeployments_List",
+  "title": "List Agent Deployments."
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/start.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/start.json
@@ -1,0 +1,16 @@
+{
+  "operationId": "AgentDeployments_Start",
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "deploymentName": "deployment-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Start Agent Deployment.",
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/stop.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/AgentDeployment/stop.json
@@ -1,0 +1,16 @@
+{
+  "operationId": "AgentDeployments_Stop",
+  "parameters": {
+    "accountName": "my-cognitive-services-account",
+    "api-version": "2026-08-31-preview",
+    "appName": "agent-app-1",
+    "deploymentName": "deployment-1",
+    "projectName": "my-project",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Stop Agent Deployment.",
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CalculateModelCapacity.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CalculateModelCapacity.json
@@ -1,0 +1,48 @@
+{
+  "operationId": "calculateModelCapacity",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "parameters": {
+      "model": {
+        "name": "gpt-4",
+        "format": "OpenAI",
+        "version": "0613"
+      },
+      "skuName": "ProvisionedManaged",
+      "workloads": [
+        {
+          "requestParameters": {
+            "avgGeneratedTokens": 50,
+            "avgPromptTokens": 30
+          },
+          "requestPerMinute": 10
+        },
+        {
+          "requestParameters": {
+            "avgGeneratedTokens": 20,
+            "avgPromptTokens": 60
+          },
+          "requestPerMinute": 20
+        }
+      ]
+    },
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Calculate Model Capacity",
+  "responses": {
+    "200": {
+      "body": {
+        "estimatedCapacity": {
+          "deployableValue": 400,
+          "value": 346
+        },
+        "model": {
+          "name": "gpt-4",
+          "format": "OpenAI",
+          "version": "0613"
+        },
+        "skuName": "ProvisionedManaged"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CheckDomainAvailability.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CheckDomainAvailability.json
@@ -1,0 +1,23 @@
+{
+  "operationId": "CheckDomainAvailability",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "westus",
+    "parameters": {
+      "type": "Microsoft.CognitiveServices/accounts",
+      "subdomainName": "contosodemoapp1"
+    },
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Check SKU Availability",
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.CognitiveServices/accounts",
+        "isSubdomainAvailable": false,
+        "reason": "Sub domain name 'contosodemoapp1' is not valid",
+        "subdomainName": "contosodemoapp1"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CheckSkuAvailability.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CheckSkuAvailability.json
@@ -1,0 +1,30 @@
+{
+  "operationId": "CheckSkuAvailability",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "westus",
+    "parameters": {
+      "type": "Microsoft.CognitiveServices/accounts",
+      "kind": "Face",
+      "skus": [
+        "S0"
+      ]
+    },
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Check SKU Availability",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.CognitiveServices/accounts",
+            "kind": "Face",
+            "skuAvailable": true,
+            "skuName": "S0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateAccount.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateAccount.json
@@ -1,0 +1,142 @@
+{
+  "operationId": "Accounts_Create",
+  "parameters": {
+    "account": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "kind": "Emotion",
+      "location": "West US",
+      "properties": {
+        "encryption": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": {
+            "keyName": "KeyName",
+            "keyVaultUri": "https://pltfrmscrts-use-pc-dev.vault.azure.net/",
+            "keyVersion": "891CF236-D241-4738-9462-D506AF493DFA"
+          }
+        },
+        "userOwnedStorage": [
+          {
+            "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+          }
+        ]
+      },
+      "sku": {
+        "name": "S0"
+      }
+    },
+    "accountName": "testCreate1",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Account",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T08%3A00%3A05.445595Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": {
+              "keyName": "FakeKeyName",
+              "keyVaultUri": "https://pltfrmscrts-use-pc-dev.vault.azure.net/",
+              "keyVersion": "891CF236-D241-4738-9462-D506AF493DFA"
+            }
+          },
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded",
+          "userOwnedStorage": [
+            {
+              "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+            }
+          ]
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": {
+              "keyName": "FakeKeyName",
+              "keyVaultUri": "https://pltfrmscrts-use-pc-dev.vault.azure.net/",
+              "keyVersion": "891CF236-D241-4738-9462-D506AF493DFA"
+            }
+          },
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded",
+          "userOwnedStorage": [
+            {
+              "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+            }
+          ]
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "encryption": {
+            "keySource": "Microsoft.KeyVault",
+            "keyVaultProperties": {
+              "keyName": "FakeKeyName",
+              "keyVaultUri": "https://pltfrmscrts-use-pc-dev.vault.azure.net/",
+              "keyVersion": "891CF236-D241-4738-9462-D506AF493DFA"
+            }
+          },
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded",
+          "userOwnedStorage": [
+            {
+              "resourceId": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"
+            }
+          ]
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateAccountMin.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateAccountMin.json
@@ -1,0 +1,89 @@
+{
+  "operationId": "Accounts_Create",
+  "parameters": {
+    "account": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "kind": "CognitiveServices",
+      "location": "West US",
+      "properties": {},
+      "sku": {
+        "name": "S0"
+      }
+    },
+    "accountName": "testCreate1",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Account Min",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T08%3A00%3A05.445595Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "testCreate1",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "kind": "Emotion",
+        "location": "West US",
+        "properties": {
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateOrUpdateBudgetPolicy.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateOrUpdateBudgetPolicy.json
@@ -1,0 +1,140 @@
+{
+  "operationId": "BudgetPolicies_CreateOrUpdate",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "budgetPolicyName": "monthly-project-budget",
+    "resource": {
+      "properties": {
+        "displayName": "Monthly project budget",
+        "rules": [
+          {
+            "name": "project-spend",
+            "counterKey": [
+              {
+                "type": "project"
+              }
+            ],
+            "unit": "usd",
+            "amount": 200,
+            "period": "month",
+            "recurring": true,
+            "match": {
+              "foundry.caller.project.id": [
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+              ]
+            },
+            "thresholds": [
+              {
+                "type": "percentage",
+                "value": 80,
+                "action": "alert"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Create or replace a budget policy",
+  "responses": {
+    "200": {
+      "headers": {
+        "ETag": "\"00000000-0000-0000-0000-000000000002\""
+      },
+      "body": {
+        "name": "monthly-project-budget",
+        "type": "Microsoft.CognitiveServices/accounts/budgetPolicies",
+        "etag": "\"00000000-0000-0000-0000-000000000002\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget",
+        "properties": {
+          "displayName": "Monthly project budget",
+          "rules": [
+            {
+              "name": "project-spend",
+              "counterKey": [
+                {
+                  "type": "project"
+                }
+              ],
+              "unit": "usd",
+              "amount": 200,
+              "period": "month",
+              "recurring": true,
+              "match": {
+                "foundry.caller.project.id": [
+                  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+                ]
+              },
+              "thresholds": [
+                {
+                  "type": "percentage",
+                  "value": 80,
+                  "action": "alert"
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2026-08-13T18:00:00Z",
+          "createdBy": "00000000-0000-0000-0000-000000000001",
+          "createdByType": "User",
+          "lastModifiedAt": "2026-08-13T18:30:00Z",
+          "lastModifiedBy": "00000000-0000-0000-0000-000000000001",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "ETag": "\"00000000-0000-0000-0000-000000000001\""
+      },
+      "body": {
+        "name": "monthly-project-budget",
+        "type": "Microsoft.CognitiveServices/accounts/budgetPolicies",
+        "etag": "\"00000000-0000-0000-0000-000000000001\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget",
+        "properties": {
+          "displayName": "Monthly project budget",
+          "rules": [
+            {
+              "name": "project-spend",
+              "counterKey": [
+                {
+                  "type": "project"
+                }
+              ],
+              "unit": "usd",
+              "amount": 200,
+              "period": "month",
+              "recurring": true,
+              "match": {
+                "foundry.caller.project.id": [
+                  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+                ]
+              },
+              "thresholds": [
+                {
+                  "type": "percentage",
+                  "value": 80,
+                  "action": "alert"
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2026-08-13T18:00:00Z",
+          "createdBy": "00000000-0000-0000-0000-000000000001",
+          "createdByType": "User",
+          "lastModifiedAt": "2026-08-13T18:00:00Z",
+          "lastModifiedBy": "00000000-0000-0000-0000-000000000001",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateOrUpdateQuotaTier.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateOrUpdateQuotaTier.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "QuotaTiers_CreateOrUpdate",
+  "parameters": {
+    "default": "default",
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tier": {
+      "properties": {
+        "tierUpgradePolicy": "NoAutoUpgrade"
+      }
+    }
+  },
+  "title": "Update the quota tier resource for a subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/quotaTiers",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/quotaTiers/default",
+        "properties": {
+          "assignmentDate": "2025-06-09T18:13:29.389Z",
+          "currentTierName": "Free-Tier",
+          "tierUpgradePolicy": "NoAutoUpgrade"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/quotaTiers",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/quotaTiers/default",
+        "properties": {
+          "assignmentDate": "2025-06-09T18:13:29.389Z",
+          "currentTierName": "Free-Tier",
+          "tierUpgradePolicy": "NoAutoUpgrade"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateProject.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateProject.json
@@ -1,0 +1,98 @@
+{
+  "operationId": "Projects_Create",
+  "parameters": {
+    "accountName": "testCreate1",
+    "api-version": "2026-08-31-preview",
+    "project": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "West US",
+      "properties": {
+        "description": "Description of this project",
+        "displayName": "p1"
+      }
+    },
+    "projectName": "testProject1",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Project",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T08%3A00%3A05.445595Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "description": "Description of this project",
+          "displayName": "p1",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "description": "Description of this project",
+          "displayName": "p1",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "description": "Description of this project",
+          "displayName": "p1",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateProjectMin.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateProjectMin.json
@@ -1,0 +1,89 @@
+{
+  "operationId": "Projects_Create",
+  "parameters": {
+    "accountName": "testCreate1",
+    "api-version": "2026-08-31-preview",
+    "project": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "West US",
+      "properties": {}
+    },
+    "projectName": "testProject1",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Project Min",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T08%3A00%3A05.445595Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "testProject1",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A57%3A48.4582781Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/testCreate1/projects/testProject1",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "b5cf119e-a5c2-42c7-802f-592e0efb169f",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "West US",
+        "properties": {
+          "endpoints": {
+            "OpenAI Dall-E API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://sub-donmain-name.openai.azure.com/",
+            "OpenAI Sora API": "https://sub-donmain-name.openai.azure.com/"
+          },
+          "isDefault": true,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateSharedCommitmentPlan.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateSharedCommitmentPlan.json
@@ -1,0 +1,69 @@
+{
+  "operationId": "CommitmentPlans_CreateOrUpdatePlan",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlan": {
+      "kind": "SpeechServices",
+      "location": "West US",
+      "properties": {
+        "autoRenew": true,
+        "current": {
+          "tier": "T1"
+        },
+        "hostingModel": "Web",
+        "planType": "STT"
+      },
+      "sku": {
+        "name": "S0"
+      }
+    },
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Commitment Plan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+        "kind": "SpeechServices",
+        "location": "West US",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "STT",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+        "kind": "SpeechServices",
+        "location": "West US",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "STT",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateSharedCommitmentPlanAssociation.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/CreateSharedCommitmentPlanAssociation.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "CommitmentPlans_CreateOrUpdateAssociation",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "association": {
+      "properties": {
+        "accountId": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName"
+      }
+    },
+    "commitmentPlanAssociationName": "commitmentPlanAssociationName",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PutCommitmentPlan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanAssociationName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans/accountAssociations",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName/accountAssociations/commitmentPlanAssociationName",
+        "properties": {
+          "accountId": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "commitmentPlanAssociationName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans/accountAssociations",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName/accountAssociations/commitmentPlanAssociationName",
+        "properties": {
+          "accountId": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteAccount.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteAccount.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "Accounts_Delete",
+  "parameters": {
+    "accountName": "PropTest01",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Account",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteBudgetPolicy.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteBudgetPolicy.json
@@ -1,0 +1,14 @@
+{
+  "operationId": "BudgetPolicies_Delete",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "budgetPolicyName": "monthly-project-budget",
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Delete a budget policy",
+  "responses": {
+    "200": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteCommitmentPlan.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteCommitmentPlan.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "CommitmentPlans_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeleteCommitmentPlan",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteDeployment.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "Deployments_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeleteDeployment",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteEncryptionScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteEncryptionScope.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "EncryptionScopes_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "encryptionScopeName": "encryptionScopeName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteEncryptionScope",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeletePrivateEndpointConnection.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeletePrivateEndpointConnection.json
@@ -1,0 +1,21 @@
+{
+  "operationId": "PrivateEndpointConnections_Delete",
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-08-31-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeletePrivateEndpointConnection",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteProject.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteProject.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "Projects_Delete",
+  "parameters": {
+    "accountName": "PropTest01",
+    "api-version": "2026-08-31-preview",
+    "projectName": "myProject",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Project",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiBlocklist.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiBlocklist.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "RaiBlocklists_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiBlocklist",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiBlocklistItem.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiBlocklistItem.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "RaiBlocklistItems_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiBlocklistItem",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiBlocklistItems.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiBlocklistItems.json
@@ -1,0 +1,18 @@
+{
+  "operationId": "RaiBlocklistItems_BatchDelete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistItemsNames": [
+      "myblocklistitem1",
+      "myblocklistitem2"
+    ],
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiBlocklistItems",
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiExternalSafetyProvider.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiExternalSafetyProvider.json
@@ -1,0 +1,17 @@
+{
+  "operationId": "RaiExternalSafetyProvider_Delete",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "safetyProviderName": "safetyProviderName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiTopic",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiPolicy.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiPolicy.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "RaiPolicies_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiPolicy",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiToolLabel.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiToolLabel.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "RaiToolLabels_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiToolConnectionName": "Web_Search",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiToolLabel",
+  "responses": {
+    "202": {
+      "description": "Accepted -- delete operation started.",
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {
+      "description": "No Content -- RAI Tool Label does not exist."
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiTopic.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteRaiTopic.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "RaiTopics_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiTopicName": "raiTopicName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiTopic",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteSharedCommitmentPlan.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteSharedCommitmentPlan.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "CommitmentPlans_DeletePlan",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Commitment Plan",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteSharedCommitmentPlanAssociation.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteSharedCommitmentPlanAssociation.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "CommitmentPlans_DeleteAssociation",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanAssociationName": "commitmentPlanAssociationName",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeleteCommitmentPlan",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteSubscriptionRaiPolicy.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/DeleteSubscriptionRaiPolicy.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "SubscriptionRaiPolicy_Delete",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "DeleteRaiPolicy",
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetAccount.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetAccount.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "Accounts_Get",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get Account",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myAccount",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T04%3A42%3A19.7067387Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/myAccount",
+        "kind": "Emotion",
+        "location": "westus",
+        "properties": {
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "F0"
+        },
+        "tags": {
+          "ExpiredDate": "2017/09/01",
+          "Owner": "felixwa"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetBudgetPolicy.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetBudgetPolicy.json
@@ -1,0 +1,61 @@
+{
+  "operationId": "BudgetPolicies_Get",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "budgetPolicyName": "monthly-project-budget",
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get a budget policy",
+  "responses": {
+    "200": {
+      "headers": {
+        "ETag": "\"00000000-0000-0000-0000-000000000001\""
+      },
+      "body": {
+        "name": "monthly-project-budget",
+        "type": "Microsoft.CognitiveServices/accounts/budgetPolicies",
+        "etag": "\"00000000-0000-0000-0000-000000000001\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget",
+        "properties": {
+          "displayName": "Monthly project budget",
+          "rules": [
+            {
+              "name": "project-spend",
+              "counterKey": [
+                {
+                  "type": "project"
+                }
+              ],
+              "unit": "usd",
+              "amount": 200,
+              "period": "month",
+              "recurring": true,
+              "match": {
+                "foundry.caller.project.id": [
+                  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+                ]
+              },
+              "thresholds": [
+                {
+                  "type": "percentage",
+                  "value": 80,
+                  "action": "alert"
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2026-08-13T18:00:00Z",
+          "createdBy": "00000000-0000-0000-0000-000000000001",
+          "createdByType": "User",
+          "lastModifiedAt": "2026-08-13T18:00:00Z",
+          "lastModifiedBy": "00000000-0000-0000-0000-000000000001",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetCommitmentPlan.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetCommitmentPlan.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "CommitmentPlans_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetCommitmentPlan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/accounts/commitmentPlans",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/commitmentPlans/commitmentPlanName",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "Speech2Text"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetDefenderForAISetting.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetDefenderForAISetting.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "DefenderForAISettings_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "defenderForAISettingName": "Default",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetDefenderForAISetting",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default",
+        "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/defenderForAISettings/Default",
+        "properties": {
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2022-04-03T04:41:33.937Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-04-03T04:41:33.937Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetDeletedAccount.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetDeletedAccount.json
@@ -1,0 +1,34 @@
+{
+  "operationId": "DeletedAccounts_Get",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "location": "westus",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get Account",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myAccount",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T04%3A42%3A19.7067387Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/resourceGroups/myResourceGroup/deletedAccounts/myAccount",
+        "kind": "Emotion",
+        "location": "westus",
+        "properties": {
+          "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "F0"
+        },
+        "tags": {
+          "ExpiredDate": "2017/09/01",
+          "Owner": "felixwa"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetDeployment.json
@@ -1,0 +1,34 @@
+{
+  "operationId": "Deployments_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetDeployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Running",
+          "model": {
+            "name": "ada",
+            "format": "OpenAI",
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "serviceTier": "Default"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetEncryptionScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetEncryptionScope.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "EncryptionScopes_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "encryptionScopeName": "encryptionScopeName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetEncryptionScope",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "encryptionScopeName",
+        "type": "Microsoft.CognitiveServices/accounts/encryptionScopes",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/encryptionScopes/encryptionScopeName",
+        "properties": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": {
+            "identityClientId": "00000000-0000-0000-0000-000000000000",
+            "keyName": "DevKeyWestUS2",
+            "keyVaultUri": "https://devkvwestus2.vault.azure.net/",
+            "keyVersion": "9f85549d7bf14ff4bf178c10d3bdca95"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2023-06-08T06:35:08.0662558Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2023-06-08T06:35:08.0662558Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetNetworkSecurityPerimeterConfigurations.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetNetworkSecurityPerimeterConfigurations.json
@@ -1,0 +1,48 @@
+{
+  "operationId": "NetworkSecurityPerimeterConfigurations_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "nspConfigurationName": "NSPConfigurationName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetNetworkSecurityPerimeterConfigurations",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "networkSecurityPerimeterConfigurationName",
+        "type": "Microsoft.CognitiveServices/accounts/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/networkSecurityPerimeterConfigurations/config1",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Network/networkSecurityPerimeters/perimeter",
+            "location": "East US",
+            "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+          },
+          "profile": {
+            "name": "profileName",
+            "accessRules": [
+              {
+                "name": "ruleName",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8",
+                    "152.4.6.0/24"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": 1
+          },
+          "provisioningState": "Succeeded",
+          "resourceAssociation": {
+            "name": "associationName",
+            "accessMode": "Enforced"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetOperations.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetOperations.json
@@ -1,0 +1,45 @@
+{
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview"
+  },
+  "title": "Get Operations",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.CognitiveServices/accounts/read",
+            "display": {
+              "description": "Reads API accounts.",
+              "operation": "Read API Account",
+              "provider": "Microsoft Cognitive Services",
+              "resource": "Cognitive Services API Account"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.CognitiveServices/accounts/write",
+            "display": {
+              "description": "Writes API Accounts.",
+              "operation": "Write API Account",
+              "provider": "Microsoft Cognitive Services",
+              "resource": "Cognitive Services API Account"
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.CognitiveServices/accounts/delete",
+            "display": {
+              "description": "Deletes API accounts",
+              "operation": "Delete API Account",
+              "provider": "Microsoft Cognitive Services",
+              "resource": "Cognitive Services API Account"
+            },
+            "origin": "user,system"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetPrivateEndpointConnection.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetPrivateEndpointConnection.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "PrivateEndpointConnections_Get",
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-08-31-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetPrivateEndpointConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.CognitiveServices/accounts/privateEndpointConnections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.CognitiveServices/accounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetProject.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetProject.json
@@ -1,0 +1,36 @@
+{
+  "operationId": "Projects_Get",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "projectName": "myProject",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get Project",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myProject",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T04%3A42%3A19.7067387Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/myAccount/projects/myProject",
+        "location": "westus",
+        "properties": {
+          "description": "This is my project",
+          "displayName": "myProject",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://customSubDomainName.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://customSubDomainName.openai.azure.com/"
+          },
+          "isDefault": false,
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "ExpiredDate": "2017/09/01",
+          "Owner": "felixwa"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetQuotaTier.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetQuotaTier.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "QuotaTiers_Get",
+  "parameters": {
+    "default": "default",
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get the Quota Tier information for a subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/quotaTiers",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/quotaTiers/default",
+        "properties": {
+          "assignmentDate": "2025-06-09T18:13:29.389Z",
+          "currentTierName": "Free-Tier",
+          "tierUpgradeEligibilityInfo": {
+            "nextTierName": "Tier-1",
+            "upgradeApplicableDate": "2025-06-15T18:13:29.389Z",
+            "upgradeAvailabilityStatus": "Available"
+          },
+          "tierUpgradePolicy": "OnceUpgradeIsAvailable"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiBlocklist.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiBlocklist.json
@@ -1,0 +1,22 @@
+{
+  "operationId": "RaiBlocklists_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiBlocklist",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "This is a sample blocklist"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiBlocklistItem.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiBlocklistItem.json
@@ -1,0 +1,24 @@
+{
+  "operationId": "RaiBlocklistItems_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiBlocklistItem",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiContentFilter.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiContentFilter.json
@@ -1,0 +1,24 @@
+{
+  "operationId": "RaiContentFilters_Get",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "filterName": "IndirectAttack",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiContentFilters",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "IndirectAttack",
+        "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/IndirectAttack",
+        "properties": {
+          "name": "Indirect Attack",
+          "isMultiLevelFilter": false,
+          "source": "Prompt"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiExternalSafetyProvider.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiExternalSafetyProvider.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "RaiExternalSafetyProvider_Get",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "safetyProviderName": "safetyProviderName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiExternalSafetyProvider",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "safetyProviderName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/safetyProviderName",
+        "properties": {
+          "createdAt": "2025-07-01T00:00:00Z",
+          "keyVaultUri": "https://example.vault.azure.net",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "managedIdentity": "00000000-0000-0000-0000-000000000000",
+          "mode": "sync",
+          "providerId": "00000000-0000-0000-0000-000000000000",
+          "providerName": "safetyProviderName",
+          "secretName": "mySecretName",
+          "url": "https://example.webhook.endpoint"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiPolicy.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiPolicy.json
@@ -1,0 +1,107 @@
+{
+  "operationId": "RaiPolicies_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "effective": true,
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiPolicy",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiToolLabel.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiToolLabel.json
@@ -1,0 +1,44 @@
+{
+  "operationId": "RaiToolLabels_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiToolConnectionName": "ToolLabelName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiToolLabel",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiToolLabelName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiIfcToolLabels/raiIfcToolLabelName",
+        "properties": {
+          "accountScope": {
+            "labelValues": {
+              "confidentiality": "low",
+              "dataDirection": "egress"
+            }
+          },
+          "projectScopes": [
+            {
+              "labelValues": {
+                "confidentiality": "low",
+                "dataDirection": "egress"
+              },
+              "project": "ProjectA"
+            },
+            {
+              "labelValues": {
+                "confidentiality": "high",
+                "dataDirection": "egress"
+              },
+              "project": "ProjectB"
+            }
+          ],
+          "toolConnectionName": "SampleToolLabel"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiTopic.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetRaiTopic.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "RaiTopics_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiTopicName": "raiTopicName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiTopic",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiTopicName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiTopics/raiTopicName",
+        "properties": {
+          "description": "This is a sample topic.",
+          "createdAt": "2025-07-01T00:00:00Z",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "sampleBlobUrl": "https://example.blob.core.windows.net/sampleblob",
+          "status": "Succeeded",
+          "topicId": "00000000-0000-0000-0000-000000000000",
+          "topicName": "raiTopicName"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetSharedCommitmentPlan.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetSharedCommitmentPlan.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "CommitmentPlans_GetPlan",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get Commitment Plan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+        "kind": "SpeechServices",
+        "location": "West US",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "STT",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetSharedCommitmentPlanAssociation.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetSharedCommitmentPlanAssociation.json
@@ -1,0 +1,23 @@
+{
+  "operationId": "CommitmentPlans_GetAssociation",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanAssociationName": "commitmentPlanAssociationName",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetCommitmentPlan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanAssociationName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans/accountAssociations",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName/accountAssociations/commitmentPlanAssociationName",
+        "properties": {
+          "accountId": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetSkus.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetSkus.json
@@ -1,0 +1,2166 @@
+{
+  "operationId": "ResourceSkus_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "f1c637e4-72ec-4f89-8d2b-0f933c036002"
+  },
+  "title": "Regenerate Keys",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "F0",
+            "kind": "Bing.Speech",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Bing.Speech",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "SpeechTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "SpeechTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "SpeechTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "SpeechTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "SpeechTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "TextTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextTranslation",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S5",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S6",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S7",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S8",
+            "kind": "Bing.Search.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "Bing.Autosuggest.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "Bing.CustomSearch",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "Bing.SpellCheck.v7",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Bing.EntitySearch",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "Bing.EntitySearch",
+            "locations": [
+              "GLOBAL"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "AUSTRALIAEAST"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "BRAZILSOUTH"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "CENTRALUSEUAP"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "SpeakerRecognition",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "SpeakerRecognition",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "CustomSpeech",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S2",
+            "kind": "CustomSpeech",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "NORTHEUROPE"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHEASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTASIA"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "WESTCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "CustomVision.Training",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "CustomVision.Training",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "CustomVision.Prediction",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "CustomVision.Prediction",
+            "locations": [
+              "SOUTHCENTRALUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTUS"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "ContentModerator",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "Face",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "Face",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "LUIS",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S1",
+            "kind": "ComputerVision",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "F0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Free"
+          },
+          {
+            "name": "S0",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S1",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S2",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S3",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          },
+          {
+            "name": "S4",
+            "kind": "TextAnalytics",
+            "locations": [
+              "EASTUS2"
+            ],
+            "resourceType": "accounts",
+            "restrictions": [],
+            "tier": "Standard"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetSubscriptionRaiPolicy.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetSubscriptionRaiPolicy.json
@@ -1,0 +1,107 @@
+{
+  "operationId": "SubscriptionRaiPolicy_Get",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "effective": true,
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "GetRaiPolicy",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetUsages.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetUsages.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "Accounts_ListUsages",
+  "parameters": {
+    "accountName": "TestUsage02",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
+  },
+  "title": "Get Usages",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Face.Transactions",
+              "value": "Face.Transactions"
+            },
+            "currentValue": 3,
+            "limit": 30000,
+            "nextResetTime": "2018-03-28T09:33:51Z",
+            "quotaPeriod": "30.00:00:00",
+            "status": "Included",
+            "unit": "Count",
+            "scopeType": "Regional",
+            "scopeId": "eastus"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetUsagesClassicScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetUsagesClassicScope.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "Accounts_ListUsages",
+  "parameters": {
+    "accountName": "TestUsage02",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
+  },
+  "title": "Get Usages Classic Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Face.Transactions",
+              "value": "Face.Transactions"
+            },
+            "currentValue": 2,
+            "limit": 20000,
+            "nextResetTime": "2018-03-28T09:33:51Z",
+            "quotaPeriod": "30.00:00:00",
+            "status": "Included",
+            "unit": "Count",
+            "scopeType": "Classic"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetUsagesDataZoneScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetUsagesDataZoneScope.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "Accounts_ListUsages",
+  "parameters": {
+    "accountName": "TestUsage02",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
+  },
+  "title": "Get Usages DataZone Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Face.Transactions",
+              "value": "Face.Transactions"
+            },
+            "currentValue": 4,
+            "limit": 40000,
+            "nextResetTime": "2018-03-28T09:33:51Z",
+            "quotaPeriod": "30.00:00:00",
+            "status": "Included",
+            "unit": "Count",
+            "scopeType": "DataZone",
+            "scopeId": "US"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetUsagesGlobalScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/GetUsagesGlobalScope.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "Accounts_ListUsages",
+  "parameters": {
+    "accountName": "TestUsage02",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "5a4f5c2e-6983-4ccb-bd34-2196d5b5bbd3"
+  },
+  "title": "Get Usages Global Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Face.Transactions",
+              "value": "Face.Transactions"
+            },
+            "currentValue": 5,
+            "limit": 50000,
+            "nextResetTime": "2018-03-28T09:33:51Z",
+            "quotaPeriod": "30.00:00:00",
+            "status": "Included",
+            "unit": "Count",
+            "scopeType": "Global",
+            "scopeId": "Global"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListAccountModels.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListAccountModels.json
@@ -1,0 +1,189 @@
+{
+  "operationId": "Accounts_ListModels",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "location": "location",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List AccountModels",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ada.1",
+            "format": "OpenAI",
+            "baseModel": {
+              "name": "ada",
+              "format": "OpenAI",
+              "version": "1"
+            },
+            "capabilities": {
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "false"
+            },
+            "deprecation": {
+              "deprecationStatus": "Planned",
+              "fineTune": "2024-01-01T00:00:00Z",
+              "inference": "2024-01-01T00:00:00Z"
+            },
+            "isDefaultVersion": false,
+            "lifecycleStatus": "Legacy",
+            "maxCapacity": 10,
+            "systemData": {
+              "createdAt": "2021-10-07T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2021-10-07T00:00:00Z",
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": "Application"
+            },
+            "version": "1"
+          },
+          {
+            "name": "dall-e-3",
+            "format": "OpenAI",
+            "capabilities": {
+              "imageGenerations": "true",
+              "inference": "true"
+            },
+            "deprecation": {
+              "deprecationStatus": "Tentative",
+              "inference": "2025-06-30T00:00:00Z"
+            },
+            "isDefaultVersion": true,
+            "lifecycleStatus": "GenerallyAvailable",
+            "maxCapacity": 2,
+            "modelCatalogAssetId": "azureml://registries/azure-openai/models/dall-e-3/versions/3.0",
+            "systemData": {
+              "createdAt": "2023-08-11T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2023-08-11T00:00:00Z",
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": "Application"
+            },
+            "version": "3.0"
+          },
+          {
+            "name": "gpt-35-turbo",
+            "format": "OpenAI",
+            "capabilities": {
+              "chatCompletion": "true",
+              "completion": "true",
+              "fineTune": "false",
+              "scaleType": "Manual,Standard"
+            },
+            "deprecation": {
+              "deprecationStatus": "Planned",
+              "inference": "2025-04-30T00:00:00Z"
+            },
+            "isDefaultVersion": false,
+            "lifecycleStatus": "Deprecated",
+            "maxCapacity": 9,
+            "systemData": {
+              "createdAt": "2023-03-09T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2023-07-06T00:00:00Z",
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": "Application"
+            },
+            "version": "0301"
+          },
+          {
+            "name": "gpt-4o",
+            "format": "OpenAI",
+            "capabilities": {
+              "chat": "true",
+              "completion": "true",
+              "fineTune": "false",
+              "inference": "true",
+              "vision": "true"
+            },
+            "deprecation": {
+              "deprecationStatus": "Tentative",
+              "inference": "2025-09-15T00:00:00Z"
+            },
+            "lifecycleStatus": "Deprecating",
+            "maxCapacity": 50,
+            "modelCatalogAssetId": "azureml://registries/azure-openai/models/gpt-4o/versions/2024-05-13",
+            "replacementConfig": {
+              "autoUpgradeStartDate": "2025-03-26T07:00:00Z",
+              "targetModelName": "gpt-4.1",
+              "targetModelVersion": "2025-04-14",
+              "upgradeOnExpiryLeadTimeDays": 7
+            },
+            "systemData": {
+              "createdAt": "2024-05-13T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2024-12-15T00:00:00Z",
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": "Application"
+            },
+            "version": "2024-05-13"
+          },
+          {
+            "name": "Llama-3.2-90B-Vision-Instruct",
+            "format": "Meta",
+            "capabilities": {
+              "chatCompletion": "true"
+            },
+            "deprecation": {
+              "deprecationStatus": "Tentative",
+              "inference": "2099-12-31T00:00:00Z"
+            },
+            "isDefaultVersion": false,
+            "lifecycleStatus": "Stable",
+            "maxCapacity": 3,
+            "modelCatalogAssetId": "azureml://registries/azureml-meta/models/Llama-3.2-90B-Vision-Instruct/versions/2",
+            "systemData": {
+              "createdAt": "2024-10-01T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2025-04-16T04:45:33.9367873Z",
+              "lastModifiedBy": "MaaSModelConverter",
+              "lastModifiedByType": "Application"
+            },
+            "version": "2"
+          },
+          {
+            "name": "gpt-4o",
+            "format": "OpenAI",
+            "capabilities": {
+              "chat": "true",
+              "completion": "true",
+              "fineTune": "false",
+              "functionCalling": "true",
+              "inference": "true",
+              "vision": "true"
+            },
+            "finetuneCapabilities": {
+              "chat": "true",
+              "completion": "true",
+              "fineTune": "true",
+              "inference": "true",
+              "scaleType": "Manual"
+            },
+            "lifecycleStatus": "GenerallyAvailable",
+            "maxCapacity": 50,
+            "modelCatalogAssetId": "azureml://registries/azure-openai/models/gpt-4o/versions/2024-08-06",
+            "systemData": {
+              "createdAt": "2024-08-06T00:00:00Z",
+              "createdBy": "Microsoft",
+              "createdByType": "Application",
+              "lastModifiedAt": "2024-11-01T00:00:00Z",
+              "lastModifiedBy": "Microsoft",
+              "lastModifiedByType": "Application"
+            },
+            "version": "2024-08-06"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListAccountsByResourceGroup.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListAccountsByResourceGroup.json
@@ -1,0 +1,52 @@
+{
+  "operationId": "Accounts_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Accounts by Resource Group",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myAccount",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-04-10T04%3A42%3A19.7067387Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/myAccount",
+            "kind": "Emotion",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "F0"
+            },
+            "tags": {
+              "ExpiredDate": "2017/09/01",
+              "Owner": "felixwa"
+            }
+          },
+          {
+            "name": "TestPropertyWU2",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-04-07T04%3A32%3A38.9187216Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/TestPropertyWU2",
+            "kind": "Face",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/face/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListAccountsBySubscription.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListAccountsBySubscription.json
@@ -1,0 +1,79 @@
+{
+  "operationId": "Accounts_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Accounts by Subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "bingSearch",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-27T11%3A19%3A08.762494Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch",
+            "kind": "Bing.Search",
+            "location": "global",
+            "properties": {
+              "endpoint": "https://api.cognitive.microsoft.com/bing/v5.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S1"
+            }
+          },
+          {
+            "name": "CrisProd",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-31T08%3A57%3A07.4499566Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/CrisProd",
+            "kind": "CRIS",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/sts/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            },
+            "tags": {
+              "can't delete it successfully": "v-yunjin"
+            }
+          },
+          {
+            "name": "rayrptest0308",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-27T11%3A15%3A23.5232645Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/rayrptest0308",
+            "kind": "Face",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/face/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          },
+          {
+            "name": "raytest02",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-04-04T02%3A07%3A07.3957572Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/raytest02",
+            "kind": "Emotion",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListBlocklistItems.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListBlocklistItems.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "RaiBlocklistItems_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListBlocklistItems",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "raiBlocklistItemName",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+            "properties": {
+              "isRegex": false,
+              "pattern": "Pattern To Block"
+            }
+          },
+          {
+            "name": "raiBlocklistItemName2",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName2",
+            "properties": {
+              "isRegex": false,
+              "pattern": "Another Pattern To Block"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListBlocklists.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListBlocklists.json
@@ -1,0 +1,25 @@
+{
+  "operationId": "RaiBlocklists_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListBlocklists",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "raiBlocklistName",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName",
+            "properties": {
+              "description": "This is a sample blocklist"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListBudgetPolicies.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListBudgetPolicies.json
@@ -1,0 +1,61 @@
+{
+  "operationId": "BudgetPolicies_List",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "List budget policies",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "monthly-project-budget",
+            "type": "Microsoft.CognitiveServices/accounts/budgetPolicies",
+            "etag": "\"00000000-0000-0000-0000-000000000001\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget",
+            "properties": {
+              "displayName": "Monthly project budget",
+              "rules": [
+                {
+                  "name": "project-spend",
+                  "counterKey": [
+                    {
+                      "type": "project"
+                    }
+                  ],
+                  "unit": "usd",
+                  "amount": 200,
+                  "period": "month",
+                  "recurring": true,
+                  "match": {
+                    "foundry.caller.project.id": [
+                      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+                    ]
+                  },
+                  "thresholds": [
+                    {
+                      "type": "percentage",
+                      "value": 80,
+                      "action": "alert"
+                    }
+                  ]
+                }
+              ]
+            },
+            "systemData": {
+              "createdAt": "2026-08-13T18:00:00Z",
+              "createdBy": "00000000-0000-0000-0000-000000000001",
+              "createdByType": "User",
+              "lastModifiedAt": "2026-08-13T18:00:00Z",
+              "lastModifiedBy": "00000000-0000-0000-0000-000000000001",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListCommitmentPlans.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListCommitmentPlans.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "CommitmentPlans_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ListCommitmentPlans",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "commitmentPlanName",
+            "type": "Microsoft.CognitiveServices/accounts/commitmentPlans",
+            "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/commitmentPlans/commitmentPlanName",
+            "properties": {
+              "autoRenew": true,
+              "current": {
+                "tier": "T1"
+              },
+              "hostingModel": "Web",
+              "planType": "Speech2Text"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListCommitmentTiers.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListCommitmentTiers.json
@@ -1,0 +1,30 @@
+{
+  "operationId": "CommitmentTiers_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "location",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ListCommitmentTiers",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "cost": {},
+            "hostingModel": "Web",
+            "kind": "TextAnalytics",
+            "planType": "TA",
+            "quota": {
+              "quantity": 1000000,
+              "unit": "Transaction"
+            },
+            "skuName": "S",
+            "tier": "T1"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListDefenderForAISetting.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListDefenderForAISetting.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "DefenderForAISettings_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListDefenderForAISetting",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Default",
+            "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+            "etag": "\"00000000-0000-0000-0000-000000000000\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/defenderForAISettings/Default",
+            "properties": {
+              "state": "Enabled"
+            },
+            "systemData": {
+              "createdAt": "2022-04-03T04:41:33.937Z",
+              "createdBy": "xxx@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-04-03T04:41:33.937Z",
+              "lastModifiedBy": "xxx@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListDeletedAccountsBySubscription.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListDeletedAccountsBySubscription.json
@@ -1,0 +1,79 @@
+{
+  "operationId": "DeletedAccounts_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Deleted Accounts by Subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "bingSearch",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-27T11%3A19%3A08.762494Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch",
+            "kind": "Bing.Search",
+            "location": "global",
+            "properties": {
+              "endpoint": "https://api.cognitive.microsoft.com/bing/v5.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S1"
+            }
+          },
+          {
+            "name": "CrisProd",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-31T08%3A57%3A07.4499566Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/CrisProd",
+            "kind": "CRIS",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/sts/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            },
+            "tags": {
+              "can't delete it successfully": "v-yunjin"
+            }
+          },
+          {
+            "name": "rayrptest0308",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-03-27T11%3A15%3A23.5232645Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/rayrptest0308",
+            "kind": "Face",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/face/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          },
+          {
+            "name": "raytest02",
+            "type": "Microsoft.CognitiveServices/accounts",
+            "etag": "W/\"datetime'2017-04-04T02%3A07%3A07.3957572Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/raytest02",
+            "kind": "Emotion",
+            "location": "westus",
+            "properties": {
+              "endpoint": "https://westus.api.cognitive.microsoft.com/emotion/v1.0",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListDeploymentSkus.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListDeploymentSkus.json
@@ -1,0 +1,36 @@
+{
+  "operationId": "Deployments_ListSkus",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListDeploymentSkus",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "capacity": {
+              "default": 100,
+              "allowedValues": [
+                100,
+                200
+              ],
+              "maximum": 1000,
+              "minimum": 100,
+              "step": 100
+            },
+            "resourceType": "Microsoft.CognitiveServices/accounts/deployments",
+            "sku": {
+              "name": "Standard",
+              "capacity": 1
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListDeployments.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListDeployments.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "Deployments_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ListDeployments",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "deploymentName",
+            "type": "Microsoft.CognitiveServices/accounts/deployments",
+            "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+            "properties": {
+              "deploymentState": "Running",
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "provisioningState": "Succeeded",
+              "serviceTier": "Default"
+            },
+            "sku": {
+              "name": "Standard",
+              "capacity": 1
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListEncryptionScopes.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListEncryptionScopes.json
@@ -1,0 +1,43 @@
+{
+  "operationId": "EncryptionScopes_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListEncryptionScopes",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "encryptionScopeName",
+            "type": "Microsoft.CognitiveServices/accounts/encryptionScopes",
+            "etag": "\"00000000-0000-0000-0000-000000000000\"",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/encryptionScopes/encryptionScopeName",
+            "properties": {
+              "keySource": "Microsoft.KeyVault",
+              "keyVaultProperties": {
+                "identityClientId": "00000000-0000-0000-0000-000000000000",
+                "keyName": "DevKeyWestUS2",
+                "keyVaultUri": "https://devkvwestus2.vault.azure.net/",
+                "keyVersion": "9f85549d7bf14ff4bf178c10d3bdca95"
+              },
+              "provisioningState": "Succeeded",
+              "state": "Enabled"
+            },
+            "systemData": {
+              "createdAt": "2023-06-08T06:35:08.0662558Z",
+              "createdBy": "xxx@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2023-06-08T06:35:08.0662558Z",
+              "lastModifiedBy": "xxx@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListKeys.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListKeys.json
@@ -1,0 +1,18 @@
+{
+  "operationId": "Accounts_ListKeys",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Keys",
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "KEY1",
+        "key2": "KEY2"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListLocationBasedModelCapacities.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListLocationBasedModelCapacities.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "LocationBasedModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListLocationBasedModelCapacities",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 300,
+              "availableFinetuneCapacity": 20,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "Standard",
+              "scopeId": "WestUS",
+              "scopeType": "Regional"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListLocationBasedModelCapacitiesClassicScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListLocationBasedModelCapacitiesClassicScope.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "LocationBasedModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListLocationBasedModelCapacities Classic Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 200,
+              "availableFinetuneCapacity": 15,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "Standard",
+              "scopeType": "Classic"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListLocationBasedModelCapacitiesDataZoneScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListLocationBasedModelCapacitiesDataZoneScope.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "LocationBasedModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListLocationBasedModelCapacities DataZone Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "DataZoneStandard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/DataZoneStandard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 400,
+              "availableFinetuneCapacity": 25,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "DataZoneStandard",
+              "scopeId": "US",
+              "scopeType": "DataZone"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListLocationBasedModelCapacitiesGlobalScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListLocationBasedModelCapacitiesGlobalScope.json
@@ -1,0 +1,38 @@
+{
+  "operationId": "LocationBasedModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListLocationBasedModelCapacities Global Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "GlobalStandard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/GlobalStandard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 500,
+              "availableFinetuneCapacity": 30,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "GlobalStandard",
+              "scopeId": "Global",
+              "scopeType": "Global"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListLocationModels.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListLocationModels.json
@@ -1,0 +1,292 @@
+{
+  "operationId": "Models_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListLocationModels",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "kind": "OpenAI",
+            "model": {
+              "name": "ada",
+              "format": "OpenAI",
+              "capabilities": {
+                "FineTuneTokensMaxValue": "2000000000",
+                "FineTuneTokensMaxValuePerExample": "4096",
+                "completion": "true",
+                "inference": "false",
+                "scaleType": "Manual",
+                "search": "true"
+              },
+              "deprecation": {
+                "deprecationStatus": "Planned",
+                "fineTune": "2024-06-14T00:00:00Z",
+                "inference": "2024-06-14T00:00:00Z"
+              },
+              "lifecycleStatus": "Legacy",
+              "maxCapacity": 3,
+              "skus": [
+                {
+                  "name": "provisioned",
+                  "capacity": {
+                    "default": 100,
+                    "maximum": 1000,
+                    "minimum": 100,
+                    "step": 100
+                  },
+                  "usageName": "OpenAI.Provisioned.Class1"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2021-10-07T00:00:00Z",
+                "createdBy": "Microsoft",
+                "lastModifiedAt": "2021-10-07T00:00:00Z",
+                "lastModifiedBy": "Microsoft"
+              },
+              "version": "1"
+            },
+            "skuName": "S0"
+          },
+          {
+            "kind": "AIServices",
+            "model": {
+              "name": "dall-e-3",
+              "format": "OpenAI",
+              "capabilities": {
+                "imageGenerations": "true",
+                "inference": "true"
+              },
+              "deprecation": {
+                "deprecationStatus": "Tentative",
+                "inference": "2025-06-30T00:00:00Z"
+              },
+              "isDefaultVersion": true,
+              "lifecycleStatus": "GenerallyAvailable",
+              "maxCapacity": 2,
+              "modelCatalogAssetId": "azureml://registries/azure-openai/models/dall-e-3/versions/3.0",
+              "skus": [
+                {
+                  "name": "Provisioned",
+                  "capacity": {
+                    "default": 300,
+                    "maximum": 60000,
+                    "minimum": 300,
+                    "step": 100
+                  },
+                  "deprecationDate": "2025-09-30T00:00:00Z",
+                  "usageName": "OpenAI.Provisioned.Dalle"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2023-08-11T00:00:00Z",
+                "createdBy": "Microsoft",
+                "lastModifiedAt": "2023-08-11T00:00:00Z",
+                "lastModifiedBy": "Microsoft"
+              },
+              "version": "3.0"
+            },
+            "skuName": "S0"
+          },
+          {
+            "kind": "OpenAI",
+            "model": {
+              "name": "gpt-35-turbo",
+              "format": "OpenAI",
+              "capabilities": {
+                "chatCompletion": "true",
+                "completion": "true",
+                "maxTotalToken": "4096",
+                "scaleType": "Manual,Standard"
+              },
+              "deprecation": {
+                "deprecationStatus": "Planned",
+                "inference": "2025-04-30T00:00:00Z"
+              },
+              "isDefaultVersion": false,
+              "lifecycleStatus": "Deprecated",
+              "maxCapacity": 9,
+              "skus": [
+                {
+                  "name": "Standard",
+                  "capacity": {
+                    "default": 120,
+                    "maximum": 1000000
+                  },
+                  "deprecationDate": "2025-02-13T00:00:00Z",
+                  "usageName": "OpenAI.Standard.gpt-35-turbo"
+                },
+                {
+                  "name": "Provisioned",
+                  "capacity": {
+                    "default": 300,
+                    "maximum": 30000,
+                    "minimum": 300,
+                    "step": 100
+                  },
+                  "deprecationDate": "2025-05-15T00:00:00Z",
+                  "usageName": "OpenAI.Provisioned.gpt-35-turbo"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2023-03-09T00:00:00Z",
+                "createdBy": "Microsoft",
+                "createdByType": "Application",
+                "lastModifiedAt": "2023-07-06T00:00:00Z",
+                "lastModifiedBy": "Microsoft",
+                "lastModifiedByType": "Application"
+              },
+              "version": "0301"
+            },
+            "skuName": "S0"
+          },
+          {
+            "kind": "OpenAI",
+            "model": {
+              "name": "gpt-4o",
+              "format": "OpenAI",
+              "capabilities": {
+                "chat": "true",
+                "completion": "true",
+                "fineTune": "false",
+                "inference": "true",
+                "scaleType": "Manual,Provisioned",
+                "vision": "true"
+              },
+              "deprecation": {
+                "deprecationStatus": "Tentative",
+                "inference": "2025-09-15T00:00:00Z"
+              },
+              "lifecycleStatus": "Deprecating",
+              "maxCapacity": 50,
+              "modelCatalogAssetId": "azureml://registries/azure-openai/models/gpt-4o/versions/2024-05-13",
+              "replacementConfig": {
+                "autoUpgradeStartDate": "2025-03-26T07:00:00Z",
+                "targetModelName": "gpt-4.1",
+                "targetModelVersion": "2025-04-14",
+                "upgradeOnExpiryLeadTimeDays": 7
+              },
+              "skus": [
+                {
+                  "name": "provisioned",
+                  "capacity": {
+                    "default": 100,
+                    "maximum": 2000,
+                    "minimum": 50,
+                    "step": 50
+                  },
+                  "usageName": "OpenAI.Provisioned.GPT4o"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2024-05-13T00:00:00Z",
+                "createdBy": "Microsoft",
+                "lastModifiedAt": "2024-12-15T00:00:00Z",
+                "lastModifiedBy": "Microsoft"
+              },
+              "version": "2024-05-13"
+            },
+            "skuName": "S0"
+          },
+          {
+            "kind": "AIServices",
+            "model": {
+              "name": "Llama-3.2-90B-Vision-Instruct",
+              "format": "Meta",
+              "capabilities": {
+                "chatCompletion": "true"
+              },
+              "deprecation": {
+                "inference": "2099-12-31T00:00:00Z"
+              },
+              "isDefaultVersion": false,
+              "lifecycleStatus": "Stable",
+              "maxCapacity": 3,
+              "modelCatalogAssetId": "azureml://registries/azureml-meta/models/Llama-3.2-90B-Vision-Instruct/versions/2",
+              "skus": [
+                {
+                  "name": "GlobalStandard",
+                  "capacity": {
+                    "default": 1,
+                    "maximum": 1
+                  },
+                  "usageName": "AIServices.GlobalStandard.MaaS"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2024-10-01T00:00:00Z",
+                "createdBy": "Microsoft",
+                "createdByType": "Application",
+                "lastModifiedAt": "2025-04-16T04:45:33.9367873Z",
+                "lastModifiedBy": "MaaSModelConverter",
+                "lastModifiedByType": "Application"
+              },
+              "version": "2"
+            },
+            "skuName": "S0"
+          },
+          {
+            "kind": "OpenAI",
+            "model": {
+              "name": "gpt-4o",
+              "format": "OpenAI",
+              "capabilities": {
+                "chat": "true",
+                "completion": "true",
+                "fineTune": "false",
+                "functionCalling": "true",
+                "inference": "true",
+                "scaleType": "Manual,Standard,Provisioned",
+                "vision": "true"
+              },
+              "finetuneCapabilities": {
+                "chat": "true",
+                "completion": "true",
+                "fineTune": "true",
+                "inference": "true",
+                "scaleType": "Manual"
+              },
+              "lifecycleStatus": "GenerallyAvailable",
+              "maxCapacity": 50,
+              "modelCatalogAssetId": "azureml://registries/azure-openai/models/gpt-4o/versions/2024-08-06",
+              "skus": [
+                {
+                  "name": "Standard",
+                  "capacity": {
+                    "default": 10,
+                    "maximum": 100,
+                    "minimum": 1,
+                    "step": 1
+                  },
+                  "usageName": "OpenAI.Standard.GPT4o"
+                },
+                {
+                  "name": "provisioned",
+                  "capacity": {
+                    "default": 100,
+                    "maximum": 2000,
+                    "minimum": 50,
+                    "step": 50
+                  },
+                  "usageName": "OpenAI.Provisioned.GPT4o"
+                }
+              ],
+              "systemData": {
+                "createdAt": "2024-08-06T00:00:00Z",
+                "createdBy": "Microsoft",
+                "lastModifiedAt": "2024-11-01T00:00:00Z",
+                "lastModifiedBy": "Microsoft"
+              },
+              "version": "2024-08-06"
+            },
+            "skuName": "S0"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListModelCapacities.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListModelCapacities.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "ModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListModelCapacities",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 300,
+              "availableFinetuneCapacity": 20,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "Standard",
+              "scopeId": "WestUS",
+              "scopeType": "Regional"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListModelCapacitiesClassicScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListModelCapacitiesClassicScope.json
@@ -1,0 +1,36 @@
+{
+  "operationId": "ModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListModelCapacities Classic Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Standard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/Standard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 200,
+              "availableFinetuneCapacity": 15,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "Standard",
+              "scopeType": "Classic"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListModelCapacitiesDataZoneScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListModelCapacitiesDataZoneScope.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "ModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListModelCapacities DataZone Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "DataZoneStandard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/DataZoneStandard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 400,
+              "availableFinetuneCapacity": 25,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "DataZoneStandard",
+              "scopeId": "US",
+              "scopeType": "DataZone"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListModelCapacitiesGlobalScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListModelCapacitiesGlobalScope.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "ModelCapacities_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "modelFormat": "OpenAI",
+    "modelName": "ada",
+    "modelVersion": "1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListModelCapacities Global Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "GlobalStandard",
+            "type": "Microsoft.CognitiveServices/locations/models/skuCapacities",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/models/OpenAI.ada.1/skuCapacities/GlobalStandard",
+            "location": "WestUS",
+            "properties": {
+              "availableCapacity": 500,
+              "availableFinetuneCapacity": 30,
+              "model": {
+                "name": "ada",
+                "format": "OpenAI",
+                "version": "1"
+              },
+              "skuName": "GlobalStandard",
+              "scopeId": "Global",
+              "scopeType": "Global"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListNetworkSecurityPerimeterConfigurations.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListNetworkSecurityPerimeterConfigurations.json
@@ -1,0 +1,51 @@
+{
+  "operationId": "NetworkSecurityPerimeterConfigurations_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListNetworkSecurityPerimeterConfigurations",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "networkSecurityPerimeterConfigurationName",
+            "type": "Microsoft.CognitiveServices/accounts/networkSecurityPerimeterConfigurations",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/networkSecurityPerimeterConfigurations/config1",
+            "properties": {
+              "networkSecurityPerimeter": {
+                "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Network/networkSecurityPerimeters/perimeter",
+                "location": "East US",
+                "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+              },
+              "profile": {
+                "name": "profileName",
+                "accessRules": [
+                  {
+                    "name": "ruleName",
+                    "properties": {
+                      "addressPrefixes": [
+                        "148.0.0.0/8",
+                        "152.4.6.0/24"
+                      ],
+                      "direction": "Inbound"
+                    }
+                  }
+                ],
+                "accessRulesVersion": 1
+              },
+              "provisioningState": "Succeeded",
+              "resourceAssociation": {
+                "name": "associationName",
+                "accessMode": "Enforced"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListPrivateEndpointConnections.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListPrivateEndpointConnections.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "PrivateEndpointConnections_List",
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetPrivateEndpointConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "{privateEndpointConnectionName}",
+            "type": "Microsoft.CognitiveServices/accounts/privateEndpointConnections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.CognitiveServices/accounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+            "properties": {
+              "privateEndpoint": {
+                "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+              },
+              "privateLinkServiceConnectionState": {
+                "description": "Auto-Approved",
+                "actionsRequired": "None",
+                "status": "Approved"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListPrivateLinkResources.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListPrivateLinkResources.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "PrivateLinkResources_List",
+  "parameters": {
+    "accountName": "sto2527",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "res6977",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ListPrivateLinkResources",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blob",
+            "type": "Microsoft.CognitiveServices/accounts/privateLinkResources",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res6977/providers/Microsoft.CognitiveServices/accounts/sto2527/privateLinkResources/account",
+            "properties": {
+              "groupId": "account",
+              "requiredMembers": [
+                "default"
+              ],
+              "requiredZoneNames": [
+                "privatelink.cognitiveservices.azure.com"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListProjects.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListProjects.json
@@ -1,0 +1,57 @@
+{
+  "operationId": "Projects_List",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Project",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myProject",
+            "type": "Microsoft.CognitiveServices/accounts/projects",
+            "etag": "W/\"datetime'2017-04-10T04%3A42%3A19.7067387Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/myAccount/projects/myProject",
+            "location": "westus",
+            "properties": {
+              "description": "This is my project 1",
+              "displayName": "myProject1",
+              "endpoints": {
+                "OpenAI Dall-E API": "https://customSubDomainName.openai.azure.com/",
+                "OpenAI Language Model Instance API": "https://customSubDomainName.openai.azure.com/"
+              },
+              "isDefault": true,
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "ExpiredDate": "2017/09/01",
+              "Owner": "felixwa"
+            }
+          },
+          {
+            "name": "myProject-2",
+            "type": "Microsoft.CognitiveServices/accounts/projects",
+            "etag": "W/\"datetime'2017-04-07T04%3A32%3A38.9187216Z'\"",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/myResourceGroup/providers/Microsoft.CognitiveServices/accounts/myAccount/projects/myProject-2",
+            "location": "westus",
+            "properties": {
+              "description": "This is my project 2",
+              "displayName": "myProject2",
+              "endpoints": {
+                "OpenAI Dall-E API": "https://customSubDomainName2.openai.azure.com/",
+                "OpenAI Language Model Instance API": "https://customSubDomainName2.openai.azure.com/"
+              },
+              "isDefault": false,
+              "provisioningState": "Succeeded"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListQuotaTiers.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListQuotaTiers.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "QuotaTiers_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List the Quota Tier for a subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.CognitiveServices/quotaTiers",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/quotaTiers/default",
+            "properties": {
+              "assignmentDate": "2025-06-09T18:13:29.389Z",
+              "currentTierName": "Free-Tier",
+              "tierUpgradeEligibilityInfo": {
+                "nextTierName": "Tier-1",
+                "upgradeApplicableDate": "2025-06-15T18:13:29.389Z",
+                "upgradeAvailabilityStatus": "Available"
+              },
+              "tierUpgradePolicy": "OnceUpgradeIsAvailable"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListRaiContentFilters.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListRaiContentFilters.json
@@ -1,0 +1,102 @@
+{
+  "operationId": "RaiContentFilters_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListRaiContentFilters",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Hate",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Hate",
+            "properties": {
+              "name": "Hate",
+              "isMultiLevelFilter": true
+            }
+          },
+          {
+            "name": "Sexual",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Sexual",
+            "properties": {
+              "name": "Sexual",
+              "isMultiLevelFilter": true
+            }
+          },
+          {
+            "name": "Violence",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Violence",
+            "properties": {
+              "name": "Violence",
+              "isMultiLevelFilter": true
+            }
+          },
+          {
+            "name": "Selfharm",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Selfharm",
+            "properties": {
+              "name": "Selfharm",
+              "isMultiLevelFilter": true
+            }
+          },
+          {
+            "name": "Jailbreak",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Jailbreak",
+            "properties": {
+              "name": "Jailbreak",
+              "isMultiLevelFilter": false,
+              "source": "Prompt"
+            }
+          },
+          {
+            "name": "ProtectedMaterialText",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/ProtectedMaterialText",
+            "properties": {
+              "name": "Protected Material Text",
+              "isMultiLevelFilter": false,
+              "source": "Completion"
+            }
+          },
+          {
+            "name": "ProtectedMaterialCode",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/ProtectedMaterialCode",
+            "properties": {
+              "name": "Protected Material Code",
+              "isMultiLevelFilter": false,
+              "source": "Completion"
+            }
+          },
+          {
+            "name": "Profanity",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/Profanity",
+            "properties": {
+              "name": "Profanity",
+              "isMultiLevelFilter": false
+            }
+          },
+          {
+            "name": "IndirectAttack",
+            "type": "Microsoft.CognitiveServices/locations/raiContentFilters",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/WestUS/raiContentFilters/IndirectAttack",
+            "properties": {
+              "name": "Indirect Attack",
+              "isMultiLevelFilter": false,
+              "source": "Prompt"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListRaiExternalSafetyProviders.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListRaiExternalSafetyProviders.json
@@ -1,0 +1,61 @@
+{
+  "operationId": "RaiExternalSafetyProviders_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListRaiExternalSafetyProviders",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "purview",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/purview",
+            "properties": {
+              "createdAt": "2025-07-01T00:00:00Z",
+              "keyVaultUri": "https://example.vault.azure.net",
+              "lastModifiedAt": "2025-07-02T00:00:00Z",
+              "managedIdentity": "00000000-0000-0000-0000-000000000000",
+              "mode": "sync",
+              "providerId": "00000000-0000-0000-0000-000000000000",
+              "providerName": "purview",
+              "secretName": "mySecretName",
+              "url": "https://example.webhook.endpoint"
+            }
+          },
+          {
+            "name": "microsoftDefenderForCloud",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/microsoftDefenderForCloud",
+            "properties": {
+              "createdAt": "2025-07-01T00:00:00Z",
+              "keyVaultUri": "https://example.vault.azure.net",
+              "lastModifiedAt": "2025-07-02T00:00:00Z",
+              "managedIdentity": "00000000-0000-0000-0000-000000000000",
+              "mode": "sync",
+              "providerId": "00000000-0000-0000-0000-000000000000",
+              "providerName": "microsoftDefenderForCloud",
+              "secretName": "mySecretName",
+              "url": "https://example.webhook.endpoint"
+            }
+          },
+          {
+            "name": "sampleSafetyProvider",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/sampleSafetyProvider",
+            "properties": {
+              "createdAt": "2025-07-01T00:00:00Z",
+              "keyVaultUri": "https://example.vault.azure.net",
+              "lastModifiedAt": "2025-07-02T00:00:00Z",
+              "managedIdentity": "00000000-0000-0000-0000-000000000000",
+              "mode": "sync",
+              "providerId": "00000000-0000-0000-0000-000000000000",
+              "providerName": "sampleSafetyProvider",
+              "secretName": "mySecretName",
+              "url": "https://example.webhook.endpoint"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListRaiPolicies.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListRaiPolicies.json
@@ -1,0 +1,108 @@
+{
+  "operationId": "RaiPolicies_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListRaiPolicies",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "raiPolicyName",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+            "properties": {
+              "basePolicyName": "Microsoft.Default",
+              "contentFilters": [
+                {
+                  "name": "Hate",
+                  "blocking": false,
+                  "enabled": false,
+                  "severityThreshold": "High",
+                  "source": "Prompt"
+                },
+                {
+                  "name": "Hate",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "Medium",
+                  "source": "Completion"
+                },
+                {
+                  "name": "Sexual",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "High",
+                  "source": "Prompt"
+                },
+                {
+                  "name": "Sexual",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "Medium",
+                  "source": "Completion"
+                },
+                {
+                  "name": "Selfharm",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "High",
+                  "source": "Prompt"
+                },
+                {
+                  "name": "Selfharm",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "Medium",
+                  "source": "Completion"
+                },
+                {
+                  "name": "Violence",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "Medium",
+                  "source": "Prompt"
+                },
+                {
+                  "name": "Violence",
+                  "blocking": true,
+                  "enabled": true,
+                  "severityThreshold": "Medium",
+                  "source": "Completion"
+                },
+                {
+                  "name": "Jailbreak",
+                  "blocking": true,
+                  "enabled": true,
+                  "source": "Prompt"
+                },
+                {
+                  "name": "Protected Material Text",
+                  "blocking": true,
+                  "enabled": true,
+                  "source": "Completion"
+                },
+                {
+                  "name": "Protected Material Code",
+                  "blocking": true,
+                  "enabled": true,
+                  "source": "Completion"
+                },
+                {
+                  "name": "Profanity",
+                  "blocking": true,
+                  "enabled": true,
+                  "source": "Prompt"
+                }
+              ],
+              "mode": "Asynchronous_filter"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListRaiToolLabels.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListRaiToolLabels.json
@@ -1,0 +1,44 @@
+{
+  "operationId": "RaiToolLabels_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListRaiToolLabels",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "raiIfcToolLabelName",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiIfcToolLabels/raiIfcToolLabelName",
+            "properties": {
+              "accountScope": {
+                "labelValues": {
+                  "confidentiality": "low"
+                }
+              },
+              "projectScopes": [
+                {
+                  "labelValues": {
+                    "confidentiality": "low"
+                  },
+                  "project": "hualiang-project"
+                },
+                {
+                  "labelValues": {
+                    "confidentiality": "low"
+                  },
+                  "project": "sahana-project"
+                }
+              ],
+              "toolConnectionName": "Web_Search"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListRaiTopics.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListRaiTopics.json
@@ -1,0 +1,31 @@
+{
+  "operationId": "RaiTopics_List",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ListRaiTopics",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "raiTopicName",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiTopics/raiTopicName",
+            "properties": {
+              "description": "This is a sample topic.",
+              "createdAt": "2025-07-01T00:00:00Z",
+              "lastModifiedAt": "2025-07-02T00:00:00Z",
+              "sampleBlobUrl": "https://example.blob.core.windows.net/sampleblob",
+              "status": "Succeeded",
+              "topicId": "00000000-0000-0000-0000-000000000000",
+              "topicName": "raiTopicName"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListSharedCommitmentPlanAssociations.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListSharedCommitmentPlanAssociations.json
@@ -1,0 +1,26 @@
+{
+  "operationId": "CommitmentPlans_ListAssociations",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ListCommitmentPlans",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "accountAssociationName",
+            "type": "Microsoft.CognitiveServices/commitmentPlans/accountAssociations",
+            "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName/accountAssociations/accountAssociationName",
+            "properties": {
+              "accountId": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListSharedCommitmentPlansByResourceGroup.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListSharedCommitmentPlansByResourceGroup.json
@@ -1,0 +1,36 @@
+{
+  "operationId": "CommitmentPlans_ListPlansByResourceGroup",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Commitment Plans by Resource Group",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "commitmentPlanName",
+            "type": "Microsoft.CognitiveServices/commitmentPlans",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+            "kind": "SpeechServices",
+            "location": "West US",
+            "properties": {
+              "autoRenew": true,
+              "current": {
+                "tier": "T1"
+              },
+              "hostingModel": "Web",
+              "planType": "STT",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListSharedCommitmentPlansBySubscription.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListSharedCommitmentPlansBySubscription.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "CommitmentPlans_ListPlansBySubscription",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List Accounts by Subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "commitmentPlanName",
+            "type": "Microsoft.CognitiveServices/commitmentPlans",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+            "kind": "SpeechServices",
+            "location": "West US",
+            "properties": {
+              "autoRenew": true,
+              "current": {
+                "tier": "T1"
+              },
+              "hostingModel": "Web",
+              "planType": "STT",
+              "provisioningState": "Succeeded"
+            },
+            "sku": {
+              "name": "S0"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListSkus.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListSkus.json
@@ -1,0 +1,32 @@
+{
+  "operationId": "Accounts_ListSkus",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List SKUs",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "resourceType": "Microsoft.CognitiveServices/accounts",
+            "sku": {
+              "name": "F0",
+              "tier": "Free"
+            }
+          },
+          {
+            "resourceType": "Microsoft.CognitiveServices/accounts",
+            "sku": {
+              "name": "S0",
+              "tier": "Standard"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListUsages.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListUsages.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "Usages_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get Usages",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Cognitive Services total account limit",
+              "value": "AccountCount"
+            },
+            "currentValue": 3,
+            "limit": 200,
+            "unit": "Count",
+            "scopeType": "Regional",
+            "scopeId": "westus"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListUsagesClassicScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListUsagesClassicScope.json
@@ -1,0 +1,27 @@
+{
+  "operationId": "Usages_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get Usages Classic Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Cognitive Services total account limit",
+              "value": "AccountCount"
+            },
+            "currentValue": 2,
+            "limit": 100,
+            "unit": "Count",
+            "scopeType": "Classic"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListUsagesDataZoneScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListUsagesDataZoneScope.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "Usages_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get Usages DataZone Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Cognitive Services total account limit",
+              "value": "AccountCount"
+            },
+            "currentValue": 4,
+            "limit": 300,
+            "unit": "Count",
+            "scopeType": "DataZone",
+            "scopeId": "US"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListUsagesGlobalScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ListUsagesGlobalScope.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "Usages_List",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "location": "WestUS",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get Usages Global Scope",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Cognitive Services total account limit",
+              "value": "AccountCount"
+            },
+            "currentValue": 5,
+            "limit": 500,
+            "unit": "Count",
+            "scopeType": "Global",
+            "scopeId": "Global"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/createOrUpdateManagedNetworkV2.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/createOrUpdateManagedNetworkV2.json
@@ -1,0 +1,59 @@
+{
+  "operationId": "ManagedNetworkSettings_Put",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "body": {
+      "properties": {
+        "managedNetwork": {
+          "firewallSku": "Standard",
+          "isolationMode": "AllowOnlyApprovedOutbound",
+          "outboundRules": {
+            "rule_name_1": {
+              "type": "FQDN",
+              "category": "UserDefined",
+              "destination": "destination_endpoint"
+            }
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Put ManagedNetworkSettings",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/accounts/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "status": "Active"
+              }
+            },
+            "provisioningState": "Succeeded"
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/createOrUpdateRuleV2.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/createOrUpdateRuleV2.json
@@ -1,0 +1,41 @@
+{
+  "operationId": "OutboundRule_CreateOrUpdate",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "body": {
+      "properties": {
+        "type": "FQDN",
+        "category": "UserDefined",
+        "destination": "destination_endpoint",
+        "status": "Active"
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule_name_1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "CreateOrUpdate OutboundRule",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "accounts/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_endpoint",
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/deleteManagedNetworkV2.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/deleteManagedNetworkV2.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "ManagedNetworkSettings_Delete",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete ManagedNetworkSettings",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-03-15-preview",
+        "Retry-After": "10"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/deleteRuleV2.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/deleteRuleV2.json
@@ -1,0 +1,21 @@
+{
+  "operationId": "OutboundRule_Delete",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "rule-name",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete OutboundRule",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-1111-2222-3333-444444444444/providers/Microsoft.CognitiveServices/locations/westus/operationResults/00000000-0000-0000-0000-000000000000?api-version=2026-08-31-preview",
+        "Retry-After": "10"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/getManagedNetworkV2.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/getManagedNetworkV2.json
@@ -1,0 +1,39 @@
+{
+  "operationId": "ManagedNetworkSettings_Get",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get ManagedNetworkSettings",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/accounts/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "status": "Active"
+              }
+            },
+            "provisioningState": "Succeeded"
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/getRuleV2.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/getRuleV2.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "OutboundRule_Get",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "ruleName": "name_of_the_fqdn_rule",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Get OutboundRule",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "rule_name_1",
+        "type": "accounts/outboundRules",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default/outboundRules/rule_name_1",
+        "properties": {
+          "type": "FQDN",
+          "category": "UserDefined",
+          "destination": "destination_of_the_fqdn_rule",
+          "status": "Active"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/listManagedNetworkV2.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/listManagedNetworkV2.json
@@ -1,0 +1,43 @@
+{
+  "operationId": "ManagedNetworkSettings_List",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List ManagedNetworkSettings",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.CognitiveServices/accounts/managedNetworks",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default",
+            "properties": {
+              "managedNetwork": {
+                "firewallPublicIpAddress": "22.22.131.49",
+                "firewallSku": "Standard",
+                "isolationMode": "AllowOnlyApprovedOutbound",
+                "networkId": "00000000-1111-2222-3333-444444444444",
+                "outboundRules": {
+                  "rule_name_1": {
+                    "type": "FQDN",
+                    "category": "UserDefined",
+                    "destination": "destination_endpoint",
+                    "status": "Active"
+                  }
+                },
+                "provisioningState": "Succeeded"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/listRuleV2.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/listRuleV2.json
@@ -1,0 +1,44 @@
+{
+  "operationId": "OutboundRule_List",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "List OutboundRules",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule_name_1",
+            "type": "accounts/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default/outboundRules/rule_name_1",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "errorInformation": "Error message",
+              "status": "Inactive"
+            }
+          },
+          {
+            "name": "rule_name_2",
+            "type": "accounts/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default/outboundRules/rule_name_2",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "errorInformation": "Error message",
+              "status": "Inactive"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/patchManagedNetworkV2.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/patchManagedNetworkV2.json
@@ -1,0 +1,59 @@
+{
+  "operationId": "ManagedNetworkSettings_Patch",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "body": {
+      "properties": {
+        "managedNetwork": {
+          "firewallSku": "Standard",
+          "isolationMode": "AllowOnlyApprovedOutbound",
+          "outboundRules": {
+            "rule_name_1": {
+              "type": "FQDN",
+              "category": "UserDefined",
+              "destination": "destination_endpoint"
+            }
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Patch ManagedNetworkSettings",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/accounts/managedNetworks",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default",
+        "properties": {
+          "managedNetwork": {
+            "firewallPublicIpAddress": "22.22.131.49",
+            "firewallSku": "Standard",
+            "isolationMode": "AllowOnlyApprovedOutbound",
+            "networkId": "00000000-1111-2222-3333-444444444444",
+            "outboundRules": {
+              "rule_name_1": {
+                "type": "FQDN",
+                "category": "UserDefined",
+                "destination": "destination_endpoint",
+                "status": "Active"
+              }
+            },
+            "provisioningState": "Succeeded"
+          },
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/postOutboundRulesV2.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/postOutboundRulesV2.json
@@ -1,0 +1,49 @@
+{
+  "operationId": "OutboundRules_Post",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "body": {
+      "properties": {
+        "firewallSku": "Standard",
+        "isolationMode": "AllowOnlyApprovedOutbound",
+        "outboundRules": {
+          "rule_name_1": {
+            "type": "FQDN",
+            "category": "UserDefined",
+            "destination": "destination_endpoint"
+          }
+        }
+      }
+    },
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Post OutboundRules",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "rule_name_1",
+            "type": "accounts/outboundRules",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/cognitive-account-name/managedNetworks/default/outboundRules/rule_name_1",
+            "properties": {
+              "type": "FQDN",
+              "category": "Required",
+              "destination": "destination_of_the_fqdn_rule",
+              "status": "Active"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/provisionManagedNetwork.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ManagedNetwork/provisionManagedNetwork.json
@@ -1,0 +1,24 @@
+{
+  "operationId": "ManagedNetworkProvisions_ProvisionManagedNetwork",
+  "parameters": {
+    "accountName": "cognitive-account-name",
+    "api-version": "2026-08-31-preview",
+    "body": {},
+    "managedNetworkName": "default",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Provision ManagedNetwork",
+  "responses": {
+    "200": {
+      "body": {
+        "status": "Active"
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "location_url_to_poll_for_status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PauseDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PauseDeployment.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "Deployments_Pause",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PauseDeployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Paused",
+          "model": {
+            "name": "gpt-4",
+            "format": "OpenAI",
+            "version": "0613"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectCapabilityHost/createOrUpdate.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectCapabilityHost/createOrUpdate.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHost": {
+      "properties": {
+        "aiServicesConnections": [
+          "aoai_connection"
+        ],
+        "storageConnections": [
+          "blob_connection"
+        ],
+        "threadStorageConnections": [
+          "aca_connection"
+        ],
+        "vectorStoreConnections": [
+          "acs_connection"
+        ]
+      }
+    },
+    "capabilityHostName": "capabilityHostName",
+    "projectName": "project-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/projects/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "aiServicesConnections": [
+            "aoai_connection"
+          ],
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "blob_connection"
+          ],
+          "threadStorageConnections": [
+            "aca_connection"
+          ],
+          "vectorStoreConnections": [
+            "acs_connection"
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/projects/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "aiServicesConnections": [
+            "aoai_connection"
+          ],
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "blob_connection"
+          ],
+          "threadStorageConnections": [
+            "aca_connection"
+          ],
+          "vectorStoreConnections": [
+            "acs_connection"
+          ]
+        }
+      },
+      "headers": {
+        "Location": "example_location"
+      }
+    }
+  },
+  "operationId": "ProjectCapabilityHosts_CreateOrUpdate",
+  "title": "CreateOrUpdate Project CapabilityHost."
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectCapabilityHost/delete.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectCapabilityHost/delete.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "ProjectCapabilityHosts_Delete",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHostName": "capabilityHostName",
+    "projectName": "project-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Project CapabilityHost.",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "location_header_to_poll"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectCapabilityHost/get.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectCapabilityHost/get.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "capabilityHostName": "capabilityHostName",
+    "projectName": "project-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "capabilityHostName",
+        "type": "Microsoft.CognitiveServices/accounts/projects/capabilityHosts",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/capabilityHosts/capabilityHostName",
+        "properties": {
+          "aiServicesConnections": [
+            "aoai_connection"
+          ],
+          "provisioningState": "Succeeded",
+          "storageConnections": [
+            "blob_connection"
+          ],
+          "threadStorageConnections": [
+            "aca_connection"
+          ],
+          "vectorStoreConnections": [
+            "acs_connection"
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ProjectCapabilityHosts_Get",
+  "title": "Get Project CapabilityHost."
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectCapabilityHost/list.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectCapabilityHost/list.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "projectName": "project-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "capabilityHostName",
+            "type": "Microsoft.CognitiveServices/accounts/projects/capabilityHosts",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/test-rg/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/capabilityHosts/capabilityHostName",
+            "properties": {
+              "aiServicesConnections": [
+                "aoai_connection"
+              ],
+              "provisioningState": "Succeeded",
+              "storageConnections": [
+                "blob_connection"
+              ],
+              "threadStorageConnections": [
+                "aca_connection"
+              ],
+              "vectorStoreConnections": [
+                "acs_connection"
+              ]
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ProjectCapabilityHosts_List",
+  "title": "List Project CapabilityHosts."
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectConnection/create.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectConnection/create.json
@@ -1,0 +1,35 @@
+{
+  "operationId": "ProjectConnections_Create",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connection": {
+      "properties": {
+        "authType": "None",
+        "category": "ContainerRegistry",
+        "expiryTime": "2024-03-15T14:30:00Z",
+        "target": "[target url]"
+      }
+    },
+    "connectionName": "connection-1",
+    "projectName": "project-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "CreateProjectConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "[target url]"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectConnection/delete.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectConnection/delete.json
@@ -1,0 +1,16 @@
+{
+  "operationId": "ProjectConnections_Delete",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connectionName": "connection-1",
+    "projectName": "project-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "DeleteProjectConnection",
+  "responses": {
+    "200": {},
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectConnection/get.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectConnection/get.json
@@ -1,0 +1,27 @@
+{
+  "operationId": "ProjectConnections_Get",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connectionName": "connection-1",
+    "projectName": "project-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "GetProjectConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/connections/connection-1",
+        "properties": {
+          "authType": "None",
+          "category": "ContainerRegistry",
+          "expiryTime": "2024-03-15T14:30:00Z",
+          "target": "[target url]"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectConnection/list.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectConnection/list.json
@@ -1,0 +1,42 @@
+{
+  "operationId": "ProjectConnections_List",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "category": "ContainerRegistry",
+    "projectName": "project-1",
+    "resourceGroupName": "resourceGroup-1",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444",
+    "target": "[target url]"
+  },
+  "title": "ListProjectConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "connection-1",
+            "type": "Microsoft.CognitiveServices/accounts/projects/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/connections/connection-1",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "expiryTime": "2024-03-15T14:30:00Z",
+              "target": "[target url]"
+            }
+          },
+          {
+            "name": "connection-2",
+            "type": "Microsoft.CognitiveServices/accounts/projects/connections",
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/connections/connection-2",
+            "properties": {
+              "authType": "PAT",
+              "category": "ContainerRegistry",
+              "target": "[target url]"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectConnection/update.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ProjectConnection/update.json
@@ -1,0 +1,42 @@
+{
+  "operationId": "ProjectConnections_Update",
+  "parameters": {
+    "accountName": "account-1",
+    "api-version": "2026-08-31-preview",
+    "connection": {
+      "properties": {
+        "authType": "AccessKey",
+        "category": "ADLSGen2",
+        "credentials": {
+          "accessKeyId": "some_string",
+          "secretAccessKey": "some_string"
+        },
+        "expiryTime": "2020-01-01T00:00:00Z",
+        "metadata": {},
+        "target": "some_string"
+      }
+    },
+    "connectionName": "connection-1",
+    "projectName": "project-1",
+    "resourceGroupName": "test-rg",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "UpdateProjectConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "connection-1",
+        "type": "Microsoft.CognitiveServices/accounts/projects/connections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroup-1/providers/Microsoft.CognitiveServices/accounts/account-1/projects/project-1/connections/connection-1",
+        "properties": {
+          "authType": "AccessKey",
+          "category": "ADLSGen2",
+          "expiryTime": "2020-01-01T00:00:00Z",
+          "metadata": {},
+          "target": "some_string"
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PurgeDeletedAccount.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PurgeDeletedAccount.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "DeletedAccounts_Purge",
+  "parameters": {
+    "accountName": "PropTest01",
+    "api-version": "2026-08-31-preview",
+    "location": "westus",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Delete Account",
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutCommitmentPlan.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutCommitmentPlan.json
@@ -1,0 +1,53 @@
+{
+  "operationId": "CommitmentPlans_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "commitmentPlan": {
+      "properties": {
+        "autoRenew": true,
+        "current": {
+          "tier": "T1"
+        },
+        "hostingModel": "Web",
+        "planType": "Speech2Text"
+      }
+    },
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PutCommitmentPlan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/accounts/commitmentPlans",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/commitmentPlans/commitmentPlanName",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "Speech2Text"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/accounts/commitmentPlans",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/commitmentPlans/commitmentPlanName",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "Speech2Text"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutDefenderForAISetting.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutDefenderForAISetting.json
@@ -1,0 +1,56 @@
+{
+  "operationId": "DefenderForAISettings_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "defenderForAISettingName": "Default",
+    "defenderForAISettings": {
+      "properties": {
+        "state": "Enabled"
+      }
+    },
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutDefenderForAISetting",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default",
+        "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/defenderForAISettings/Default",
+        "properties": {
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2022-04-03T04:41:33.937Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-04-03T04:41:33.937Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "Default",
+        "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/defenderForAISettings/Default",
+        "properties": {
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2022-04-03T04:41:33.937Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-04-03T04:41:33.937Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutDeployment.json
@@ -1,0 +1,70 @@
+{
+  "operationId": "Deployments_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deployment": {
+      "properties": {
+        "deploymentState": "Running",
+        "model": {
+          "name": "ada",
+          "format": "OpenAI",
+          "version": "1"
+        },
+        "serviceTier": "Priority"
+      },
+      "sku": {
+        "name": "Standard",
+        "capacity": 1
+      }
+    },
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PutDeployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Running",
+          "model": {
+            "name": "ada",
+            "format": "OpenAI",
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "serviceTier": "Priority"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Running",
+          "model": {
+            "name": "ada",
+            "format": "OpenAI",
+            "version": "1"
+          },
+          "provisioningState": "Accepted",
+          "serviceTier": "Priority"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutEncryptionScope.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutEncryptionScope.json
@@ -1,0 +1,79 @@
+{
+  "operationId": "EncryptionScopes_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "encryptionScope": {
+      "properties": {
+        "keySource": "Microsoft.KeyVault",
+        "keyVaultProperties": {
+          "identityClientId": "00000000-0000-0000-0000-000000000000",
+          "keyName": "DevKeyWestUS2",
+          "keyVaultUri": "https://devkvwestus2.vault.azure.net/",
+          "keyVersion": "9f85549d7bf14ff4bf178c10d3bdca95"
+        },
+        "state": "Enabled"
+      }
+    },
+    "encryptionScopeName": "encryptionScopeName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutEncryptionScope",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "encryptionScopeName",
+        "type": "Microsoft.CognitiveServices/accounts/encryptionScopes",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/encryptionScopes/encryptionScopeName",
+        "properties": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": {
+            "identityClientId": "00000000-0000-0000-0000-000000000000",
+            "keyName": "DevKeyWestUS2",
+            "keyVaultUri": "https://devkvwestus2.vault.azure.net/",
+            "keyVersion": "9f85549d7bf14ff4bf178c10d3bdca95"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2023-06-08T06:35:08.0662558Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2023-06-08T06:35:08.0662558Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "encryptionScopeName",
+        "type": "Microsoft.CognitiveServices/accounts/encryptionScopes",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/encryptionScopes/encryptionScopeName",
+        "properties": {
+          "keySource": "Microsoft.KeyVault",
+          "keyVaultProperties": {
+            "identityClientId": "00000000-0000-0000-0000-000000000000",
+            "keyName": "DevKeyWestUS2",
+            "keyVaultUri": "https://devkvwestus2.vault.azure.net/",
+            "keyVersion": "9f85549d7bf14ff4bf178c10d3bdca95"
+          },
+          "provisioningState": "Succeeded",
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2023-06-08T06:35:08.0662558Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2023-06-08T06:35:08.0662558Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutPrivateEndpointConnection.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutPrivateEndpointConnection.json
@@ -1,0 +1,56 @@
+{
+  "operationId": "PrivateEndpointConnections_CreateOrUpdate",
+  "parameters": {
+    "accountName": "sto9699",
+    "api-version": "2026-08-31-preview",
+    "monitor": "true",
+    "privateEndpointConnectionName": "{privateEndpointConnectionName}",
+    "properties": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "description": "Auto-Approved",
+          "status": "Approved"
+        }
+      }
+    },
+    "resourceGroupName": "res7687",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "PutPrivateEndpointConnection",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.CognitiveServices/accounts/privateEndpointConnections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.CognitiveServices/accounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          }
+        }
+      }
+    },
+    "202": {
+      "body": {
+        "name": "{privateEndpointConnectionName}",
+        "type": "Microsoft.CognitiveServices/accounts/privateEndpointConnections",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.CognitiveServices/accounts/sto288/privateEndpointConnections/{privateEndpointConnectionName}",
+        "properties": {
+          "privateEndpoint": {
+            "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/res7231/providers/Microsoft.Network/privateEndpoints/petest01"
+          },
+          "privateLinkServiceConnectionState": {
+            "description": "Auto-Approved",
+            "actionsRequired": "None",
+            "status": "Approved"
+          }
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiBlocklist.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiBlocklist.json
@@ -1,0 +1,36 @@
+{
+  "operationId": "RaiBlocklists_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklist": {
+      "properties": {
+        "description": "Basic blocklist description"
+      }
+    },
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiBlocklist",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "Basic blocklist description"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "raiBlocklistName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName",
+        "properties": {
+          "description": "Basic blocklist description"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiBlocklistItem.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiBlocklistItem.json
@@ -1,0 +1,40 @@
+{
+  "operationId": "RaiBlocklistItems_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiBlocklistItem": {
+      "properties": {
+        "isRegex": false,
+        "pattern": "Pattern To Block"
+      }
+    },
+    "raiBlocklistItemName": "raiBlocklistItemName",
+    "raiBlocklistName": "raiBlocklistName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiBlocklistItem",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "raiBlocklistItemName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiBlocklists/raiBlocklistName/raiBlocklistItems/raiBlocklistItemName",
+        "properties": {
+          "isRegex": false,
+          "pattern": "Pattern To Block"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiExternalSafetyProvider.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiExternalSafetyProvider.json
@@ -1,0 +1,53 @@
+{
+  "operationId": "RaiExternalSafetyProvider_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "safetyProvider": {
+      "properties": {
+        "keyVaultUri": "https://example.vault.azure.net",
+        "managedIdentity": "00000000-0000-0000-0000-000000000000",
+        "mode": "sync",
+        "providerId": "00000000-0000-0000-0000-000000000000",
+        "providerName": "safetyProviderName",
+        "secretName": "mySecretName",
+        "url": "https://example.webhook.endpoint"
+      }
+    },
+    "safetyProviderName": "safetyProviderName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiExternalSafetyProvider",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "safetyProviderName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/safetyProviderName",
+        "properties": {
+          "createdAt": "2025-07-01T00:00:00Z",
+          "keyVaultUri": "https://example.vault.azure.net",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "managedIdentity": "00000000-0000-0000-0000-000000000000",
+          "mode": "sync",
+          "providerId": "00000000-0000-0000-0000-000000000000",
+          "providerName": "safetyProviderName",
+          "secretName": "mySecretName",
+          "url": "https://example.webhook.endpoint"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "safetyProviderName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/safetyProviderName",
+        "properties": {
+          "createdAt": "2025-07-01T00:00:00Z",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "mode": "sync",
+          "providerId": "00000000-0000-0000-0000-000000000000",
+          "providerName": "safetyProviderName",
+          "url": "https://example.webhook.endpoint"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiPolicy.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiPolicy.json
@@ -1,0 +1,285 @@
+{
+  "operationId": "RaiPolicies_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiPolicy": {
+      "properties": {
+        "basePolicyName": "Microsoft.Default",
+        "contentFilters": [
+          {
+            "name": "Hate",
+            "blocking": false,
+            "enabled": false,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Hate",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Sexual",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Sexual",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Selfharm",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Selfharm",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Violence",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Prompt"
+          },
+          {
+            "name": "Violence",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Jailbreak",
+            "blocking": true,
+            "enabled": true,
+            "source": "Prompt"
+          },
+          {
+            "name": "Protected Material Text",
+            "blocking": true,
+            "enabled": true,
+            "source": "Completion"
+          },
+          {
+            "name": "Protected Material Code",
+            "blocking": true,
+            "enabled": true,
+            "source": "Completion"
+          },
+          {
+            "name": "Profanity",
+            "blocking": true,
+            "enabled": true,
+            "source": "Prompt"
+          }
+        ],
+        "mode": "Asynchronous_filter"
+      }
+    },
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiPolicy",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiToolLabel.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiToolLabel.json
@@ -1,0 +1,95 @@
+{
+  "operationId": "RaiToolLabels_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiToolConnectionName": "Web_Search",
+    "raiToolLabel": {
+      "properties": {
+        "accountScope": {
+          "labelValues": {
+            "confidentiality": "low"
+          }
+        },
+        "projectScopes": [
+          {
+            "labelValues": {
+              "confidentiality": "low"
+            },
+            "project": "test-project"
+          },
+          {
+            "labelValues": {
+              "confidentiality": "low"
+            },
+            "project": "sample-project"
+          }
+        ],
+        "toolConnectionName": "Web_Search"
+      }
+    },
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiToolLabel",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Web_Search",
+        "type": "Microsoft.CognitiveServices/accounts/raiToolLabels",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiToolLabels/Web_Search",
+        "properties": {
+          "accountScope": {
+            "labelValues": {
+              "confidentiality": "low"
+            }
+          },
+          "projectScopes": [
+            {
+              "labelValues": {
+                "confidentiality": "low"
+              },
+              "project": "test-project"
+            },
+            {
+              "labelValues": {
+                "confidentiality": "low"
+              },
+              "project": "sample-project"
+            }
+          ],
+          "toolConnectionName": "Web_Search"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "Web_Search",
+        "type": "Microsoft.CognitiveServices/accounts/raiToolLabels",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiToolLabels/Web_Search",
+        "properties": {
+          "accountScope": {
+            "labelValues": {
+              "confidentiality": "low"
+            }
+          },
+          "projectScopes": [
+            {
+              "labelValues": {
+                "confidentiality": "low"
+              },
+              "project": "test-project"
+            },
+            {
+              "labelValues": {
+                "confidentiality": "low"
+              },
+              "project": "sample-project"
+            }
+          ],
+          "toolConnectionName": "Web_Search"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiTopic.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutRaiTopic.json
@@ -1,0 +1,50 @@
+{
+  "operationId": "RaiTopics_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiTopic": {
+      "properties": {
+        "description": "This is a sample topic.",
+        "sampleBlobUrl": "https://example.blob.core.windows.net/sampleblob",
+        "topicName": "raiTopicName"
+      }
+    },
+    "raiTopicName": "raiTopicName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiTopic",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiTopicName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiTopics/raiTopicName",
+        "properties": {
+          "description": "This is a sample topic.",
+          "createdAt": "2025-07-01T00:00:00Z",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "sampleBlobUrl": "https://example.blob.core.windows.net/sampleblob",
+          "status": "Training",
+          "topicId": "00000000-0000-0000-0000-000000000000",
+          "topicName": "raiTopicName"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "raiTopicName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiTopics/raiTopicName",
+        "properties": {
+          "description": "This is a sample topic.",
+          "createdAt": "2025-07-01T00:00:00Z",
+          "lastModifiedAt": "2025-07-02T00:00:00Z",
+          "sampleBlobUrl": "https://example.blob.core.windows.net/sampleblob",
+          "status": "Training",
+          "topicId": "00000000-0000-0000-0000-000000000000",
+          "topicName": "raiTopicName"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutSubscriptionRaiPolicy.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/PutSubscriptionRaiPolicy.json
@@ -1,0 +1,285 @@
+{
+  "operationId": "SubscriptionRaiPolicy_CreateOrUpdate",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "raiPolicy": {
+      "properties": {
+        "basePolicyName": "Microsoft.Default",
+        "contentFilters": [
+          {
+            "name": "Hate",
+            "blocking": false,
+            "enabled": false,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Hate",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Sexual",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Sexual",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Selfharm",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "High",
+            "source": "Prompt"
+          },
+          {
+            "name": "Selfharm",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Violence",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Prompt"
+          },
+          {
+            "name": "Violence",
+            "blocking": true,
+            "enabled": true,
+            "severityThreshold": "Medium",
+            "source": "Completion"
+          },
+          {
+            "name": "Jailbreak",
+            "blocking": true,
+            "enabled": true,
+            "source": "Prompt"
+          },
+          {
+            "name": "Protected Material Text",
+            "blocking": true,
+            "enabled": true,
+            "source": "Completion"
+          },
+          {
+            "name": "Protected Material Code",
+            "blocking": true,
+            "enabled": true,
+            "source": "Completion"
+          },
+          {
+            "name": "Profanity",
+            "blocking": true,
+            "enabled": true,
+            "source": "Prompt"
+          }
+        ],
+        "mode": "Asynchronous_filter"
+      }
+    },
+    "raiPolicyName": "raiPolicyName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "PutRaiPolicy",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "raiPolicyName",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/raiPolicies/raiPolicyName",
+        "properties": {
+          "basePolicyName": "Microsoft.Default",
+          "contentFilters": [
+            {
+              "name": "Hate",
+              "blocking": false,
+              "enabled": false,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Hate",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Sexual",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "High",
+              "source": "Prompt"
+            },
+            {
+              "name": "Selfharm",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Prompt"
+            },
+            {
+              "name": "Violence",
+              "blocking": true,
+              "enabled": true,
+              "severityThreshold": "Medium",
+              "source": "Completion"
+            },
+            {
+              "name": "Jailbreak",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            },
+            {
+              "name": "Protected Material Text",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Protected Material Code",
+              "blocking": true,
+              "enabled": true,
+              "source": "Completion"
+            },
+            {
+              "name": "Profanity",
+              "blocking": true,
+              "enabled": true,
+              "source": "Prompt"
+            }
+          ],
+          "mode": "Asynchronous_filter"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ReconcileNetworkSecurityPerimeterConfigurations.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ReconcileNetworkSecurityPerimeterConfigurations.json
@@ -1,0 +1,53 @@
+{
+  "operationId": "NetworkSecurityPerimeterConfigurations_Reconcile",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "nspConfigurationName": "NSPConfigurationName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ReconcileNetworkSecurityPerimeterConfigurations",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "networkSecurityPerimeterConfigurationName",
+        "type": "Microsoft.CognitiveServices/accounts/networkSecurityPerimeterConfigurations",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/networkSecurityPerimeterConfigurations/config1",
+        "properties": {
+          "networkSecurityPerimeter": {
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.Network/networkSecurityPerimeters/perimeter",
+            "location": "East US",
+            "perimeterGuid": "00000000-0000-0000-0000-000000000000"
+          },
+          "profile": {
+            "name": "profileName",
+            "accessRules": [
+              {
+                "name": "ruleName",
+                "properties": {
+                  "addressPrefixes": [
+                    "148.0.0.0/8",
+                    "152.4.6.0/24"
+                  ],
+                  "direction": "Inbound"
+                }
+              }
+            ],
+            "accessRulesVersion": 1
+          },
+          "provisioningState": "Succeeded",
+          "resourceAssociation": {
+            "name": "associationName",
+            "accessMode": "Enforced"
+          }
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/RegenerateKey.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/RegenerateKey.json
@@ -1,0 +1,21 @@
+{
+  "operationId": "Accounts_RegenerateKey",
+  "parameters": {
+    "accountName": "myAccount",
+    "api-version": "2026-08-31-preview",
+    "parameters": {
+      "keyName": "Key2"
+    },
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Regenerate Keys",
+  "responses": {
+    "200": {
+      "body": {
+        "key1": "KEY1",
+        "key2": "KEY2"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ResumeDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/ResumeDeployment.json
@@ -1,0 +1,33 @@
+{
+  "operationId": "Deployments_Resume",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "ResumeDeployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/subscriptionId/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Running",
+          "model": {
+            "name": "gpt-4",
+            "format": "OpenAI",
+            "version": "0613"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/TestRaiExternalSafetyProvider.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/TestRaiExternalSafetyProvider.json
@@ -1,0 +1,62 @@
+{
+  "operationId": "TestRaiExternalSafetyProvider_CreateOrUpdate",
+  "parameters": {
+    "accountName": "myCognitiveAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "myResourceGroup",
+    "safetyProvider": {
+      "properties": {
+        "keyVaultUri": "https://contoso-vault.vault.azure.net/",
+        "managedIdentity": "f3b9c2e7-4aad-4b1f-9d9c-9e9b1e9b1f9b",
+        "mode": "sync",
+        "providerId": "00000000-0000-0000-0000-000000000000",
+        "providerName": "safetyProviderName",
+        "secretName": "safety-provider-secret",
+        "url": "https://example-safety-provider.contoso.com/webhook"
+      }
+    },
+    "safetyProviderName": "mySafetyProvider",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "TestRaiExternalSafetyProvider",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mySafetyProvider",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/mySafetyProvider",
+        "properties": {
+          "keyVaultUri": "https://contoso-vault.vault.azure.net/",
+          "managedIdentity": "f3b9c2e7-4aad-4b1f-9d9c-9e9b1e9b1f9b",
+          "mode": "sync",
+          "providerId": "00000000-0000-0000-0000-000000000000",
+          "providerName": "safetyProviderName",
+          "secretName": "safety-provider-secret",
+          "url": "https://example-safety-provider.contoso.com/webhook"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "mySafetyProvider",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/raiExternalSafetyProviders/mySafetyProvider",
+        "properties": {
+          "keyVaultUri": "https://contoso-vault.vault.azure.net/",
+          "managedIdentity": "f3b9c2e7-4aad-4b1f-9d9c-9e9b1e9b1f9b",
+          "mode": "sync",
+          "providerId": "00000000-0000-0000-0000-000000000000",
+          "providerName": "safetyProviderName",
+          "secretName": "safety-provider-secret",
+          "url": "https://example-safety-provider.contoso.com/webhook"
+        }
+      }
+    },
+    "default": {
+      "body": {
+        "error": {
+          "code": "BadRequest",
+          "message": "The request is invalid."
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateAccount.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateAccount.json
@@ -1,0 +1,60 @@
+{
+  "operationId": "Accounts_Update",
+  "parameters": {
+    "account": {
+      "location": "global",
+      "sku": {
+        "name": "S2"
+      }
+    },
+    "accountName": "bingSearch",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "bvttest",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Update Account",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "bingSearch",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A46%3A21.5618831Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch",
+        "kind": "Bing.Search",
+        "location": "global",
+        "properties": {
+          "endpoint": "https://api.cognitive.microsoft.com/bing/v5.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S2"
+        }
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/global/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-06-01",
+        "azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "body": {
+        "name": "bingSearch",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "W/\"datetime'2017-04-10T07%3A46%3A21.5618831Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch",
+        "kind": "Bing.Search",
+        "location": "global",
+        "properties": {
+          "endpoint": "https://api.cognitive.microsoft.com/bing/v5.0",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S2"
+        }
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/global/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-06-01",
+        "azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateAccountWithBudgetPolicyIds.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateAccountWithBudgetPolicyIds.json
@@ -1,0 +1,43 @@
+{
+  "operationId": "Accounts_Update",
+  "parameters": {
+    "account": {
+      "properties": {
+        "budgetPolicyIds": [
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget"
+        ]
+      }
+    },
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Attach a budget policy to an account",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "foundryAccount",
+        "type": "Microsoft.CognitiveServices/accounts",
+        "etag": "\"00000000-0000-0000-0000-000000000002\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount",
+        "kind": "AIServices",
+        "location": "eastus",
+        "properties": {
+          "budgetPolicyIds": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget"
+          ],
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-AsyncOperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000003?api-version=2026-08-31-preview"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateBudgetPolicy.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateBudgetPolicy.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "BudgetPolicies_Update",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "budgetPolicyName": "monthly-project-budget",
+    "properties": {
+      "properties": {
+        "displayName": "Monthly project budget - updated"
+      }
+    },
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Update selected budget policy properties",
+  "responses": {
+    "200": {
+      "headers": {
+        "ETag": "\"00000000-0000-0000-0000-000000000002\""
+      },
+      "body": {
+        "name": "monthly-project-budget",
+        "type": "Microsoft.CognitiveServices/accounts/budgetPolicies",
+        "etag": "\"00000000-0000-0000-0000-000000000002\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget",
+        "properties": {
+          "displayName": "Monthly project budget - updated",
+          "rules": [
+            {
+              "name": "project-spend",
+              "counterKey": [
+                {
+                  "type": "project"
+                }
+              ],
+              "unit": "usd",
+              "amount": 200,
+              "period": "month",
+              "recurring": true,
+              "match": {
+                "foundry.caller.project.id": [
+                  "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/projects/customer-support"
+                ]
+              },
+              "thresholds": [
+                {
+                  "type": "percentage",
+                  "value": 80,
+                  "action": "alert"
+                }
+              ]
+            }
+          ]
+        },
+        "systemData": {
+          "createdAt": "2026-08-13T18:00:00Z",
+          "createdBy": "00000000-0000-0000-0000-000000000001",
+          "createdByType": "User",
+          "lastModifiedAt": "2026-08-13T18:30:00Z",
+          "lastModifiedBy": "00000000-0000-0000-0000-000000000001",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateDefenderForAISetting.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateDefenderForAISetting.json
@@ -1,0 +1,37 @@
+{
+  "operationId": "DefenderForAISettings_Update",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "defenderForAISettingName": "Default",
+    "defenderForAISettings": {
+      "properties": {
+        "state": "Enabled"
+      }
+    },
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "UpdateDefenderForAISetting",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "Default",
+        "type": "Microsoft.CognitiveServices/accounts/defenderForAISettings",
+        "etag": "\"00000000-0000-0000-0000-000000000000\"",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/defenderForAISettings/Default",
+        "properties": {
+          "state": "Enabled"
+        },
+        "systemData": {
+          "createdAt": "2022-04-03T04:41:33.937Z",
+          "createdBy": "xxx@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-04-03T04:41:33.937Z",
+          "lastModifiedBy": "xxx@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateDeployment.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateDeployment.json
@@ -1,0 +1,45 @@
+{
+  "operationId": "Deployments_Update",
+  "parameters": {
+    "accountName": "accountName",
+    "api-version": "2026-08-31-preview",
+    "deployment": {
+      "sku": {
+        "name": "Standard",
+        "capacity": 1
+      }
+    },
+    "deploymentName": "deploymentName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "UpdateDeployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "deploymentName",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/accounts/accountName/deployments/deploymentName",
+        "properties": {
+          "deploymentState": "Paused",
+          "model": {
+            "name": "ada",
+            "format": "OpenAI",
+            "version": "1"
+          },
+          "provisioningState": "Succeeded",
+          "serviceTier": "Priority"
+        },
+        "sku": {
+          "name": "Standard",
+          "capacity": 1
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateDeploymentWithBudgetPolicyIds.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateDeploymentWithBudgetPolicyIds.json
@@ -1,0 +1,47 @@
+{
+  "operationId": "Deployments_Update",
+  "parameters": {
+    "accountName": "foundryAccount",
+    "api-version": "2026-08-31-preview",
+    "deployment": {
+      "properties": {
+        "budgetPolicyIds": [
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget"
+        ]
+      }
+    },
+    "deploymentName": "customer-support-model",
+    "resourceGroupName": "foundry-rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Attach a budget policy to a deployment",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "customer-support-model",
+        "type": "Microsoft.CognitiveServices/accounts/deployments",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/deployments/customer-support-model",
+        "properties": {
+          "budgetPolicyIds": [
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/foundry-rg/providers/Microsoft.CognitiveServices/accounts/foundryAccount/budgetPolicies/monthly-project-budget"
+          ],
+          "model": {
+            "format": "OpenAI",
+            "name": "gpt-4.1",
+            "version": "2025-04-14"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "capacity": 1,
+          "name": "GlobalStandard"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/eastus/operationResults/00000000-0000-0000-0000-000000000004?api-version=2026-08-31-preview"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateProjects.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateProjects.json
@@ -1,0 +1,65 @@
+{
+  "operationId": "Projects_Update",
+  "parameters": {
+    "accountName": "bingSearch",
+    "api-version": "2026-08-31-preview",
+    "project": {
+      "location": "global",
+      "properties": {
+        "description": "new description."
+      }
+    },
+    "projectName": "projectName",
+    "resourceGroupName": "bvttest",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Update Project",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "projectName",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A46%3A21.5618831Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch/projects/projectName",
+        "location": "global",
+        "properties": {
+          "description": "new description.",
+          "displayName": "myProject",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://customSubDomainName.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://customSubDomainName.openai.azure.com/"
+          },
+          "isDefault": false,
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/global/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-06-01",
+        "azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    },
+    "202": {
+      "body": {
+        "name": "projectName",
+        "type": "Microsoft.CognitiveServices/accounts/projects",
+        "etag": "W/\"datetime'2017-04-10T07%3A46%3A21.5618831Z'\"",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/bvttest/providers/Microsoft.CognitiveServices/accounts/bingSearch/projects/projectName",
+        "location": "global",
+        "properties": {
+          "description": "new description.",
+          "displayName": "myProject",
+          "endpoints": {
+            "OpenAI Dall-E API": "https://customSubDomainName.openai.azure.com/",
+            "OpenAI Language Model Instance API": "https://customSubDomainName.openai.azure.com/"
+          },
+          "isDefault": false,
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/locations/global/operationResults/00000000-0000-0000-0000-000000000000?api-version=2025-06-01",
+        "azure-AsyncOperation": "http://azure.async.operation/status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateQuotaTier.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateQuotaTier.json
@@ -1,0 +1,28 @@
+{
+  "operationId": "QuotaTiers_Update",
+  "parameters": {
+    "default": "default",
+    "api-version": "2026-08-31-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000",
+    "tier": {
+      "properties": {
+        "tierUpgradePolicy": "NoAutoUpgrade"
+      }
+    }
+  },
+  "title": "Update the quota tier resource for a subscription",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.CognitiveServices/quotaTiers",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.CognitiveServices/quotaTiers/default",
+        "properties": {
+          "assignmentDate": "2025-06-09T18:13:29.389Z",
+          "currentTierName": "Free-Tier",
+          "tierUpgradePolicy": "NoAutoUpgrade"
+        }
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateSharedCommitmentPlan.json
+++ b/specification/cognitiveservices/resource-manager/Microsoft.CognitiveServices/preview/2026-08-31-preview/examples/UpdateSharedCommitmentPlan.json
@@ -1,0 +1,46 @@
+{
+  "operationId": "CommitmentPlans_UpdatePlan",
+  "parameters": {
+    "api-version": "2026-08-31-preview",
+    "commitmentPlan": {
+      "tags": {
+        "name": "value"
+      }
+    },
+    "commitmentPlanName": "commitmentPlanName",
+    "resourceGroupName": "resourceGroupName",
+    "subscriptionId": "00000000-1111-2222-3333-444444444444"
+  },
+  "title": "Create Commitment Plan",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "commitmentPlanName",
+        "type": "Microsoft.CognitiveServices/commitmentPlans",
+        "id": "/subscriptions/00000000-1111-2222-3333-444444444444/resourceGroups/resourceGroupName/providers/Microsoft.CognitiveServices/commitmentPlans/commitmentPlanName",
+        "kind": "SpeechServices",
+        "location": "West US",
+        "properties": {
+          "autoRenew": true,
+          "current": {
+            "tier": "T1"
+          },
+          "hostingModel": "Web",
+          "planType": "STT",
+          "provisioningState": "Succeeded"
+        },
+        "sku": {
+          "name": "S0"
+        },
+        "tags": {
+          "name": "value"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "http://azure.async.operation/status"
+      }
+    }
+  }
+}

--- a/specification/cognitiveservices/resource-manager/readme.md
+++ b/specification/cognitiveservices/resource-manager/readme.md
@@ -30,7 +30,98 @@ These are the global settings for the CognitiveServices API.
 
 ```yaml
 openapi-type: arm
-tag: package-2026-07-01
+tag: package-2026-08-31-preview
+```
+
+### Tag: package-2026-08-31-preview
+
+These settings apply only when `--tag=package-2026-08-31-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-08-31-preview'
+input-file:
+  - Microsoft.CognitiveServices/preview/2026-08-31-preview/cognitiveservices.json
+suppressions:
+  - code: ArmResourcePropertiesBag
+    reason: This API is copied from Machine Learning Services RP where this behavior is already established.
+    where:
+      - $.definitions.OutboundRuleBasicResource
+  - code: AvoidAdditionalProperties
+    reason: This API is copied from Machine Learning Services RP where this behavior is already established.
+    where:
+      - $.definitions.ManagedNetworkSettings.properties.outboundRules
+  - code: ProvisioningStateSpecifiedForLROPut
+    reason: This API is copied from Machine Learning Services RP where this behavior is already established.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/outboundRules/{ruleName}"].put
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}"].put
+  - code: PutResponseCodes
+    reason: This API is copied from Machine Learning Services RP where it is already established and in use.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}/outboundRules/{ruleName}"].put
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/managedNetworks/{managedNetworkName}"].put
+  - code: PutResponseCodes
+    reason: This is existing behavior in all other APIs and already in stable version, will keep the same.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}"].put
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/connections/{connectionName}"].put
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/connections/{connectionName}"].put
+  - code: PatchResponseCodes
+    reason: This is existing behavior in all other APIs and already in stable version, will keep the same.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}"].patch
+  - code: PatchBodyParametersSchema
+    reason: this is a required field for in a optional property this experience exist in other stable schemas as well.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/connections/{connectionName}"].patch.parameters[5].schema.properties.properties
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}"].patch.parameters[3].schema.properties.properties
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}"].patch.parameters[3].schema.properties.sku
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}/connections/{connectionName}"].patch.parameters[6].schema.properties.properties
+  - code: GuidUsage
+    reason: Approved to be suppressed in AML swagger.
+    where:
+      - $.definitions.ConnectionOAuth2.properties.clientId.format
+  - code: DeleteResponseCodes
+    reason: Behavior is align with other existing API for this RP
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}"].delete
+  - code: AvoidAdditionalProperties
+    reason: Approved to be suppressed in AML swagger
+    where:
+      - $.definitions.ConnectionPropertiesV2.properties.metadata
+      - $.definitions.CustomKeys.properties.keys
+  - code: LroLocationHeader
+    reason: Align with existing API behavior in other APIs
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}"].put.responses.202
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}"].patch.responses.202
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/projects/{projectName}"].delete.responses.202
+  - code: AvoidAdditionalProperties
+    reason: Same as existing account resource, trying to have the same behavior
+    where:
+      - $.definitions.ProjectProperties.properties.endpoints
+  - code: AvoidAdditionalProperties
+    reason: Provide customers ability to assign customize labels to rules.
+    where:
+      - $.definitions.RaiToolLabelProperties.properties.accountScope.properties.labelValues
+      - $.definitions.RaiToolLabelProperties.properties.projectScopes.items.properties.labelValues
+      - $.definitions.RaiIfcRuleProperties.properties.conditions
+  - code: AvoidAdditionalProperties
+    reason: Provide customers ability to define custom conditions for when a rule is activated.
+    where:
+      - $.definitions.RaiIfcRuleProperties.properties.conditions
+  - code: TopLevelResourcesListByResourceGroup
+    reason: These are subscription level resources and are modeled after the RaiPolicy List operation
+    where:
+      - $.definitions.RaiExternalSafetyProvider
+      - $.definitions.RaiExternalSafetyProviderSchema
+  - code: ResourceNameRestriction
+    reason: Parameter exists in previous API versions without pattern, cannot add now without breaking change.
+    from: cognitiveservices.json
+  - code: ParametersSchemaAsTypeObject
+    reason: Backend requires array type for bulk operations since 2024-04-01 API. Changing to object would be a breaking change.
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/addRaiBlocklistItems"].post.parameters[5].schema.type
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CognitiveServices/accounts/{accountName}/raiBlocklists/{raiBlocklistName}/deleteRaiBlocklistItems"].post.parameters[5].schema.type
 ```
 
 ### Tag: package-2026-07-01


### PR DESCRIPTION
## Summary

Add the `2026-08-31-preview` Cognitive Services Management API version and the Budget Policies control-plane contract.

Budget policies let an account define reusable budget rules and attach those policies directly to the owning account or its deployments. The specification follows the final implementation and integration tests rather than stale features mentioned in earlier PR descriptions.

## Service implementation PRs

- [CRUD APIs for budget policies](https://msazure.visualstudio.com/Cognitive%20Services/_git/Platform-ResourceProvider/pullrequest/16781932) implements and tests the account-child CRUD/list endpoints, account and deployment attachments, validation limits, ETag concurrency, feature gating, and delete-in-use behavior. Its final revision explicitly removes the effective-policy projection from this change.
- [Add Budget Policies ARM contracts](https://msazure.visualstudio.com/Cognitive%20Services/_git/Platform-ResourceProvider/pullrequest/16756995) defines the resource and rule models, attachment properties, serialized names, initial preview constraints, and API-version gating that the implementation PR consumes.

## API changes

- Add preview API version `2026-08-31-preview`.
- Add account-child resource `Microsoft.CognitiveServices/accounts/budgetPolicies`.
- Add synchronous operations:
  - `BudgetPolicies_Get`
  - `BudgetPolicies_CreateOrUpdate`
  - `BudgetPolicies_Update`
  - `BudgetPolicies_Delete`
  - `BudgetPolicies_List`
- Add budget policy, patch, rule, counter dimension, match, threshold, unit, period, and list-result models.
- Add `budgetPolicyIds` to account and deployment properties, with up to 20 full Budget Policy resource IDs.
- Model ETag response headers and conditional `If-Match`/`If-None-Match` request headers.
- Carry the complete `2026-07-01` API surface into the new preview without exclusions.
- Add 166 source examples and generated examples: 159 carried-forward examples with the new API version, five Budget Policy operation examples, and two attachment examples.
- Add generated Swagger under `preview/2026-08-31-preview` and register the new AutoRest package tag.

## Contract decisions

- Budget policies are proxy resources nested under accounts; they have no tags, location, SKU, identity, or provisioning state.
- PUT fully replaces policy properties. PATCH distinguishes omitted `displayName` from explicit `null`, allowing callers to clear it.
- Policy and rule names use the service identifier pattern and 64-character limit.
- The initial preview supports exactly one built-in counter dimension per rule.
- `usd` is the only budget unit in this preview.
- Recurring rules default `recurring` to `true` and require a calendar-aligned period; the service validates the recurring/period relationship.
- Threshold action defaults to `audit`; `audit` and `alert` are supported, while `block` is excluded because the implementation rejects it.
- Attachments are supported only on accounts and deployments in this change.
- Project attachments, `tokens`, and the effective-policy projection are intentionally excluded because they are not present in the final implementation and tests.
- Operations are synchronous and are not pageable beyond the standard optional `nextLink` list shape.

## Validation

- `npm ci`: passed.
- `npx tsp compile .`: passed with no diagnostics.
- `npx tsp compile client.tsp`: passed with no diagnostics.
- Example verification: passed; 159 carried examples match `2026-07-01` after API-version substitution, all 166 JSON files parse, and generated examples match source examples.
- `git diff --check`: passed.
- Emitted Swagger review: passed against both implementation PRs. Verified API-version isolation, methods, paths, operation IDs, path/body/header parameters, requiredness, defaults, constraints, response codes, ETag headers, conditional headers, attachment ARM ID typing, and absence of the removed effective-policy contract.

## Unresolved questions or known failures

None.
