### PR TITLE
Add stable DenyAssignment API version

### DIFF
--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/DenyAssignments_CreateForSubscription.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/DenyAssignments_CreateForSubscription.json
@@ -1,0 +1,139 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "denyAssignmentId": "64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+    "parameters": {
+      "properties": {
+        "description": "Prevent all users from deleting critical resources in the subscription.",
+        "denyAssignmentEffect": "enforced",
+        "denyAssignmentName": "Deny delete on critical resources",
+        "doNotApplyToChildScopes": false,
+        "excludePrincipals": [
+          {
+            "type": "ServicePrincipal",
+            "id": "ce2ce14e-85d7-4629-bdbc-454d0519d987"
+          }
+        ],
+        "permissions": [
+          {
+            "actions": [
+              "*/delete"
+            ],
+            "dataActions": [],
+            "notActions": [],
+            "notDataActions": []
+          }
+        ],
+        "principals": [
+          {
+            "type": "SystemDefined",
+            "id": "00000000-0000-0000-0000-000000000000"
+          }
+        ]
+      }
+    },
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+        "type": "Microsoft.Authorization/denyAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/denyAssignments/64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+        "properties": {
+          "description": "Prevent all users from deleting critical resources in the subscription.",
+          "createdBy": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "createdOn": "2024-07-01T00:00:00.0000000Z",
+          "denyAssignmentEffect": "enforced",
+          "denyAssignmentName": "Deny delete on critical resources",
+          "doNotApplyToChildScopes": false,
+          "excludePrincipals": [
+            {
+              "type": "ServicePrincipal",
+              "id": "ce2ce14e-85d7-4629-bdbc-454d0519d987"
+            }
+          ],
+          "isSystemProtected": false,
+          "permissions": [
+            {
+              "actions": [
+                "*/delete"
+              ],
+              "dataActions": [],
+              "notActions": [],
+              "notDataActions": []
+            }
+          ],
+          "principals": [
+            {
+              "type": "SystemDefined",
+              "id": "00000000-0000-0000-0000-000000000000"
+            }
+          ],
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+          "updatedBy": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "updatedOn": "2024-07-01T00:00:00.0000000Z"
+        },
+        "systemData": {
+          "createdAt": "2024-07-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-07-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+        "type": "Microsoft.Authorization/denyAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/denyAssignments/64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+        "properties": {
+          "description": "Prevent all users from deleting critical resources in the subscription.",
+          "createdBy": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "createdOn": "2024-07-01T00:00:00.0000000Z",
+          "denyAssignmentEffect": "enforced",
+          "denyAssignmentName": "Deny delete on critical resources",
+          "doNotApplyToChildScopes": false,
+          "excludePrincipals": [
+            {
+              "type": "ServicePrincipal",
+              "id": "ce2ce14e-85d7-4629-bdbc-454d0519d987"
+            }
+          ],
+          "isSystemProtected": false,
+          "permissions": [
+            {
+              "actions": [
+                "*/delete"
+              ],
+              "dataActions": [],
+              "notActions": [],
+              "notDataActions": []
+            }
+          ],
+          "principals": [
+            {
+              "type": "SystemDefined",
+              "id": "00000000-0000-0000-0000-000000000000"
+            }
+          ],
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+          "updatedBy": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "updatedOn": "2024-07-01T00:00:00.0000000Z"
+        },
+        "systemData": {
+          "createdAt": "2024-07-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-07-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "DenyAssignments_CreateOrUpdate",
+  "title": "Create deny assignment for subscription"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/DenyAssignments_Delete.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/DenyAssignments_Delete.json
@@ -1,0 +1,13 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "denyAssignmentId": "64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DenyAssignments_Delete",
+  "title": "Delete deny assignment"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetAllDenyAssignments.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetAllDenyAssignments.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "denyAssignmentName": "Deny assignment name",
+              "description": "Deny assignment description",
+              "permissions": [
+                {
+                  "actions": [
+                    "action"
+                  ],
+                  "notActions": [],
+                  "dataActions": [],
+                  "notDataActions": []
+                }
+              ],
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+              "doNotApplyToChildScopes": false,
+              "principals": [
+                {
+                  "id": "principalId1",
+                  "type": "principalType1"
+                }
+              ],
+              "excludePrincipals": [
+                {
+                  "id": "principalId2",
+                  "type": "principalType2"
+                }
+              ],
+              "isSystemProtected": true,
+              "denyAssignmentEffect": "enforced"
+            },
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+            "type": "Microsoft.Authorization/denyAssignments",
+            "name": "denyAssignmentId",
+            "systemData": {
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "createdAt": "2024-07-01T00:00:00.0000000Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-07-01T00:00:00.0000000Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DenyAssignments_List",
+  "title": "List deny assignments for subscription"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetDenyAssignmentById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetDenyAssignmentById.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "denyAssignmentId": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "denyAssignmentName": "Deny assignment name",
+          "description": "Deny assignment description",
+          "permissions": [
+            {
+              "actions": [
+                "action"
+              ],
+              "notActions": [],
+              "dataActions": [],
+              "notDataActions": []
+            }
+          ],
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname",
+          "doNotApplyToChildScopes": false,
+          "principals": [
+            {
+              "id": "principalId1",
+              "type": "principalType1"
+            }
+          ],
+          "excludePrincipals": [
+            {
+              "id": "principalId2",
+              "type": "principalType2"
+            }
+          ],
+          "isSystemProtected": true,
+          "denyAssignmentEffect": "enforced"
+        },
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+        "type": "Microsoft.Authorization/denyAssignments",
+        "name": "denyAssignmentId",
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2024-07-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-07-01T00:00:00.0000000Z"
+        }
+      }
+    }
+  },
+  "operationId": "DenyAssignments_GetById",
+  "title": "Get deny assignment by ID"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetDenyAssignmentByNameId.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetDenyAssignmentByNameId.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "denyAssignmentId": "denyAssignmentId",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "denyAssignmentId",
+        "type": "Microsoft.Authorization/denyAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+        "properties": {
+          "description": "Deny assignment description",
+          "denyAssignmentEffect": "enforced",
+          "denyAssignmentName": "Deny assignment name",
+          "doNotApplyToChildScopes": false,
+          "excludePrincipals": [
+            {
+              "type": "principalType2",
+              "id": "principalId2"
+            }
+          ],
+          "isSystemProtected": true,
+          "permissions": [
+            {
+              "actions": [
+                "action"
+              ],
+              "dataActions": [],
+              "notActions": [],
+              "notDataActions": []
+            }
+          ],
+          "principals": [
+            {
+              "type": "principalType1",
+              "id": "principalId1"
+            }
+          ],
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname"
+        },
+        "systemData": {
+          "createdAt": "2024-07-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-07-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "DenyAssignments_Get",
+  "title": "Get deny assignment by name"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetDenyAssignmentByScope.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetDenyAssignmentByScope.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "denyAssignmentName": "Deny assignment name",
+              "description": "Deny assignment description",
+              "permissions": [
+                {
+                  "actions": [
+                    "action"
+                  ],
+                  "notActions": [],
+                  "dataActions": [],
+                  "notDataActions": []
+                }
+              ],
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname",
+              "doNotApplyToChildScopes": false,
+              "principals": [
+                {
+                  "id": "principalId1",
+                  "type": "principalType1"
+                }
+              ],
+              "excludePrincipals": [
+                {
+                  "id": "principalId2",
+                  "type": "principalType2"
+                }
+              ],
+              "isSystemProtected": true,
+              "denyAssignmentEffect": "enforced"
+            },
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+            "type": "Microsoft.Authorization/denyAssignments",
+            "name": "denyAssignmentId",
+            "systemData": {
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "createdAt": "2024-07-01T00:00:00.0000000Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-07-01T00:00:00.0000000Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DenyAssignments_ListForScope",
+  "title": "List deny assignments for scope"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetDenyAssignmentsForResource.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetDenyAssignmentsForResource.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "parentResourcePath": "parentResourceType/parentResourceName",
+    "resourceGroupName": "rgname",
+    "resourceName": "resourceName",
+    "resourceProviderNamespace": "resourceProviderNamespace",
+    "resourceType": "resourceType",
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "denyAssignmentId",
+            "type": "Microsoft.Authorization/denyAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/resourceProviderNamespace/parentResourceType/parentResourceName/resourceType/resourceName/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+            "properties": {
+              "description": "Deny assignment description",
+              "denyAssignmentEffect": "enforced",
+              "denyAssignmentName": "Deny assignment name",
+              "doNotApplyToChildScopes": false,
+              "excludePrincipals": [
+                {
+                  "type": "principalType2",
+                  "id": "principalId2"
+                }
+              ],
+              "isSystemProtected": true,
+              "permissions": [
+                {
+                  "actions": [
+                    "action"
+                  ],
+                  "dataActions": [],
+                  "notActions": [],
+                  "notDataActions": []
+                }
+              ],
+              "principals": [
+                {
+                  "type": "principalType1",
+                  "id": "principalId1"
+                }
+              ],
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/resourceProviderNamespace/parentResourceType/parentResourceName/resourceType/resourceName"
+            },
+            "systemData": {
+              "createdAt": "2024-07-01T00:00:00.0000000Z",
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-07-01T00:00:00.0000000Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DenyAssignments_ListForResource",
+  "title": "List deny assignments for resource"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetDenyAssignmentsForResourceGroup.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/examples/2026-09-01/GetDenyAssignmentsForResourceGroup.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+    "resourceGroupName": "rgname",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "denyAssignmentName": "Deny assignment name",
+              "description": "Deny assignment description",
+              "permissions": [
+                {
+                  "actions": [
+                    "action"
+                  ],
+                  "notActions": [],
+                  "dataActions": [],
+                  "notDataActions": []
+                }
+              ],
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname",
+              "doNotApplyToChildScopes": false,
+              "principals": [
+                {
+                  "id": "principalId1",
+                  "type": "principalType1"
+                }
+              ],
+              "excludePrincipals": [
+                {
+                  "id": "principalId2",
+                  "type": "principalType2"
+                }
+              ],
+              "isSystemProtected": true,
+              "denyAssignmentEffect": "enforced"
+            },
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+            "type": "Microsoft.Authorization/denyAssignments",
+            "name": "denyAssignmentId",
+            "systemData": {
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "createdAt": "2024-07-01T00:00:00.0000000Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-07-01T00:00:00.0000000Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DenyAssignments_ListForResourceGroup",
+  "title": "List deny assignments for resource group"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/main.tsp
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/main.tsp
@@ -40,4 +40,9 @@ enum Versions {
    * The 2024-07-01-preview API version.
    */
   v2024_07_01_preview: "2024-07-01-preview",
+
+  /**
+   * The 2026-09-01 API version.
+   */
+  v2026_09_01: "2026-09-01",
 }

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/service.yaml
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/DenyAssignment/service.yaml
@@ -7,3 +7,7 @@ versions:
     source: typespec
     swagger-files:
       - ../preview/2024-07-01-preview/authorization-DenyAssignmentCalls.json
+  - version: 2026-09-01
+    source: typespec
+    swagger-files:
+      - ../stable/2026-09-01/authorization-DenyAssignmentCalls.json

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/readme.md
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the Authorization API.
 
 ```yaml
 openapi-type: arm
-tag: package-2025-12-01-preview
+tag: package-2026-09-01
 modelerfour:
   lenient-model-deduplication: true
 ```
@@ -104,14 +104,14 @@ directive:
     reason: The scope property in DenyAssignmentProperties is readOnly and returned in responses only. It does not repeat the path parameter in requests.
 ```
 
-### Tag: package-2025-12-01-preview
+### Tag: package-2026-09-01
 
-These settings apply only when `--tag=package-2025-12-01-preview` is specified on the command line.
+These settings apply only when `--tag=package-2026-09-01` is specified on the command line.
 
-```yaml $(tag) == 'package-2025-12-01-preview'
+```yaml $(tag) == 'package-2026-09-01'
 input-file:
   - stable/2015-07-01/ClassicAdmin.json
-  - preview/2024-07-01-preview/authorization-DenyAssignmentCalls.json
+  - stable/2026-09-01/authorization-DenyAssignmentCalls.json
   - stable/2022-04-01/authorization-ProviderOperationsCalls.json
   - stable/2022-04-01/authorization-RoleAssignmentsCalls.json
   - preview/2022-05-01-preview/authorization-RoleDefinitionsCalls.json

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/authorization-DenyAssignmentCalls.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/authorization-DenyAssignmentCalls.json
@@ -1,0 +1,686 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "AuthorizationManagementClient",
+    "version": "2026-09-01",
+    "description": "Role based access control provides you a way to apply granular level policy administration down to individual resources or resource groups. These operations enable you to manage deny assignments. A deny assignment describes the set of actions on resources that are denied for Azure Active Directory users.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "DenyAssignments"
+    }
+  ],
+  "paths": {
+    "/{denyAssignmentId}": {
+      "get": {
+        "operationId": "DenyAssignments_GetById",
+        "tags": [
+          "DenyAssignments"
+        ],
+        "description": "Gets a deny assignment by ID.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "denyAssignmentId",
+            "in": "path",
+            "description": "The fully qualified ID of the role assignment including scope, resource name, and resource type. Format: /{scope}/providers/Microsoft.Authorization/roleAssignments/{roleAssignmentName}. Example: /subscriptions/<SUB_ID>/resourcegroups/<RESOURCE_GROUP>/providers/Microsoft.Authorization/roleAssignments/<ROLE_ASSIGNMENT_NAME>",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DenyAssignment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get deny assignment by ID": {
+            "$ref": "./examples/GetDenyAssignmentById.json"
+          }
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.Authorization/denyAssignments": {
+      "get": {
+        "operationId": "DenyAssignments_ListForScope",
+        "tags": [
+          "DenyAssignments"
+        ],
+        "description": "Gets deny assignments for a scope.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. Use $filter=atScope() to return all deny assignments at or above the scope. Use $filter=denyAssignmentName eq '{name}' to search deny assignments by name at specified scope. Use $filter=principalId eq '{id}' to return all deny assignments at, above and below the scope for the specified principal. Use $filter=gdprExportPrincipalId eq '{id}' to return all deny assignments at, above and below the scope for the specified principal. This filter is different from the principalId filter as it returns not only those deny assignments that contain the specified principal is the Principals list but also those deny assignments that contain the specified principal is the ExcludePrincipals list. Additionally, when gdprExportPrincipalId filter is used, only the deny assignment name and description properties are returned.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DenyAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List deny assignments for scope": {
+            "$ref": "./examples/GetDenyAssignmentByScope.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/{scope}/providers/Microsoft.Authorization/denyAssignments/{denyAssignmentId}": {
+      "get": {
+        "operationId": "DenyAssignments_Get",
+        "tags": [
+          "DenyAssignments"
+        ],
+        "description": "Get the specified deny assignment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "denyAssignmentId",
+            "in": "path",
+            "description": "The ID of the deny assignment to get.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DenyAssignment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get deny assignment by name": {
+            "$ref": "./examples/GetDenyAssignmentByNameId.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DenyAssignments_CreateOrUpdate",
+        "tags": [
+          "DenyAssignments"
+        ],
+        "description": "Create or update a deny assignment by scope and name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "denyAssignmentId",
+            "in": "path",
+            "description": "The ID of the deny assignment to get.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "Parameters for the deny assignment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DenyAssignment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DenyAssignment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DenyAssignment"
+            }
+          },
+          "201": {
+            "description": "Resource 'DenyAssignment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DenyAssignment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create deny assignment for subscription": {
+            "$ref": "./examples/DenyAssignments_CreateForSubscription.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DenyAssignments_Delete",
+        "tags": [
+          "DenyAssignments"
+        ],
+        "description": "Delete a deny assignment by scope and name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "scope",
+            "in": "path",
+            "description": "The fully qualified Azure Resource manager identifier of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "denyAssignmentId",
+            "in": "path",
+            "description": "The ID of the deny assignment to get.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete deny assignment": {
+            "$ref": "./examples/DenyAssignments_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Authorization/denyAssignments": {
+      "get": {
+        "operationId": "DenyAssignments_List",
+        "tags": [
+          "DenyAssignments"
+        ],
+        "description": "Gets all deny assignments for the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. Use $filter=atScope() to return all deny assignments at or above the scope. Use $filter=denyAssignmentName eq '{name}' to search deny assignments by name at specified scope. Use $filter=principalId eq '{id}' to return all deny assignments at, above and below the scope for the specified principal. Use $filter=gdprExportPrincipalId eq '{id}' to return all deny assignments at, above and below the scope for the specified principal. This filter is different from the principalId filter as it returns not only those deny assignments that contain the specified principal is the Principals list but also those deny assignments that contain the specified principal is the ExcludePrincipals list. Additionally, when gdprExportPrincipalId filter is used, only the deny assignment name and description properties are returned.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DenyAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List deny assignments for subscription": {
+            "$ref": "./examples/GetAllDenyAssignments.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{parentResourcePath}/{resourceType}/{resourceName}/providers/Microsoft.Authorization/denyAssignments": {
+      "get": {
+        "operationId": "DenyAssignments_ListForResource",
+        "tags": [
+          "DenyAssignments"
+        ],
+        "description": "Gets deny assignments for a resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "description": "The ID of the target subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "description": "The name of the resource group. The name is case insensitive.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resourceProviderNamespace",
+            "in": "path",
+            "description": "The namespace of the resource provider.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "parentResourcePath",
+            "in": "path",
+            "description": "The parent resource identity.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "resourceType",
+            "in": "path",
+            "description": "The resource type of the resource.",
+            "required": true,
+            "type": "string",
+            "x-ms-skip-url-encoding": true
+          },
+          {
+            "name": "resourceName",
+            "in": "path",
+            "description": "The name of the resource to get deny assignments for.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9._-]+$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. Use $filter=atScope() to return all deny assignments at or above the scope. Use $filter=denyAssignmentName eq '{name}' to search deny assignments by name at specified scope. Use $filter=principalId eq '{id}' to return all deny assignments at, above and below the scope for the specified principal. Use $filter=gdprExportPrincipalId eq '{id}' to return all deny assignments at, above and below the scope for the specified principal. This filter is different from the principalId filter as it returns not only those deny assignments that contain the specified principal is the Principals list but also those deny assignments that contain the specified principal is the ExcludePrincipals list. Additionally, when gdprExportPrincipalId filter is used, only the deny assignment name and description properties are returned.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DenyAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List deny assignments for resource": {
+            "$ref": "./examples/GetDenyAssignmentsForResource.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Authorization/denyAssignments": {
+      "get": {
+        "operationId": "DenyAssignments_ListForResourceGroup",
+        "tags": [
+          "DenyAssignments"
+        ],
+        "description": "Gets deny assignments for a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. Use $filter=atScope() to return all deny assignments at or above the scope. Use $filter=denyAssignmentName eq '{name}' to search deny assignments by name at specified scope. Use $filter=principalId eq '{id}' to return all deny assignments at, above and below the scope for the specified principal. Use $filter=gdprExportPrincipalId eq '{id}' to return all deny assignments at, above and below the scope for the specified principal. This filter is different from the principalId filter as it returns not only those deny assignments that contain the specified principal is the Principals list but also those deny assignments that contain the specified principal is the ExcludePrincipals list. Additionally, when gdprExportPrincipalId filter is used, only the deny assignment name and description properties are returned.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DenyAssignmentListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List deny assignments for resource group": {
+            "$ref": "./examples/GetDenyAssignmentsForResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "DenyAssignment": {
+      "type": "object",
+      "description": "Deny Assignment",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DenyAssignmentProperties",
+          "description": "Deny assignment properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DenyAssignmentEffect": {
+      "type": "string",
+      "description": "The effect of the deny assignment. 'enforced' blocks access, 'audit' logs without blocking.",
+      "enum": [
+        "enforced",
+        "audit"
+      ],
+      "x-ms-enum": {
+        "name": "DenyAssignmentEffect",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "enforced",
+            "value": "enforced",
+            "description": "enforced"
+          },
+          {
+            "name": "audit",
+            "value": "audit",
+            "description": "audit"
+          }
+        ]
+      }
+    },
+    "DenyAssignmentListResult": {
+      "type": "object",
+      "description": "The response of a DenyAssignment list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DenyAssignment items on this page",
+          "items": {
+            "$ref": "#/definitions/DenyAssignment"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DenyAssignmentPermission": {
+      "type": "object",
+      "description": "Deny assignment permissions.",
+      "properties": {
+        "actions": {
+          "type": "array",
+          "description": "Actions to which the deny assignment does not grant access.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notActions": {
+          "type": "array",
+          "description": "Actions to exclude from that the deny assignment does not grant access.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dataActions": {
+          "type": "array",
+          "description": "Data actions to which the deny assignment does not grant access.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "notDataActions": {
+          "type": "array",
+          "description": "Data actions to exclude from that the deny assignment does not grant access.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the Deny assignment permission. This limits the resources it applies to."
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition."
+        }
+      }
+    },
+    "DenyAssignmentPrincipal": {
+      "type": "object",
+      "description": "Deny assignment principal.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The object ID of the principal."
+        },
+        "type": {
+          "$ref": "#/definitions/DenyAssignmentPrincipalType",
+          "description": "The type of the principal such as user, group, servicePrincipal, etc."
+        }
+      }
+    },
+    "DenyAssignmentPrincipalType": {
+      "type": "string",
+      "x-nullable": false
+    },
+    "DenyAssignmentProperties": {
+      "type": "object",
+      "description": "Deny assignment properties.",
+      "properties": {
+        "denyAssignmentName": {
+          "type": "string",
+          "description": "The display name of the deny assignment."
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the deny assignment."
+        },
+        "permissions": {
+          "type": "array",
+          "description": "An array of permissions that are denied by the deny assignment.",
+          "items": {
+            "$ref": "#/definitions/DenyAssignmentPermission"
+          },
+          "x-ms-identifiers": []
+        },
+        "scope": {
+          "type": "string",
+          "description": "The deny assignment scope.",
+          "readOnly": true
+        },
+        "doNotApplyToChildScopes": {
+          "type": "boolean",
+          "description": "Determines if the deny assignment applies to child scopes. Default value is false."
+        },
+        "principals": {
+          "type": "array",
+          "description": "Array of principals to which the deny assignment applies.",
+          "items": {
+            "$ref": "#/definitions/DenyAssignmentPrincipal"
+          }
+        },
+        "excludePrincipals": {
+          "type": "array",
+          "description": "Array of principals to which the deny assignment does not apply.",
+          "items": {
+            "$ref": "#/definitions/DenyAssignmentPrincipal"
+          }
+        },
+        "isSystemProtected": {
+          "type": "boolean",
+          "description": "Specifies whether this deny assignment was created by Azure and cannot be edited or deleted."
+        },
+        "denyAssignmentEffect": {
+          "$ref": "#/definitions/DenyAssignmentEffect",
+          "description": "The effect of the deny assignment. 'enforced' blocks access, 'audit' logs without blocking."
+        },
+        "condition": {
+          "type": "string",
+          "description": "The conditions on the deny assignment. This limits the resources it can be assigned to. e.g.: @Resource[Microsoft.Storage/storageAccounts/blobServices/containers:ContainerName] StringEqualsIgnoreCase 'foo_storage_container'"
+        },
+        "conditionVersion": {
+          "type": "string",
+          "description": "Version of the condition."
+        },
+        "createdOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time it was created",
+          "readOnly": true
+        },
+        "updatedOn": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Time it was updated",
+          "readOnly": true
+        },
+        "createdBy": {
+          "type": "string",
+          "description": "Id of the user who created the assignment",
+          "readOnly": true
+        },
+        "updatedBy": {
+          "type": "string",
+          "description": "Id of the user who updated the assignment",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/DenyAssignments_CreateForSubscription.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/DenyAssignments_CreateForSubscription.json
@@ -1,0 +1,139 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "denyAssignmentId": "64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+    "parameters": {
+      "properties": {
+        "description": "Prevent all users from deleting critical resources in the subscription.",
+        "denyAssignmentEffect": "enforced",
+        "denyAssignmentName": "Deny delete on critical resources",
+        "doNotApplyToChildScopes": false,
+        "excludePrincipals": [
+          {
+            "type": "ServicePrincipal",
+            "id": "ce2ce14e-85d7-4629-bdbc-454d0519d987"
+          }
+        ],
+        "permissions": [
+          {
+            "actions": [
+              "*/delete"
+            ],
+            "dataActions": [],
+            "notActions": [],
+            "notDataActions": []
+          }
+        ],
+        "principals": [
+          {
+            "type": "SystemDefined",
+            "id": "00000000-0000-0000-0000-000000000000"
+          }
+        ]
+      }
+    },
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+        "type": "Microsoft.Authorization/denyAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/denyAssignments/64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+        "properties": {
+          "description": "Prevent all users from deleting critical resources in the subscription.",
+          "createdBy": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "createdOn": "2024-07-01T00:00:00.0000000Z",
+          "denyAssignmentEffect": "enforced",
+          "denyAssignmentName": "Deny delete on critical resources",
+          "doNotApplyToChildScopes": false,
+          "excludePrincipals": [
+            {
+              "type": "ServicePrincipal",
+              "id": "ce2ce14e-85d7-4629-bdbc-454d0519d987"
+            }
+          ],
+          "isSystemProtected": false,
+          "permissions": [
+            {
+              "actions": [
+                "*/delete"
+              ],
+              "dataActions": [],
+              "notActions": [],
+              "notDataActions": []
+            }
+          ],
+          "principals": [
+            {
+              "type": "SystemDefined",
+              "id": "00000000-0000-0000-0000-000000000000"
+            }
+          ],
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+          "updatedBy": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "updatedOn": "2024-07-01T00:00:00.0000000Z"
+        },
+        "systemData": {
+          "createdAt": "2024-07-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-07-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+        "type": "Microsoft.Authorization/denyAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/denyAssignments/64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+        "properties": {
+          "description": "Prevent all users from deleting critical resources in the subscription.",
+          "createdBy": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "createdOn": "2024-07-01T00:00:00.0000000Z",
+          "denyAssignmentEffect": "enforced",
+          "denyAssignmentName": "Deny delete on critical resources",
+          "doNotApplyToChildScopes": false,
+          "excludePrincipals": [
+            {
+              "type": "ServicePrincipal",
+              "id": "ce2ce14e-85d7-4629-bdbc-454d0519d987"
+            }
+          ],
+          "isSystemProtected": false,
+          "permissions": [
+            {
+              "actions": [
+                "*/delete"
+              ],
+              "dataActions": [],
+              "notActions": [],
+              "notDataActions": []
+            }
+          ],
+          "principals": [
+            {
+              "type": "SystemDefined",
+              "id": "00000000-0000-0000-0000-000000000000"
+            }
+          ],
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+          "updatedBy": "ce2ce14e-85d7-4629-bdbc-454d0519d987",
+          "updatedOn": "2024-07-01T00:00:00.0000000Z"
+        },
+        "systemData": {
+          "createdAt": "2024-07-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-07-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "DenyAssignments_CreateOrUpdate",
+  "title": "Create deny assignment for subscription"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/DenyAssignments_Delete.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/DenyAssignments_Delete.json
@@ -1,0 +1,13 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "denyAssignmentId": "64b75d79-7a26-4341-944e-4f1a19f0e6ca",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DenyAssignments_Delete",
+  "title": "Delete deny assignment"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetAllDenyAssignments.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetAllDenyAssignments.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "denyAssignmentName": "Deny assignment name",
+              "description": "Deny assignment description",
+              "permissions": [
+                {
+                  "actions": [
+                    "action"
+                  ],
+                  "notActions": [],
+                  "dataActions": [],
+                  "notDataActions": []
+                }
+              ],
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+              "doNotApplyToChildScopes": false,
+              "principals": [
+                {
+                  "id": "principalId1",
+                  "type": "principalType1"
+                }
+              ],
+              "excludePrincipals": [
+                {
+                  "id": "principalId2",
+                  "type": "principalType2"
+                }
+              ],
+              "isSystemProtected": true,
+              "denyAssignmentEffect": "enforced"
+            },
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+            "type": "Microsoft.Authorization/denyAssignments",
+            "name": "denyAssignmentId",
+            "systemData": {
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "createdAt": "2024-07-01T00:00:00.0000000Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-07-01T00:00:00.0000000Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DenyAssignments_List",
+  "title": "List deny assignments for subscription"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetDenyAssignmentById.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetDenyAssignmentById.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "denyAssignmentId": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "denyAssignmentName": "Deny assignment name",
+          "description": "Deny assignment description",
+          "permissions": [
+            {
+              "actions": [
+                "action"
+              ],
+              "notActions": [],
+              "dataActions": [],
+              "notDataActions": []
+            }
+          ],
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname",
+          "doNotApplyToChildScopes": false,
+          "principals": [
+            {
+              "id": "principalId1",
+              "type": "principalType1"
+            }
+          ],
+          "excludePrincipals": [
+            {
+              "id": "principalId2",
+              "type": "principalType2"
+            }
+          ],
+          "isSystemProtected": true,
+          "denyAssignmentEffect": "enforced"
+        },
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+        "type": "Microsoft.Authorization/denyAssignments",
+        "name": "denyAssignmentId",
+        "systemData": {
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "createdAt": "2024-07-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2024-07-01T00:00:00.0000000Z"
+        }
+      }
+    }
+  },
+  "operationId": "DenyAssignments_GetById",
+  "title": "Get deny assignment by ID"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetDenyAssignmentByNameId.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetDenyAssignmentByNameId.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "denyAssignmentId": "denyAssignmentId",
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "denyAssignmentId",
+        "type": "Microsoft.Authorization/denyAssignments",
+        "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+        "properties": {
+          "description": "Deny assignment description",
+          "denyAssignmentEffect": "enforced",
+          "denyAssignmentName": "Deny assignment name",
+          "doNotApplyToChildScopes": false,
+          "excludePrincipals": [
+            {
+              "type": "principalType2",
+              "id": "principalId2"
+            }
+          ],
+          "isSystemProtected": true,
+          "permissions": [
+            {
+              "actions": [
+                "action"
+              ],
+              "dataActions": [],
+              "notActions": [],
+              "notDataActions": []
+            }
+          ],
+          "principals": [
+            {
+              "type": "principalType1",
+              "id": "principalId1"
+            }
+          ],
+          "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname"
+        },
+        "systemData": {
+          "createdAt": "2024-07-01T00:00:00.0000000Z",
+          "createdBy": "user@example.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2024-07-01T00:00:00.0000000Z",
+          "lastModifiedBy": "user@example.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  },
+  "operationId": "DenyAssignments_Get",
+  "title": "Get deny assignment by name"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetDenyAssignmentByScope.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetDenyAssignmentByScope.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "scope": "subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "denyAssignmentName": "Deny assignment name",
+              "description": "Deny assignment description",
+              "permissions": [
+                {
+                  "actions": [
+                    "action"
+                  ],
+                  "notActions": [],
+                  "dataActions": [],
+                  "notDataActions": []
+                }
+              ],
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname",
+              "doNotApplyToChildScopes": false,
+              "principals": [
+                {
+                  "id": "principalId1",
+                  "type": "principalType1"
+                }
+              ],
+              "excludePrincipals": [
+                {
+                  "id": "principalId2",
+                  "type": "principalType2"
+                }
+              ],
+              "isSystemProtected": true,
+              "denyAssignmentEffect": "enforced"
+            },
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+            "type": "Microsoft.Authorization/denyAssignments",
+            "name": "denyAssignmentId",
+            "systemData": {
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "createdAt": "2024-07-01T00:00:00.0000000Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-07-01T00:00:00.0000000Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DenyAssignments_ListForScope",
+  "title": "List deny assignments for scope"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetDenyAssignmentsForResource.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetDenyAssignmentsForResource.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2026-09-01",
+    "parentResourcePath": "parentResourceType/parentResourceName",
+    "resourceGroupName": "rgname",
+    "resourceName": "resourceName",
+    "resourceProviderNamespace": "resourceProviderNamespace",
+    "resourceType": "resourceType",
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "denyAssignmentId",
+            "type": "Microsoft.Authorization/denyAssignments",
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/resourceProviderNamespace/parentResourceType/parentResourceName/resourceType/resourceName/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+            "properties": {
+              "description": "Deny assignment description",
+              "denyAssignmentEffect": "enforced",
+              "denyAssignmentName": "Deny assignment name",
+              "doNotApplyToChildScopes": false,
+              "excludePrincipals": [
+                {
+                  "type": "principalType2",
+                  "id": "principalId2"
+                }
+              ],
+              "isSystemProtected": true,
+              "permissions": [
+                {
+                  "actions": [
+                    "action"
+                  ],
+                  "dataActions": [],
+                  "notActions": [],
+                  "notDataActions": []
+                }
+              ],
+              "principals": [
+                {
+                  "type": "principalType1",
+                  "id": "principalId1"
+                }
+              ],
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/resourceProviderNamespace/parentResourceType/parentResourceName/resourceType/resourceName"
+            },
+            "systemData": {
+              "createdAt": "2024-07-01T00:00:00.0000000Z",
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2024-07-01T00:00:00.0000000Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DenyAssignments_ListForResource",
+  "title": "List deny assignments for resource"
+}

--- a/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetDenyAssignmentsForResourceGroup.json
+++ b/specification/authorization/resource-manager/Microsoft.Authorization/Authorization/stable/2026-09-01/examples/GetDenyAssignmentsForResourceGroup.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "subscriptionId": "a925f2f7-5c63-4b7b-8799-25a5f97bc3b2",
+    "resourceGroupName": "rgname",
+    "api-version": "2026-09-01"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "denyAssignmentName": "Deny assignment name",
+              "description": "Deny assignment description",
+              "permissions": [
+                {
+                  "actions": [
+                    "action"
+                  ],
+                  "notActions": [],
+                  "dataActions": [],
+                  "notDataActions": []
+                }
+              ],
+              "scope": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname",
+              "doNotApplyToChildScopes": false,
+              "principals": [
+                {
+                  "id": "principalId1",
+                  "type": "principalType1"
+                }
+              ],
+              "excludePrincipals": [
+                {
+                  "id": "principalId2",
+                  "type": "principalType2"
+                }
+              ],
+              "isSystemProtected": true,
+              "denyAssignmentEffect": "enforced"
+            },
+            "id": "/subscriptions/a925f2f7-5c63-4b7b-8799-25a5f97bc3b2/resourceGroups/rgname/providers/Microsoft.Authorization/denyAssignments/denyAssignmentId",
+            "type": "Microsoft.Authorization/denyAssignments",
+            "name": "denyAssignmentId",
+            "systemData": {
+              "createdBy": "user@example.com",
+              "createdByType": "User",
+              "createdAt": "2024-07-01T00:00:00.0000000Z",
+              "lastModifiedBy": "user@example.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2024-07-01T00:00:00.0000000Z"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DenyAssignments_ListForResourceGroup",
+  "title": "List deny assignments for resource group"
+}


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

  - [ ] New resource provider.
  - [x] New API version for an existing resource provider. (If API spec is not defined in TypeSpec, the PR should have been created in adherence to [OpenAPI specs PR creation guidance](https://aka.ms/azsdkdocs/createopenapispec)).
  - [ ] Update existing version for a new feature. (This is applicable only when you are revising a private preview API version.)
  - [ ] Update existing version to fix OpenAPI spec quality issues in S360.
  - [ ] Convert existing [OpenAPI spec to TypeSpec spec](https://aka.ms/typespec/conversion) (do not combine this with implementing changes for a new API version).
  - [ ] Other, please clarify.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [ ] I have reviewed the Resource Provider guidelines, ARM resource provider contract, and REST guidelines.
- [ ] A release plan has been created.

## Summary

- Promotes the existing DenyAssignment contract to stable API version `2026-09-01`.
- Adds version-specific source examples and generated stable OpenAPI.
- Preserves the existing `2024-07-01-preview` contract unchanged.

## Validation

- TypeSpec compilation and repository validation passed with TypeSpec 1.15.0.
- Formatting and OAV example validation passed.
- Stable OpenAPI and all eight examples match the preview contract after substituting only the API version.

WILink: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3730991