### PR TITLE
Remove preview decorator on AzureFunctionToolCall

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -28590,12 +28590,7 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ],
-        "description": "An Azure Function tool call.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "preview_tool"
-          ]
-        }
+        "description": "An Azure Function tool call."
       },
       "AzureFunctionToolCallOutput": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -39522,9 +39522,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: An Azure Function tool call.
-      x-ms-foundry-meta:
-        required_previews:
-          - preview_tool
     AzureFunctionToolCallOutput:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -31854,12 +31854,7 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ],
-        "description": "An Azure Function tool call.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "preview_tool"
-          ]
-        }
+        "description": "An Azure Function tool call."
       },
       "AzureFunctionToolCallOutput": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -41716,9 +41716,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
       description: An Azure Function tool call.
-      x-ms-foundry-meta:
-        required_previews:
-          - preview_tool
     AzureFunctionToolCallOutput:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/tools/models.tsp
@@ -1233,7 +1233,6 @@ namespace Azure.AI.Projects {
   // ==============================================================================
 
   @doc("An Azure Function tool call.")
-  @extension("x-ms-foundry-meta", PreviewTool)
   model AzureFunctionToolCall extends OpenAI.OutputItem {
     type: "azure_function_call";
 


### PR DESCRIPTION
Removes the preview decorator on the `AzureFunctionToolCall` model. `AzureFunctionTool` has been GA'd. This decorator was previously erroneously added.