### PR TITLE
Add job execution detailedStatus, reason and message to Microsoft.App 2026-07-01

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/Job_Execution_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/Job_Execution_Get.json
@@ -12,7 +12,24 @@
         "name": "jobExecution1",
         "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0/executions/jobExecution1",
         "properties": {
+          "detailedStatus": {
+            "replicas": [
+              {
+                "name": "testcontainerappsjob0-0",
+                "containers": [
+                  {
+                    "name": "testcontainerappsjob0",
+                    "additionalInformation": "Completed",
+                    "code": 0,
+                    "status": "Succeeded"
+                  }
+                ]
+              }
+            ]
+          },
           "endTime": "2023-02-13T20:47:30+00:00",
+          "message": "Job has reached the specified backoff limit",
+          "reason": "BackoffLimitExceeded",
           "startTime": "2023-02-13T20:37:30+00:00",
           "status": "Running",
           "template": {

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/Job_Executions_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/Job_Executions_Get.json
@@ -14,7 +14,30 @@
             "name": "testcontainerAppJob-27944454",
             "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0/executions/testcontainerAppJob-27944454",
             "properties": {
+              "detailedStatus": {
+                "replicas": [
+                  {
+                    "name": "testcontainerappsjob0-0",
+                    "containers": [
+                      {
+                        "name": "container1",
+                        "additionalInformation": "Completed",
+                        "code": 0,
+                        "status": "Succeeded"
+                      },
+                      {
+                        "name": "container2",
+                        "additionalInformation": "Completed",
+                        "code": 0,
+                        "status": "Succeeded"
+                      }
+                    ]
+                  }
+                ]
+              },
               "endTime": "2023-02-13T20:47:30+00:00",
+              "message": "Job has reached the specified backoff limit",
+              "reason": "BackoffLimitExceeded",
               "startTime": "2023-02-13T20:37:30+00:00",
               "status": "Running",
               "template": {

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
@@ -4364,7 +4364,7 @@ model JobExecutionProperties {
    * Detailed status of the job execution.
    */
   @removed(Versions.v2026_01_01)
-  @removed(Versions.v2026_07_01)
+  @added(Versions.v2026_07_01)
   detailedStatus?: ExecutionStatus;
 
   /**
@@ -4372,7 +4372,7 @@ model JobExecutionProperties {
    */
   @visibility(Lifecycle.Read)
   @removed(Versions.v2026_01_01)
-  @removed(Versions.v2026_07_01)
+  @added(Versions.v2026_07_01)
   reason?: string;
 
   /**
@@ -4380,7 +4380,7 @@ model JobExecutionProperties {
    */
   @visibility(Lifecycle.Read)
   @removed(Versions.v2026_01_01)
-  @removed(Versions.v2026_07_01)
+  @added(Versions.v2026_07_01)
   message?: string;
 }
 

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/Job_Execution_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/Job_Execution_Get.json
@@ -12,7 +12,24 @@
         "name": "jobExecution1",
         "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0/executions/jobExecution1",
         "properties": {
+          "detailedStatus": {
+            "replicas": [
+              {
+                "name": "testcontainerappsjob0-0",
+                "containers": [
+                  {
+                    "name": "testcontainerappsjob0",
+                    "additionalInformation": "Completed",
+                    "code": 0,
+                    "status": "Succeeded"
+                  }
+                ]
+              }
+            ]
+          },
           "endTime": "2023-02-13T20:47:30+00:00",
+          "message": "Job has reached the specified backoff limit",
+          "reason": "BackoffLimitExceeded",
           "startTime": "2023-02-13T20:37:30+00:00",
           "status": "Running",
           "template": {

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/Job_Executions_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/Job_Executions_Get.json
@@ -14,7 +14,30 @@
             "name": "testcontainerAppJob-27944454",
             "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0/executions/testcontainerAppJob-27944454",
             "properties": {
+              "detailedStatus": {
+                "replicas": [
+                  {
+                    "name": "testcontainerappsjob0-0",
+                    "containers": [
+                      {
+                        "name": "container1",
+                        "additionalInformation": "Completed",
+                        "code": 0,
+                        "status": "Succeeded"
+                      },
+                      {
+                        "name": "container2",
+                        "additionalInformation": "Completed",
+                        "code": 0,
+                        "status": "Succeeded"
+                      }
+                    ]
+                  }
+                ]
+              },
               "endTime": "2023-02-13T20:47:30+00:00",
+              "message": "Job has reached the specified backoff limit",
+              "reason": "BackoffLimitExceeded",
               "startTime": "2023-02-13T20:37:30+00:00",
               "status": "Running",
               "template": {

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
@@ -9879,6 +9879,29 @@
         }
       }
     },
+    "ContainerExecutionStatus": {
+      "type": "object",
+      "description": "Container Apps Job execution container status. Contains status code and reason",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Container Name."
+        },
+        "code": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Exit code"
+        },
+        "additionalInformation": {
+          "type": "string",
+          "description": "Additional information for the container status"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the container"
+        }
+      }
+    },
     "ContainerResources": {
       "type": "object",
       "description": "Container App container resource requirements.",
@@ -11170,6 +11193,22 @@
         "message": {
           "type": "string",
           "description": "Any details of the error."
+        }
+      }
+    },
+    "ExecutionStatus": {
+      "type": "object",
+      "description": "Container Apps Job execution status.",
+      "properties": {
+        "replicas": {
+          "type": "array",
+          "description": "Replicas in the execution.",
+          "items": {
+            "$ref": "#/definitions/ReplicaExecutionStatus"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
         }
       }
     },
@@ -12496,6 +12535,20 @@
         "template": {
           "$ref": "#/definitions/JobExecutionTemplate",
           "description": "Job's execution container."
+        },
+        "detailedStatus": {
+          "$ref": "#/definitions/ExecutionStatus",
+          "description": "Detailed status of the job execution."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Reason for the current condition of job execution.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Human readable message indicating details about the current condition of the job execution.",
+          "readOnly": true
         }
       }
     },
