### PR TITLE
Make resources fields read-only and add priority to CommandJob

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_CreateOrUpdate_MaximumSet_Gen.json
@@ -11,8 +11,12 @@
         "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
         "displayName": "My Training Job",
         "description": "A sample command job for training",
-        "tags": { "framework": "pytorch" },
-        "properties": { "experimentName": "my-experiment" },
+        "tags": {
+          "framework": "pytorch"
+        },
+        "properties": {
+          "experimentName": "my-experiment"
+        },
         "codeId": "azureai:my-training-code:1",
         "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster",
         "inputs": {
@@ -54,13 +58,17 @@
         "services": {
           "my_ssh": {
             "jobServiceType": "SSH",
-            "nodes": { "nodesValueType": "All" },
+            "nodes": {
+              "nodesValueType": "All"
+            },
             "properties": {
               "sshPublicKeys": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPykbeMQW4AN94tfWncTg3qegSMi6dwvIEmrW7rWq6OV user@host"
             }
           }
         },
-        "queueSettings": { "jobTier": "Standard" },
+        "queueSettings": {
+          "jobTier": "Standard"
+        },
         "priority": "High",
         "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
         "gpuCount": 4,
@@ -81,8 +89,12 @@
           "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
           "displayName": "My Training Job",
           "description": "A sample command job for training",
-          "tags": { "framework": "pytorch" },
-          "properties": { "experimentName": "my-experiment" },
+          "tags": {
+            "framework": "pytorch"
+          },
+          "properties": {
+            "experimentName": "my-experiment"
+          },
           "codeId": "azureai:my-training-code:1",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster",
           "inputs": {
@@ -125,18 +137,28 @@
             "timeout": "PT2H30M"
           },
           "services": {
-            "Studio": { "jobServiceType": "Studio", "port": 8080, "endpoint": "https://studio.example.com" },
-            "Tracking": { "jobServiceType": "Tracking" },
+            "Studio": {
+              "jobServiceType": "Studio",
+              "port": 8080,
+              "endpoint": "https://studio.example.com"
+            },
+            "Tracking": {
+              "jobServiceType": "Tracking"
+            },
             "my_ssh": {
               "jobServiceType": "SSH",
-              "nodes": { "nodesValueType": "All" },
+              "nodes": {
+                "nodesValueType": "All"
+              },
               "properties": {
                 "sshPublicKeys": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPykbeMQW4AN94tfWncTg3qegSMi6dwvIEmrW7rWq6OV user@host"
               },
               "status": "Running"
             }
           },
-          "queueSettings": { "jobTier": "Standard" },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
           "priority": "High",
           "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
           "gpuCount": 4,
@@ -164,8 +186,12 @@
           "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
           "displayName": "My Training Job",
           "description": "A sample command job for training",
-          "tags": { "framework": "pytorch" },
-          "properties": { "experimentName": "my-experiment" },
+          "tags": {
+            "framework": "pytorch"
+          },
+          "properties": {
+            "experimentName": "my-experiment"
+          },
           "codeId": "azureai:my-training-code:1",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster",
           "inputs": {
@@ -208,17 +234,27 @@
             "timeout": "PT2H30M"
           },
           "services": {
-            "Studio": { "jobServiceType": "Studio", "port": 8080, "endpoint": "https://studio.example.com" },
-            "Tracking": { "jobServiceType": "Tracking" },
+            "Studio": {
+              "jobServiceType": "Studio",
+              "port": 8080,
+              "endpoint": "https://studio.example.com"
+            },
+            "Tracking": {
+              "jobServiceType": "Tracking"
+            },
             "my_ssh": {
               "jobServiceType": "SSH",
-              "nodes": { "nodesValueType": "All" },
+              "nodes": {
+                "nodesValueType": "All"
+              },
               "properties": {
                 "sshPublicKeys": "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPykbeMQW4AN94tfWncTg3qegSMi6dwvIEmrW7rWq6OV user@host"
               }
             }
           },
-          "queueSettings": { "jobTier": "Standard" },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
           "priority": "High",
           "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
           "gpuCount": 4,

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_CreateOrUpdate_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_CreateOrUpdate_MaximumSet_Gen.json
@@ -45,10 +45,7 @@
           "processCountPerInstance": 4
         },
         "resources": {
-          "instanceCount": 2,
-          "instanceType": "Standard_NC6s_v3",
-          "shmSize": "2g",
-          "dockerArgs": "--privileged"
+          "instanceCount": 2
         },
         "limits": {
           "jobLimitsType": "Command",
@@ -64,6 +61,7 @@
           }
         },
         "queueSettings": { "jobTier": "Standard" },
