### PR TITLE
Add Contoso stable and preview API versions

### DIFF
--- a/specification/contosowidgetmanager/Contoso.Management/employee.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/employee.tsp
@@ -1,10 +1,12 @@
 import "@typespec/rest";
 import "@typespec/http";
+import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
 import "@azure-tools/typespec-azure-resource-manager";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;
+using TypeSpec.Versioning;
 using Azure.Core;
 using Azure.ResourceManager;
 
@@ -22,6 +24,14 @@ model EmployeeProperties {
 
   /** City of employee */
   city?: string;
+
+  /** Department of employee */
+  @added(Versions.v2026_07_01)
+  department?: string;
+
+  /** Whether the employee is a contractor */
+  @added(Versions.v2026_08_01_preview)
+  isContractor?: boolean;
 
   /** Profile of employee */
   @encode("base64url")

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_CreateOrUpdate.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_CreateOrUpdate.json
@@ -1,0 +1,76 @@
+{
+  "title": "Employees_CreateOrUpdate",
+  "operationId": "Employees_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "9KF-f-8b",
+    "resource": {
+      "properties": {
+        "age": 30,
+        "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+        "profile": "ms"
+      },
+      "tags": {
+        "key2913": "urperxmkkhhkp"
+      },
+      "location": "itajgxyqozseoygnl"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/9KF-f-8b",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_Delete.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Employees_Delete",
+  "operationId": "Employees_Delete",
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "5vX--BxSu3ux48rI4O9OQ569"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Retry-After": 30,
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_Get.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_Get.json
@@ -1,0 +1,37 @@
+{
+  "title": "Employees_Get",
+  "operationId": "Employees_Get",
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "le-8MU--J3W6q8D386p3-iT3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_ListByResourceGroup.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_ListByResourceGroup.json
@@ -2,7 +2,7 @@
   "title": "Employees_ListByResourceGroup",
   "operationId": "Employees_ListByResourceGroup",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-07-01",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
     "resourceGroupName": "rgopenapi"
   },

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_ListBySubscription.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_ListBySubscription.json
@@ -2,7 +2,7 @@
   "title": "Employees_ListBySubscription",
   "operationId": "Employees_ListBySubscription",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-07-01",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9"
   },
   "responses": {

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_Update.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Employees_Update.json
@@ -2,7 +2,7 @@
   "title": "Employees_Update",
   "operationId": "Employees_Update",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-07-01",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
     "resourceGroupName": "rgopenapi",
     "employeeName": "-XhyNJ--",

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Operations_List.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-07-01/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-07-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ymeow",
+            "isDataAction": true,
+            "display": {
+              "provider": "qxyznq",
+              "resource": "bqfwkox",
+              "operation": "td",
+              "description": "yvgkhsuwartgxb"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "https://sample.com/nextLink"
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_CreateOrUpdate.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_CreateOrUpdate.json
@@ -2,7 +2,7 @@
   "title": "Employees_CreateOrUpdate",
   "operationId": "Employees_CreateOrUpdate",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-08-01-preview",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
     "resourceGroupName": "rgopenapi",
     "employeeName": "9KF-f-8b",

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_Delete.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_Delete.json
@@ -2,7 +2,7 @@
   "title": "Employees_Delete",
   "operationId": "Employees_Delete",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-08-01-preview",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
     "resourceGroupName": "rgopenapi",
     "employeeName": "5vX--BxSu3ux48rI4O9OQ569"

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_Get.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_Get.json
@@ -1,0 +1,37 @@
+{
+  "title": "Employees_Get",
+  "operationId": "Employees_Get",
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "le-8MU--J3W6q8D386p3-iT3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_ListByResourceGroup.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_ListByResourceGroup.json
@@ -1,0 +1,41 @@
+{
+  "title": "Employees_ListByResourceGroup",
+  "operationId": "Employees_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_ListBySubscription.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_ListBySubscription.json
@@ -1,0 +1,40 @@
+{
+  "title": "Employees_ListBySubscription",
+  "operationId": "Employees_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_Update.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Employees_Update.json
@@ -1,11 +1,21 @@
 {
-  "title": "Employees_Get",
-  "operationId": "Employees_Get",
+  "title": "Employees_Update",
+  "operationId": "Employees_Update",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-08-01-preview",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
     "resourceGroupName": "rgopenapi",
-    "employeeName": "le-8MU--J3W6q8D386p3-iT3"
+    "employeeName": "-XhyNJ--",
+    "properties": {
+      "tags": {
+        "key7952": "no"
+      },
+      "properties": {
+        "age": 24,
+        "city": "uyfg",
+        "profile": "oapgijcswfkruiuuzbwco"
+      }
+    }
   },
   "responses": {
     "200": {
@@ -20,7 +30,7 @@
           "key2913": "urperxmkkhhkp"
         },
         "location": "itajgxyqozseoygnl",
-        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/contoso/providers/Microsoft.Contoso/employees/test",
         "name": "xepyxhpb",
         "type": "svvamxrdnnv",
         "systemData": {

--- a/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Operations_List.json
+++ b/specification/contosowidgetmanager/Contoso.Management/examples/2026-08-01-preview/Operations_List.json
@@ -2,7 +2,7 @@
   "title": "Operations_List",
   "operationId": "Operations_List",
   "parameters": {
-    "api-version": "2021-10-01-preview"
+    "api-version": "2026-08-01-preview"
   },
   "responses": {
     "200": {

--- a/specification/contosowidgetmanager/Contoso.Management/main.tsp
+++ b/specification/contosowidgetmanager/Contoso.Management/main.tsp
@@ -19,13 +19,18 @@ namespace Microsoft.Contoso;
 
 /** The available API versions. */
 enum Versions {
-  /** 2021-10-01-preview version */
-  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
-  v2021_10_01_preview: "2021-10-01-preview",
-
   /** 2021-11-01 version */
   @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
   v2021_11_01: "2021-11-01",
+
+  /** 2026-07-01 version */
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  v2026_07_01: "2026-07-01",
+
+  /** 2026-08-01-preview version */
+  @previewVersion
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  v2026_08_01_preview: "2026-08-01-preview",
 }
 
 interface Operations extends Azure.ResourceManager.Operations {}

--- a/specification/contosowidgetmanager/Contoso.Management/service.yaml
+++ b/specification/contosowidgetmanager/Contoso.Management/service.yaml
@@ -1,9 +1,13 @@
 versions:
-  - version: 2021-10-01-preview
-    source: typespec
-    swagger-files:
-      - ../resource-manager/Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
   - version: 2021-11-01
     source: typespec
     swagger-files:
       - ../resource-manager/Microsoft.Contoso/stable/2021-11-01/contoso.json
+  - version: 2026-07-01
+    source: typespec
+    swagger-files:
+      - ../resource-manager/Microsoft.Contoso/stable/2026-07-01/contoso.json
+  - version: 2026-08-01-preview
+    source: typespec
+    swagger-files:
+      - ../resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/contoso.json

--- a/specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml
+++ b/specification/contosowidgetmanager/Contoso.Management/tspconfig.yaml
@@ -10,26 +10,31 @@ options:
     azure-resource-provider-folder: "resource-manager"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/contoso.json"
   "@azure-typespec/http-client-csharp-mgmt":
+    api-version: "2026-07-01"
     namespace: "Azure.ResourceManager.Contoso"
     emitter-output-dir: "{output-dir}/{service-dir}/{namespace}"
   "@azure-tools/typespec-python":
+    api-version: "2026-07-01"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-contoso"
     namespace: "azure.mgmt.contoso"
     generate-test: true
     generate-sample: true
     flavor: "azure"
   "@azure-tools/typespec-java":
+    api-version: "2026-07-01"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-resourcemanager-contoso"
     namespace: "com.azure.resourcemanager.contoso"
     service-name: "Contoso" # human-readable service name, whitespace allowed
     flavor: azure
   "@azure-tools/typespec-ts":
+    api-version: "2026-07-01"
     emitter-output-dir: "{output-dir}/{service-dir}/arm-contoso"
     flavor: azure
     experimental-extensible-enums: true
     package-details:
       name: "@azure/arm-contoso"
   "@azure-tools/typespec-go":
+    api-version: "2026-07-01"
     service-dir: "sdk/resourcemanager/contoso"
     emitter-output-dir: "{output-dir}/{service-dir}/armcontoso"
     module: "github.com/Azure/azure-sdk-for-go/{service-dir}/armcontoso"

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/contoso.json
@@ -1,0 +1,565 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft.Contoso management service",
+    "version": "2026-08-01-preview",
+    "description": "Microsoft.Contoso Resource Provider management API.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "Employees"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.Contoso/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Contoso/employees": {
+      "get": {
+        "operationId": "Employees_ListBySubscription",
+        "tags": [
+          "Employees"
+        ],
+        "description": "List Employee resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EmployeeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_ListBySubscription": {
+            "$ref": "./examples/Employees_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/employees": {
+      "get": {
+        "operationId": "Employees_ListByResourceGroup",
+        "tags": [
+          "Employees"
+        ],
+        "description": "List Employee resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EmployeeListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_ListByResourceGroup": {
+            "$ref": "./examples/Employees_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Contoso/employees/{employeeName}": {
+      "get": {
+        "operationId": "Employees_Get",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Get a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_Get": {
+            "$ref": "./examples/Employees_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Employees_CreateOrUpdate",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Create a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Employee' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          },
+          "201": {
+            "description": "Resource 'Employee' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_CreateOrUpdate": {
+            "$ref": "./examples/Employees_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Employees_Update",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Update a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EmployeeUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Employee"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_Update": {
+            "$ref": "./examples/Employees_Update.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Employees_Delete",
+        "tags": [
+          "Employees"
+        ],
+        "description": "Delete a Employee",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "employeeName",
+            "in": "path",
+            "description": "The name of the Employee",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-]{3,24}$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Employees_Delete": {
+            "$ref": "./examples/Employees_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "Azure.ResourceManager.CommonTypes.TrackedResourceUpdate": {
+      "type": "object",
+      "title": "Tracked Resource",
+      "description": "The resource model definition for an Azure Resource Manager tracked top level resource which has 'tags' and a 'location'",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "Employee": {
+      "type": "object",
+      "description": "Employee resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EmployeeProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "EmployeeListResult": {
+      "type": "object",
+      "description": "The response of a Employee list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Employee items on this page",
+          "items": {
+            "$ref": "#/definitions/Employee"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EmployeeProperties": {
+      "type": "object",
+      "description": "Employee properties",
+      "properties": {
+        "age": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Age of employee"
+        },
+        "city": {
+          "type": "string",
+          "description": "City of employee"
+        },
+        "department": {
+          "type": "string",
+          "description": "Department of employee"
+        },
+        "isContractor": {
+          "type": "boolean",
+          "description": "Whether the employee is a contractor"
+        },
+        "profile": {
+          "type": "string",
+          "format": "base64url",
+          "description": "Profile of employee"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        }
+      }
+    },
+    "EmployeeUpdate": {
+      "type": "object",
+      "description": "Employee resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EmployeeProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate"
+        }
+      ]
+    },
+    "ProvisioningState": {
+      "type": "string",
+      "description": "The resource provisioning state.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Provisioning",
+        "Updating",
+        "Deleting",
+        "Accepted"
+      ],
+      "x-ms-enum": {
+        "name": "ProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "The resource is being provisioned"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "The resource is updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "The resource is being deleted"
+          },
+          {
+            "name": "Accepted",
+            "value": "Accepted",
+            "description": "The resource create request has been accepted"
+          }
+        ]
+      },
+      "readOnly": true
+    }
+  },
+  "parameters": {}
+}

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_CreateOrUpdate.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_CreateOrUpdate.json
@@ -2,7 +2,7 @@
   "title": "Employees_CreateOrUpdate",
   "operationId": "Employees_CreateOrUpdate",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-08-01-preview",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
     "resourceGroupName": "rgopenapi",
     "employeeName": "9KF-f-8b",

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_Delete.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_Delete.json
@@ -2,7 +2,7 @@
   "title": "Employees_Delete",
   "operationId": "Employees_Delete",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-08-01-preview",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
     "resourceGroupName": "rgopenapi",
     "employeeName": "5vX--BxSu3ux48rI4O9OQ569"

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_Get.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_Get.json
@@ -1,0 +1,37 @@
+{
+  "title": "Employees_Get",
+  "operationId": "Employees_Get",
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "le-8MU--J3W6q8D386p3-iT3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_ListByResourceGroup.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_ListByResourceGroup.json
@@ -1,0 +1,41 @@
+{
+  "title": "Employees_ListByResourceGroup",
+  "operationId": "Employees_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_ListBySubscription.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_ListBySubscription.json
@@ -1,0 +1,40 @@
+{
+  "title": "Employees_ListBySubscription",
+  "operationId": "Employees_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-08-01-preview",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "age": 30,
+              "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+              "profile": "ms",
+              "provisioningState": "Succeeded"
+            },
+            "tags": {
+              "key2913": "urperxmkkhhkp"
+            },
+            "location": "itajgxyqozseoygnl",
+            "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/test",
+            "name": "xepyxhpb",
+            "type": "svvamxrdnnv",
+            "systemData": {
+              "createdBy": "iewyxsnriqktsvp",
+              "createdByType": "User",
+              "createdAt": "2023-05-19T00:28:48.610Z",
+              "lastModifiedBy": "xrchbnnuzierzpxw",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+            }
+          }
+        ],
+        "nextLink": "https://microsoft.com/a"
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_Update.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Employees_Update.json
@@ -1,11 +1,21 @@
 {
-  "title": "Employees_Get",
-  "operationId": "Employees_Get",
+  "title": "Employees_Update",
+  "operationId": "Employees_Update",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-08-01-preview",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
     "resourceGroupName": "rgopenapi",
-    "employeeName": "le-8MU--J3W6q8D386p3-iT3"
+    "employeeName": "-XhyNJ--",
+    "properties": {
+      "tags": {
+        "key7952": "no"
+      },
+      "properties": {
+        "age": 24,
+        "city": "uyfg",
+        "profile": "oapgijcswfkruiuuzbwco"
+      }
+    }
   },
   "responses": {
     "200": {
@@ -20,7 +30,7 @@
           "key2913": "urperxmkkhhkp"
         },
         "location": "itajgxyqozseoygnl",
-        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/contoso/providers/Microsoft.Contoso/employees/test",
         "name": "xepyxhpb",
         "type": "svvamxrdnnv",
         "systemData": {

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Operations_List.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/preview/2026-08-01-preview/examples/Operations_List.json
@@ -2,7 +2,7 @@
   "title": "Operations_List",
   "operationId": "Operations_List",
   "parameters": {
-    "api-version": "2021-10-01-preview"
+    "api-version": "2026-08-01-preview"
   },
   "responses": {
     "200": {

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/contoso.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/contoso.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Microsoft.Contoso management service",
-    "version": "2021-10-01-preview",
+    "version": "2026-07-01",
     "description": "Microsoft.Contoso Resource Provider management API.",
     "x-typespec-generated": [
       {
@@ -469,6 +469,10 @@
         "city": {
           "type": "string",
           "description": "City of employee"
+        },
+        "department": {
+          "type": "string",
+          "description": "Department of employee"
         },
         "profile": {
           "type": "string",

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_CreateOrUpdate.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_CreateOrUpdate.json
@@ -1,0 +1,76 @@
+{
+  "title": "Employees_CreateOrUpdate",
+  "operationId": "Employees_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "9KF-f-8b",
+    "resource": {
+      "properties": {
+        "age": 30,
+        "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+        "profile": "ms"
+      },
+      "tags": {
+        "key2913": "urperxmkkhhkp"
+      },
+      "location": "itajgxyqozseoygnl"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://contoso.com/operationstatus"
+      },
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/9KF-f-8b",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_Delete.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Employees_Delete",
+  "operationId": "Employees_Delete",
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "5vX--BxSu3ux48rI4O9OQ569"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "Retry-After": 30,
+        "location": "https://contoso.com/operationstatus"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_Get.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_Get.json
@@ -1,0 +1,37 @@
+{
+  "title": "Employees_Get",
+  "operationId": "Employees_Get",
+  "parameters": {
+    "api-version": "2026-07-01",
+    "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
+    "resourceGroupName": "rgopenapi",
+    "employeeName": "le-8MU--J3W6q8D386p3-iT3"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "age": 30,
+          "city": "gydhnntudughbmxlkyzrskcdkotrxn",
+          "profile": "ms",
+          "provisioningState": "Succeeded"
+        },
+        "tags": {
+          "key2913": "urperxmkkhhkp"
+        },
+        "location": "itajgxyqozseoygnl",
+        "id": "/subscriptions/11809CA1-E126-4017-945E-AA795CD5C5A9/resourceGroups/rgopenapi/providers/Microsoft.Contoso/employees/le-8MU--J3W6q8D386p3-iT3",
+        "name": "xepyxhpb",
+        "type": "svvamxrdnnv",
+        "systemData": {
+          "createdBy": "iewyxsnriqktsvp",
+          "createdByType": "User",
+          "createdAt": "2023-05-19T00:28:48.610Z",
+          "lastModifiedBy": "xrchbnnuzierzpxw",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2023-05-19T00:28:48.610Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_ListByResourceGroup.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_ListByResourceGroup.json
@@ -2,7 +2,7 @@
   "title": "Employees_ListByResourceGroup",
   "operationId": "Employees_ListByResourceGroup",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-07-01",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
     "resourceGroupName": "rgopenapi"
   },

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_ListBySubscription.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_ListBySubscription.json
@@ -2,7 +2,7 @@
   "title": "Employees_ListBySubscription",
   "operationId": "Employees_ListBySubscription",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-07-01",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9"
   },
   "responses": {

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_Update.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Employees_Update.json
@@ -2,7 +2,7 @@
   "title": "Employees_Update",
   "operationId": "Employees_Update",
   "parameters": {
-    "api-version": "2021-10-01-preview",
+    "api-version": "2026-07-01",
     "subscriptionId": "11809CA1-E126-4017-945E-AA795CD5C5A9",
     "resourceGroupName": "rgopenapi",
     "employeeName": "-XhyNJ--",

--- a/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Operations_List.json
+++ b/specification/contosowidgetmanager/resource-manager/Microsoft.Contoso/stable/2026-07-01/examples/Operations_List.json
@@ -1,0 +1,28 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-07-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "ymeow",
+            "isDataAction": true,
+            "display": {
+              "provider": "qxyznq",
+              "resource": "bqfwkox",
+              "operation": "td",
+              "description": "yvgkhsuwartgxb"
+            },
+            "origin": "user",
+            "actionType": "Internal"
+          }
+        ],
+        "nextLink": "https://sample.com/nextLink"
+      }
+    }
+  }
+}

--- a/specification/contosowidgetmanager/resource-manager/readme.md
+++ b/specification/contosowidgetmanager/resource-manager/readme.md
@@ -24,7 +24,7 @@ These are the global settings for the containerstorage.
 ```yaml
 openapi-type: arm
 openapi-subtype: rpaas
-tag: package-2021-11-01
+tag: package-2026-08-01-preview
 ```
 
 ### Tag: package-2021-11-01
@@ -36,13 +36,22 @@ input-file:
   - Microsoft.Contoso/stable/2021-11-01/contoso.json
 ```
 
-### Tag: package-2021-10-01-preview
+### Tag: package-2026-07-01
 
-These settings apply only when `--tag=package-2021-10-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2026-07-01` is specified on the command line.
 
-```yaml $(tag) == 'package-2021-10-01-preview'
+```yaml $(tag) == 'package-2026-07-01'
 input-file:
-  - Microsoft.Contoso/preview/2021-10-01-preview/contoso.json
+  - Microsoft.Contoso/stable/2026-07-01/contoso.json
+```
+
+### Tag: package-2026-08-01-preview
+
+These settings apply only when `--tag=package-2026-08-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-08-01-preview'
+input-file:
+  - Microsoft.Contoso/preview/2026-08-01-preview/contoso.json
 ```
 
 ---


### PR DESCRIPTION
## Summary

- remove the superseded `2021-10-01-preview` API version
- add stable `2026-07-01` with optional `department`
- add preview `2026-08-01-preview` with optional `isContractor`
- pin all SDK emitters to stable `2026-07-01`
- update `service.yaml` and regenerate examples and resource-manager OpenAPI files

## Validation

- `tsp format` on changed TypeSpec files
- `tsp compile specification/contosowidgetmanager/Contoso.Management/main.tsp`
