### PR TITLE
Localize Network Security Perimeter and fix version types in 2026-09-01-preview

### DIFF
--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/NetworkSecurityPerimeter.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/NetworkSecurityPerimeter.tsp
@@ -3,9 +3,11 @@ import "@typespec/http";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/openapi";
 
 using TypeSpec.Versioning;
 using Azure.ResourceManager;
+using TypeSpec.OpenAPI;
 
 namespace Microsoft.AppConfiguration;
 
@@ -35,6 +37,8 @@ union AccessRuleDirection {
  * Provisioning state of a network security perimeter configuration that is being created or updated.
  */
 @added(Versions.v2026_09_01_preview)
+// readOnly must live on the definition (not the $ref sibling) to satisfy ProvisioningStateMustBeReadOnly for this newly-introduced enum.
+@extension("readOnly", true)
 union NetworkSecurityPerimeterConfigurationProvisioningState {
   string,
 

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/NetworkSecurityPerimeter.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/NetworkSecurityPerimeter.tsp
@@ -1,0 +1,374 @@
+import "@typespec/rest";
+import "@typespec/http";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Versioning;
+using Azure.ResourceManager;
+
+namespace Microsoft.AppConfiguration;
+
+// Local Network Security Perimeter types, introduced in 2026-09-01-preview.
+// Earlier versions continue to use the ARM common-types v5 NSP shape via
+// @typeChangedFrom on NetworkSecurityPerimeterConfiguration.properties.
+
+/**
+ * Direction of Access Rule
+ */
+@added(Versions.v2026_09_01_preview)
+union AccessRuleDirection {
+  string,
+
+  /**
+   * Applies to inbound network traffic to the secured resources.
+   */
+  Inbound: "Inbound",
+
+  /**
+   * Applies to outbound network traffic from the secured resources
+   */
+  Outbound: "Outbound",
+}
+
+/**
+ * Provisioning state of a network security perimeter configuration that is being created or updated.
+ */
+@added(Versions.v2026_09_01_preview)
+union NetworkSecurityPerimeterConfigurationProvisioningState {
+  string,
+
+  /**
+   * The configuration was provisioned successfully.
+   */
+  Succeeded: "Succeeded",
+
+  /**
+   * The configuration is being created.
+   */
+  Creating: "Creating",
+
+  /**
+   * The configuration is being updated.
+   */
+  Updating: "Updating",
+
+  /**
+   * The configuration is being deleted.
+   */
+  Deleting: "Deleting",
+
+  /**
+   * The configuration request was accepted and provisioning has not started yet.
+   */
+  Accepted: "Accepted",
+
+  /**
+   * The configuration failed to provision.
+   */
+  Failed: "Failed",
+
+  /**
+   * The configuration provisioning was canceled.
+   */
+  Canceled: "Canceled",
+}
+
+/**
+ * Type of issue
+ */
+@added(Versions.v2026_09_01_preview)
+union IssueType {
+  string,
+
+  /**
+   * Unknown issue type
+   */
+  Unknown: "Unknown",
+
+  /**
+   * An error occurred while applying the network security perimeter (NSP) configuration.
+   */
+  ConfigurationPropagationFailure: "ConfigurationPropagationFailure",
+
+  /**
+   * A network connectivity issue is happening on the resource which could be addressed either by adding new resources to the network security perimeter (NSP) or by modifying access rules.
+   */
+  MissingPerimeterConfiguration: "MissingPerimeterConfiguration",
+
+  /**
+   * An managed identity hasn't been associated with the resource. The resource will still be able to validate inbound traffic from the network security perimeter (NSP) or matching inbound access rules, but it won't be able to perform outbound access as a member of the NSP.
+   */
+  MissingIdentityConfiguration: "MissingIdentityConfiguration",
+}
+
+/**
+ * Severity of the issue.
+ */
+@added(Versions.v2026_09_01_preview)
+union Severity {
+  string,
+
+  /**
+   * The issue is a warning and does not prevent the configuration from being applied.
+   */
+  Warning: "Warning",
+
+  /**
+   * The issue is an error and prevents the configuration from being applied.
+   */
+  Error: "Error",
+}
+
+/**
+ * Access mode of the resource association
+ */
+@added(Versions.v2026_09_01_preview)
+union ResourceAssociationAccessMode {
+  string,
+
+  /**
+   * Enforced access mode - traffic to the resource that failed access checks is blocked
+   */
+  Enforced: "Enforced",
+
+  /**
+   * Learning access mode - traffic to the resource is enabled for analysis but not blocked
+   */
+  Learning: "Learning",
+
+  /**
+   * Audit access mode - traffic to the resource that fails access checks is logged but not blocked
+   */
+  Audit: "Audit",
+}
+
+/**
+ * Access rule in a network security perimeter configuration profile
+ */
+@added(Versions.v2026_09_01_preview)
+model AccessRule {
+  /**
+   * Name of the access rule
+   */
+  name?: string;
+
+  /**
+   * Properties of the access rule
+   */
+  properties?: AccessRuleProperties;
+}
+
+/**
+ * Properties of Access Rule
+ */
+@added(Versions.v2026_09_01_preview)
+model AccessRuleProperties {
+  /**
+   * Direction of the access rule
+   */
+  direction?: AccessRuleDirection;
+
+  /**
+   * Address prefixes in the CIDR format for inbound rules
+   */
+  addressPrefixes?: string[];
+
+  /**
+   * Subscriptions for inbound rules
+   */
+  subscriptions?: {
+    /**
+     * The fully qualified Azure resource ID of the subscription e.g. ('/subscriptions/00000000-0000-0000-0000-000000000000')
+     */
+    id?: Azure.Core.armResourceIdentifier;
+  }[];
+
+  /**
+   * Network security perimeters for inbound rules
+   */
+  networkSecurityPerimeters?: NetworkSecurityPerimeter[];
+
+  /**
+   * Fully qualified domain names (FQDN) for outbound rules
+   */
+  fullyQualifiedDomainNames?: string[];
+
+  /**
+   * Email addresses for outbound rules
+   */
+  emailAddresses?: string[];
+
+  /**
+   * Phone numbers for outbound rules
+   */
+  phoneNumbers?: string[];
+
+  /**
+   * Inbound rules of type service tag. This access rule type is currently unavailable for use.
+   */
+  serviceTags?: string[];
+}
+
+/**
+ * Information about a network security perimeter (NSP)
+ */
+@added(Versions.v2026_09_01_preview)
+model NetworkSecurityPerimeter {
+  /**
+   * Fully qualified Azure resource ID of the NSP resource
+   */
+  id?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Network/networkSecurityPerimeters";
+    }
+  ]>;
+
+  /**
+   * Universal unique ID (UUID) of the network security perimeter
+   */
+  perimeterGuid?: string;
+
+  /**
+   * Location of the network security perimeter
+   */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  location?: string;
+}
+
+/**
+ * Describes a provisioning issue for a network security perimeter configuration
+ */
+@added(Versions.v2026_09_01_preview)
+model ProvisioningIssue {
+  /**
+   * Name of the issue
+   */
+  @visibility(Lifecycle.Read)
+  name?: string;
+
+  /**
+   * Details of the provisioning issue
+   */
+  @visibility(Lifecycle.Read)
+  properties?: ProvisioningIssueProperties;
+}
+
+/**
+ * Details of a provisioning issue for a network security perimeter (NSP) configuration. Resource providers should generate separate provisioning issue elements for each separate issue detected, and include a meaningful and distinctive description, as well as any appropriate suggestedResourceIds and suggestedAccessRules
+ */
+@added(Versions.v2026_09_01_preview)
+model ProvisioningIssueProperties {
+  /**
+   * Type of issue
+   */
+  @visibility(Lifecycle.Read)
+  issueType?: IssueType;
+
+  /**
+   * Severity of the issue.
+   */
+  @visibility(Lifecycle.Read)
+  severity?: Severity;
+
+  /**
+   * Description of the issue
+   */
+  @visibility(Lifecycle.Read)
+  description?: string;
+
+  /**
+   * Fully qualified resource IDs of suggested resources that can be associated to the network security perimeter (NSP) to remediate the issue.
+   */
+  @visibility(Lifecycle.Read)
+  suggestedResourceIds?: Azure.Core.armResourceIdentifier[];
+
+  /**
+   * Access rules that can be added to the network security profile (NSP) to remediate the issue.
+   */
+  @visibility(Lifecycle.Read)
+  @identifiers(#[])
+  suggestedAccessRules?: AccessRule[];
+}
+
+/**
+ * Information about resource association
+ */
+@added(Versions.v2026_09_01_preview)
+model ResourceAssociation {
+  /**
+   * Name of the resource association
+   */
+  name?: string;
+
+  /**
+   * Access mode of the resource association
+   */
+  accessMode?: ResourceAssociationAccessMode;
+}
+
+/**
+ * Network security perimeter configuration profile
+ */
+@added(Versions.v2026_09_01_preview)
+model NetworkSecurityProfile {
+  /**
+   * Name of the profile
+   */
+  name?: string;
+
+  /**
+   * Current access rules version
+   */
+  accessRulesVersion?: string;
+
+  /**
+   * List of Access Rules
+   */
+  @identifiers(#["name"])
+  accessRules?: AccessRule[];
+
+  /**
+   * Current diagnostic settings version
+   */
+  diagnosticSettingsVersion?: string;
+
+  /**
+   * List of log categories that are enabled
+   */
+  enabledLogCategories?: string[];
+}
+
+/**
+ * Network security configuration properties.
+ */
+@added(Versions.v2026_09_01_preview)
+model NetworkSecurityPerimeterConfigurationProperties {
+  /**
+   * Provisioning state of the network security perimeter configuration
+   */
+  @visibility(Lifecycle.Read)
+  provisioningState?: NetworkSecurityPerimeterConfigurationProvisioningState;
+
+  /**
+   * List of provisioning issues, if any
+   */
+  @visibility(Lifecycle.Read)
+  @identifiers(#[])
+  provisioningIssues?: ProvisioningIssue[];
+
+  /**
+   * Information about the network security perimeter (NSP)
+   */
+  networkSecurityPerimeter?: NetworkSecurityPerimeter;
+
+  /**
+   * Information about the resource association
+   */
+  resourceAssociation?: ResourceAssociation;
+
+  /**
+   * Network security perimeter configuration profile
+   */
+  profile?: NetworkSecurityProfile;
+}

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/NetworkSecurityPerimeter.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/NetworkSecurityPerimeter.tsp
@@ -3,11 +3,9 @@ import "@typespec/http";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
-import "@typespec/openapi";
 
 using TypeSpec.Versioning;
 using Azure.ResourceManager;
-using TypeSpec.OpenAPI;
 
 namespace Microsoft.AppConfiguration;
 
@@ -37,8 +35,6 @@ union AccessRuleDirection {
  * Provisioning state of a network security perimeter configuration that is being created or updated.
  */
 @added(Versions.v2026_09_01_preview)
-// readOnly must live on the definition (not the $ref sibling) to satisfy ProvisioningStateMustBeReadOnly for this newly-introduced enum.
-@extension("readOnly", true)
 union NetworkSecurityPerimeterConfigurationProvisioningState {
   string,
 

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/NetworkSecurityPerimeterConfigurations.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/NetworkSecurityPerimeterConfigurations.tsp
@@ -14,7 +14,7 @@ namespace Microsoft.AppConfiguration;
 @parentResource(ConfigurationStore)
 @added(Versions.v2025_08_01_preview)
 model NetworkSecurityPerimeterConfiguration
-  is CommonTypes.NetworkSecurityPerimeterConfiguration {
+  is Azure.ResourceManager.ProxyResource<NetworkSecurityPerimeterConfigurationProperties> {
   ...ResourceNameParameter<
     Resource = NetworkSecurityPerimeterConfiguration,
     KeyName = "networkSecurityPerimeterConfigurationName",
@@ -22,6 +22,12 @@ model NetworkSecurityPerimeterConfiguration
     NamePattern = ""
   >;
 }
+
+// Before 2026-09-01-preview the NSP configuration used the ARM common-types v5 shape.
+@@typeChangedFrom(NetworkSecurityPerimeterConfiguration.properties,
+  Versions.v2026_09_01_preview,
+  Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationProperties
+);
 
 @armResourceOperations
 @added(Versions.v2025_08_01_preview)

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/NetworkSecurityPerimeterConfigurations.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/NetworkSecurityPerimeterConfigurations.tsp
@@ -24,7 +24,8 @@ model NetworkSecurityPerimeterConfiguration
 }
 
 // Before 2026-09-01-preview the NSP configuration used the ARM common-types v5 shape.
-@@typeChangedFrom(NetworkSecurityPerimeterConfiguration.properties,
+@@typeChangedFrom(
+  NetworkSecurityPerimeterConfiguration.properties,
   Versions.v2026_09_01_preview,
   Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationProperties
 );

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/examples/2026-09-01-preview/ConfigurationStoresGetNetworkSecurityPerimeterConfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/examples/2026-09-01-preview/ConfigurationStoresGetNetworkSecurityPerimeterConfiguration.json
@@ -37,7 +37,7 @@
           },
           "profile": {
             "name": "myProfileName",
-            "accessRulesVersion": 1,
+            "accessRulesVersion": "1",
             "accessRules": [
               {
                 "name": "accessRule1",
@@ -50,7 +50,7 @@
                 }
               }
             ],
-            "diagnosticSettingsVersion": 1,
+            "diagnosticSettingsVersion": "1",
             "enabledLogCategories": [
               "logCategory1",
               "logCategory2"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/examples/2026-09-01-preview/ConfigurationStoresListNetworkSecurityPerimeterConfigurations.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/examples/2026-09-01-preview/ConfigurationStoresListNetworkSecurityPerimeterConfigurations.json
@@ -38,7 +38,7 @@
               },
               "profile": {
                 "name": "myProfileName",
-                "accessRulesVersion": 1,
+                "accessRulesVersion": "1",
                 "accessRules": [
                   {
                     "name": "accessRule1",
@@ -51,7 +51,7 @@
                     }
                   }
                 ],
-                "diagnosticSettingsVersion": 1,
+                "diagnosticSettingsVersion": "1",
                 "enabledLogCategories": [
                   "logCategory1",
                   "logCategory2"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/examples/2026-09-01-preview/ConfigurationStoresReconcileNetworkSecurityPerimeterConfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/examples/2026-09-01-preview/ConfigurationStoresReconcileNetworkSecurityPerimeterConfiguration.json
@@ -37,7 +37,7 @@
           },
           "profile": {
             "name": "myProfileName",
-            "accessRulesVersion": 1,
+            "accessRulesVersion": "1",
             "accessRules": [
               {
                 "name": "accessRule1",
@@ -50,7 +50,7 @@
                 }
               }
             ],
-            "diagnosticSettingsVersion": 1,
+            "diagnosticSettingsVersion": "1",
             "enabledLogCategories": [
               "logCategory1",
               "logCategory2"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/main.tsp
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/main.tsp
@@ -16,6 +16,7 @@ import "./back-compatible.tsp";
 import "./ConfigurationStore.tsp";
 import "./DeletedConfigurationStore.tsp";
 import "./PrivateEndpointConnection.tsp";
+import "./NetworkSecurityPerimeter.tsp";
 import "./NetworkSecurityPerimeterConfigurations.tsp";
 import "./PrivateLinkResource.tsp";
 import "./KeyValue.tsp";

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2025-08-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2025-08-01-preview/appconfiguration.json
@@ -1088,7 +1088,7 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/networksecurityperimeter.json#/definitions/NetworkSecurityPerimeterConfiguration"
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
             }
           },
           "default": {
@@ -1144,7 +1144,7 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/networksecurityperimeter.json#/definitions/NetworkSecurityPerimeterConfiguration"
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
             }
           },
           "202": {
@@ -2775,6 +2775,21 @@
         }
       }
     },
+    "NetworkSecurityPerimeterConfiguration": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "../../../../../../common-types/resource-management/v5/networksecurityperimeter.json#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
     "NetworkSecurityPerimeterConfigurationListResult": {
       "type": "object",
       "description": "The response of a NetworkSecurityPerimeterConfiguration list operation.",
@@ -2783,7 +2798,7 @@
           "type": "array",
           "description": "The NetworkSecurityPerimeterConfiguration items on this page",
           "items": {
-            "$ref": "../../../../../../common-types/resource-management/v5/networksecurityperimeter.json#/definitions/NetworkSecurityPerimeterConfiguration"
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
           }
         },
         "nextLink": {

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
@@ -3796,8 +3796,7 @@
             "description": "The configuration provisioning was canceled."
           }
         ]
