### PR TITLE
Add hcpopenshiftclusters service group to Microsoft.RedHatOpenShift ARM lease

### DIFF
--- a/.github/arm-leases/redhatopenshift/Microsoft.RedHatOpenShift/hcpopenshiftclusters/lease.yaml
+++ b/.github/arm-leases/redhatopenshift/Microsoft.RedHatOpenShift/hcpopenshiftclusters/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.RedHatOpenShift
+  startdate: 2026-08-14
+  duration: P180D
+  reviewer: "@vidapour"


### PR DESCRIPTION
Adds an ARM lease for **Microsoft.RedHatOpenShift** (service group **hcpopenshiftclusters**) per `.github/arm-leases/README.md`.

- Path: `.github/arm-leases/redhatopenshift/Microsoft.RedHatOpenShift/hcpopenshiftclusters/lease.yaml`
- Resource provider: `Microsoft.RedHatOpenShift`
- Start date: 2026-08-14
- Duration: P180D
- Reviewer: @vidapour