### PR TITLE
Preserve Java Consumption enum names

### DIFF
--- a/specification/consumption/resource-manager/Microsoft.Consumption/Consumption/client.tsp
+++ b/specification/consumption/resource-manager/Microsoft.Consumption/Consumption/client.tsp
@@ -532,3 +532,11 @@ model ConsumptionModernReservationRecommendation
   ModernChargeSummary.properties,
   "csharp"
 );
+
+// Preserve Java enum value names from the released SDK.
+@@clientName(Metrictype.ActualCostMetricType, "ACTUALCOST", "java");
+@@clientName(Metrictype.AmortizedCostMetricType, "AMORTIZEDCOST", "java");
+@@clientName(Metrictype.UsageMetricType, "USAGE", "java");
+@@clientName(Datagrain.DailyGrain, "DAILY", "java");
+@@clientName(Datagrain.MonthlyGrain, "MONTHLY", "java");
+@@clientName(LookBackPeriod.Last07Days, "LAST7DAYS", "java");


### PR DESCRIPTION
Preserves the released Java enum constant names during the Consumption TypeSpec migration.

Validation:
- `tsp format client.tsp`
- TypeSpec compilation passed.
- Java emitter 0.46.0 generated `ACTUALCOST`, `AMORTIZEDCOST`, `USAGE`, `DAILY`, `MONTHLY`, and `LAST7DAYS`.