-      },
-      "readOnly": true
+      }
     },
     "NetworkSecurityProfile": {
       "type": "object",

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
@@ -3796,7 +3796,8 @@
             "description": "The configuration provisioning was canceled."
           }
         ]
-      }
+      },
+      "readOnly": true
     },
     "NetworkSecurityProfile": {
       "type": "object",

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/appconfiguration.json
@@ -1325,7 +1325,7 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/networksecurityperimeter.json#/definitions/NetworkSecurityPerimeterConfiguration"
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
             }
           },
           "default": {
@@ -1381,7 +1381,7 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/networksecurityperimeter.json#/definitions/NetworkSecurityPerimeterConfiguration"
+              "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
             }
           },
           "202": {
@@ -2271,6 +2271,110 @@
     }
   },
   "definitions": {
+    "AccessRule": {
+      "type": "object",
+      "description": "Access rule in a network security perimeter configuration profile",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the access rule"
+        },
+        "properties": {
+          "$ref": "#/definitions/AccessRuleProperties",
+          "description": "Properties of the access rule"
+        }
+      }
+    },
+    "AccessRuleDirection": {
+      "type": "string",
+      "description": "Direction of Access Rule",
+      "enum": [
+        "Inbound",
+        "Outbound"
+      ],
+      "x-ms-enum": {
+        "name": "AccessRuleDirection",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Inbound",
+            "value": "Inbound",
+            "description": "Applies to inbound network traffic to the secured resources."
+          },
+          {
+            "name": "Outbound",
+            "value": "Outbound",
+            "description": "Applies to outbound network traffic from the secured resources"
+          }
+        ]
+      }
+    },
+    "AccessRuleProperties": {
+      "type": "object",
+      "description": "Properties of Access Rule",
+      "properties": {
+        "direction": {
+          "$ref": "#/definitions/AccessRuleDirection",
+          "description": "Direction of the access rule"
+        },
+        "addressPrefixes": {
+          "type": "array",
+          "description": "Address prefixes in the CIDR format for inbound rules",
+          "items": {
+            "type": "string"
+          }
+        },
+        "subscriptions": {
+          "type": "array",
+          "description": "Subscriptions for inbound rules",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "arm-id",
+                "description": "The fully qualified Azure resource ID of the subscription e.g. ('/subscriptions/00000000-0000-0000-0000-000000000000')"
+              }
+            }
+          }
+        },
+        "networkSecurityPerimeters": {
+          "type": "array",
+          "description": "Network security perimeters for inbound rules",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityPerimeter"
+          }
+        },
+        "fullyQualifiedDomainNames": {
+          "type": "array",
+          "description": "Fully qualified domain names (FQDN) for outbound rules",
+          "items": {
+            "type": "string"
+          }
+        },
+        "emailAddresses": {
+          "type": "array",
+          "description": "Email addresses for outbound rules",
+          "items": {
+            "type": "string"
+          }
+        },
+        "phoneNumbers": {
+          "type": "array",
+          "description": "Phone numbers for outbound rules",
+          "items": {
+            "type": "string"
+          }
+        },
+        "serviceTags": {
+          "type": "array",
+          "description": "Inbound rules of type service tag. This access rule type is currently unavailable for use.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "ActionsRequired": {
       "type": "string",
       "description": "Any action that is required beyond basic workflow (approve/ reject/ disconnect)",
@@ -3307,6 +3411,42 @@
         ]
       }
     },
