### PR TITLE
fix(chaos): allow template-based scenario creation and author-managed version (AB#39305402)

### DIFF
--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Scenarios_CreateOrUpdate_From_Template.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/examples/2026-11-01/Scenarios_CreateOrUpdate_From_Template.json
@@ -8,39 +8,7 @@
     "resource": {
       "properties": {
         "createdFrom": "/providers/Microsoft.Chaos/scenarioTemplates/ComputeZoneDown/versions/1.2",
-        "description": "Simulates a datacenter/availability zone failure by shutting down VMSS instances and standalone VMs in the target zone. Zone failures account for ~25% of all cloud incidents — this scenario validates your application's cross-zone resilience.",
-        "parameters": [
-          {
-            "name": "duration",
-            "type": "string",
-            "default": "PT15M",
-            "required": false,
-            "description": "The duration of the zone down scenario.",
-            "format": {
-              "formatType": "Duration"
-            }
-          }
-        ],
-        "actions": [
-          {
-            "name": "vmssZoneShutdown",
-            "actionId": "urn:csci:microsoft:virtualMachineScaleSet:shutdown/1.0.0",
-            "description": "Shut down VMSS instances in target zone",
-            "duration": "%%{parameters.duration}%%",
-            "parameters": [
-              {
-                "key": "Zones",
-                "value": "%%{resourceTargeting.include.zones}%%"
-              }
-            ]
-          },
-          {
-            "name": "vmZoneShutdown",
-            "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
-            "description": "Shut down VMs in target zone",
-            "duration": "%%{parameters.duration}%%"
-          }
-        ]
+        "description": "Simulates a datacenter/availability zone failure by shutting down VMSS instances and standalone VMs in the target zone. Zone failures account for ~25% of all cloud incidents — this scenario validates your application's cross-zone resilience."
       }
     }
   },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-05-01-preview/openapi.json
