### PR TITLE
Use latest Microsoft Resources API version for Java

### DIFF
--- a/specification/resources/resource-manager/Microsoft.Resources/resources/tspconfig.yaml
+++ b/specification/resources/resource-manager/Microsoft.Resources/resources/tspconfig.yaml
@@ -31,7 +31,6 @@ options:
     enable-sync-stack: false
     flavor: azure
     use-object-for-unknown: true
-    api-version: "2025-04-01"
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/{service-dir}/arm-resources"
     flavor: azure


### PR DESCRIPTION
Removes the Java API-version pin for Microsoft Resources so SDK generation uses the latest API version.

Related to Azure/azure-sdk-for-java#49803.