+    "IssueType": {
+      "type": "string",
+      "description": "Type of issue",
+      "enum": [
+        "Unknown",
+        "ConfigurationPropagationFailure",
+        "MissingPerimeterConfiguration",
+        "MissingIdentityConfiguration"
+      ],
+      "x-ms-enum": {
+        "name": "IssueType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown issue type"
+          },
+          {
+            "name": "ConfigurationPropagationFailure",
+            "value": "ConfigurationPropagationFailure",
+            "description": "An error occurred while applying the network security perimeter (NSP) configuration."
+          },
+          {
+            "name": "MissingPerimeterConfiguration",
+            "value": "MissingPerimeterConfiguration",
+            "description": "A network connectivity issue is happening on the resource which could be addressed either by adding new resources to the network security perimeter (NSP) or by modifying access rules."
+          },
+          {
+            "name": "MissingIdentityConfiguration",
+            "value": "MissingIdentityConfiguration",
+            "description": "An managed identity hasn't been associated with the resource. The resource will still be able to validate inbound traffic from the network security perimeter (NSP) or matching inbound access rules, but it won't be able to perform outbound access as a member of the NSP."
+          }
+        ]
+      }
+    },
     "KeyValue": {
       "type": "object",
       "description": "The key-value resource along with all resource properties.",
@@ -3506,6 +3646,51 @@
         }
       }
     },
