### PR TITLE
Fix DataFlowDebugSession_AddDataFlow example: remove extra "properties" wrapper

### DIFF
--- a/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/examples/2018-06-01/DataFlowDebugSession_AddDataFlow.json
+++ b/specification/datafactory/resource-manager/Microsoft.DataFactory/DataFactory/examples/2018-06-01/DataFlowDebugSession_AddDataFlow.json
@@ -5,94 +5,92 @@
     "resourceGroupName": "exampleResourceGroup",
     "subscriptionId": "12345678-1234-1234-1234-123456789012",
     "request": {
-      "properties": {
-        "dataFlow": {
-          "name": "dataflow1",
+      "dataFlow": {
+        "name": "dataflow1",
+        "properties": {
+          "type": "MappingDataFlow",
+          "typeProperties": {
+            "script": "\n\nsource(output(\n\t\tColumn_1 as string\n\t),\n\tallowSchemaDrift: true,\n\tvalidateSchema: false) ~> source1",
+            "sinks": [],
+            "sources": [
+              {
+                "name": "source1",
+                "dataset": {
+                  "type": "DatasetReference",
+                  "referenceName": "DelimitedText2"
+                }
+              }
+            ],
+            "transformations": []
+          }
+        }
+      },
+      "datasets": [
+        {
+          "name": "dataset1",
           "properties": {
-            "type": "MappingDataFlow",
+            "type": "DelimitedText",
+            "schema": [
+              {
+                "type": "String"
+              }
+            ],
+            "annotations": [],
+            "linkedServiceName": {
+              "type": "LinkedServiceReference",
+              "referenceName": "linkedService5"
+            },
             "typeProperties": {
-              "script": "\n\nsource(output(\n\t\tColumn_1 as string\n\t),\n\tallowSchemaDrift: true,\n\tvalidateSchema: false) ~> source1",
-              "sinks": [],
-              "sources": [
-                {
-                  "name": "source1",
-                  "dataset": {
-                    "type": "DatasetReference",
-                    "referenceName": "DelimitedText2"
-                  }
-                }
-              ],
-              "transformations": []
-            }
-          }
-        },
-        "datasets": [
-          {
-            "name": "dataset1",
-            "properties": {
-              "type": "DelimitedText",
-              "schema": [
-                {
-                  "type": "String"
-                }
-              ],
-              "annotations": [],
-              "linkedServiceName": {
-                "type": "LinkedServiceReference",
-                "referenceName": "linkedService5"
+              "columnDelimiter": ",",
+              "escapeChar": "\\",
+              "firstRowAsHeader": true,
+              "location": {
+                "type": "AzureBlobStorageLocation",
+                "container": "dataflow-sample-data",
+                "fileName": "Ansiencoding.csv"
               },
-              "typeProperties": {
-                "columnDelimiter": ",",
-                "escapeChar": "\\",
-                "firstRowAsHeader": true,
-                "location": {
-                  "type": "AzureBlobStorageLocation",
-                  "container": "dataflow-sample-data",
-                  "fileName": "Ansiencoding.csv"
-                },
-                "quoteChar": "\""
-              }
+              "quoteChar": "\""
             }
           }
-        ],
-        "debugSettings": {
-          "datasetParameters": {
-            "Movies": {
-              "path": "abc"
-            },
-            "Output": {
-              "time": "def"
-            }
+        }
+      ],
+      "debugSettings": {
+        "datasetParameters": {
+          "Movies": {
+            "path": "abc"
           },
-          "parameters": {
-            "sourcePath": "Toy"
-          },
-          "sourceSettings": [
-            {
-              "rowLimit": 1000,
-              "sourceName": "source1"
-            },
-            {
-              "rowLimit": 222,
-              "sourceName": "source2"
-            }
-          ]
+          "Output": {
+            "time": "def"
+          }
         },
-        "linkedServices": [
+        "parameters": {
+          "sourcePath": "Toy"
+        },
+        "sourceSettings": [
           {
-            "name": "linkedService1",
-            "properties": {
-              "type": "AzureBlobStorage",
-              "annotations": [],
-              "typeProperties": {
-                "connectionString": "DefaultEndpointsProtocol=https;AccountName=<storageName>;EndpointSuffix=core.windows.net;",
-                "encryptedCredential": "<credential>"
-              }
+            "rowLimit": 1000,
+            "sourceName": "source1"
+          },
+          {
+            "rowLimit": 222,
+            "sourceName": "source2"
+          }
+        ]
+      },
+      "linkedServices": [
+        {
+          "name": "linkedService1",
+          "properties": {
+            "type": "AzureBlobStorage",
+            "annotations": [],
+            "typeProperties": {
+              "connectionString": "DefaultEndpointsProtocol=https;AccountName=<storageName>;EndpointSuffix=core.windows.net;",
+              "encryptedCredential": "<credential>"
             }
           }
-        ],
-        "sessionId": "f06ed247-9d07-49b2-b05e-2cb4a2fc871e"
-      }
+        }
+      ],
+      "sessionId": "f06ed247-9d07-49b2-b05e-2cb4a2fc871e"
     }
   },
   "responses": {


### PR DESCRIPTION
The example for `DataFlowDebugSession_AddDataFlow` wraps the request body in an extra `properties` object, but the `DataFlowDebugPackage` schema declares its fields at the root.

**Schema** (`stable/2018-06-01/openapi.json`, `DataFlowDebugPackage`) declares exactly:
`sessionId`, `dataFlow`, `dataFlows`, `datasets`, `linkedServices`, `staging`, `debugSettings`.
There is no `properties` member and no `x-ms-client-flatten`.

**Example** (before this change) nests `dataFlow`, `datasets`, `debugSettings`, `linkedServices` and `sessionId` inside `request.properties`.

**Effect.** Sending the body as shown in the example makes the service reply:

```
Invalid value provided for Parameter 'sessionId'
```

Because the schema sets `additionalProperties: {}`, the unexpected `properties` object is accepted without a validation error — the service simply never finds `sessionId` at the root. The failure is therefore silent and misleading, which makes the example hard to debug.

**Change.** Lift the five fields from `request.properties` to `request`. Only the example file is touched; the swagger is unchanged, and the request now matches the schema it documents. The inner `properties` of `dataFlow` is preserved, since that one does belong to `DataFlowDebugResource`.
