### PR TITLE
Add DecisionWorkflows service group to Microsoft.DecisionWorkflows ARM lease

### DIFF
--- a/.github/arm-leases/decisionworkflows/Microsoft.DecisionWorkflows/DecisionWorkflows/lease.yaml
+++ b/.github/arm-leases/decisionworkflows/Microsoft.DecisionWorkflows/DecisionWorkflows/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.DecisionWorkflows
+  startdate: 2026-08-14
+  duration: P180D
+  reviewer: "@vidapour"


### PR DESCRIPTION
Adds an ARM lease for **Microsoft.DecisionWorkflows** (service group **DecisionWorkflows**) per `.github/arm-leases/README.md`.

- Path: `.github/arm-leases/decisionworkflows/Microsoft.DecisionWorkflows/DecisionWorkflows/lease.yaml`
- Resource provider: `Microsoft.DecisionWorkflows`
- Start date: 2026-08-14
- Duration: P180D
- Reviewer: @vidapour