+    "NetworkSecurityPerimeter": {
+      "type": "object",
+      "description": "Information about a network security perimeter (NSP)",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Fully qualified Azure resource ID of the NSP resource",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/networkSecurityPerimeters"
+              }
+            ]
+          }
+        },
+        "perimeterGuid": {
+          "type": "string",
+          "description": "Universal unique ID (UUID) of the network security perimeter"
+        },
+        "location": {
+          "type": "string",
+          "description": "Location of the network security perimeter",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfiguration": {
+      "type": "object",
+      "description": "Concrete proxy resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
     "NetworkSecurityPerimeterConfigurationListResult": {
       "type": "object",
       "description": "The response of a NetworkSecurityPerimeterConfiguration list operation.",
@@ -3514,7 +3699,7 @@
           "type": "array",
           "description": "The NetworkSecurityPerimeterConfiguration items on this page",
           "items": {
-            "$ref": "../../../../../../common-types/resource-management/v5/networksecurityperimeter.json#/definitions/NetworkSecurityPerimeterConfiguration"
+            "$ref": "#/definitions/NetworkSecurityPerimeterConfiguration"
           }
         },
         "nextLink": {
@@ -3526,6 +3711,127 @@
       "required": [
         "value"
       ]
+    },
+    "NetworkSecurityPerimeterConfigurationProperties": {
+      "type": "object",
+      "description": "Network security configuration properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProvisioningState",
+          "description": "Provisioning state of the network security perimeter configuration",
+          "readOnly": true
+        },
+        "provisioningIssues": {
+          "type": "array",
+          "description": "List of provisioning issues, if any",
+          "items": {
+            "$ref": "#/definitions/ProvisioningIssue"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        },
+        "networkSecurityPerimeter": {
+          "$ref": "#/definitions/NetworkSecurityPerimeter",
+          "description": "Information about the network security perimeter (NSP)"
+        },
+        "resourceAssociation": {
+          "$ref": "#/definitions/ResourceAssociation",
+          "description": "Information about the resource association"
+        },
+        "profile": {
+          "$ref": "#/definitions/NetworkSecurityProfile",
+          "description": "Network security perimeter configuration profile"
+        }
+      }
+    },
+    "NetworkSecurityPerimeterConfigurationProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of a network security perimeter configuration that is being created or updated.",
+      "enum": [
+        "Succeeded",
+        "Creating",
+        "Updating",
+        "Deleting",
+        "Accepted",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "NetworkSecurityPerimeterConfigurationProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "The configuration was provisioned successfully."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "The configuration is being created."
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The configuration is being updated."
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The configuration is being deleted."
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The configuration request was accepted and provisioning has not started yet."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "The configuration failed to provision."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "The configuration provisioning was canceled."
+          }
+        ]
+      }
+    },
+    "NetworkSecurityProfile": {
+      "type": "object",
+      "description": "Network security perimeter configuration profile",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the profile"
+        },
+        "accessRulesVersion": {
+          "type": "string",
+          "description": "Current access rules version"
+        },
+        "accessRules": {
+          "type": "array",
+          "description": "List of Access Rules",
+          "items": {
+            "$ref": "#/definitions/AccessRule"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "diagnosticSettingsVersion": {
+          "type": "string",
+          "description": "Current diagnostic settings version"
+        },
+        "enabledLogCategories": {
+          "type": "array",
+          "description": "List of log categories that are enabled",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     },
     "OperationDefinition": {
       "type": "object",
@@ -3809,6 +4115,62 @@
         }
       }
     },