+        "priority": "High",
         "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
         "gpuCount": 4,
         "isArchived": false
@@ -139,6 +137,7 @@
             }
           },
           "queueSettings": { "jobTier": "Standard" },
+          "priority": "High",
           "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
           "gpuCount": 4,
           "status": "Running",
@@ -220,6 +219,7 @@
             }
           },
           "queueSettings": { "jobTier": "Standard" },
+          "priority": "High",
           "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
           "gpuCount": 4,
           "status": "NotStarted",

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_Get_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_Get_MaximumSet_Gen.json
@@ -19,8 +19,12 @@
           "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
           "displayName": "My Training Job",
           "description": "A sample command job for training",
-          "tags": { "framework": "pytorch" },
-          "properties": { "experimentName": "my-experiment" },
+          "tags": {
+            "framework": "pytorch"
+          },
+          "properties": {
+            "experimentName": "my-experiment"
+          },
           "codeId": "azureai:my-training-code:1",
           "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster",
           "inputs": {
@@ -63,10 +67,18 @@
             "timeout": "PT2H30M"
           },
           "services": {
-            "Studio": { "jobServiceType": "Studio", "port": 8080, "endpoint": "https://studio.example.com" },
-            "Tracking": { "jobServiceType": "Tracking" }
+            "Studio": {
+              "jobServiceType": "Studio",
+              "port": 8080,
+              "endpoint": "https://studio.example.com"
+            },
+            "Tracking": {
+              "jobServiceType": "Tracking"
+            }
           },
-          "queueSettings": { "jobTier": "Standard" },
+          "queueSettings": {
+            "jobTier": "Standard"
+          },
           "priority": "High",
           "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
           "gpuCount": 4,

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_Get_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_Get_MaximumSet_Gen.json
@@ -67,6 +67,7 @@
             "Tracking": { "jobServiceType": "Tracking" }
           },
           "queueSettings": { "jobTier": "Standard" },
+          "priority": "High",
           "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
           "gpuCount": 4,
           "status": "Running",

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_List_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_List_MaximumSet_Gen.json
@@ -72,6 +72,7 @@
                 "Tracking": { "jobServiceType": "Tracking" }
               },
               "queueSettings": { "jobTier": "Standard" },
+              "priority": "High",
               "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
               "gpuCount": 4,
               "status": "Running",

--- a/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_List_MaximumSet_Gen.json
+++ b/specification/ai-foundry/data-plane/Foundry/examples/v1/Jobs_List_MaximumSet_Gen.json
@@ -24,8 +24,12 @@
               "environmentImageReference": "mcr.microsoft.com/azureml/openmpi4.1.0-cuda11.8-cudnn8-ubuntu22.04:latest",
               "displayName": "My Training Job",
               "description": "A sample command job for training",
-              "tags": { "framework": "pytorch" },
-              "properties": { "experimentName": "my-experiment" },
+              "tags": {
+                "framework": "pytorch"
+              },
+              "properties": {
+                "experimentName": "my-experiment"
+              },
               "codeId": "azureai:my-training-code:1",
               "computeId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.MachineLearningServices/workspaces/my-ws/computes/my-cluster",
               "inputs": {
@@ -68,10 +72,18 @@
                 "timeout": "PT2H30M"
               },
               "services": {
-                "Studio": { "jobServiceType": "Studio", "port": 8080, "endpoint": "https://studio.example.com" },
-                "Tracking": { "jobServiceType": "Tracking" }
+                "Studio": {
+                  "jobServiceType": "Studio",
+                  "port": 8080,
+                  "endpoint": "https://studio.example.com"
+                },
+                "Tracking": {
+                  "jobServiceType": "Tracking"
+                }
               },
