### PR TITLE
Add session probes to Container Apps 2026-07-01

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
@@ -4805,12 +4805,12 @@ union SessionProbeType {
   string,
 
   /**
-   * Liveness
+   * Checks whether the session is still running and healthy.
    */
   Liveness: "Liveness",
 
   /**
-   * Startup
+   * Checks whether the session has started successfully.
    */
   Startup: "Startup",
 }

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
@@ -6199,7 +6199,7 @@ model SessionContainer {
    */
   @identifiers(#["type"])
   @removed(Versions.v2026_01_01)
-  @removed(Versions.v2026_07_01)
+  @added(Versions.v2026_07_01)
   probes?: SessionProbe[];
 }
 

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2025-10-02-preview/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2025-10-02-preview/openapi.json
@@ -20869,12 +20869,12 @@
           {
             "name": "Liveness",
             "value": "Liveness",
-            "description": "Liveness"
+            "description": "Checks whether the session is still running and healthy."
           },
           {
             "name": "Startup",
             "value": "Startup",
-            "description": "Startup"
+            "description": "Checks whether the session has started successfully."
           }
         ]
       }

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
@@ -15082,12 +15082,12 @@
           {
             "name": "Liveness",
             "value": "Liveness",
-            "description": "Liveness"
+            "description": "Checks whether the session is still running and healthy."
           },
           {
             "name": "Startup",
             "value": "Startup",
-            "description": "Startup"
+            "description": "Checks whether the session has started successfully."
           }
         ]
       }

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
@@ -14630,6 +14630,16 @@
         "resources": {
           "$ref": "#/definitions/SessionContainerResources",
           "description": "Container resource requirements."
+        },
+        "probes": {
+          "type": "array",
+          "description": "List of probes for the container.",
+          "items": {
+            "$ref": "#/definitions/SessionProbe"
+          },
+          "x-ms-identifiers": [
+            "type"
+          ]
         }
       }
     },
@@ -14936,6 +14946,150 @@
           "$ref": "#/definitions/SessionNetworkConfiguration",
           "description": "The network configuration of the sessions in the session pool."
         }
+      }
+    },
+    "SessionProbe": {
+      "type": "object",
+      "description": "Session probe configuration.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/SessionProbeType",
+          "description": "Denotes the type of probe. Can be Liveness or Startup, Readiness probe is not supported in sessions. Type must be unique for each probe within the context of a list of probes (SessionProbes)."
+        },
+        "httpGet": {
+          "$ref": "#/definitions/SessionProbeHttpGet",
+          "description": "HTTPGet specifies the http request to perform."
+        },
+        "tcpSocket": {
+          "$ref": "#/definitions/SessionProbeTcpSocket",
+          "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported."
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1. Maximum value is 10."
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of seconds after the container has started before liveness probes are initiated. Minimum value is 1. Maximum value is 60."
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1. Maximum value is 240."
+        },
+        "successThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1. Maximum value is 10."
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate. Maximum value is 3600 seconds (1 hour)"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 240."
+        }
+      }
+    },
+    "SessionProbeHttpGet": {
+      "type": "object",
+      "description": "HTTPGet specifies the http request to perform.",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead."
+        },
+        "httpHeaders": {
+          "type": "array",
+          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+          "items": {
+            "$ref": "#/definitions/SessionProbeHttpGetHttpHeadersItem"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to access on the HTTP server."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+        },
+        "scheme": {
+          "$ref": "#/definitions/Scheme",
+          "description": "Scheme to use for connecting to the host. Defaults to HTTP."
+        }
+      },
+      "required": [
+        "port"
+      ]
+    },
+    "SessionProbeHttpGetHttpHeadersItem": {
+      "type": "object",
+      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The header field name"
+        },
+        "value": {
+          "type": "string",
+          "description": "The header field value"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    },
+    "SessionProbeTcpSocket": {
+      "type": "object",
+      "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported.",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Optional: Host name to connect to, defaults to the pod IP."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+        }
+      },
+      "required": [
+        "port"
+      ]
+    },
+    "SessionProbeType": {
+      "type": "string",
+      "description": "Denotes the type of probe. Can be Liveness or Startup, Readiness probe is not supported in sessions. Type must be unique for each probe within the context of a list of probes (SessionProbes).",
+      "enum": [
+        "Liveness",
+        "Startup"
+      ],
+      "x-ms-enum": {
+        "name": "SessionProbeType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Liveness",
+            "value": "Liveness",
+            "description": "Liveness"
+          },
+          {
+            "name": "Startup",
+            "value": "Startup",
+            "description": "Startup"
+          }
+        ]
       }
     },
     "SessionRegistryCredentials": {


### PR DESCRIPTION
## Summary
- restore `SessionContainer.probes` for the stable `2026-07-01` API
- reuse the existing session probe, HTTP GET, TCP socket, and header models
- keep session probes excluded from stable `2026-01-01`

## Validation
- TypeSpec validation
- `tsp compile .`