+    "ProvisioningIssue": {
+      "type": "object",
+      "description": "Describes a provisioning issue for a network security perimeter configuration",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the issue",
+          "readOnly": true
+        },
+        "properties": {
+          "$ref": "#/definitions/ProvisioningIssueProperties",
+          "description": "Details of the provisioning issue",
+          "readOnly": true
+        }
+      }
+    },
+    "ProvisioningIssueProperties": {
+      "type": "object",
+      "description": "Details of a provisioning issue for a network security perimeter (NSP) configuration. Resource providers should generate separate provisioning issue elements for each separate issue detected, and include a meaningful and distinctive description, as well as any appropriate suggestedResourceIds and suggestedAccessRules",
+      "properties": {
+        "issueType": {
+          "$ref": "#/definitions/IssueType",
+          "description": "Type of issue",
+          "readOnly": true
+        },
+        "severity": {
+          "$ref": "#/definitions/Severity",
+          "description": "Severity of the issue.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the issue",
+          "readOnly": true
+        },
+        "suggestedResourceIds": {
+          "type": "array",
+          "description": "Fully qualified resource IDs of suggested resources that can be associated to the network security perimeter (NSP) to remediate the issue.",
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource."
+          },
+          "readOnly": true
+        },
+        "suggestedAccessRules": {
+          "type": "array",
+          "description": "Access rules that can be added to the network security profile (NSP) to remediate the issue.",
+          "items": {
+            "$ref": "#/definitions/AccessRule"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
     "ProvisioningState": {
       "type": "string",
       "description": "The provisioning state of the configuration store.",
@@ -3989,6 +4351,50 @@
         ]
       }
     },
+    "ResourceAssociation": {
+      "type": "object",
+      "description": "Information about resource association",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the resource association"
+        },
+        "accessMode": {
+          "$ref": "#/definitions/ResourceAssociationAccessMode",
+          "description": "Access mode of the resource association"
+        }
+      }
+    },
+    "ResourceAssociationAccessMode": {
+      "type": "string",
+      "description": "Access mode of the resource association",
+      "enum": [
+        "Enforced",
+        "Learning",
+        "Audit"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceAssociationAccessMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enforced",
+            "value": "Enforced",
+            "description": "Enforced access mode - traffic to the resource that failed access checks is blocked"
+          },
+          {
+            "name": "Learning",
+            "value": "Learning",
+            "description": "Learning access mode - traffic to the resource is enabled for analysis but not blocked"
+          },
+          {
+            "name": "Audit",
+            "value": "Audit",
+            "description": "Audit access mode - traffic to the resource that fails access checks is logged but not blocked"
+          }
+        ]
+      }
+    },
     "ResourceIdentity": {
       "type": "object",
       "description": "An identity that can be associated with a resource.",
@@ -4040,6 +4446,30 @@
             "name"
           ]
         }
