### PR TITLE
Promote auth blob token store properties to 2026-07-01

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/AuthConfigs_BlobStorageTokenStore_ClientId_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/AuthConfigs_BlobStorageTokenStore_ClientId_CreateOrUpdate.json
@@ -21,7 +21,8 @@
         "login": {
           "tokenStore": {
             "azureBlobStorage": {
-              "sasUrlSettingName": "sasUrlSettingName1"
+              "blobContainerUri": "https://test.blob.core.windows.net/container1",
+              "clientId": "00000000-0000-0000-0000-000000000000"
             }
           }
         },
@@ -60,7 +61,8 @@
           "login": {
             "tokenStore": {
               "azureBlobStorage": {
-                "sasUrlSettingName": "sasUrlSettingName1"
+                "blobContainerUri": "https://test.blob.core.windows.net/container1",
+                "clientId": "00000000-0000-0000-0000-000000000000"
               }
             }
           },

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/AuthConfigs_BlobStorageTokenStore_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/AuthConfigs_BlobStorageTokenStore_CreateOrUpdate.json
@@ -21,7 +21,8 @@
         "login": {
           "tokenStore": {
             "azureBlobStorage": {
-              "sasUrlSettingName": "sasUrlSettingName1"
+              "blobContainerUri": "https://test.blob.core.windows.net/container1",
+              "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
             }
           }
         },
@@ -60,7 +61,8 @@
           "login": {
             "tokenStore": {
               "azureBlobStorage": {
-                "sasUrlSettingName": "sasUrlSettingName1"
+                "blobContainerUri": "https://test.blob.core.windows.net/container1",
+                "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
               }
             }
           },

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
@@ -1623,28 +1623,27 @@ model BlobStorageTokenStore {
   /**
    * The name of the app secrets containing the SAS URL of the blob storage containing the tokens.
    */
-  @madeRequired(Versions.v2026_01_01)
-  sasUrlSettingName: string;
+  sasUrlSettingName?: string;
 
   /**
    * The URI of the blob storage containing the tokens. Should not be used along with sasUrlSettingName.
    */
   @removed(Versions.v2026_01_01)
-  @removed(Versions.v2026_07_01)
+  @added(Versions.v2026_07_01)
   blobContainerUri?: string;
 
   /**
    * The Client ID of a User-Assigned Managed Identity. Should not be used along with managedIdentityResourceId.
    */
   @removed(Versions.v2026_01_01)
-  @removed(Versions.v2026_07_01)
+  @added(Versions.v2026_07_01)
   clientId?: string;
 
   /**
    * The Resource ID of a User-Assigned Managed Identity. Should not be used along with clientId.
    */
   @removed(Versions.v2026_01_01)
-  @removed(Versions.v2026_07_01)
+  @added(Versions.v2026_07_01)
   managedIdentityResourceId?: string;
 }
 

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-01-01/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-01-01/openapi.json
@@ -8725,10 +8725,7 @@
           "type": "string",
           "description": "The name of the app secrets containing the SAS URL of the blob storage containing the tokens."
         }
-      },
-      "required": [
-        "sasUrlSettingName"
-      ]
+      }
     },
     "Certificate": {
       "type": "object",

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/AuthConfigs_BlobStorageTokenStore_ClientId_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/AuthConfigs_BlobStorageTokenStore_ClientId_CreateOrUpdate.json
@@ -21,7 +21,8 @@
         "login": {
           "tokenStore": {
             "azureBlobStorage": {
-              "sasUrlSettingName": "sasUrlSettingName1"
+              "blobContainerUri": "https://test.blob.core.windows.net/container1",
+              "clientId": "00000000-0000-0000-0000-000000000000"
             }
           }
         },
@@ -60,7 +61,8 @@
           "login": {
             "tokenStore": {
               "azureBlobStorage": {
-                "sasUrlSettingName": "sasUrlSettingName1"
+                "blobContainerUri": "https://test.blob.core.windows.net/container1",
+                "clientId": "00000000-0000-0000-0000-000000000000"
               }
             }
           },

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/AuthConfigs_BlobStorageTokenStore_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/AuthConfigs_BlobStorageTokenStore_CreateOrUpdate.json
@@ -21,7 +21,8 @@
         "login": {
           "tokenStore": {
             "azureBlobStorage": {
-              "sasUrlSettingName": "sasUrlSettingName1"
+              "blobContainerUri": "https://test.blob.core.windows.net/container1",
+              "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
             }
           }
         },
@@ -60,7 +61,8 @@
           "login": {
             "tokenStore": {
               "azureBlobStorage": {
-                "sasUrlSettingName": "sasUrlSettingName1"
+                "blobContainerUri": "https://test.blob.core.windows.net/container1",
+                "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
               }
             }
           },

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
@@ -8784,11 +8784,20 @@
         "sasUrlSettingName": {
           "type": "string",
           "description": "The name of the app secrets containing the SAS URL of the blob storage containing the tokens."
+        },
+        "blobContainerUri": {
+          "type": "string",
+          "description": "The URI of the blob storage containing the tokens. Should not be used along with sasUrlSettingName."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The Client ID of a User-Assigned Managed Identity. Should not be used along with managedIdentityResourceId."
+        },
+        "managedIdentityResourceId": {
+          "type": "string",
+          "description": "The Resource ID of a User-Assigned Managed Identity. Should not be used along with clientId."
         }
-      },
-      "required": [
-        "sasUrlSettingName"
-      ]
+      }
     },
     "Certificate": {
       "type": "object",


### PR DESCRIPTION
Expose blobContainerUri, clientId, and managedIdentityResourceId in the stable Container Apps auth config schema, keep sasUrlSettingName optional, and update the corresponding examples and generated OpenAPI.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
