### PR TITLE
Preserve C# Authorization principal type compatibility

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/client.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/client.tsp
@@ -90,7 +90,7 @@ union RoleManagementScopeType {
 @@alternateType(
   Microsoft.RoleAssignment.RoleAssignmentProperties.principalType,
   Microsoft.Common.PrincipalType,
-  "java,python"
+  "csharp,java,python"
 );
 
 // Restore C# GA resource, model, and extensible-enum names.


### PR DESCRIPTION
Extends the existing Role Assignment principal-type compatibility mapping to C#. This preserves the released `RoleManagementPrincipalType` SDK surface while the REST contract uses the newer RoleAssignment-scoped union.

Validated by regenerating and building Azure/azure-sdk-for-net#62087.