### PR TITLE
Microsoft.App 2026-07-01: add per-app networking.outboundVnetSubnetId…

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/ContainerApps_CreateOrUpdate_Networking.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-07-01/ContainerApps_CreateOrUpdate_Networking.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01",
+    "containerAppEnvelope": {
+      "location": "East US",
+      "properties": {
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/expressenv",
+        "networking": {
+          "outboundVnetSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/appsubnet"
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerApp0",
+              "image": "repo/testcontainerApp0:v1",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "resourceGroupName": "rg",
+    "containerAppName": "testcontainerApp0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/expressenv",
+          "networking": {
+            "outboundVnetSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/appsubnet"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "provisioningState": "InProgress",
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/expressenv",
+          "networking": {
+            "outboundVnetSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/appsubnet"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update Container App with per-app outbound VNet subnet"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
@@ -6947,6 +6947,12 @@ model ContainerAppProperties {
   environmentId?: string;
 
   /**
+   * Networking configuration for the Container App.
+   */
+  @added(Versions.v2026_07_01)
+  networking?: ContainerAppNetworkingConfiguration;
+
+  /**
    * Workload profile name to pin for container app execution.
    */
   workloadProfileName?: string;
@@ -7003,6 +7009,18 @@ model ContainerAppProperties {
    */
   @visibility(Lifecycle.Read)
   eventStreamEndpoint?: string;
+}
+
+/**
+ * Networking configuration for a Container App. Only supported for Container Apps deployed into an Express managed environment.
+ */
+@added(Versions.v2026_07_01)
+model ContainerAppNetworkingConfiguration {
+  /**
+   * Resource ID of a subnet used for outbound (egress) traffic from this Container App. Only supported for Container Apps in an Express managed environment. Mutually exclusive with the environment-level VNet configuration and immutable after the Container App is created.
+   */
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  outboundVnetSubnetId?: string;
 }
 
 /**

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/ContainerApps_CreateOrUpdate_Networking.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/examples/ContainerApps_CreateOrUpdate_Networking.json
@@ -1,0 +1,64 @@
+{
+  "parameters": {
+    "api-version": "2026-07-01",
+    "containerAppEnvelope": {
+      "location": "East US",
+      "properties": {
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/expressenv",
+        "networking": {
+          "outboundVnetSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/appsubnet"
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerApp0",
+              "image": "repo/testcontainerApp0:v1",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "resourceGroupName": "rg",
+    "containerAppName": "testcontainerApp0"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/expressenv",
+          "networking": {
+            "outboundVnetSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/appsubnet"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "provisioningState": "InProgress",
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/expressenv",
+          "networking": {
+            "outboundVnetSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/myvnet/subnets/appsubnet"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update Container App with per-app outbound VNet subnet"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/stable/2026-07-01/openapi.json
@@ -1920,6 +1920,9 @@
           "Create or Update Container App": {
             "$ref": "./examples/ContainerApps_CreateOrUpdate.json"
           },
+          "Create or Update Container App with per-app outbound VNet subnet": {
+            "$ref": "./examples/ContainerApps_CreateOrUpdate_Networking.json"
+          },
           "Create or Update FunctionApp Kind": {
             "$ref": "./examples/ContainerApps_Kind_FunctionApp_CreateOrUpdate.json"
           },
@@ -9540,6 +9543,20 @@
         "value"
       ]
     },
+    "ContainerAppNetworkingConfiguration": {
+      "type": "object",
+      "description": "Networking configuration for a Container App. Only supported for Container Apps deployed into an Express managed environment.",
+      "properties": {
+        "outboundVnetSubnetId": {
+          "type": "string",
+          "description": "Resource ID of a subnet used for outbound (egress) traffic from this Container App. Only supported for Container Apps in an Express managed environment. Mutually exclusive with the environment-level VNet configuration and immutable after the Container App is created.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
     "ContainerAppProbe": {
       "type": "object",
       "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
@@ -9689,6 +9706,10 @@
             "read",
             "create"
           ]
+        },
+        "networking": {
+          "$ref": "#/definitions/ContainerAppNetworkingConfiguration",
+          "description": "Networking configuration for the Container App."
         },
         "workloadProfileName": {
           "type": "string",


### PR DESCRIPTION
## Summary

Adds `properties.networking.outboundVnetSubnetId` to Container Apps in api-version **2026-07-01**.

- New `ContainerAppNetworkingConfiguration` model with a single `outboundVnetSubnetId` property.
- Enables **per-app outbound (egress) VNet** integration: traffic leaving the Container App egresses through the specified subnet.
- Supported **only** for Container Apps deployed into an **Express** managed environment.
- **Mutually exclusive** with the environment-level VNet configuration.
- **Immutable after create** — modeled as `@visibility(Lifecycle.Read, Lifecycle.Create)` → `x-ms-mutability: [read, create]`.
- Version-gated with `@added(Versions.v2026_07_01)`; only the `stable/2026-07-01` swagger changes.

## Changes

| File | Type |
|------|------|
| `ContainerApps/models.tsp` | TypeSpec source — added `networking` property + `ContainerAppNetworkingConfiguration` model |
| `ContainerApps/examples/2026-07-01/ContainerApps_CreateOrUpdate_Networking.json` | New create example (source) |
| `ContainerApps/stable/2026-07-01/openapi.json` | Regenerated Swagger (`tsp compile`) |
| `ContainerApps/stable/2026-07-01/examples/ContainerApps_CreateOrUpdate_Networking.json` | Regenerated example copy |

## Purpose of this PR
What's the purpose of this PR? Check the specific option that applies. This is **mandatory**!

- [ ] New resource provider.
- [ ] New API version for an existing resource provider. (If API spec is not defined in TypeSpec, the PR should have been created in adherence to [OpenAPI specs PR creation guidance](https://aka.ms/azsdkdocs/createopenapispec)).
- [x] Update existing version for a new feature.
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing [OpenAPI spec to TypeSpec spec](https://aka.ms/typespec/conversion) (do not combine this with implementing changes for a new API version).
- [ ] Other, please clarify:
  - *Adding the per-app `networking.outboundVnetSubnetId` feature to the in-development `2026-07-01` stable API version on its release branch (`release-app-Microsoft.App-stable/2026-07-01`), before that version ships.*