-              "queueSettings": { "jobTier": "Standard" },
+              "queueSettings": {
+                "jobTier": "Standard"
+              },
               "priority": "High",
               "userAssignedIdentityId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity",
               "gpuCount": 4,

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -19872,6 +19872,14 @@
             ],
             "description": "Queue settings for the job."
           },
+          "priority": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobPriority"
+              }
+            ],
+            "description": "Priority of the job. If omitted, the service defaults to Low."
+          },
           "userAssignedIdentityId": {
             "type": "string",
             "description": "user-assigned managed identity"
@@ -25460,6 +25468,22 @@
         },
         "description": "The error response returned for a job's service instance."
       },
+      "JobPriority": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Low",
+              "Mid",
+              "High"
+            ]
+          }
+        ],
+        "description": "Priority of the job."
+      },
       "JobProperties": {
         "type": "object",
         "required": [
@@ -25489,20 +25513,24 @@
           },
           "instanceType": {
             "type": "string",
-            "description": "Optional type of VM used as supported by the compute target."
+            "description": "Optional type of VM used as supported by the compute target.",
+            "readOnly": true
           },
           "properties": {
             "type": "object",
             "additionalProperties": {},
-            "description": "Additional properties bag."
+            "description": "Additional properties bag.",
+            "readOnly": true
           },
           "shmSize": {
             "type": "string",
-            "description": "Size of the docker container's shared memory block."
+            "description": "Size of the docker container's shared memory block.",
+            "readOnly": true
           },
           "dockerArgs": {
             "type": "string",
-            "description": "Extra arguments to pass to the Docker run command."
+            "description": "Extra arguments to pass to the Docker run command.",
+            "readOnly": true
           }
         },
         "description": "Compute Resource configuration for the job."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -47249,7 +47249,8 @@
       "Output": {
         "type": "object",
         "required": [
-          "jobOutputType"
+          "jobOutputType",
+          "assetName"
         ],
         "properties": {
           "jobOutputType": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -13225,6 +13225,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/QueueSettings'
           description: Queue settings for the job.
+        priority:
+          allOf:
+            - $ref: '#/components/schemas/JobPriority'
+          description: Priority of the job. If omitted, the service defaults to Low.
         userAssignedIdentityId:
           type: string
           description: user-assigned managed identity
@@ -17235,6 +17239,15 @@ components:
           type: string
           description: Component name where the error originated or was encountered.
       description: The error response returned for a job's service instance.
+    JobPriority:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - Low
+            - Mid
+            - High
+      description: Priority of the job.
     JobProperties:
       type: object
       required:
@@ -17258,16 +17271,20 @@ components:
         instanceType:
           type: string
           description: Optional type of VM used as supported by the compute target.
+          readOnly: true
         properties:
           type: object
           additionalProperties: {}
           description: Additional properties bag.
+          readOnly: true
         shmSize:
           type: string
           description: Size of the docker container's shared memory block.
+          readOnly: true
         dockerArgs:
           type: string
           description: Extra arguments to pass to the Docker run command.
+          readOnly: true
       description: Compute Resource configuration for the job.
     JobService:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -33383,6 +33383,7 @@ components:
       type: object
       required:
         - jobOutputType
+        - assetName
       properties:
         jobOutputType:
           allOf:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -22911,6 +22911,14 @@
             ],
             "description": "Queue settings for the job."
           },
