### PR TITLE
Fix TypeSpec service version metadata

### DIFF
--- a/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/service.yaml
+++ b/specification/dataprotection/resource-manager/Microsoft.DataProtection/DataProtection/service.yaml
@@ -127,3 +127,7 @@ versions:
     source: typespec
     swagger-files:
       - preview/2026-04-01-preview/dataprotection.json
+  - version: 2026-06-01
+    source: typespec
+    swagger-files:
+      - stable/2026-06-01/dataprotection.json

--- a/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/service.yaml
+++ b/specification/horizondb/resource-manager/Microsoft.HorizonDb/HorizonDb/service.yaml
@@ -3,3 +3,7 @@ versions:
     source: typespec
     swagger-files:
       - preview/2026-01-20-preview/openapi.json
+  - version: 2026-05-01-preview
+    source: typespec
+    swagger-files:
+      - preview/2026-05-01-preview/openapi.json


### PR DESCRIPTION
Adds the generated API version entries required by TypeSpec validation for Data Protection and HorizonDb.\n\nThe PR contains exactly two service.yaml changes.