### PR TITLE
[Compute BulkActions] Fix C# resolved item model name

### DIFF
--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -212,7 +212,11 @@ namespace Microsoft.Compute;
 // =====================================================================
 // .NET naming convention fixes (C# only)
 // =====================================================================
-@@clientName(BulkCreateCustomResource, "BulkCreateCustomResolvedItem", "csharp");
+@@clientName(
+  BulkCreateCustomResource,
+  "BulkCreateCustomResolvedItem",
+  "csharp"
+);
 // Expand "Op" abbreviation to "Operation".
 @@clientName(ResourceOperationDetails.opType, "operationKind", "csharp");
 @@clientName(FallbackOperationInfo.lastOpType, "lastOperationKind", "csharp");

--- a/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
+++ b/specification/compute/resource-manager/Microsoft.Compute/Bulkactions/client.tsp
@@ -212,6 +212,7 @@ namespace Microsoft.Compute;
 // =====================================================================
 // .NET naming convention fixes (C# only)
 // =====================================================================
+@@clientName(BulkCreateCustomResource, "BulkCreateCustomResolvedItem", "csharp");
 // Expand "Op" abbreviation to "Operation".
 @@clientName(ResourceOperationDetails.opType, "operationKind", "csharp");
 @@clientName(FallbackOperationInfo.lastOpType, "lastOperationKind", "csharp");


### PR DESCRIPTION
## Purpose

Fix the generated .NET management SDK model name for the non-resource `BulkCreateCustomResource` response item.

The .NET management SDK inheritance validation treats public types ending in `Resource` as ARM resources and requires them to inherit from `ArmResource`. This model is a plain response item, so the generated `BulkCreateCustomResource` type causes `ValidateInheritanceForResourceAndCollectionSuffix` to fail in Azure/azure-sdk-for-net#62204.

## Change

Add a C#-scoped `@@clientName` customization that generates `BulkCreateCustomResolvedItem` while preserving the REST API schema and all other language SDK names.

## Validation

- TypeSpec project validation passed.
- Related SDK PR: https://github.com/Azure/azure-sdk-for-net/pull/62204
- Related release plan: 36132