### PR TITLE
Fix SDK Validation: package deviceregistry common directory for tsp-client

### DIFF
--- a/specification/deviceregistry/DeviceRegistry.Management/tspconfig.yaml
+++ b/specification/deviceregistry/DeviceRegistry.Management/tspconfig.yaml
@@ -42,6 +42,9 @@ options:
     generate-fakes: true
     head-as-boolean: true
     inject-spans: true
+  "@azure-tools/typespec-client-generator-cli":
+    additionalDirectories:
+      - "specification/deviceregistry/common"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"


### PR DESCRIPTION
## Problem

`SDK Validation` fails for all configured languages (.NET, Go, JS, Java, Python) on the `adr-vnext-specs-v2` branch (PR #45288). During generation, `tsp-client init` copies only the `DeviceRegistry.Management/` folder into its temp workspace, so imports of the sibling `../common/*.tsp` shared types cannot be resolved:

```
error import-not-found: Couldn't resolve import "../common/groupTypes.tsp"
  (also common.tsp, deviceTypes.tsp, deviceAttributeTypes.tsp,
   deviceCapabilityTypes.tsp, deviceAuthenticationProfileTypes.tsp)
→ cascading invalid-ref: Unknown identifier GroupType, InstallResult,
   RegistryDevicePropertiesBase, DeviceAttributeProperties, ...
```

Those shared types live in `specification/deviceregistry/common/` and are imported by `groups.tsp`, `jobs.tsp`, `registryDevices.tsp`, `registryDeviceAttributes.tsp`, `registryDeviceCapabilities.tsp`, and `registryDeviceAuthenticationProfiles.tsp`.

## Fix

Declare the shared `common` folder under `@azure-tools/typespec-client-generator-cli` → `additionalDirectories` in `tspconfig.yaml`, so `tsp-client` packages it into the temp workspace. This matches the established pattern used by `discovery`, `keyvault`, `storage`, and `contosowidgetmanager`.

This change only affects SDK-automation packaging; local `tsp compile` is unaffected (`../common` already resolves in a full-repo compile).
