### PR TITLE
ContainerService: fix .NET acronym casing for 2026-06

### DIFF
--- a/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
+++ b/specification/containerservice/resource-manager/Microsoft.ContainerService/aks/client.tsp
@@ -60,6 +60,14 @@ using Microsoft.ContainerService;
 
 @@clientName(Microsoft.ContainerService.IPFamily, "IpFamily", "javascript");
 
+// .NET SDK acronym casing.
+@@clientName(
+  ManagedClusterNATGatewaySku,
+  "ManagedClusterNatGatewaySku",
+  "csharp"
+);
+@@clientName(DRANETMode, "DranetMode", "csharp");
+
 // Java specific renaming for backward compatibility
 @@clientName(
   ManagedClusterAPIServerAccessProfile,


### PR DESCRIPTION
Adds C# `@@clientName` mappings `ManagedClusterNATGatewaySku` -> `ManagedClusterNatGatewaySku` and `DRANETMode` -> `DranetMode` to address blocking review comments on Azure/azure-sdk-for-net#62085. TypeSpec compilation with warnings as errors and Prettier both passed.