@@ -6540,7 +6540,7 @@
     },
     "ScenarioProperties": {
       "type": "object",
-      "description": "Model that represents the properties of the scenario.",
+      "description": "Model that represents the properties of the scenario.\n\nA scenario's structure comes from exactly one of two sources, and they are\nmutually exclusive:\n\n- **Template-based**: `createdFrom` references a scenario template version,\nand that template is the authoritative source for the scenario's structure.\nInline `parameters` and `actions` are not used.\n- **Inline**: `createdFrom` is absent, and the scenario's structure is taken\nfrom the `parameters` and `actions` supplied in the request.\n\nSupplying neither source is rejected. This constraint cannot be expressed in\nthe schema and is enforced at request validation.",
       "properties": {
         "provisioningState": {
           "$ref": "#/definitions/ProvisioningState",
@@ -6557,8 +6557,7 @@
         },
         "version": {
           "type": "string",
-          "description": "Version of the scenario.",
-          "readOnly": true
+          "description": "Version of the scenario, supplied by the author. Defaults to `1.0` when not\nsupplied on create. This is the scenario's own version and is independent of\nthe version of any template it was created from."
         },
         "description": {
           "type": "string",
@@ -6566,7 +6565,7 @@
         },
         "parameters": {
           "type": "array",
-          "description": "Parameter definitions for the scenario.",
+          "description": "Parameter definitions for the scenario. Used as the scenario's parameter\ndefinitions when `createdFrom` is not supplied; not used when it is,\nbecause the referenced template is then the authoritative source for the\nscenario's structure.",
           "items": {
             "$ref": "#/definitions/ScenarioParameter"
           },
@@ -6576,7 +6575,7 @@
         },
         "actions": {
           "type": "array",
-          "description": "Array of actions that define the scenario's orchestration.",
+          "description": "Array of actions that define the scenario's orchestration. Used as the\nscenario's actions when `createdFrom` is not supplied; not used when it is,\nbecause the referenced template is then the authoritative source for the\nscenario's structure. When supplied, at least one action must be present.",
           "minItems": 1,
           "items": {
             "$ref": "#/definitions/ScenarioAction"

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/preview/2026-08-01-preview/openapi.json
@@ -6984,7 +6984,7 @@
     },
     "ScenarioProperties": {
       "type": "object",
-      "description": "Model that represents the properties of the scenario.",
+      "description": "Model that represents the properties of the scenario.\n\nA scenario's structure comes from exactly one of two sources, and they are\nmutually exclusive:\n\n- **Template-based**: `createdFrom` references a scenario template version,\nand that template is the authoritative source for the scenario's structure.\nInline `parameters` and `actions` are not used.\n- **Inline**: `createdFrom` is absent, and the scenario's structure is taken\nfrom the `parameters` and `actions` supplied in the request.\n\nSupplying neither source is rejected. This constraint cannot be expressed in\nthe schema and is enforced at request validation.",
       "properties": {
         "provisioningState": {
           "$ref": "#/definitions/ProvisioningState",
@@ -7001,8 +7001,7 @@
         },
         "version": {
           "type": "string",
-          "description": "Version of the scenario.",
-          "readOnly": true
+          "description": "Version of the scenario, supplied by the author. Defaults to `1.0` when not\nsupplied on create. This is the scenario's own version and is independent of\nthe version of any template it was created from."
         },
         "description": {
           "type": "string",
@@ -7010,7 +7009,7 @@
         },
         "parameters": {
           "type": "array",
-          "description": "Parameter definitions for the scenario.",
+          "description": "Parameter definitions for the scenario. Used as the scenario's parameter\ndefinitions when `createdFrom` is not supplied; not used when it is,\nbecause the referenced template is then the authoritative source for the\nscenario's structure.",
           "items": {
             "$ref": "#/definitions/ScenarioParameter"
           },
@@ -7020,7 +7019,7 @@
         },
         "actions": {
           "type": "array",
-          "description": "Array of actions that define the scenario's orchestration.",
+          "description": "Array of actions that define the scenario's orchestration. Used as the\nscenario's actions when `createdFrom` is not supplied; not used when it is,\nbecause the referenced template is then the authoritative source for the\nscenario's structure. When supplied, at least one action must be present.",
           "minItems": 1,
           "items": {
             "$ref": "#/definitions/ScenarioAction"

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenario.models.tsp
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/scenario.models.tsp
@@ -26,6 +26,18 @@ model Scenario is Azure.ResourceManager.ProxyResource<ScenarioProperties> {
 
 /**
  * Model that represents the properties of the scenario.
+ *
+ * A scenario's structure comes from exactly one of two sources, and they are
+ * mutually exclusive:
+ *
+ * - **Template-based**: `createdFrom` references a scenario template version,
+ *   and that template is the authoritative source for the scenario's structure.
+ *   Inline `parameters` and `actions` are not used.
+ * - **Inline**: `createdFrom` is absent, and the scenario's structure is taken
+ *   from the `parameters` and `actions` supplied in the request.
+ *
+ * Supplying neither source is rejected. This constraint cannot be expressed in
+ * the schema and is enforced at request validation.
  */
 model ScenarioProperties {
   /**
@@ -41,9 +53,10 @@ model ScenarioProperties {
   createdFrom?: string;
 
   /**
-   * Version of the scenario.
+   * Version of the scenario, supplied by the author. Defaults to `1.0` when not
+   * supplied on create. This is the scenario's own version and is independent of
+   * the version of any template it was created from.
    */
-  @visibility(Lifecycle.Read)
   version?: string;
 
   /**
@@ -52,17 +65,25 @@ model ScenarioProperties {
   description?: string;
 
   /**
-   * Parameter definitions for the scenario.
+   * Parameter definitions for the scenario. Used as the scenario's parameter
+   * definitions when `createdFrom` is not supplied; not used when it is,
+   * because the referenced template is then the authoritative source for the
+   * scenario's structure.
    */
+  @madeOptional(Microsoft.Chaos.Versions.v2026_11_01)
   @identifiers(#["name"])
-  parameters: ScenarioParameter[];
+  parameters?: ScenarioParameter[];
 
   /**
-   * Array of actions that define the scenario's orchestration.
+   * Array of actions that define the scenario's orchestration. Used as the
+   * scenario's actions when `createdFrom` is not supplied; not used when it is,
+   * because the referenced template is then the authoritative source for the
+   * scenario's structure. When supplied, at least one action must be present.
    */
+  @madeOptional(Microsoft.Chaos.Versions.v2026_11_01)
   @minItems(1)
   @identifiers(#["name"])
-  actions: ScenarioAction[];
+  actions?: ScenarioAction[];
 
   /**
    * The recommendation information for this scenario.

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Scenarios_CreateOrUpdate_From_Template.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/examples/Scenarios_CreateOrUpdate_From_Template.json
@@ -8,39 +8,7 @@
     "resource": {
       "properties": {
         "createdFrom": "/providers/Microsoft.Chaos/scenarioTemplates/ComputeZoneDown/versions/1.2",
-        "description": "Simulates a datacenter/availability zone failure by shutting down VMSS instances and standalone VMs in the target zone. Zone failures account for ~25% of all cloud incidents — this scenario validates your application's cross-zone resilience.",
-        "parameters": [
-          {
-            "name": "duration",
-            "type": "string",
-            "default": "PT15M",
-            "required": false,
-            "description": "The duration of the zone down scenario.",
-            "format": {
-              "formatType": "Duration"
-            }
-          }
-        ],
-        "actions": [
-          {
-            "name": "vmssZoneShutdown",
-            "actionId": "urn:csci:microsoft:virtualMachineScaleSet:shutdown/1.0.0",
-            "description": "Shut down VMSS instances in target zone",
-            "duration": "%%{parameters.duration}%%",
-            "parameters": [
-              {
-                "key": "Zones",
-                "value": "%%{resourceTargeting.include.zones}%%"
-              }
-            ]
-          },
-          {
-            "name": "vmZoneShutdown",
-            "actionId": "urn:csci:microsoft:compute:shutdown/1.0.0",
-            "description": "Shut down VMs in target zone",
-            "duration": "%%{parameters.duration}%%"
-          }
-        ]
+        "description": "Simulates a datacenter/availability zone failure by shutting down VMSS instances and standalone VMs in the target zone. Zone failures account for ~25% of all cloud incidents — this scenario validates your application's cross-zone resilience."
       }
     }
   },

--- a/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/openapi.json
+++ b/specification/chaos/resource-manager/Microsoft.Chaos/Chaos/stable/2026-11-01/openapi.json
@@ -7230,7 +7230,7 @@
     },
     "ScenarioProperties": {
       "type": "object",
-      "description": "Model that represents the properties of the scenario.",
+      "description": "Model that represents the properties of the scenario.\n\nA scenario's structure comes from exactly one of two sources, and they are\nmutually exclusive:\n\n- **Template-based**: `createdFrom` references a scenario template version,\nand that template is the authoritative source for the scenario's structure.\nInline `parameters` and `actions` are not used.\n- **Inline**: `createdFrom` is absent, and the scenario's structure is taken\nfrom the `parameters` and `actions` supplied in the request.\n\nSupplying neither source is rejected. This constraint cannot be expressed in\nthe schema and is enforced at request validation.",
       "properties": {
         "provisioningState": {
           "$ref": "#/definitions/ProvisioningState",
@@ -7247,8 +7247,7 @@
         },
         "version": {
           "type": "string",
-          "description": "Version of the scenario.",
-          "readOnly": true
+          "description": "Version of the scenario, supplied by the author. Defaults to `1.0` when not\nsupplied on create. This is the scenario's own version and is independent of\nthe version of any template it was created from."
         },
         "description": {
           "type": "string",
@@ -7256,7 +7255,7 @@
         },
         "parameters": {
           "type": "array",
-          "description": "Parameter definitions for the scenario.",
+          "description": "Parameter definitions for the scenario. Used as the scenario's parameter\ndefinitions when `createdFrom` is not supplied; not used when it is,\nbecause the referenced template is then the authoritative source for the\nscenario's structure.",
           "items": {
             "$ref": "#/definitions/ScenarioParameter"
           },
@@ -7266,7 +7265,7 @@
         },
         "actions": {
           "type": "array",
-          "description": "Array of actions that define the scenario's orchestration.",
+          "description": "Array of actions that define the scenario's orchestration. Used as the\nscenario's actions when `createdFrom` is not supplied; not used when it is,\nbecause the referenced template is then the authoritative source for the\nscenario's structure. When supplied, at least one action must be present.",
           "minItems": 1,
           "items": {
             "$ref": "#/definitions/ScenarioAction"
@@ -7280,11 +7279,7 @@
           "description": "The recommendation information for this scenario.",
           "readOnly": true
         }
-      },
-      "required": [
-        "parameters",
-        "actions"
-      ]
+      }
     },
     "ScenarioRun": {
       "type": "object",


### PR DESCRIPTION
Fixes the two `ScenarioProperties` fields named in **AB#39305402**, both of which contradict what the Backend already implements.

## What changed

**1. `parameters` and `actions` are optional from 2026-11-01**

They were required with `@minItems(1)`, so a template-based create — supply `createdFrom`, let the template define the structure — could not be expressed at all. This is not a hypothetical: BE has implemented template-only creation *deliberately* since `ScenariosController.cs:85-92`, whose own comment reads *"the user's request body actions are intentionally not used."* The contract was the only thing blocking it.

**2. `version` is no longer `readOnly`**

BE accepts a caller-supplied version on **both** paths — `ScenariosController.cs:113` (`Version: requestBody.Version ?? "1.0"`) on create, and `:141` → `Scenario.UpdateProperties(..., string version, ...)` on update. Scenarios are customer-owned instances whatever they were stamped from, so their version is author-managed. Note this is the *opposite* direction from `createdFrom`: one was read-only and needed create, this one was read-only and needed full write.

**3. The template example no longer sends fields the service discards**

`Scenarios_CreateOrUpdate_From_Template.json` sent `createdFrom` **and** `parameters` **and** `actions`. BE ignores the latter two. The request is reduced to what is actually honoured; the responses still show the fully resolved scenario, which is the point of template-based creation.

## Why the obvious fix would have been wrong

The obvious change is to drop `required` and edit the docs. Both parts have a trap.

- **`required` must be version-gated.** An ungated edit silently removed `required: [parameters, actions]` from `2026-05-01-preview` and `2026-08-01-preview` — the first of which is the pinned Portal contract. `@madeOptional(...v2026_11_01)` confines it to the GA version. Verified: `required` is gone from 2026-11-01 and still present in both previews.
- **Doc text cannot be version-gated at all** — TypeSpec's versioning library exposes only `@added`, `@removed`, `@renamedFrom`, `@madeOptional`, `@madeRequired`, `@typeChangedFrom`, `@returnTypeChangedFrom`. There is no visibility or doc equivalent. So the docs here describe **behaviour**, which is version-invariant ("when `createdFrom` is supplied the template is authoritative and inline structure is not used"), rather than **schema** ("omit `parameters` and `actions`"), which would be false for the previews where they remain required.

## Blast radius

The two preview files change by 4 insertions / 5 deletions each: the `readOnly` removal on `version`, plus description text.

The `version` change cannot be confined to 2026-11-01 for the language reason above. There is direct precedent on this branch — #45311 flipped `createdFrom` to `read, create` ungated, and both previews carry `x-ms-mutability: [read, create]` today. It is also a relaxation rather than a restriction, and it makes the previews *more* accurate: BE has always accepted a caller-supplied version, so `readOnly: true` was already false for those versions.

## What this deliberately does not do

- **No format or identity constraint on `createdFrom`.** Which wire form is canonical, and where resolution happens, is open — see **AB#39312160**. Constraining the shape here would prejudge it.
- **No BE change.** None is required; `@minItems(1)` was the entire blocker.
- **`@minItems(1)` is retained**, so an inline create still cannot send an empty `actions` array.

## Reading order

`scenario.models.tsp` first — it is the only hand-edited file. The other five are emitter output.

## Verification

`tsp compile` clean (compiler v1.14.0). Emitted swagger inspected directly rather than assumed: `required: [parameters, actions]` removed from 2026-11-01 only; `readOnly` removed from `version`. `service.yaml` is deliberately **not** included — a bare `tsp compile` regenerates it and drops every swagger-sourced version from 2021-09-15-preview through 2024-03-22-preview, which is unrelated collateral.

## Rigor gate

Reviewed before implementation by `claude-opus-5` and `gpt-5.6-sol` independently, read-only, against pinned baselines — Chaos `ee187c044312e754ef771ee7fbb1a6c6e30aa2cd`, specs `c764f40c93fdbf36156134c6b0a019f0f649c02d`. Neither returned clean and each found blocking issues the other missed; the original design was discarded and the direction kept. The surviving warning both raised independently: **do not make `ScenarioValidationService.cs:71-81` conditional** — that guard is what turns a structureless scenario into a 400 rather than a silent empty resource.

**Could not verify:** that `azure-rest-api-specs-pr` agrees with the public repo (not cloned locally); that Julia's `!16703100` behaves as its description claims (read the description, not the diff).

**One correction to the record this PR rests on.** The bug originally claimed that stripping `createdFrom` produces an empty scenario with HTTP 200. That is false, and it was repeated by four sessions before being checked. It fails 400 at three independent layers — contract `@minItems(1)`, `ScenarioValidationService.cs:71-81`, and `ScenariosController.cs:150-154`. The genuine defect nearby is a **500**, not a silent success, and it is tracked separately as AB#39312160.