+      }
+    },
+    "Severity": {
+      "type": "string",
+      "description": "Severity of the issue.",
+      "enum": [
+        "Warning",
+        "Error"
+      ],
+      "x-ms-enum": {
+        "name": "Severity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Warning",
+            "value": "Warning",
+            "description": "The issue is a warning and does not prevent the configuration from being applied."
+          },
+          {
+            "name": "Error",
+            "value": "Error",
+            "description": "The issue is an error and prevents the configuration from being applied."
+          }
+        ]
       }
     },
     "Sku": {

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/examples/ConfigurationStoresGetNetworkSecurityPerimeterConfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/examples/ConfigurationStoresGetNetworkSecurityPerimeterConfiguration.json
@@ -37,7 +37,7 @@
           },
           "profile": {
             "name": "myProfileName",
-            "accessRulesVersion": 1,
+            "accessRulesVersion": "1",
             "accessRules": [
               {
                 "name": "accessRule1",
@@ -50,7 +50,7 @@
                 }
               }
             ],
-            "diagnosticSettingsVersion": 1,
+            "diagnosticSettingsVersion": "1",
             "enabledLogCategories": [
               "logCategory1",
               "logCategory2"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/examples/ConfigurationStoresListNetworkSecurityPerimeterConfigurations.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/examples/ConfigurationStoresListNetworkSecurityPerimeterConfigurations.json
@@ -38,7 +38,7 @@
               },
               "profile": {
                 "name": "myProfileName",
-                "accessRulesVersion": 1,
+                "accessRulesVersion": "1",
                 "accessRules": [
                   {
                     "name": "accessRule1",
@@ -51,7 +51,7 @@
                     }
                   }
                 ],