@@ -14194,6 +14247,26 @@
           "type": "string",
           "description": "Container exec endpoint",
           "readOnly": true
+        }
+      }
+    },
+    "ReplicaExecutionStatus": {
+      "type": "object",
+      "description": "Container Apps Job execution replica status.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Replica Name."
+        },
+        "containers": {
+          "type": "array",
+          "description": "Containers in the execution replica",
+          "items": {
+            "$ref": "#/definitions/ContainerExecutionStatus"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
         }
       }
     },


### PR DESCRIPTION
## Summary

Promotes three `Microsoft.App/jobs` execution **response** properties from preview to the `2026-07-01` stable (GA) API version:

| Property | Preview since |
| --- | --- |
| `detailedStatus` (`replicas[]` → `containers[]`) | `2024-02-02-preview` |
| `detailedStatus.replicas[].containers[].additionalInformation` | `2024-02-02-preview` |
| `reason` and `message` | `2025-10-02-preview` |

These are part of the Microsoft.App/jobs 2026-07-01 GA contract gap review — properties that have been live in preview for some time and are being brought into the stable contract.

## Change

The models were already defined in `models.tsp`, but each property carried a second `@removed(Versions.v2026_07_01)` in addition to `@removed(Versions.v2026_01_01)`, which kept them out of the GA contract. That second decorator is replaced with `@added(Versions.v2026_07_01)`:

```diff
   @removed(Versions.v2026_01_01)
-  @removed(Versions.v2026_07_01)
+  @added(Versions.v2026_07_01)
   detailedStatus?: ExecutionStatus;
```

(same for `reason` and `message`)

Net effect on the versioned contract:

| API version | `detailedStatus` / `reason` / `message` |
| --- | --- |
| `2025-10-02-preview` | present (unchanged) |
| `2026-01-01` | absent (unchanged) |
| `2026-07-01` | **present (this change)** |

`2026-01-01` is deliberately left untouched, so no already-shipped stable version changes.

## Generated output

`stable/2026-07-01/openapi.json` was regenerated with `tsp compile` — **+73 lines, 0 deletions**:

- `JobExecutionProperties` gains `detailedStatus`, `reason` (`readOnly`) and `message` (`readOnly`)
- `ExecutionStatus`, `ReplicaExecutionStatus` and `ContainerExecutionStatus` definitions are now reachable in this version; `ContainerExecutionStatus` carries `name`, `code`, `status` and `additionalInformation`

The job execution GET examples were updated to demonstrate the promoted properties, matching the equivalent `2025-10-02-preview` examples.

## Compatibility

Purely additive to a read-only response contract, so no existing client is affected and there is no breaking change. The Container Apps resource provider already populates all three properties on this route today (they are emitted version-agnostically), so the service behavior matches the contract as soon as this merges.

## Validation

- `tsp compile` — completed successfully, no linter warnings (ARM ruleset)
- `tsp format --check` — pass
- `prettier --check` on all changed JSON — pass
- `oav validate-example` on `stable/2026-07-01/openapi.json` — `Validation completes without errors`
