### PR TITLE
Enable KubernetesConfiguration provisioning emitters

### DIFF
--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensionTypes/tspconfig.yaml
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensionTypes/tspconfig.yaml
@@ -16,7 +16,7 @@ options:
     emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.KubernetesConfiguration.ExtensionTypes"
-    emitter-output-dir: "{project-root}/Azure.Provisioning.KubernetesConfiguration.ExtensionTypes"
+    emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
     api-version: "2024-11-01-preview"
   "@azure-tools/typespec-python":
     service-dir: "sdk/kubernetesconfiguration"

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensionTypes/tspconfig.yaml
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensionTypes/tspconfig.yaml
@@ -14,6 +14,10 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.KubernetesConfiguration.ExtensionTypes"
     emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.KubernetesConfiguration.ExtensionTypes"
+    emitter-output-dir: "{project-root}/Azure.Provisioning.KubernetesConfiguration.ExtensionTypes"
+    api-version: "2024-11-01-preview"
   "@azure-tools/typespec-python":
     service-dir: "sdk/kubernetesconfiguration"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-kubernetesconfiguration-extensiontypes"

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensions/tspconfig.yaml
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensions/tspconfig.yaml
@@ -45,6 +45,10 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.KubernetesConfiguration.Extensions"
     emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.KubernetesConfiguration.Extensions"
+    emitter-output-dir: "{project-root}/Azure.Provisioning.KubernetesConfiguration.Extensions"
+    api-version: "2025-03-01"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensions/tspconfig.yaml
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensions/tspconfig.yaml
@@ -47,7 +47,7 @@ options:
     emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.KubernetesConfiguration.Extensions"
-    emitter-output-dir: "{project-root}/Azure.Provisioning.KubernetesConfiguration.Extensions"
+    emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
     api-version: "2025-03-01"
 linter:
   extends:

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/fluxConfigurations/tspconfig.yaml
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/fluxConfigurations/tspconfig.yaml
@@ -16,7 +16,7 @@ options:
     emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.KubernetesConfiguration.FluxConfigurations"
-    emitter-output-dir: "{project-root}/Azure.Provisioning.KubernetesConfiguration.FluxConfigurations"
+    emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
     api-version: "2025-04-01"
   "@azure-tools/typespec-python":
     service-dir: "sdk/kubernetesconfiguration"

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/fluxConfigurations/tspconfig.yaml
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/fluxConfigurations/tspconfig.yaml
@@ -14,6 +14,10 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.KubernetesConfiguration.FluxConfigurations"
     emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.KubernetesConfiguration.FluxConfigurations"
+    emitter-output-dir: "{project-root}/Azure.Provisioning.KubernetesConfiguration.FluxConfigurations"
+    api-version: "2025-04-01"
   "@azure-tools/typespec-python":
     service-dir: "sdk/kubernetesconfiguration"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-kubernetesconfiguration-fluxconfigurations"

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/tspconfig.yaml
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/tspconfig.yaml
@@ -16,7 +16,7 @@ options:
     emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes"
-    emitter-output-dir: "{project-root}/Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes"
+    emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
     api-version: "2024-11-01-preview"
   "@azure-tools/typespec-python":
     service-dir: "sdk/kubernetesconfiguration"

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/tspconfig.yaml
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/privateLinkScopes/tspconfig.yaml
@@ -14,6 +14,10 @@ options:
   "@azure-typespec/http-client-csharp-mgmt":
     namespace: "Azure.ResourceManager.KubernetesConfiguration.PrivateLinkScopes"
     emitter-output-dir: "{output-dir}/sdk/kubernetesconfiguration/{namespace}"
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes"
+    emitter-output-dir: "{project-root}/Azure.Provisioning.KubernetesConfiguration.PrivateLinkScopes"
+    api-version: "2024-11-01-preview"
   "@azure-tools/typespec-python":
     service-dir: "sdk/kubernetesconfiguration"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-kubernetesconfiguration-privatelinkscopes"


### PR DESCRIPTION
Enables the C# provisioning emitter for the four TypeSpec-based KubernetesConfiguration services:

- Extensions
- ExtensionTypes
- FluxConfigurations
- PrivateLinkScopes

This supports onboarding their corresponding Azure.Provisioning packages in azure-sdk-for-net.