-                "diagnosticSettingsVersion": 1,
+                "diagnosticSettingsVersion": "1",
                 "enabledLogCategories": [
                   "logCategory1",
                   "logCategory2"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/examples/ConfigurationStoresReconcileNetworkSecurityPerimeterConfiguration.json
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/preview/2026-09-01-preview/examples/ConfigurationStoresReconcileNetworkSecurityPerimeterConfiguration.json
@@ -37,7 +37,7 @@
           },
           "profile": {
             "name": "myProfileName",
-            "accessRulesVersion": 1,
+            "accessRulesVersion": "1",
             "accessRules": [
               {
                 "name": "accessRule1",
@@ -50,7 +50,7 @@
                 }
               }
             ],
-            "diagnosticSettingsVersion": 1,
+            "diagnosticSettingsVersion": "1",
             "enabledLogCategories": [
               "logCategory1",
               "logCategory2"

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/readme.md
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/readme.md
@@ -255,6 +255,12 @@ See configuration in [readme.cli.md](./readme.cli.md)
 
 ``` yaml
 directive:
+  - suppress: ProvisioningStateMustBeReadOnly
+    from: appconfiguration.json
+    reason: provisioningState is marked read-only in TypeSpec via @visibility(Lifecycle.Read), but the autorest emitter places readOnly as a sibling of $ref rather than in the type definition itself. The linter does not follow $ref siblings per OpenAPI 2.0 spec. Known issue https://github.com/Azure/azure-openapi-validator/issues/637
+    where:
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}"].get.responses["200"].schema
+      - $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.AppConfiguration/configurationStores/{configStoreName}/networkSecurityPerimeterConfigurations/{networkSecurityPerimeterConfigurationName}/reconcile"].post.responses["200"].schema
   - suppress: EnumInsteadOfBoolean
     from: appconfiguration.json
     where: $.definitions.NameAvailabilityStatus.properties.nameAvailable

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/suppressions.yaml
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/suppressions.yaml
@@ -15,6 +15,11 @@
     - preview/2026-09-01-preview/appconfiguration.json
   reason: This brownfield TypeSpec project emits all existing API versions with common types v5; upgrading globally would modify established contracts outside this change.
 
+- tool: ProvisioningStateMustBeReadOnly
+  paths:
+    - preview/2026-09-01-preview/appconfiguration.json
+  reason: The network security perimeter provisioning state is marked read-only in TypeSpec via @visibility(Lifecycle.Read), but the autorest emitter places readOnly as a sibling of $ref rather than in the type definition itself. The linter does not follow $ref siblings per OpenAPI 2.0 spec. Known issue https://github.com/Azure/azure-openapi-validator/issues/637
+
 - tool: TypeSpecRequirement
   path: ./preview/2019-02-01-preview/*.json
   reason: Brownfield service not ready to migrate

--- a/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/suppressions.yaml
+++ b/specification/appconfiguration/resource-manager/Microsoft.AppConfiguration/AppConfiguration/suppressions.yaml
@@ -15,11 +15,6 @@
     - preview/2026-09-01-preview/appconfiguration.json
   reason: This brownfield TypeSpec project emits all existing API versions with common types v5; upgrading globally would modify established contracts outside this change.
 
-- tool: ProvisioningStateMustBeReadOnly
-  paths:
-    - preview/2026-09-01-preview/appconfiguration.json
-  reason: The network security perimeter provisioning state is marked read-only in TypeSpec via @visibility(Lifecycle.Read), but the autorest emitter places readOnly as a sibling of $ref rather than in the type definition itself. The linter does not follow $ref siblings per OpenAPI 2.0 spec. Known issue https://github.com/Azure/azure-openapi-validator/issues/637
-
 - tool: TypeSpecRequirement
   path: ./preview/2019-02-01-preview/*.json
   reason: Brownfield service not ready to migrate


### PR DESCRIPTION

Define NSP types locally for 2026-09-01-preview (with required fixes: string accessRulesVersion/diagnosticSettingsVersion, add serviceTags). 2025-08-01-preview keeps the ARM common-types v5 NSP shape via @typeChangedFrom, so it stays non-breaking.

## NSP type changes in `2026-09-01-preview` vs. ARM common-types v5

| # | Model.property | common-types v5 | This PR (2026-09) | Reason |
|---|---|---|---|---|
| 1 | `NetworkSecurityProfile.accessRulesVersion` | `integer` (`int32`) | `string` | Bug fix — service returns a string; `int32` broke the API |
| 2 | `NetworkSecurityProfile.diagnosticSettingsVersion` | `integer` (`int32`) | `string` | Bug fix — same |
| 3 | `AccessRuleProperties.serviceTags` | _(absent)_ | `string[]` (added) | Required addition — missing from common-types |
| 4 | `NetworkSecurityPerimeter.perimeterGuid` | `string` + `format: uuid` | `string` (no format) | Avoids `GuidUsage` lint; matches Microsoft.Network + peer RPs |
