### PR TITLE
Add AppService provisioning configuration

### DIFF
--- a/specification/web/resource-manager/Microsoft.Web/AppService/client.tsp
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/client.tsp
@@ -4178,6 +4178,7 @@ op webAppsStartWebSiteNetworkTraceOperationSlotForJs(
 @@clientName(SkuInfoCollection, "AppServicePoolSkuInfoListResult", "csharp");
 @@clientName(SkuInfos, "AppServiceSkuResult", "csharp");
 @@clientName(SlotDifferenceCollection, "SlotDifferenceListResult", "csharp");
+@@clientName(SlotConfigNames, "SlotConfigNamesProperties", "csharp");
 @@clientName(Snapshot, "AppSnapshot", "csharp");
 @@clientName(SnapshotCollection, "AppSnapshotListResult", "csharp");
 @@clientName(Solution, "DiagnosticSolution", "csharp");

--- a/specification/web/resource-manager/Microsoft.Web/AppService/client.tsp
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/client.tsp
@@ -3796,6 +3796,24 @@ op webAppsStartWebSiteNetworkTraceOperationSlotForJs(
 );
 
 // --- Model renames ---
+// Preserve the App Service RBAC role helpers emitted by the reflection-based provisioning generator.
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "RBAC roles for provisioning compatibility"
+@@clientOption(
+  AppServicePlan,
+  "resource-rbac-roles",
+  #{ WebPlanContributor: "2cc479cb-7b4d-49a8-b449-8c00fd0f0a4b" },
+  "csharp"
+);
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "RBAC roles for provisioning compatibility"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "RBAC roles for provisioning compatibility"
+@@clientOption(
+  Site,
+  "resource-rbac-roles",
+  #{ WebsiteContributor: "de139f84-1756-47ae-9be6-808fbbe84772" },
+  "csharp"
+);
+
 @@clientName(AddressResponse, "AppServiceEnvironmentAddress", "csharp");
 @@clientName(AllowedPrincipals, "AppServiceAadAllowedPrincipals", "csharp");
 @@clientName(AnalysisData, "AnalysisDetectorEvidences", "csharp");

--- a/specification/web/resource-manager/Microsoft.Web/AppService/client.tsp
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/client.tsp
@@ -3814,6 +3814,18 @@ op webAppsStartWebSiteNetworkTraceOperationSlotForJs(
   "csharp"
 );
 
+#suppress "@azure-tools/typespec-client-generator-core/client-option" "Provisioning resource names"
+#suppress "@azure-tools/typespec-client-generator-core/client-option-requires-scope" "Provisioning resource names"
+@@clientOption(
+  CsmPublishingCredentialsPoliciesEntity,
+  "provisioning-resource-name",
+  #{
+    `Microsoft.Web/sites/basicPublishingCredentialsPolicies`: "WebSiteFtpPublishingCredentialsPolicy",
+    `Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies`: "WebSiteSlotFtpPublishingCredentialsPolicy",
+  },
+  "csharp"
+);
+
 @@clientName(AddressResponse, "AppServiceEnvironmentAddress", "csharp");
 @@clientName(AllowedPrincipals, "AppServiceAadAllowedPrincipals", "csharp");
 @@clientName(AnalysisData, "AnalysisDetectorEvidences", "csharp");

--- a/specification/web/resource-manager/Microsoft.Web/AppService/client.tsp
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/client.tsp
@@ -3820,8 +3820,8 @@ op webAppsStartWebSiteNetworkTraceOperationSlotForJs(
   CsmPublishingCredentialsPoliciesEntity,
   "provisioning-resource-name",
   #{
-    `Microsoft.Web/sites/basicPublishingCredentialsPolicies`: "WebSiteFtpPublishingCredentialsPolicy",
-    `Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies`: "WebSiteSlotFtpPublishingCredentialsPolicy",
+    `Microsoft.Web/sites/basicPublishingCredentialsPolicies`: "WebSitePublishingCredentialsPolicy",
+    `Microsoft.Web/sites/slots/basicPublishingCredentialsPolicies`: "WebSiteSlotPublishingCredentialsPolicy",
   },
   "csharp"
 );

--- a/specification/web/resource-manager/Microsoft.Web/AppService/tspconfig.yaml
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/tspconfig.yaml
@@ -11,7 +11,7 @@ options:
   "@azure-typespec/http-client-csharp-provisioning":
     namespace: "Azure.Provisioning.AppService"
     emitter-output-dir: "{output-dir}/sdk/websites/{namespace}"
-    api-version: "2026-07-15"
+    api-version: "2025-03-01"
   "@azure-tools/typespec-autorest":
     omit-unreachable-types: true
     emitter-output-dir: "{project-root}"

--- a/specification/web/resource-manager/Microsoft.Web/AppService/tspconfig.yaml
+++ b/specification/web/resource-manager/Microsoft.Web/AppService/tspconfig.yaml
@@ -8,6 +8,10 @@ options:
     namespace: "Azure.ResourceManager.AppService"
     emitter-output-dir: "{output-dir}/sdk/websites/{namespace}"
     enable-wire-path-attribute: true
+  "@azure-typespec/http-client-csharp-provisioning":
+    namespace: "Azure.Provisioning.AppService"
+    emitter-output-dir: "{output-dir}/sdk/websites/{namespace}"
+    api-version: "2026-07-15"
   "@azure-tools/typespec-autorest":
     omit-unreachable-types: true
     emitter-output-dir: "{project-root}"


### PR DESCRIPTION
## Summary

- enable the C# provisioning emitter for AppService
- generate against API version 2025-03-01 to match the currently shipped Azure.Provisioning.AppService library

## Validation

- local Azure.Provisioning.AppService generation succeeds