+          "priority": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/JobPriority"
+              }
+            ],
+            "description": "Priority of the job. If omitted, the service defaults to Low."
+          },
           "userAssignedIdentityId": {
             "type": "string",
             "description": "user-assigned managed identity"
@@ -29629,6 +29637,22 @@
         },
         "description": "The error response returned for a job's service instance."
       },
+      "JobPriority": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "Low",
+              "Mid",
+              "High"
+            ]
+          }
+        ],
+        "description": "Priority of the job."
+      },
       "JobProperties": {
         "type": "object",
         "required": [
@@ -29658,20 +29682,24 @@
           },
           "instanceType": {
             "type": "string",
-            "description": "Optional type of VM used as supported by the compute target."
+            "description": "Optional type of VM used as supported by the compute target.",
+            "readOnly": true
           },
           "properties": {
             "type": "object",
             "additionalProperties": {},
-            "description": "Additional properties bag."
+            "description": "Additional properties bag.",
+            "readOnly": true
           },
           "shmSize": {
             "type": "string",
-            "description": "Size of the docker container's shared memory block."
+            "description": "Size of the docker container's shared memory block.",
+            "readOnly": true
           },
           "dockerArgs": {
             "type": "string",
-            "description": "Extra arguments to pass to the Docker run command."
+            "description": "Extra arguments to pass to the Docker run command.",
+            "readOnly": true
           }
         },
         "description": "Compute Resource configuration for the job."

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -51550,7 +51550,8 @@
       "Output": {
         "type": "object",
         "required": [
-          "jobOutputType"
+          "jobOutputType",
+          "assetName"
         ],
         "properties": {
           "jobOutputType": {

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -15281,6 +15281,10 @@ components:
           allOf:
             - $ref: '#/components/schemas/QueueSettings'
           description: Queue settings for the job.
+        priority:
+          allOf:
+            - $ref: '#/components/schemas/JobPriority'
+          description: Priority of the job. If omitted, the service defaults to Low.
         userAssignedIdentityId:
           type: string
           description: user-assigned managed identity
@@ -20068,6 +20072,15 @@ components:
           type: string
           description: Component name where the error originated or was encountered.
       description: The error response returned for a job's service instance.
+    JobPriority:
+      anyOf:
+        - type: string
+        - type: string
+          enum:
+            - Low
+            - Mid
+            - High
+      description: Priority of the job.
     JobProperties:
       type: object
       required:
@@ -20091,16 +20104,20 @@ components:
         instanceType:
           type: string
           description: Optional type of VM used as supported by the compute target.
+          readOnly: true
         properties:
           type: object
           additionalProperties: {}
           description: Additional properties bag.
+          readOnly: true
         shmSize:
           type: string
           description: Size of the docker container's shared memory block.
+          readOnly: true
         dockerArgs:
           type: string
           description: Extra arguments to pass to the Docker run command.
+          readOnly: true
       description: Compute Resource configuration for the job.
     JobService:
       type: object

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -36314,6 +36314,7 @@ components:
       type: object
       required:
         - jobOutputType
+        - assetName
       properties:
         jobOutputType:
           allOf:

--- a/specification/ai-foundry/data-plane/Foundry/src/jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/jobs/models.tsp
@@ -192,15 +192,19 @@ model JobResourceConfiguration {
   instanceCount?: int32;
 
   @doc("Optional type of VM used as supported by the compute target.")
+  @visibility(Lifecycle.Read)
   instanceType?: string;
 
   @doc("Additional properties bag.")
+  @visibility(Lifecycle.Read)
   properties?: Record<unknown>;
 
   @doc("Size of the docker container's shared memory block.")
+  @visibility(Lifecycle.Read)
   shmSize?: string;
 
   @doc("Extra arguments to pass to the Docker run command.")
+  @visibility(Lifecycle.Read)
   dockerArgs?: string;
 }
 
@@ -252,6 +256,20 @@ union JobType {
 
   @doc("Command job.")
   Command: "Command",
+}
+
+@doc("Priority of the job.")
+union JobPriority {
+  string,
+
+  @doc("Low priority.")
+  Low: "Low",
+
+  @doc("Medium priority.")
+  Mid: "Mid",
+
+  @doc("High priority.")
+  High: "High",
 }
 
 #suppress "@azure-tools/typespec-azure-core/no-string-discriminator" "Use an extensible union instead of a plain string"
@@ -316,6 +334,9 @@ model CommandJob extends JobProperties {
 
   @doc("Queue settings for the job.")
   queueSettings?: QueueSettings;
+
+  @doc("Priority of the job. If omitted, the service defaults to Low.")
+  priority?: JobPriority;
 
   @doc("user-assigned managed identity")
   userAssignedIdentityId?: string;

--- a/specification/ai-foundry/data-plane/Foundry/src/jobs/models.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/jobs/models.tsp
@@ -131,7 +131,7 @@ model Output {
   mode?: InputOutputModes;
 
   @doc("Name of the output data asset to register.")
-  assetName?: string;
+  assetName: string;
 
   @doc("Version of the output data asset to register.")
   assetVersion?: string;


### PR DESCRIPTION
## Summary

Aligns the Foundry jobs data-plane contract with the agreed service behavior for compute selection, per work item 5475147.

Two changes:

1. **`resources` fields are now read-only.** `instanceType`, `properties`, `shmSize` and `dockerArgs` on `JobResourceConfiguration` are marked `@visibility(Lifecycle.Read)`. The service infers these from the target cluster and ignores them on create, so accepting them in the request contract was misleading. They are still returned on GET and List. `instanceCount` stays writable - CPU jobs use it to request whole nodes.

2. **`priority` added to `CommandJob`.** The field already exists in the live service but was never modeled. Typed as the extensible `JobPriority` union with values `Low`, `Mid`, `High`.

## Details

### Read-only resources fields

| Field | Before | After |
|---|---|---|
| `instanceCount` | writable | **writable** (unchanged) |
| `instanceType` | writable | read-only |
| `properties` | writable | read-only |
| `shmSize` | writable | read-only |
| `dockerArgs` | writable | read-only |

Confirmed with the service team: these are removed from the job creation flow only, and deliberately kept for read operations because the service infers and populates them.

### `priority`

Wire contract confirmed independently by two service owners: field name `priority`, string type, values `Low` / `Mid` / `High`. The service-side C# enum uses a string converter, so the ordinals never reach the wire.

Modeled as an extensible union to match the existing convention in this file (`JobType`, `AssetTypes`, `InputOutputModes`, `ListViewType`) and so that future values are not a breaking change.

The service applies `Low` when the field is omitted. This is documented in the property description rather than emitted as an OpenAPI `default`, so generated clients do not materialize and send `"Low"` on every request. That preserves the distinction between "caller omitted" and "caller explicitly chose Low", and keeps the service authoritative if the default ever changes.

## Files changed

- `src/jobs/models.tsp` - visibility decorators, `JobPriority` union, `priority` property
- `examples/v1/Jobs_CreateOrUpdate_MaximumSet_Gen.json` - read-only fields removed from the request body, `priority` added to request and both responses
- `examples/v1/Jobs_Get_MaximumSet_Gen.json` - `priority` added to the response
- `examples/v1/Jobs_List_MaximumSet_Gen.json` - `priority` added to the response
- `openapi3/**` - regenerated

No versioning decorators are needed: the jobs surface is gated behind the required `Foundry-Features: Jobs=V1Preview` header and this contract is not yet published.

## Validation

- `npx tsp compile . --emit "@typespec/openapi3"` - clean
- `npx tsp compile . --warn-as-error` - clean, zero linter warnings
- All modified example files re-parse as valid JSON
- Verified in the emitted schema: exactly 4 `readOnly: true` under `JobResourceConfiguration`, `instanceCount` unaffected, `priority` present on `CommandJob` and absent from `required[]`, no `default` emitted for `priority`

Related: work item [5475147](https://msdata.visualstudio.com/Vienna/_workitems/edit/5475147)
