### PR TITLE
Add JoshLove-msft as .NET package name approver

### DIFF
--- a/.github/protected-labels.yml
+++ b/.github/protected-labels.yml
@@ -21,12 +21,12 @@ global-approvers:
 package-name-dotnet-approved:
   management-plane:
     - ArthurMa1978
-    - JoshLove-msft
     - m-nash
-  data-plane:
     - JoshLove-msft
+  data-plane:
     - jsquire
     - m-nash
+    - JoshLove-msft
 package-name-java-approved:
   management-plane:
     - ArthurMa1978

--- a/.github/protected-labels.yml
+++ b/.github/protected-labels.yml
@@ -21,8 +21,10 @@ global-approvers:
 package-name-dotnet-approved:
   management-plane:
     - ArthurMa1978
+    - JoshLove-msft
     - m-nash
   data-plane:
+    - JoshLove-msft
     - jsquire
     - m-nash
 package-name-java-approved:


### PR DESCRIPTION
Adds JoshLove-msft as an authorized approver for the package-name-dotnet-approved protected label for both management-plane and data-plane packages.