### PR TITLE
Remove redundant Batch C# replacement models

### DIFF
--- a/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
+++ b/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
@@ -640,6 +640,7 @@ using Microsoft.Batch;
   "csharp"
 );
 @@alternateType(PrivateEndpoint.id, Azure.Core.armResourceIdentifier, "csharp");
+@@usage(BatchAccount, Usage.input, "csharp");
 @@alternateType(
   BatchAccount.identity,
   Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,

--- a/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
+++ b/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
@@ -642,6 +642,9 @@ using Microsoft.Batch;
 );
 @@alternateType(PrivateEndpoint.id, Azure.Core.armResourceIdentifier, "csharp");
 @@usage(BatchAccount, Usage.input, "csharp");
+// TODO: Replace this legacy hierarchy override with a custom base type after
+// https://github.com/Azure/azure-sdk-for-net/issues/62140 is fixed. Narrowing the
+// generated base through custom code currently drops the Location and Tags properties.
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Change the BatchAccount base type back to ResourceData for backward compatibility"
 @@hierarchyBuilding(
   BatchAccount,

--- a/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
+++ b/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
@@ -3,6 +3,7 @@ import "@azure-tools/typespec-azure-resource-manager";
 import "./main.tsp";
 
 using Azure.ClientGenerator.Core;
+using Azure.ClientGenerator.Core.Legacy;
 using Microsoft.Batch;
 
 @@clientName(Microsoft.Batch, "BatchManagementClient", "javascript, python");
@@ -641,6 +642,12 @@ using Microsoft.Batch;
 );
 @@alternateType(PrivateEndpoint.id, Azure.Core.armResourceIdentifier, "csharp");
 @@usage(BatchAccount, Usage.input, "csharp");
+#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "Change the BatchAccount base type back to ResourceData for backward compatibility"
+@@hierarchyBuilding(
+  BatchAccount,
+  Azure.ResourceManager.Foundations.ProxyResource,
+  "csharp"
+);
 @@alternateType(
   BatchAccount.identity,
   Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,

--- a/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
+++ b/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
@@ -641,44 +641,13 @@ using Microsoft.Batch;
   "csharp"
 );
 @@alternateType(PrivateEndpoint.id, Azure.Core.armResourceIdentifier, "csharp");
-@@alternateType(BatchAccount, BatchAccountData, "csharp");
-#suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-@@Azure.ClientGenerator.Core.Legacy.flattenProperty(
-  BatchAccountData.properties,
-  "csharp"
-);
 @@alternateType(
   BatchAccount.identity,
   Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
   "csharp"
 );
 
-// added to solve the problem that the c# resource class can inherit the `resource data` class
 namespace Microsoft.Batch {
-  /**
-   * Contains information about an Azure Batch account.
-   */
-  @usage(Usage.input, "csharp")
-  @clientName("BatchAccount", "csharp")
-  model BatchAccountData
-    is Azure.ResourceManager.ProxyResource<BatchAccountProperties> {
-    ...Azure.ResourceManager.ResourceNameParameter<
-      Resource = BatchAccount,
-      KeyName = "accountName",
-      SegmentName = "batchAccounts",
-      NamePattern = "^[a-zA-Z0-9]+$"
-    >;
-    ...OmitProperties<
-      BatchAccount,
-      "id" | "name" | "type" | "properties" | "location"
-    >;
-
-    /** The geo-location where the resource lives */
-    #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"
-    @visibility(Lifecycle.Read, Lifecycle.Create)
-    location?: Azure.Core.azureLocation;
-  }
-
   /**
    * The provisioned state of the resource
    */

--- a/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
+++ b/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
@@ -626,11 +626,6 @@ using Microsoft.Batch;
   "csharp"
 );
 @@alternateType(
-  Azure.ResourceManager.CommonTypes.AccessRuleProperties.subscriptions,
-  Azure.ResourceManager.Models.SubResource[],
-  "csharp"
-);
-@@alternateType(
   BatchAccountUpdateParameters.identity,
   Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
   "csharp"
@@ -730,14 +725,5 @@ namespace Microsoft.Batch {
   union BatchAccountCertificateProvisioningState {
     CertificateProvisioningState,
     string,
-  }
-}
-
-// we add this model in this namespace in order to replace some models with this model via alternateType decorator
-namespace Azure.ResourceManager.Models {
-  /** represents a reference to an existing resource by its id */
-  model SubResource {
-    /** the id */
-    id?: Azure.Core.armResourceIdentifier;
   }
 }

--- a/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
+++ b/specification/batch/resource-manager/Microsoft.Batch/Batch/client.tsp
@@ -598,7 +598,6 @@ using Microsoft.Batch;
   "BatchAccountRegenerateKeyContent",
   "csharp"
 );
-@@clientName(BatchAccount, "BatchAccountRenamed", "csharp");
 @@clientName(
   LocationOperationGroup.checkNameAvailability,
   "CheckBatchNameAvailability",


### PR DESCRIPTION
Removes C#-specific client.tsp replacement and rename patterns, then applies customizations directly to the original BatchAccount model:

- Removes the locally defined Azure.ResourceManager.Models.SubResource model and its alternateType replacement.
- Removes the locally defined BatchAccountData model, its alternateType replacement, and legacy flatten customization.
- Removes the BatchAccountRenamed clientName.
- Adds C# input usage to BatchAccount.
- Adds an explicitly approved legacy hierarchyBuilding override to ProxyResource so BatchAccountData derives ResourceData while Location and Tags remain model properties.

The remaining SDK compatibility differences are property type/nullability rather than missing properties.