### PR TITLE
Add validation for multiple new API versions

### DIFF
--- a/.github/shared/package.json
+++ b/.github/shared/package.json
@@ -26,6 +26,7 @@
     "./swagger-suppressions": "./src/swagger-suppressions.js",
     "./tag": "./src/tag.js",
     "./time": "./src/time.js",
+    "./typespec-metadata": "./src/typespec-metadata.js",
     "./test/examples": "./test/examples.js"
   },
   "bin": {

--- a/.github/shared/readme.md
+++ b/.github/shared/readme.md
@@ -153,15 +153,15 @@ Single source of truth for breaking-change and versioning approval label names a
 ### `time` — time/duration helpers
 
 - `Duration` — frozen map of common durations in milliseconds.
+- `add(date, ms)` / `subtract(date, ms)` — date arithmetic.
+- `formatDuration(ms)` — human-readable duration string.
+- `getDuration(from, to)` — milliseconds between two dates.
 
 ### `typespec-metadata` — TypeSpec SDK metadata
 
 - `generateTypeSpecMetadata(folder, options)` — run the `@azure-tools/typespec-metadata` emitter,
   validate its JSON output, and clean up its temporary output.
 - `TypeSpecMetadataSchema`, `TypeSpecLanguageMetadataSchema` — zod schemas for metadata output.
-- `add(date, ms)` / `subtract(date, ms)` — date arithmetic.
-- `formatDuration(ms)` — human-readable duration string.
-- `getDuration(from, to)` — milliseconds between two dates.
 
 ## Folder structure & contributing
 

--- a/.github/shared/readme.md
+++ b/.github/shared/readme.md
@@ -153,6 +153,12 @@ Single source of truth for breaking-change and versioning approval label names a
 ### `time` — time/duration helpers
 
 - `Duration` — frozen map of common durations in milliseconds.
+
+### `typespec-metadata` — TypeSpec SDK metadata
+
+- `generateTypeSpecMetadata(folder, options)` — run the `@azure-tools/typespec-metadata` emitter,
+  validate its JSON output, and clean up its temporary output.
+- `TypeSpecMetadataSchema`, `TypeSpecLanguageMetadataSchema` — zod schemas for metadata output.
 - `add(date, ms)` / `subtract(date, ms)` — date arithmetic.
 - `formatDuration(ms)` — human-readable duration string.
 - `getDuration(from, to)` — milliseconds between two dates.

--- a/.github/shared/src/typespec-metadata.js
+++ b/.github/shared/src/typespec-metadata.js
@@ -1,0 +1,84 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import * as z from "zod";
+import { execNpmExec, isExecError } from "./exec.js";
+
+export const TypeSpecLanguageMetadataSchema = z.looseObject({
+  emitterName: z.string(),
+  packageName: z.string().optional(),
+  namespace: z.string().optional(),
+  outputDir: z.string().optional(),
+  flavor: z.string().optional(),
+  serviceDir: z.string().optional(),
+  apiVersion: z.string().optional(),
+  sdkType: z.enum(["preview", "stable"]).optional(),
+});
+
+export const TypeSpecMetadataSchema = z.looseObject({
+  emitterVersion: z.string(),
+  generatedAt: z.string(),
+  typespec: z.looseObject({
+    namespace: z.string(),
+    documentation: z.string().optional(),
+    type: z.enum(["data", "management"]),
+  }),
+  languages: z.record(z.string(), z.array(TypeSpecLanguageMetadataSchema)),
+  sourceConfigPath: z.string().optional(),
+});
+
+/** @typedef {z.infer<typeof TypeSpecLanguageMetadataSchema>} TypeSpecLanguageMetadata */
+/** @typedef {z.infer<typeof TypeSpecMetadataSchema>} TypeSpecMetadata */
+
+/**
+ * Generates and parses JSON output from the `@azure-tools/typespec-metadata` emitter.
+ *
+ * @param {string} folder TypeSpec project folder.
+ * @param {{ logger?: import("./logger.js").ILogger }} [options]
+ * @returns {Promise<TypeSpecMetadata>}
+ */
+export async function generateTypeSpecMetadata(folder, options = {}) {
+  const absoluteFolder = resolve(folder);
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "typespec-metadata-"));
+  const metadataFile = join(temporaryDirectory, "typespec-metadata.json");
+
+  try {
+    try {
+      await execNpmExec(
+        [
+          "tsp",
+          "compile",
+          absoluteFolder,
+          "--emit",
+          "@azure-tools/typespec-metadata",
+          "--option",
+          `@azure-tools/typespec-metadata.outputFile=${metadataFile}`,
+          "--option",
+          "@azure-tools/typespec-metadata.format=json",
+        ],
+        {
+          cwd: absoluteFolder,
+          logger: options.logger,
+          maxBuffer: 64 * 1024 * 1024,
+        },
+      );
+    } catch (error) {
+      // The TypeSpec compiler writes its diagnostics to stdout, not stderr.
+      const details = isExecError(error) ? [error.stdout, error.stderr].join("").trim() : undefined;
+
+      throw new Error(`Failed to generate TypeSpec metadata: ${details || String(error)}`, {
+        cause: error,
+      });
+    }
+
+    const parsed = TypeSpecMetadataSchema.safeParse(
+      JSON.parse(await readFile(metadataFile, "utf8")),
+    );
+    if (!parsed.success) {
+      throw new Error(`TypeSpec metadata has an unexpected format: ${parsed.error.message}`);
+    }
+    return parsed.data;
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}

--- a/.github/shared/test/typespec-metadata.test.js
+++ b/.github/shared/test/typespec-metadata.test.js
@@ -1,0 +1,126 @@
+import { access, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { execNpmExec } from "../src/exec.js";
+import { debugLogger } from "../src/logger.js";
+import { generateTypeSpecMetadata } from "../src/typespec-metadata.js";
+
+vi.mock("../src/exec.js", async (importOriginal) => ({
+  .../** @type {object} */ (await importOriginal()),
+  execNpmExec: vi.fn(),
+}));
+
+const validMetadata = {
+  emitterVersion: "0.3.0",
+  generatedAt: "2026-08-18T00:00:00.000Z",
+  typespec: {
+    namespace: "Contoso.Management",
+    documentation: "Contoso service",
+    type: "management",
+  },
+  languages: {
+    python: [
+      {
+        emitterName: "@azure-tools/typespec-python",
+        packageName: "azure-mgmt-contoso",
+        namespace: "azure.mgmt.contoso",
+        outputDir: "{output-dir}/sdk/contoso/azure-mgmt-contoso",
+        flavor: "azure",
+        serviceDir: "sdk/contoso",
+        apiVersion: "2026-01-01",
+        sdkType: "stable",
+      },
+    ],
+  },
+  sourceConfigPath: "specification/contoso/tspconfig.yaml",
+};
+
+/**
+ * @param {string[]} args
+ * @returns {string}
+ */
+function getMetadataFile(args) {
+  const outputOption = args.find((arg) => arg.includes(".outputFile="));
+  if (!outputOption) throw new Error("Metadata output option was not provided");
+  return outputOption.split("=").slice(1).join("=");
+}
+
+/** @param {string | undefined} file */
+async function expectMetadataDirectoryRemoved(file) {
+  if (!file) throw new Error("Metadata output path was not captured");
+  await expect(access(dirname(file))).rejects.toThrow();
+}
+
+describe("generateTypeSpecMetadata", () => {
+  /** @type {string | undefined} */
+  let metadataFile;
+
+  beforeEach(() => {
+    metadataFile = undefined;
+    vi.mocked(execNpmExec).mockReset();
+  });
+
+  it("generates, validates, and cleans up TypeSpec metadata", async () => {
+    vi.mocked(execNpmExec).mockImplementation(async (args, options) => {
+      metadataFile = getMetadataFile(args);
+      await writeFile(metadataFile, JSON.stringify(validMetadata));
+
+      expect(args).toContain("@azure-tools/typespec-metadata");
+      expect(options?.cwd).toMatch(/contoso$/);
+      expect(options?.maxBuffer).toBe(64 * 1024 * 1024);
+      return { stdout: "", stderr: "" };
+    });
+
+    await expect(generateTypeSpecMetadata("contoso")).resolves.toEqual(validMetadata);
+    await expectMetadataDirectoryRemoved(metadataFile);
+  });
+
+  it("passes the logger to command execution", async () => {
+    vi.mocked(execNpmExec).mockImplementation(async (args, options) => {
+      metadataFile = getMetadataFile(args);
+      await writeFile(metadataFile, JSON.stringify(validMetadata));
+      expect(options?.logger).toBe(debugLogger);
+      return { stdout: "", stderr: "" };
+    });
+
+    await generateTypeSpecMetadata("contoso", { logger: debugLogger });
+  });
+
+  it("rejects invalid metadata and cleans up", async () => {
+    vi.mocked(execNpmExec).mockImplementation(async (args) => {
+      metadataFile = getMetadataFile(args);
+      await writeFile(metadataFile, JSON.stringify({ languages: [] }));
+      return { stdout: "", stderr: "" };
+    });
+
+    await expect(generateTypeSpecMetadata("contoso")).rejects.toThrow("unexpected format");
+    await expectMetadataDirectoryRemoved(metadataFile);
+  });
+
+  it("wraps execution errors and cleans up", async () => {
+    vi.mocked(execNpmExec).mockImplementation((args) => {
+      metadataFile = getMetadataFile(args);
+      return Promise.reject(new Error("compile failed"));
+    });
+
+    await expect(generateTypeSpecMetadata("contoso")).rejects.toThrow(
+      "Failed to generate TypeSpec metadata: Error: compile failed",
+    );
+    await expectMetadataDirectoryRemoved(metadataFile);
+  });
+
+  it("includes compiler diagnostics written to stdout", async () => {
+    vi.mocked(execNpmExec).mockImplementation((args) => {
+      metadataFile = getMetadataFile(args);
+
+      const error = Object.assign(new Error("Command failed: tsp compile"), {
+        stdout: "error file-not-found: File main.tsp not found.",
+        stderr: "",
+      });
+      return Promise.reject(error);
+    });
+
+    await expect(generateTypeSpecMetadata("contoso")).rejects.toThrow("file-not-found");
+    await expectMetadataDirectoryRemoved(metadataFile);
+  });
+});

--- a/eng/scripts/TypeSpec-Validation.ps1
+++ b/eng/scripts/TypeSpec-Validation.ps1
@@ -49,8 +49,12 @@ if ($typespecFolders) {
       }
     }
 
-    # Example: '{"checkingAllSpecs"=true}'
-    $context = @{ checkingAllSpecs = $checkingAllSpecs } | ConvertTo-Json -Compress
+    # Example: '{"checkingAllSpecs":true,"baseCommitish":"HEAD^","headCommitish":"HEAD"}'
+    $context = @{
+      checkingAllSpecs = $checkingAllSpecs
+      baseCommitish = $BaseCommitish
+      headCommitish = $HeadCommitish
+    } | ConvertTo-Json -Compress
 
     LogInfo "npm exec --no -- tsv $typespecFolder ""$context"""
 

--- a/eng/tools/typespec-validation/src/index.ts
+++ b/eng/tools/typespec-validation/src/index.ts
@@ -121,10 +121,7 @@ export async function main() {
     new CompileRule(),
     new FormatRule(),
     new SdkTspConfigValidationRule(),
-    new MultipleNewApiVersionsRule({
-      baseCommitish: typeof context.baseCommitish === "string" ? context.baseCommitish : undefined,
-      headCommitish: typeof context.headCommitish === "string" ? context.headCommitish : undefined,
-    }),
+    new MultipleNewApiVersionsRule(),
   ];
 
   const result = await runRules(rules, absolutePath, suppressions);

--- a/eng/tools/typespec-validation/src/index.ts
+++ b/eng/tools/typespec-validation/src/index.ts
@@ -13,6 +13,7 @@ import { MultipleNewApiVersionsRule } from "./rules/multiple-new-api-versions.ts
 import { NpmPrefixRule } from "./rules/npm-prefix.ts";
 import { SdkTspConfigValidationRule } from "./rules/sdk-tspconfig-validation.ts";
 import { ServiceYamlRule } from "./rules/service-yaml.ts";
+import { StaleApiVersionPinRule } from "./rules/stale-api-version-pin.ts";
 import { fileExists, getSuppressions, normalizePath } from "./utils.ts";
 
 // Context argument may add new properties or override checkingAllSpecs
@@ -122,6 +123,7 @@ export async function main() {
     new FormatRule(),
     new SdkTspConfigValidationRule(),
     new MultipleNewApiVersionsRule(),
+    new StaleApiVersionPinRule(),
   ];
 
   const result = await runRules(rules, absolutePath, suppressions);

--- a/eng/tools/typespec-validation/src/index.ts
+++ b/eng/tools/typespec-validation/src/index.ts
@@ -9,6 +9,7 @@ import { FlavorAzureRule } from "./rules/flavor-azure.ts";
 import { FolderStructureRule } from "./rules/folder-structure.ts";
 import { FormatRule } from "./rules/format.ts";
 import { LinterRulesetRule } from "./rules/linter-ruleset.ts";
+import { MultipleNewApiVersionsRule } from "./rules/multiple-new-api-versions.ts";
 import { NpmPrefixRule } from "./rules/npm-prefix.ts";
 import { SdkTspConfigValidationRule } from "./rules/sdk-tspconfig-validation.ts";
 import { ServiceYamlRule } from "./rules/service-yaml.ts";
@@ -120,6 +121,10 @@ export async function main() {
     new CompileRule(),
     new FormatRule(),
     new SdkTspConfigValidationRule(),
+    new MultipleNewApiVersionsRule({
+      baseCommitish: typeof context.baseCommitish === "string" ? context.baseCommitish : undefined,
+      headCommitish: typeof context.headCommitish === "string" ? context.headCommitish : undefined,
+    }),
   ];
 
   const result = await runRules(rules, absolutePath, suppressions);

--- a/eng/tools/typespec-validation/src/rules/multiple-new-api-versions.ts
+++ b/eng/tools/typespec-validation/src/rules/multiple-new-api-versions.ts
@@ -3,6 +3,7 @@ import {
   type TypeSpecMetadata,
 } from "@azure-tools/specs-shared/typespec-metadata";
 import { join } from "node:path";
+import { context } from "../index.ts";
 import { type RuleResult } from "../rule-result.ts";
 import { type Rule } from "../rule.ts";
 import { parseServiceYaml } from "../service-yaml.ts";
@@ -21,15 +22,8 @@ const SDK_EMITTERS = new Set([
 // every emitter, overriding the api-version each emitter is actually configured with.
 const MULTIPLE_SERVICE_API_VERSION = "multiple-versions";
 
-type ReadFileAtCommit = typeof readFileAtCommit;
-type GenerateMetadata = (folder: string) => Promise<TypeSpecMetadata>;
-
-export interface MultipleNewApiVersionsRuleOptions {
-  baseCommitish?: string;
-  headCommitish?: string;
-  readFileAtCommit?: ReadFileAtCommit;
-  generateMetadata?: GenerateMetadata;
-}
+const WIKI_LINK =
+  "https://github.com/Azure/azure-rest-api-specs/wiki/TypeSpec-Validation#multiplenewapiversions";
 
 function parseApiVersion(version: string) {
   const match = version.match(/^(\d{4})-(\d{2})-(\d{2})(-preview)?$/);
@@ -69,10 +63,18 @@ export function evaluateApiVersionPolicy(
 ): RuleResult {
   const sdkEmitters = getSdkLanguageMetadata(metadata);
 
+  if (sdkEmitters.length === 0) {
+    return {
+      success: true,
+      stdOutput:
+        "Warning: No SDK language emitters are configured; skipping API-version validation.",
+    };
+  }
+
   if (sdkEmitters.some((emitter) => emitter.apiVersion === MULTIPLE_SERVICE_API_VERSION)) {
     return {
       success: true,
-      stdOutput: "This rule does not support multiple-service project scenarios.",
+      stdOutput: "Warning: This rule does not support multiple-service project scenarios.",
     };
   }
 
@@ -101,12 +103,6 @@ export function evaluateApiVersionPolicy(
   }
 
   const oldestNewApiVersion = [...newApiVersions].sort(compareApiVersionsAsc)[0];
-  if (sdkEmitters.length === 0) {
-    return {
-      success: false,
-      errorOutput: "TypeSpec metadata did not report any configured SDK language emitters.",
-    };
-  }
 
   // Known gap: an emitter pinned to "all" is reported here as invalid; no spec uses that value yet.
   const invalidEmitters = sdkEmitters.filter(
@@ -122,7 +118,8 @@ export function evaluateApiVersionPolicy(
       success: false,
       errorOutput:
         `This pull request adds multiple API versions. Every SDK language emitter must target ` +
-        `the oldest newly added version, ${oldestNewApiVersion}:\n${details.join("\n")}`,
+        `the oldest newly added version, ${oldestNewApiVersion}:\n${details.join("\n")}\n` +
+        `\nPlease refer to ${WIKI_LINK} for detailed guidance.`,
     };
   }
 
@@ -136,52 +133,53 @@ export class MultipleNewApiVersionsRule implements Rule {
   readonly name = "MultipleNewApiVersions";
   readonly description = "Validate SDK API-version selection when a PR adds API versions";
 
-  private readonly baseCommitish: string;
-  private readonly headCommitish: string;
-  private readonly readFileAtCommit: ReadFileAtCommit;
-  private readonly generateMetadata: GenerateMetadata;
-
-  constructor(options: MultipleNewApiVersionsRuleOptions = {}) {
-    this.baseCommitish = options.baseCommitish ?? "HEAD^";
-    this.headCommitish = options.headCommitish ?? "HEAD";
-    this.readFileAtCommit = options.readFileAtCommit ?? readFileAtCommit;
-    this.generateMetadata = options.generateMetadata ?? generateTypeSpecMetadata;
-  }
-
   async execute(folder: string): Promise<RuleResult> {
+    const baseCommitish =
+      typeof context.baseCommitish === "string" ? context.baseCommitish : "HEAD^";
+    const headCommitish =
+      typeof context.headCommitish === "string" ? context.headCommitish : "HEAD";
+
+    // Validating all specs has no pull request to diff, and runs on a shallow clone without HEAD^.
+    if (context.checkingAllSpecs === true) {
+      return {
+        success: true,
+        stdOutput: "Validating all specs; skipping comparison of newly added API versions.",
+      };
+    }
+
     const serviceYamlPath = join(folder, "service.yaml");
     let baseSource: string | undefined;
     let headSource: string | undefined;
 
     try {
       [baseSource, headSource] = await Promise.all([
-        this.readFileAtCommit(folder, this.baseCommitish, serviceYamlPath),
-        this.readFileAtCommit(folder, this.headCommitish, serviceYamlPath),
+        readFileAtCommit(folder, baseCommitish, serviceYamlPath),
+        readFileAtCommit(folder, headCommitish, serviceYamlPath),
       ]);
     } catch (error) {
       return {
         success: false,
         errorOutput:
-          `Unable to compare service.yaml between ${this.baseCommitish} and ` +
-          `${this.headCommitish}: ${String(error)}`,
+          `Unable to compare service.yaml between ${baseCommitish} and ` +
+          `${headCommitish}: ${String(error)}`,
       };
     }
 
     if (headSource === undefined) {
       return {
         success: true,
-        stdOutput: `service.yaml does not exist at ${this.headCommitish}; validation skipped.`,
+        stdOutput: `Warning: service.yaml does not exist at ${headCommitish}; validation skipped.`,
       };
     }
 
     const headService = parseServiceYaml(headSource);
     if (!headService.success) {
-      return { success: false, errorOutput: `${this.headCommitish}: ${headService.error}` };
+      return { success: false, errorOutput: `${headCommitish}: ${headService.error}` };
     }
 
     const baseService = baseSource === undefined ? undefined : parseServiceYaml(baseSource);
     if (baseService && !baseService.success) {
-      return { success: false, errorOutput: `${this.baseCommitish}: ${baseService.error}` };
+      return { success: false, errorOutput: `${baseCommitish}: ${baseService.error}` };
     }
 
     const baseVersions = new Set(
@@ -202,7 +200,7 @@ export class MultipleNewApiVersionsRule implements Rule {
     }
 
     try {
-      const metadata = await this.generateMetadata(folder);
+      const metadata = await generateTypeSpecMetadata(folder);
       return evaluateApiVersionPolicy(metadata, newApiVersions);
     } catch (error) {
       return { success: false, errorOutput: String(error) };

--- a/eng/tools/typespec-validation/src/rules/multiple-new-api-versions.ts
+++ b/eng/tools/typespec-validation/src/rules/multiple-new-api-versions.ts
@@ -117,8 +117,8 @@ export function evaluateApiVersionPolicy(
     return {
       success: false,
       errorOutput:
-        `This pull request adds multiple API versions. Every SDK language emitter must target ` +
-        `the oldest newly added version, ${oldestNewApiVersion}:\n${details.join("\n")}\n` +
+        `ERROR: This pull request adds multiple API versions. Every SDK language emitter must ` +
+        `target the oldest newly added version, ${oldestNewApiVersion}:\n${details.join("\n")}\n` +
         `\nPlease refer to ${WIKI_LINK} for detailed guidance.`,
     };
   }
@@ -134,16 +134,23 @@ export class MultipleNewApiVersionsRule implements Rule {
   readonly description = "Validate SDK API-version selection when a PR adds API versions";
 
   async execute(folder: string): Promise<RuleResult> {
-    const baseCommitish =
-      typeof context.baseCommitish === "string" ? context.baseCommitish : "HEAD^";
-    const headCommitish =
-      typeof context.headCommitish === "string" ? context.headCommitish : "HEAD";
-
     // Validating all specs has no pull request to diff, and runs on a shallow clone without HEAD^.
     if (context.checkingAllSpecs === true) {
       return {
         success: true,
         stdOutput: "Validating all specs; skipping comparison of newly added API versions.",
+      };
+    }
+
+    // Only the pull request check supplies commits; a bare "npx tsv <folder>" has nothing to diff.
+    const { baseCommitish, headCommitish } = context;
+    if (typeof baseCommitish !== "string" || typeof headCommitish !== "string") {
+      return {
+        success: true,
+        stdOutput:
+          "No commits to compare; skipping. To run this rule locally, pass the commits to " +
+          `compare:\n  npx tsv ${folder} '{"baseCommitish":"{commitShaOfMain}",` +
+          `"headCommitish":"{headShaOfLocalBranch}"}'`,
       };
     }
 
@@ -201,7 +208,18 @@ export class MultipleNewApiVersionsRule implements Rule {
 
     try {
       const metadata = await generateTypeSpecMetadata(folder);
-      return evaluateApiVersionPolicy(metadata, newApiVersions);
+      const result = evaluateApiVersionPolicy(metadata, newApiVersions);
+      if (result.success) {
+        return result;
+      }
+
+      return {
+        ...result,
+        errorOutput:
+          `${result.errorOutput}\n\nTo reproduce locally:\n` +
+          `  npx tsv ${folder} '{"baseCommitish":"{commitShaOfMain}",` +
+          `"headCommitish":"{commitShaOfPRHead}"}'`,
+      };
     } catch (error) {
       return { success: false, errorOutput: String(error) };
     }

--- a/eng/tools/typespec-validation/src/rules/multiple-new-api-versions.ts
+++ b/eng/tools/typespec-validation/src/rules/multiple-new-api-versions.ts
@@ -1,0 +1,211 @@
+import {
+  generateTypeSpecMetadata,
+  type TypeSpecMetadata,
+} from "@azure-tools/specs-shared/typespec-metadata";
+import { join } from "node:path";
+import { type RuleResult } from "../rule-result.ts";
+import { type Rule } from "../rule.ts";
+import { parseServiceYaml } from "../service-yaml.ts";
+import { readFileAtCommit } from "../utils.ts";
+
+// Scoped to management-plane SDK emitters for now.
+const SDK_EMITTERS = new Set([
+  "@azure-tools/typespec-python",
+  "@azure-tools/typespec-java",
+  "@azure-tools/typespec-ts",
+  "@azure-tools/typespec-go",
+  "@azure-typespec/http-client-csharp-mgmt",
+]);
+
+// For multiple-service projects, the typespec-metadata emitter reports "multiple-versions" for
+// every emitter, overriding the api-version each emitter is actually configured with.
+const MULTIPLE_SERVICE_API_VERSION = "multiple-versions";
+
+type ReadFileAtCommit = typeof readFileAtCommit;
+type GenerateMetadata = (folder: string) => Promise<TypeSpecMetadata>;
+
+export interface MultipleNewApiVersionsRuleOptions {
+  baseCommitish?: string;
+  headCommitish?: string;
+  readFileAtCommit?: ReadFileAtCommit;
+  generateMetadata?: GenerateMetadata;
+}
+
+function parseApiVersion(version: string) {
+  const match = version.match(/^(\d{4})-(\d{2})-(\d{2})(-preview)?$/);
+  if (!match) return undefined;
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+    isPreview: match[4] !== undefined,
+  };
+}
+
+/** Compares API versions oldest first, with preview preceding stable on the same date. */
+export function compareApiVersionsAsc(left: string, right: string): number {
+  const leftVersion = parseApiVersion(left);
+  const rightVersion = parseApiVersion(right);
+
+  if (!leftVersion || !rightVersion) return left.localeCompare(right);
+  if (leftVersion.year !== rightVersion.year) return leftVersion.year - rightVersion.year;
+  if (leftVersion.month !== rightVersion.month) return leftVersion.month - rightVersion.month;
+  if (leftVersion.day !== rightVersion.day) return leftVersion.day - rightVersion.day;
+  if (leftVersion.isPreview !== rightVersion.isPreview) {
+    return leftVersion.isPreview ? -1 : 1;
+  }
+  return left.localeCompare(right);
+}
+
+function getSdkLanguageMetadata(metadata: TypeSpecMetadata) {
+  return Object.values(metadata.languages)
+    .flat()
+    .filter((language) => SDK_EMITTERS.has(language.emitterName));
+}
+
+export function evaluateApiVersionPolicy(
+  metadata: TypeSpecMetadata,
+  newApiVersions: string[],
+): RuleResult {
+  const sdkEmitters = getSdkLanguageMetadata(metadata);
+
+  if (sdkEmitters.some((emitter) => emitter.apiVersion === MULTIPLE_SERVICE_API_VERSION)) {
+    return {
+      success: true,
+      stdOutput: "This rule does not support multiple-service project scenarios.",
+    };
+  }
+
+  if (newApiVersions.length === 1) {
+    const newApiVersion = newApiVersions[0];
+    const warnings = sdkEmitters
+      .filter(
+        (emitter) =>
+          emitter.apiVersion !== undefined &&
+          parseApiVersion(emitter.apiVersion) !== undefined &&
+          compareApiVersionsAsc(emitter.apiVersion, newApiVersion) < 0,
+      )
+      .map(
+        (emitter) =>
+          `Warning: ${emitter.emitterName} targets API version ${emitter.apiVersion}, which is ` +
+          `older than newly added API version ${newApiVersion}.`,
+      );
+
+    return {
+      success: true,
+      stdOutput:
+        warnings.length > 0
+          ? warnings.join("\n")
+          : `No SDK emitter targets an API version older than ${newApiVersion}.`,
+    };
+  }
+
+  const oldestNewApiVersion = [...newApiVersions].sort(compareApiVersionsAsc)[0];
+  if (sdkEmitters.length === 0) {
+    return {
+      success: false,
+      errorOutput: "TypeSpec metadata did not report any configured SDK language emitters.",
+    };
+  }
+
+  // Known gap: an emitter pinned to "all" is reported here as invalid; no spec uses that value yet.
+  const invalidEmitters = sdkEmitters.filter(
+    (emitter) => emitter.apiVersion !== oldestNewApiVersion,
+  );
+  if (invalidEmitters.length > 0) {
+    const details = invalidEmitters.map(
+      (emitter) =>
+        `  - ${emitter.emitterName}: ${emitter.apiVersion ?? "<not set>"} ` +
+        `(expected ${oldestNewApiVersion})`,
+    );
+    return {
+      success: false,
+      errorOutput:
+        `This pull request adds multiple API versions. Every SDK language emitter must target ` +
+        `the oldest newly added version, ${oldestNewApiVersion}:\n${details.join("\n")}`,
+    };
+  }
+
+  return {
+    success: true,
+    stdOutput: `All SDK language emitters target ${oldestNewApiVersion}.`,
+  };
+}
+
+export class MultipleNewApiVersionsRule implements Rule {
+  readonly name = "MultipleNewApiVersions";
+  readonly description = "Validate SDK API-version selection when a PR adds API versions";
+
+  private readonly baseCommitish: string;
+  private readonly headCommitish: string;
+  private readonly readFileAtCommit: ReadFileAtCommit;
+  private readonly generateMetadata: GenerateMetadata;
+
+  constructor(options: MultipleNewApiVersionsRuleOptions = {}) {
+    this.baseCommitish = options.baseCommitish ?? "HEAD^";
+    this.headCommitish = options.headCommitish ?? "HEAD";
+    this.readFileAtCommit = options.readFileAtCommit ?? readFileAtCommit;
+    this.generateMetadata = options.generateMetadata ?? generateTypeSpecMetadata;
+  }
+
+  async execute(folder: string): Promise<RuleResult> {
+    const serviceYamlPath = join(folder, "service.yaml");
+    let baseSource: string | undefined;
+    let headSource: string | undefined;
+
+    try {
+      [baseSource, headSource] = await Promise.all([
+        this.readFileAtCommit(folder, this.baseCommitish, serviceYamlPath),
+        this.readFileAtCommit(folder, this.headCommitish, serviceYamlPath),
+      ]);
+    } catch (error) {
+      return {
+        success: false,
+        errorOutput:
+          `Unable to compare service.yaml between ${this.baseCommitish} and ` +
+          `${this.headCommitish}: ${String(error)}`,
+      };
+    }
+
+    if (headSource === undefined) {
+      return {
+        success: true,
+        stdOutput: `service.yaml does not exist at ${this.headCommitish}; validation skipped.`,
+      };
+    }
+
+    const headService = parseServiceYaml(headSource);
+    if (!headService.success) {
+      return { success: false, errorOutput: `${this.headCommitish}: ${headService.error}` };
+    }
+
+    const baseService = baseSource === undefined ? undefined : parseServiceYaml(baseSource);
+    if (baseService && !baseService.success) {
+      return { success: false, errorOutput: `${this.baseCommitish}: ${baseService.error}` };
+    }
+
+    const baseVersions = new Set(
+      baseService?.value.versions
+        .filter((entry) => entry.source === "typespec")
+        .map((entry) => entry.version) ?? [],
+    );
+    const newApiVersions = [
+      ...new Set(
+        headService.value.versions
+          .filter((entry) => entry.source === "typespec" && !baseVersions.has(entry.version))
+          .map((entry) => entry.version),
+      ),
+    ];
+
+    if (newApiVersions.length === 0) {
+      return { success: true, stdOutput: "No new TypeSpec API versions were added." };
+    }
+
+    try {
+      const metadata = await this.generateMetadata(folder);
+      return evaluateApiVersionPolicy(metadata, newApiVersions);
+    } catch (error) {
+      return { success: false, errorOutput: String(error) };
+    }
+  }
+}

--- a/eng/tools/typespec-validation/src/rules/multiple-new-api-versions.ts
+++ b/eng/tools/typespec-validation/src/rules/multiple-new-api-versions.ts
@@ -2,110 +2,29 @@ import {
   generateTypeSpecMetadata,
   type TypeSpecMetadata,
 } from "@azure-tools/specs-shared/typespec-metadata";
-import { join } from "node:path";
-import { context } from "../index.ts";
 import { type RuleResult } from "../rule-result.ts";
 import { type Rule } from "../rule.ts";
-import { parseServiceYaml } from "../service-yaml.ts";
-import { readFileAtCommit } from "../utils.ts";
+import {
+  compareApiVersionsAsc,
+  reproduceLocallyHint,
+  resolveNewApiVersions,
+  resolveSdkEmitters,
+  wikiLink,
+} from "./sdk-api-version.ts";
 
-// Scoped to management-plane SDK emitters for now.
-const SDK_EMITTERS = new Set([
-  "@azure-tools/typespec-python",
-  "@azure-tools/typespec-java",
-  "@azure-tools/typespec-ts",
-  "@azure-tools/typespec-go",
-  "@azure-typespec/http-client-csharp-mgmt",
-]);
-
-// For multiple-service projects, the typespec-metadata emitter reports "multiple-versions" for
-// every emitter, overriding the api-version each emitter is actually configured with.
-const MULTIPLE_SERVICE_API_VERSION = "multiple-versions";
-
-const WIKI_LINK =
-  "https://github.com/Azure/azure-rest-api-specs/wiki/TypeSpec-Validation#multiplenewapiversions";
-
-function parseApiVersion(version: string) {
-  const match = version.match(/^(\d{4})-(\d{2})-(\d{2})(-preview)?$/);
-  if (!match) return undefined;
-  return {
-    year: Number(match[1]),
-    month: Number(match[2]),
-    day: Number(match[3]),
-    isPreview: match[4] !== undefined,
-  };
-}
-
-/** Compares API versions oldest first, with preview preceding stable on the same date. */
-export function compareApiVersionsAsc(left: string, right: string): number {
-  const leftVersion = parseApiVersion(left);
-  const rightVersion = parseApiVersion(right);
-
-  if (!leftVersion || !rightVersion) return left.localeCompare(right);
-  if (leftVersion.year !== rightVersion.year) return leftVersion.year - rightVersion.year;
-  if (leftVersion.month !== rightVersion.month) return leftVersion.month - rightVersion.month;
-  if (leftVersion.day !== rightVersion.day) return leftVersion.day - rightVersion.day;
-  if (leftVersion.isPreview !== rightVersion.isPreview) {
-    return leftVersion.isPreview ? -1 : 1;
-  }
-  return left.localeCompare(right);
-}
-
-function getSdkLanguageMetadata(metadata: TypeSpecMetadata) {
-  return Object.values(metadata.languages)
-    .flat()
-    .filter((language) => SDK_EMITTERS.has(language.emitterName));
-}
-
-export function evaluateApiVersionPolicy(
+export function evaluateMultipleNewApiVersions(
   metadata: TypeSpecMetadata,
   newApiVersions: string[],
 ): RuleResult {
-  const sdkEmitters = getSdkLanguageMetadata(metadata);
+  const resolved = resolveSdkEmitters(metadata);
+  if (resolved.kind === "skip") return resolved.result;
 
-  if (sdkEmitters.length === 0) {
-    return {
-      success: true,
-      stdOutput:
-        "Warning: No SDK language emitters are configured; skipping API-version validation.",
-    };
-  }
-
-  if (sdkEmitters.some((emitter) => emitter.apiVersion === MULTIPLE_SERVICE_API_VERSION)) {
-    return {
-      success: true,
-      stdOutput: "Warning: This rule does not support multiple-service project scenarios.",
-    };
-  }
-
-  if (newApiVersions.length === 1) {
-    const newApiVersion = newApiVersions[0];
-    const warnings = sdkEmitters
-      .filter(
-        (emitter) =>
-          emitter.apiVersion !== undefined &&
-          parseApiVersion(emitter.apiVersion) !== undefined &&
-          compareApiVersionsAsc(emitter.apiVersion, newApiVersion) < 0,
-      )
-      .map(
-        (emitter) =>
-          `Warning: ${emitter.emitterName} targets API version ${emitter.apiVersion}, which is ` +
-          `older than newly added API version ${newApiVersion}.`,
-      );
-
-    return {
-      success: true,
-      stdOutput:
-        warnings.length > 0
-          ? warnings.join("\n")
-          : `No SDK emitter targets an API version older than ${newApiVersion}.`,
-    };
-  }
-
-  const oldestNewApiVersion = [...newApiVersions].sort(compareApiVersionsAsc)[0];
+  const sortedNewApiVersions = [...newApiVersions].sort(compareApiVersionsAsc);
+  const oldestNewApiVersion = sortedNewApiVersions[0];
+  const latestNewApiVersion = sortedNewApiVersions[sortedNewApiVersions.length - 1];
 
   // Known gap: an emitter pinned to "all" is reported here as invalid; no spec uses that value yet.
-  const invalidEmitters = sdkEmitters.filter(
+  const invalidEmitters = resolved.emitters.filter(
     (emitter) => emitter.apiVersion !== oldestNewApiVersion,
   );
   if (invalidEmitters.length > 0) {
@@ -117,9 +36,11 @@ export function evaluateApiVersionPolicy(
     return {
       success: false,
       errorOutput:
-        `ERROR: This pull request adds multiple API versions. Every SDK language emitter must ` +
-        `target the oldest newly added version, ${oldestNewApiVersion}:\n${details.join("\n")}\n` +
-        `\nPlease refer to ${WIKI_LINK} for detailed guidance.`,
+        `ERROR: This pull request adds multiple API versions, so the SDKs will be generated from ` +
+        `API version ${latestNewApiVersion}. To generate and release the SDKs from ` +
+        `${oldestNewApiVersion} first, every SDK language emitter must set "api-version" to ` +
+        `${oldestNewApiVersion} in tspconfig.yaml:\n${details.join("\n")}\n` +
+        `\nPlease refer to ${wikiLink("multiplenewapiversions")} for detailed guidance.`,
     };
   }
 
@@ -131,94 +52,27 @@ export function evaluateApiVersionPolicy(
 
 export class MultipleNewApiVersionsRule implements Rule {
   readonly name = "MultipleNewApiVersions";
-  readonly description = "Validate SDK API-version selection when a PR adds API versions";
+  readonly description = "Require SDK emitters to target the oldest of several new API versions";
+  readonly suppressable = true;
 
   async execute(folder: string): Promise<RuleResult> {
-    // Validating all specs has no pull request to diff, and runs on a shallow clone without HEAD^.
-    if (context.checkingAllSpecs === true) {
-      return {
-        success: true,
-        stdOutput: "Validating all specs; skipping comparison of newly added API versions.",
-      };
-    }
+    const resolved = await resolveNewApiVersions(folder);
+    if (resolved.kind === "skip") return resolved.result;
 
-    // Only the pull request check supplies commits; a bare "npx tsv <folder>" has nothing to diff.
-    const { baseCommitish, headCommitish } = context;
-    if (typeof baseCommitish !== "string" || typeof headCommitish !== "string") {
-      return {
-        success: true,
-        stdOutput:
-          "No commits to compare; skipping. To run this rule locally, pass the commits to " +
-          `compare:\n  npx tsv ${folder} '{"baseCommitish":"{commitShaOfMain}",` +
-          `"headCommitish":"{headShaOfLocalBranch}"}'`,
-      };
-    }
-
-    const serviceYamlPath = join(folder, "service.yaml");
-    let baseSource: string | undefined;
-    let headSource: string | undefined;
-
-    try {
-      [baseSource, headSource] = await Promise.all([
-        readFileAtCommit(folder, baseCommitish, serviceYamlPath),
-        readFileAtCommit(folder, headCommitish, serviceYamlPath),
-      ]);
-    } catch (error) {
-      return {
-        success: false,
-        errorOutput:
-          `Unable to compare service.yaml between ${baseCommitish} and ` +
-          `${headCommitish}: ${String(error)}`,
-      };
-    }
-
-    if (headSource === undefined) {
-      return {
-        success: true,
-        stdOutput: `Warning: service.yaml does not exist at ${headCommitish}; validation skipped.`,
-      };
-    }
-
-    const headService = parseServiceYaml(headSource);
-    if (!headService.success) {
-      return { success: false, errorOutput: `${headCommitish}: ${headService.error}` };
-    }
-
-    const baseService = baseSource === undefined ? undefined : parseServiceYaml(baseSource);
-    if (baseService && !baseService.success) {
-      return { success: false, errorOutput: `${baseCommitish}: ${baseService.error}` };
-    }
-
-    const baseVersions = new Set(
-      baseService?.value.versions
-        .filter((entry) => entry.source === "typespec")
-        .map((entry) => entry.version) ?? [],
-    );
-    const newApiVersions = [
-      ...new Set(
-        headService.value.versions
-          .filter((entry) => entry.source === "typespec" && !baseVersions.has(entry.version))
-          .map((entry) => entry.version),
-      ),
-    ];
-
-    if (newApiVersions.length === 0) {
-      return { success: true, stdOutput: "No new TypeSpec API versions were added." };
+    if (resolved.newApiVersions.length < 2) {
+      return { success: true, stdOutput: "Only one new API version was added; skipping." };
     }
 
     try {
       const metadata = await generateTypeSpecMetadata(folder);
-      const result = evaluateApiVersionPolicy(metadata, newApiVersions);
+      const result = evaluateMultipleNewApiVersions(metadata, resolved.newApiVersions);
       if (result.success) {
         return result;
       }
 
       return {
         ...result,
-        errorOutput:
-          `${result.errorOutput}\n\nTo reproduce locally:\n` +
-          `  npx tsv ${folder} '{"baseCommitish":"{commitShaOfMain}",` +
-          `"headCommitish":"{commitShaOfPRHead}"}'`,
+        errorOutput: `${result.errorOutput}\n\n${reproduceLocallyHint(folder)}`,
       };
     } catch (error) {
       return { success: false, errorOutput: String(error) };

--- a/eng/tools/typespec-validation/src/rules/sdk-api-version.ts
+++ b/eng/tools/typespec-validation/src/rules/sdk-api-version.ts
@@ -1,0 +1,196 @@
+import { type TypeSpecMetadata } from "@azure-tools/specs-shared/typespec-metadata";
+import { join } from "node:path";
+import { context } from "../index.ts";
+import { type RuleResult } from "../rule-result.ts";
+import { parseServiceYaml } from "../service-yaml.ts";
+import { readFileAtCommit } from "../utils.ts";
+
+// Scoped to management-plane SDK emitters for now.
+const SDK_EMITTERS = new Set([
+  "@azure-tools/typespec-python",
+  "@azure-tools/typespec-java",
+  "@azure-tools/typespec-ts",
+  "@azure-tools/typespec-go",
+  "@azure-typespec/http-client-csharp-mgmt",
+]);
+
+// For multiple-service projects, the typespec-metadata emitter reports "multiple-versions" for
+// every emitter, overriding the api-version each emitter is actually configured with.
+const MULTIPLE_SERVICE_API_VERSION = "multiple-versions";
+
+const WIKI_BASE = "https://github.com/Azure/azure-rest-api-specs/wiki/TypeSpec-Validation";
+
+export function wikiLink(anchor: string): string {
+  return `${WIKI_BASE}#${anchor}`;
+}
+
+export function reproduceLocallyHint(folder: string): string {
+  return (
+    `To reproduce locally:\n  npx tsv ${folder} '{"baseCommitish":"{commitShaOfMain}",` +
+    `"headCommitish":"{commitShaOfPRHead}"}'`
+  );
+}
+
+export function parseApiVersion(version: string) {
+  const match = version.match(/^(\d{4})-(\d{2})-(\d{2})(-preview)?$/);
+  if (!match) return undefined;
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+    isPreview: match[4] !== undefined,
+  };
+}
+
+/** Compares API versions oldest first, with preview preceding stable on the same date. */
+export function compareApiVersionsAsc(left: string, right: string): number {
+  const leftVersion = parseApiVersion(left);
+  const rightVersion = parseApiVersion(right);
+
+  if (!leftVersion || !rightVersion) return left.localeCompare(right);
+  if (leftVersion.year !== rightVersion.year) return leftVersion.year - rightVersion.year;
+  if (leftVersion.month !== rightVersion.month) return leftVersion.month - rightVersion.month;
+  if (leftVersion.day !== rightVersion.day) return leftVersion.day - rightVersion.day;
+  if (leftVersion.isPreview !== rightVersion.isPreview) {
+    return leftVersion.isPreview ? -1 : 1;
+  }
+  return left.localeCompare(right);
+}
+
+export type SdkEmitter = TypeSpecMetadata["languages"][string][number];
+
+export type ResolvedSdkEmitters =
+  | { kind: "skip"; result: RuleResult }
+  | { kind: "emitters"; emitters: SdkEmitter[] };
+
+/** Returns the configured SDK language emitters, or a skip result when they cannot be compared. */
+export function resolveSdkEmitters(metadata: TypeSpecMetadata): ResolvedSdkEmitters {
+  const emitters = Object.values(metadata.languages)
+    .flat()
+    .filter((language) => SDK_EMITTERS.has(language.emitterName));
+
+  if (emitters.length === 0) {
+    return {
+      kind: "skip",
+      result: {
+        success: true,
+        stdOutput:
+          "Warning: No SDK language emitters are configured; skipping API-version validation.",
+      },
+    };
+  }
+
+  if (emitters.some((emitter) => emitter.apiVersion === MULTIPLE_SERVICE_API_VERSION)) {
+    return {
+      kind: "skip",
+      result: {
+        success: true,
+        stdOutput: "Warning: This rule does not support multiple-service project scenarios.",
+      },
+    };
+  }
+
+  return { kind: "emitters", emitters };
+}
+
+export type ResolvedNewApiVersions =
+  | { kind: "skip"; result: RuleResult }
+  | { kind: "versions"; newApiVersions: string[] };
+
+/** Diffs `service.yaml` between the configured commits to find newly added TypeSpec versions. */
+export async function resolveNewApiVersions(folder: string): Promise<ResolvedNewApiVersions> {
+  // Validating all specs has no pull request to diff, and runs on a shallow clone without HEAD^.
+  if (context.checkingAllSpecs === true) {
+    return {
+      kind: "skip",
+      result: {
+        success: true,
+        stdOutput: "Validating all specs; skipping comparison of newly added API versions.",
+      },
+    };
+  }
+
+  // Only the pull request check supplies commits; a bare "npx tsv <folder>" has nothing to diff.
+  const { baseCommitish, headCommitish } = context;
+  if (typeof baseCommitish !== "string" || typeof headCommitish !== "string") {
+    return {
+      kind: "skip",
+      result: {
+        success: true,
+        stdOutput:
+          "No commits to compare; skipping. To run this rule locally, pass the commits to " +
+          `compare:\n  npx tsv ${folder} '{"baseCommitish":"{commitShaOfMain}",` +
+          `"headCommitish":"{headShaOfLocalBranch}"}'`,
+      },
+    };
+  }
+
+  const serviceYamlPath = join(folder, "service.yaml");
+  let baseSource: string | undefined;
+  let headSource: string | undefined;
+
+  try {
+    [baseSource, headSource] = await Promise.all([
+      readFileAtCommit(folder, baseCommitish, serviceYamlPath),
+      readFileAtCommit(folder, headCommitish, serviceYamlPath),
+    ]);
+  } catch (error) {
+    return {
+      kind: "skip",
+      result: {
+        success: false,
+        errorOutput:
+          `ERROR: Unable to compare service.yaml between ${baseCommitish} and ` +
+          `${headCommitish}: ${String(error)}`,
+      },
+    };
+  }
+
+  if (headSource === undefined) {
+    return {
+      kind: "skip",
+      result: {
+        success: true,
+        stdOutput: `Warning: service.yaml does not exist at ${headCommitish}; validation skipped.`,
+      },
+    };
+  }
+
+  const headService = parseServiceYaml(headSource);
+  if (!headService.success) {
+    return {
+      kind: "skip",
+      result: { success: false, errorOutput: `ERROR: ${headCommitish}: ${headService.error}` },
+    };
+  }
+
+  const baseService = baseSource === undefined ? undefined : parseServiceYaml(baseSource);
+  if (baseService && !baseService.success) {
+    return {
+      kind: "skip",
+      result: { success: false, errorOutput: `ERROR: ${baseCommitish}: ${baseService.error}` },
+    };
+  }
+
+  const baseVersions = new Set(
+    baseService?.value.versions
+      .filter((entry) => entry.source === "typespec")
+      .map((entry) => entry.version) ?? [],
+  );
+  const newApiVersions = [
+    ...new Set(
+      headService.value.versions
+        .filter((entry) => entry.source === "typespec" && !baseVersions.has(entry.version))
+        .map((entry) => entry.version),
+    ),
+  ];
+
+  if (newApiVersions.length === 0) {
+    return {
+      kind: "skip",
+      result: { success: true, stdOutput: "No new TypeSpec API versions were added." },
+    };
+  }
+
+  return { kind: "versions", newApiVersions };
+}

--- a/eng/tools/typespec-validation/src/rules/stale-api-version-pin.ts
+++ b/eng/tools/typespec-validation/src/rules/stale-api-version-pin.ts
@@ -1,0 +1,81 @@
+import {
+  generateTypeSpecMetadata,
+  type TypeSpecMetadata,
+} from "@azure-tools/specs-shared/typespec-metadata";
+import { type RuleResult } from "../rule-result.ts";
+import { type Rule } from "../rule.ts";
+import {
+  compareApiVersionsAsc,
+  parseApiVersion,
+  reproduceLocallyHint,
+  resolveNewApiVersions,
+  resolveSdkEmitters,
+  wikiLink,
+} from "./sdk-api-version.ts";
+
+export function evaluateStaleApiVersionPin(
+  metadata: TypeSpecMetadata,
+  newApiVersion: string,
+): RuleResult {
+  const resolved = resolveSdkEmitters(metadata);
+  if (resolved.kind === "skip") return resolved.result;
+
+  // Values such as "all" are not dates, so they cannot be compared against the new version.
+  const staleEmitters = resolved.emitters.filter(
+    (emitter) =>
+      emitter.apiVersion !== undefined &&
+      parseApiVersion(emitter.apiVersion) !== undefined &&
+      compareApiVersionsAsc(emitter.apiVersion, newApiVersion) < 0,
+  );
+
+  if (staleEmitters.length > 0) {
+    const details = staleEmitters.map(
+      (emitter) => `  - ${emitter.emitterName}: ${emitter.apiVersion}`,
+    );
+    return {
+      success: false,
+      errorOutput:
+        `ERROR: This pull request adds API version ${newApiVersion}, but the SDK language ` +
+        `emitters below are pinned to an older API version, so their SDKs will be generated ` +
+        `from the pinned version instead. To generate and release the SDKs from ` +
+        `${newApiVersion}, remove the "api-version" setting from these emitters in ` +
+        `tspconfig.yaml:\n${details.join("\n")}\n` +
+        `\nPlease refer to ${wikiLink("staleapiversionpin")} for detailed guidance.`,
+    };
+  }
+
+  return {
+    success: true,
+    stdOutput: `No SDK emitter targets an API version older than ${newApiVersion}.`,
+  };
+}
+
+export class StaleApiVersionPinRule implements Rule {
+  readonly name = "StaleApiVersionPin";
+  readonly description = "Detect SDK emitters pinned to an API version older than the new one";
+  readonly suppressable = true;
+
+  async execute(folder: string): Promise<RuleResult> {
+    const resolved = await resolveNewApiVersions(folder);
+    if (resolved.kind === "skip") return resolved.result;
+
+    if (resolved.newApiVersions.length !== 1) {
+      return { success: true, stdOutput: "Multiple new API versions were added; skipping." };
+    }
+
+    try {
+      const metadata = await generateTypeSpecMetadata(folder);
+      const result = evaluateStaleApiVersionPin(metadata, resolved.newApiVersions[0]);
+      if (result.success) {
+        return result;
+      }
+
+      return {
+        ...result,
+        errorOutput: `${result.errorOutput}\n\n${reproduceLocallyHint(folder)}`,
+      };
+    } catch (error) {
+      return { success: false, errorOutput: String(error) };
+    }
+  }
+}

--- a/eng/tools/typespec-validation/src/utils.ts
+++ b/eng/tools/typespec-validation/src/utils.ts
@@ -2,7 +2,7 @@ import { execNpm, isExecError } from "@azure-tools/specs-shared/exec";
 import { ConsoleLogger } from "@azure-tools/specs-shared/logger";
 import debug from "debug";
 import { access, readdir, readFile } from "fs/promises";
-import defaultPath, { basename, dirname, join, type PlatformPath } from "path";
+import defaultPath, { basename, dirname, join, relative, type PlatformPath } from "path";
 import { simpleGit } from "simple-git";
 import { getSuppressions as getSuppressionsImpl, type Suppression } from "suppressions";
 import { context } from "./index.ts";
@@ -64,6 +64,23 @@ export function normalizePathImpl(folder: string, path: PlatformPath = defaultPa
     .split(path.sep)
     .join("/")
     .replace(/^([a-z]):/, (_match, driveLetter: string) => driveLetter.toUpperCase() + ":");
+}
+
+export async function readFileAtCommit(
+  folder: string,
+  commitish: string,
+  file: string,
+): Promise<string | undefined> {
+  const git = simpleGit(folder);
+  await git.revparse(["--verify", `${commitish}^{commit}`]);
+  const repositoryRoot = (await git.revparse(["--show-toplevel"])).trim();
+  const repositoryPath = relative(repositoryRoot, file).split(defaultPath.sep).join("/");
+
+  try {
+    return await git.show([`${commitish}:${repositoryPath}`]);
+  } catch {
+    return undefined;
+  }
 }
 
 export async function gitDiffTopSpecFolder(folder: string) {

--- a/eng/tools/typespec-validation/test/api-version-fixtures.ts
+++ b/eng/tools/typespec-validation/test/api-version-fixtures.ts
@@ -1,0 +1,27 @@
+import { type TypeSpecMetadata } from "@azure-tools/specs-shared/typespec-metadata";
+
+export const pythonEmitter = "@azure-tools/typespec-python";
+export const javaEmitter = "@azure-tools/typespec-java";
+
+export function serviceYaml(...versions: string[]) {
+  return `versions:\n${versions
+    .map((version) => `  - version: ${version}\n    source: typespec`)
+    .join("\n")}\n`;
+}
+
+export function metadata(apiVersions: Record<string, string | undefined>): TypeSpecMetadata {
+  return {
+    emitterVersion: "0.3.0",
+    generatedAt: "2026-08-18T00:00:00.000Z",
+    typespec: {
+      namespace: "Contoso.Management",
+      type: "management",
+    },
+    languages: Object.fromEntries(
+      Object.entries(apiVersions).map(([emitterName, apiVersion]) => [
+        emitterName,
+        [{ emitterName, apiVersion }],
+      ]),
+    ),
+  };
+}

--- a/eng/tools/typespec-validation/test/multiple-new-api-versions.test.ts
+++ b/eng/tools/typespec-validation/test/multiple-new-api-versions.test.ts
@@ -1,45 +1,16 @@
-import {
-  generateTypeSpecMetadata,
-  type TypeSpecMetadata,
-} from "@azure-tools/specs-shared/typespec-metadata";
+import { generateTypeSpecMetadata } from "@azure-tools/specs-shared/typespec-metadata";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { context } from "../src/index.ts";
 import {
-  compareApiVersionsAsc,
-  evaluateApiVersionPolicy,
+  evaluateMultipleNewApiVersions,
   MultipleNewApiVersionsRule,
 } from "../src/rules/multiple-new-api-versions.ts";
 import * as utils from "../src/utils.ts";
+import { javaEmitter, metadata, pythonEmitter, serviceYaml } from "./api-version-fixtures.ts";
 
 vi.mock("@azure-tools/specs-shared/typespec-metadata", () => ({
   generateTypeSpecMetadata: vi.fn(),
 }));
-
-function serviceYaml(...versions: string[]) {
-  return `versions:\n${versions
-    .map((version) => `  - version: ${version}\n    source: typespec`)
-    .join("\n")}\n`;
-}
-
-function metadata(apiVersions: Record<string, string | undefined>): TypeSpecMetadata {
-  return {
-    emitterVersion: "0.3.0",
-    generatedAt: "2026-08-18T00:00:00.000Z",
-    typespec: {
-      namespace: "Contoso.Management",
-      type: "management",
-    },
-    languages: Object.fromEntries(
-      Object.entries(apiVersions).map(([emitterName, apiVersion]) => [
-        emitterName,
-        [{ emitterName, apiVersion }],
-      ]),
-    ),
-  };
-}
-
-const pythonEmitter = "@azure-tools/typespec-python";
-const javaEmitter = "@azure-tools/typespec-java";
 
 describe("MultipleNewApiVersionsRule", function () {
   beforeEach(() => {
@@ -53,48 +24,22 @@ describe("MultipleNewApiVersionsRule", function () {
     vi.mocked(generateTypeSpecMetadata).mockReset();
   });
 
-  it("does not generate metadata when no TypeSpec API version was added", async function () {
-    vi.spyOn(utils, "readFileAtCommit").mockResolvedValue(serviceYaml("2025-01-01"));
-
-    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
-
-    expect(result.success).toBe(true);
-    expect(result.stdOutput).toContain("No new TypeSpec API versions");
-    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
-  });
-
-  it("generates metadata when one TypeSpec API version was added", async function () {
+  it("skips when only one API version was added", async function () {
     vi.spyOn(utils, "readFileAtCommit")
       .mockResolvedValueOnce(serviceYaml("2025-01-01"))
       .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01"));
-    vi.mocked(generateTypeSpecMetadata).mockResolvedValue(
-      metadata({ [pythonEmitter]: "2026-01-01" }),
-    );
 
     const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
 
     expect(result.success).toBe(true);
-    expect(result.stdOutput).not.toContain("Warning:");
-    expect(generateTypeSpecMetadata).toHaveBeenCalledOnce();
+    expect(result.stdOutput).toContain("Only one new API version was added");
+    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
   });
 
-  it("ignores swagger-sourced versions when finding newly added versions", async function () {
+  it("passes when every emitter targets the oldest new version", async function () {
     vi.spyOn(utils, "readFileAtCommit")
       .mockResolvedValueOnce(serviceYaml("2025-01-01"))
-      .mockResolvedValueOnce(
-        `${serviceYaml("2025-01-01")}  - version: 2026-01-01\n    source: swagger\n`,
-      );
-
-    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
-
-    expect(result.success).toBe(true);
-    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
-  });
-
-  it("treats all head TypeSpec versions as new when service.yaml is absent at base", async function () {
-    vi.spyOn(utils, "readFileAtCommit")
-      .mockResolvedValueOnce(undefined)
-      .mockResolvedValueOnce(serviceYaml("2026-01-01"));
+      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01", "2026-02-01"));
     vi.mocked(generateTypeSpecMetadata).mockResolvedValue(
       metadata({ [pythonEmitter]: "2026-01-01" }),
     );
@@ -102,51 +47,28 @@ describe("MultipleNewApiVersionsRule", function () {
     const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
 
     expect(result.success).toBe(true);
+    expect(result.stdOutput).toBe("All SDK language emitters target 2026-01-01.");
     expect(generateTypeSpecMetadata).toHaveBeenCalledOnce();
   });
 
-  it("skips projects without service.yaml at head", async function () {
-    vi.spyOn(utils, "readFileAtCommit").mockResolvedValue(undefined);
-
-    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
-
-    expect(result.success).toBe(true);
-    expect(result.stdOutput).toContain("Warning: service.yaml does not exist at head");
-    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
-  });
-
-  it("skips comparison when validating all specs", async function () {
-    context.checkingAllSpecs = true;
-    const readFileAtCommit = vi.spyOn(utils, "readFileAtCommit");
-
-    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
-
-    expect(result.success).toBe(true);
-    expect(result.stdOutput).toContain("Validating all specs");
-    expect(readFileAtCommit).not.toHaveBeenCalled();
-    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
-  });
-
-  it("skips when no commits are provided", async function () {
-    delete context.baseCommitish;
-    delete context.headCommitish;
-    const readFileAtCommit = vi.spyOn(utils, "readFileAtCommit");
-
-    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
-
-    expect(result.success).toBe(true);
-    expect(result.stdOutput).toContain("No commits to compare");
-    expect(result.stdOutput).toContain(
-      `npx tsv specification/foo/Foo '{"baseCommitish":"{commitShaOfMain}","headCommitish":"{headShaOfLocalBranch}"}'`,
+  it("fails and includes the reproduce hint when an emitter is not pinned", async function () {
+    vi.spyOn(utils, "readFileAtCommit")
+      .mockResolvedValueOnce(serviceYaml("2025-01-01"))
+      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01", "2026-02-01"));
+    vi.mocked(generateTypeSpecMetadata).mockResolvedValue(
+      metadata({ [pythonEmitter]: "2026-02-01" }),
     );
-    expect(readFileAtCommit).not.toHaveBeenCalled();
-    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
+
+    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
+
+    expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain("To reproduce locally:");
   });
 
   it("fails when metadata generation fails", async function () {
     vi.spyOn(utils, "readFileAtCommit")
       .mockResolvedValueOnce(serviceYaml("2025-01-01"))
-      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01"));
+      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01", "2026-02-01"));
     vi.mocked(generateTypeSpecMetadata).mockRejectedValue(new Error("metadata failed"));
 
     const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
@@ -154,75 +76,15 @@ describe("MultipleNewApiVersionsRule", function () {
     expect(result.success).toBe(false);
     expect(result.errorOutput).toContain("metadata failed");
   });
+
+  it("is suppressable", function () {
+    expect(new MultipleNewApiVersionsRule().suppressable).toBe(true);
+  });
 });
 
-describe("evaluateApiVersionPolicy", function () {
-  it("warns for each emitter targeting an older version when one version is added", function () {
-    const result = evaluateApiVersionPolicy(
-      metadata({
-        [pythonEmitter]: "2025-01-01",
-        [javaEmitter]: "2026-01-01",
-      }),
-      ["2026-01-01"],
-    );
-
-    expect(result.success).toBe(true);
-    expect(result.stdOutput).toContain(`Warning: ${pythonEmitter}`);
-    expect(result.stdOutput).not.toContain(`Warning: ${javaEmitter}`);
-  });
-
-  it("does not warn for non-date API-version values", function () {
-    const result = evaluateApiVersionPolicy(metadata({ [pythonEmitter]: "all" }), ["2026-01-01"]);
-
-    expect(result.success).toBe(true);
-    expect(result.stdOutput).toBe("No SDK emitter targets an API version older than 2026-01-01.");
-  });
-
-  it("does not warn when an emitter reports no API version", function () {
-    const result = evaluateApiVersionPolicy(metadata({ [pythonEmitter]: undefined }), [
-      "2026-01-01",
-    ]);
-
-    expect(result.success).toBe(true);
-    expect(result.stdOutput).toBe("No SDK emitter targets an API version older than 2026-01-01.");
-  });
-
-  it("reports an emitter with no API version as not set", function () {
-    const result = evaluateApiVersionPolicy(metadata({ [pythonEmitter]: undefined }), [
-      "2026-02-01-preview",
-      "2026-01-01",
-    ]);
-
-    expect(result.success).toBe(false);
-    expect(result.errorOutput).toContain(`${pythonEmitter}: <not set> (expected 2026-01-01)`);
-  });
-
-  it("skips multiple-service projects when one version is added", function () {
-    const result = evaluateApiVersionPolicy(
-      metadata({ [pythonEmitter]: "multiple-versions", [javaEmitter]: "multiple-versions" }),
-      ["2026-01-01"],
-    );
-
-    expect(result.success).toBe(true);
-    expect(result.stdOutput).toBe(
-      "Warning: This rule does not support multiple-service project scenarios.",
-    );
-  });
-
-  it("skips multiple-service projects instead of failing when multiple versions are added", function () {
-    const result = evaluateApiVersionPolicy(
-      metadata({ [pythonEmitter]: "multiple-versions", [javaEmitter]: "multiple-versions" }),
-      ["2026-02-01-preview", "2026-01-01"],
-    );
-
-    expect(result.success).toBe(true);
-    expect(result.stdOutput).toBe(
-      "Warning: This rule does not support multiple-service project scenarios.",
-    );
-  });
-
+describe("evaluateMultipleNewApiVersions", function () {
   it("requires all configured SDK emitters to target the oldest newly added version", function () {
-    const result = evaluateApiVersionPolicy(
+    const result = evaluateMultipleNewApiVersions(
       metadata({
         [pythonEmitter]: "2026-01-01",
         [javaEmitter]: "2026-02-01-preview",
@@ -232,6 +94,12 @@ describe("evaluateApiVersionPolicy", function () {
 
     expect(result.success).toBe(false);
     expect(result.errorOutput).toContain("ERROR: This pull request adds multiple API versions");
+    expect(result.errorOutput).toContain(
+      "the SDKs will be generated from API version 2026-02-01-preview",
+    );
+    expect(result.errorOutput).toContain(
+      'To generate and release the SDKs from 2026-01-01 first, every SDK language emitter must set "api-version" to 2026-01-01',
+    );
     expect(result.errorOutput).toContain(`${javaEmitter}: 2026-02-01-preview`);
     expect(result.errorOutput).toContain("expected 2026-01-01");
     expect(result.errorOutput).toContain(
@@ -240,7 +108,7 @@ describe("evaluateApiVersionPolicy", function () {
   });
 
   it("passes when all configured SDK emitters target the oldest new version", function () {
-    const result = evaluateApiVersionPolicy(
+    const result = evaluateMultipleNewApiVersions(
       metadata({
         [pythonEmitter]: "2026-01-01",
         [javaEmitter]: "2026-01-01",
@@ -251,23 +119,25 @@ describe("evaluateApiVersionPolicy", function () {
     expect(result.success).toBe(true);
   });
 
+  it("reports an emitter with no API version as not set", function () {
+    const result = evaluateMultipleNewApiVersions(metadata({ [pythonEmitter]: undefined }), [
+      "2026-02-01-preview",
+      "2026-01-01",
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain(`${pythonEmitter}: <not set> (expected 2026-01-01)`);
+  });
+
   it("skips validation when no SDK language emitters are configured", function () {
-    const result = evaluateApiVersionPolicy(metadata({}), ["2026-02-01-preview", "2026-01-01"]);
+    const result = evaluateMultipleNewApiVersions(metadata({}), [
+      "2026-02-01-preview",
+      "2026-01-01",
+    ]);
 
     expect(result.success).toBe(true);
     expect(result.stdOutput).toBe(
       "Warning: No SDK language emitters are configured; skipping API-version validation.",
     );
-  });
-});
-
-describe("compareApiVersionsAsc", function () {
-  it("sorts oldest first and treats preview as older than stable on the same date", function () {
-    const versions = ["2026-01-01", "2025-01-01", "2026-01-01-preview"];
-    expect(versions.sort(compareApiVersionsAsc)).toEqual([
-      "2025-01-01",
-      "2026-01-01-preview",
-      "2026-01-01",
-    ]);
   });
 });

--- a/eng/tools/typespec-validation/test/multiple-new-api-versions.test.ts
+++ b/eng/tools/typespec-validation/test/multiple-new-api-versions.test.ts
@@ -1,10 +1,19 @@
-import { type TypeSpecMetadata } from "@azure-tools/specs-shared/typespec-metadata";
-import { describe, expect, it, vi } from "vitest";
+import {
+  generateTypeSpecMetadata,
+  type TypeSpecMetadata,
+} from "@azure-tools/specs-shared/typespec-metadata";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { context } from "../src/index.ts";
 import {
   compareApiVersionsAsc,
   evaluateApiVersionPolicy,
   MultipleNewApiVersionsRule,
 } from "../src/rules/multiple-new-api-versions.ts";
+import * as utils from "../src/utils.ts";
+
+vi.mock("@azure-tools/specs-shared/typespec-metadata", () => ({
+  generateTypeSpecMetadata: vi.fn(),
+}));
 
 function serviceYaml(...versions: string[]) {
   return `versions:\n${versions
@@ -33,97 +42,98 @@ const pythonEmitter = "@azure-tools/typespec-python";
 const javaEmitter = "@azure-tools/typespec-java";
 
 describe("MultipleNewApiVersionsRule", function () {
-  it("does not generate metadata when no TypeSpec API version was added", async function () {
-    const generateMetadata = vi.fn();
-    const rule = new MultipleNewApiVersionsRule({
-      baseCommitish: "base",
-      headCommitish: "head",
-      readFileAtCommit: vi.fn().mockResolvedValue(serviceYaml("2025-01-01")),
-      generateMetadata,
-    });
+  beforeEach(() => {
+    context.baseCommitish = "base";
+    context.headCommitish = "head";
+    context.checkingAllSpecs = false;
+  });
 
-    const result = await rule.execute("specification/foo/Foo");
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(generateTypeSpecMetadata).mockReset();
+  });
+
+  it("does not generate metadata when no TypeSpec API version was added", async function () {
+    vi.spyOn(utils, "readFileAtCommit").mockResolvedValue(serviceYaml("2025-01-01"));
+
+    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
 
     expect(result.success).toBe(true);
     expect(result.stdOutput).toContain("No new TypeSpec API versions");
-    expect(generateMetadata).not.toHaveBeenCalled();
+    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
   });
 
   it("generates metadata when one TypeSpec API version was added", async function () {
-    const generateMetadata = vi.fn().mockResolvedValue(metadata({ [pythonEmitter]: "2026-01-01" }));
-    const readFileAtCommit = vi
-      .fn()
+    vi.spyOn(utils, "readFileAtCommit")
       .mockResolvedValueOnce(serviceYaml("2025-01-01"))
       .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01"));
-    const rule = new MultipleNewApiVersionsRule({
-      baseCommitish: "base",
-      headCommitish: "head",
-      readFileAtCommit,
-      generateMetadata,
-    });
+    vi.mocked(generateTypeSpecMetadata).mockResolvedValue(
+      metadata({ [pythonEmitter]: "2026-01-01" }),
+    );
 
-    const result = await rule.execute("specification/foo/Foo");
+    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
 
     expect(result.success).toBe(true);
     expect(result.stdOutput).not.toContain("Warning:");
-    expect(generateMetadata).toHaveBeenCalledOnce();
+    expect(generateTypeSpecMetadata).toHaveBeenCalledOnce();
   });
 
   it("ignores swagger-sourced versions when finding newly added versions", async function () {
-    const generateMetadata = vi.fn();
-    const readFileAtCommit = vi
-      .fn()
+    vi.spyOn(utils, "readFileAtCommit")
       .mockResolvedValueOnce(serviceYaml("2025-01-01"))
       .mockResolvedValueOnce(
         `${serviceYaml("2025-01-01")}  - version: 2026-01-01\n    source: swagger\n`,
       );
-    const rule = new MultipleNewApiVersionsRule({ readFileAtCommit, generateMetadata });
 
-    const result = await rule.execute("specification/foo/Foo");
+    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
 
     expect(result.success).toBe(true);
-    expect(generateMetadata).not.toHaveBeenCalled();
+    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
   });
 
   it("treats all head TypeSpec versions as new when service.yaml is absent at base", async function () {
-    const generateMetadata = vi.fn().mockResolvedValue(metadata({ [pythonEmitter]: "2026-01-01" }));
-    const readFileAtCommit = vi
-      .fn()
+    vi.spyOn(utils, "readFileAtCommit")
       .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(serviceYaml("2026-01-01"));
-    const rule = new MultipleNewApiVersionsRule({ readFileAtCommit, generateMetadata });
+    vi.mocked(generateTypeSpecMetadata).mockResolvedValue(
+      metadata({ [pythonEmitter]: "2026-01-01" }),
+    );
 
-    const result = await rule.execute("specification/foo/Foo");
+    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
 
     expect(result.success).toBe(true);
-    expect(generateMetadata).toHaveBeenCalledOnce();
+    expect(generateTypeSpecMetadata).toHaveBeenCalledOnce();
   });
 
   it("skips projects without service.yaml at head", async function () {
-    const generateMetadata = vi.fn();
-    const rule = new MultipleNewApiVersionsRule({
-      readFileAtCommit: vi.fn().mockResolvedValue(undefined),
-      generateMetadata,
-    });
+    vi.spyOn(utils, "readFileAtCommit").mockResolvedValue(undefined);
 
-    const result = await rule.execute("specification/foo/Foo");
+    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
 
     expect(result.success).toBe(true);
-    expect(result.stdOutput).toContain("validation skipped");
-    expect(generateMetadata).not.toHaveBeenCalled();
+    expect(result.stdOutput).toContain("Warning: service.yaml does not exist at head");
+    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
+  });
+
+  it("skips comparison when validating all specs", async function () {
+    context.checkingAllSpecs = true;
+    const readFileAtCommit = vi.spyOn(utils, "readFileAtCommit");
+
+    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toContain("Validating all specs");
+    expect(readFileAtCommit).not.toHaveBeenCalled();
+    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
   });
 
   it("fails when metadata generation fails", async function () {
-    const readFileAtCommit = vi
-      .fn()
+    vi.spyOn(utils, "readFileAtCommit")
       .mockResolvedValueOnce(serviceYaml("2025-01-01"))
       .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01"));
-    const rule = new MultipleNewApiVersionsRule({
-      readFileAtCommit,
-      generateMetadata: vi.fn().mockRejectedValue(new Error("metadata failed")),
-    });
+    vi.mocked(generateTypeSpecMetadata).mockRejectedValue(new Error("metadata failed"));
 
-    const result = await rule.execute("specification/foo/Foo");
+    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
 
     expect(result.success).toBe(false);
     expect(result.errorOutput).toContain("metadata failed");
@@ -145,11 +155,30 @@ describe("evaluateApiVersionPolicy", function () {
     expect(result.stdOutput).not.toContain(`Warning: ${javaEmitter}`);
   });
 
-  it("does not compare special metadata API-version values", function () {
+  it("does not warn for non-date API-version values", function () {
     const result = evaluateApiVersionPolicy(metadata({ [pythonEmitter]: "all" }), ["2026-01-01"]);
 
     expect(result.success).toBe(true);
-    expect(result.stdOutput).not.toContain("Warning:");
+    expect(result.stdOutput).toBe("No SDK emitter targets an API version older than 2026-01-01.");
+  });
+
+  it("does not warn when an emitter reports no API version", function () {
+    const result = evaluateApiVersionPolicy(metadata({ [pythonEmitter]: undefined }), [
+      "2026-01-01",
+    ]);
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toBe("No SDK emitter targets an API version older than 2026-01-01.");
+  });
+
+  it("reports an emitter with no API version as not set", function () {
+    const result = evaluateApiVersionPolicy(metadata({ [pythonEmitter]: undefined }), [
+      "2026-02-01-preview",
+      "2026-01-01",
+    ]);
+
+    expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain(`${pythonEmitter}: <not set> (expected 2026-01-01)`);
   });
 
   it("skips multiple-service projects when one version is added", function () {
@@ -159,7 +188,9 @@ describe("evaluateApiVersionPolicy", function () {
     );
 
     expect(result.success).toBe(true);
-    expect(result.stdOutput).toContain("does not support multiple-service project");
+    expect(result.stdOutput).toBe(
+      "Warning: This rule does not support multiple-service project scenarios.",
+    );
   });
 
   it("skips multiple-service projects instead of failing when multiple versions are added", function () {
@@ -169,7 +200,9 @@ describe("evaluateApiVersionPolicy", function () {
     );
 
     expect(result.success).toBe(true);
-    expect(result.stdOutput).toContain("does not support multiple-service project");
+    expect(result.stdOutput).toBe(
+      "Warning: This rule does not support multiple-service project scenarios.",
+    );
   });
 
   it("requires all configured SDK emitters to target the oldest newly added version", function () {
@@ -184,6 +217,9 @@ describe("evaluateApiVersionPolicy", function () {
     expect(result.success).toBe(false);
     expect(result.errorOutput).toContain(`${javaEmitter}: 2026-02-01-preview`);
     expect(result.errorOutput).toContain("expected 2026-01-01");
+    expect(result.errorOutput).toContain(
+      "https://github.com/Azure/azure-rest-api-specs/wiki/TypeSpec-Validation#multiplenewapiversions",
+    );
   });
 
   it("passes when all configured SDK emitters target the oldest new version", function () {
@@ -198,11 +234,13 @@ describe("evaluateApiVersionPolicy", function () {
     expect(result.success).toBe(true);
   });
 
-  it("fails multiple-version validation when no SDK emitters are reported", function () {
+  it("skips validation when no SDK language emitters are configured", function () {
     const result = evaluateApiVersionPolicy(metadata({}), ["2026-02-01-preview", "2026-01-01"]);
 
-    expect(result.success).toBe(false);
-    expect(result.errorOutput).toContain("did not report any configured SDK language emitters");
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toBe(
+      "Warning: No SDK language emitters are configured; skipping API-version validation.",
+    );
   });
 });
 

--- a/eng/tools/typespec-validation/test/multiple-new-api-versions.test.ts
+++ b/eng/tools/typespec-validation/test/multiple-new-api-versions.test.ts
@@ -127,6 +127,22 @@ describe("MultipleNewApiVersionsRule", function () {
     expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
   });
 
+  it("skips when no commits are provided", async function () {
+    delete context.baseCommitish;
+    delete context.headCommitish;
+    const readFileAtCommit = vi.spyOn(utils, "readFileAtCommit");
+
+    const result = await new MultipleNewApiVersionsRule().execute("specification/foo/Foo");
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toContain("No commits to compare");
+    expect(result.stdOutput).toContain(
+      `npx tsv specification/foo/Foo '{"baseCommitish":"{commitShaOfMain}","headCommitish":"{headShaOfLocalBranch}"}'`,
+    );
+    expect(readFileAtCommit).not.toHaveBeenCalled();
+    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
+  });
+
   it("fails when metadata generation fails", async function () {
     vi.spyOn(utils, "readFileAtCommit")
       .mockResolvedValueOnce(serviceYaml("2025-01-01"))
@@ -215,6 +231,7 @@ describe("evaluateApiVersionPolicy", function () {
     );
 
     expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain("ERROR: This pull request adds multiple API versions");
     expect(result.errorOutput).toContain(`${javaEmitter}: 2026-02-01-preview`);
     expect(result.errorOutput).toContain("expected 2026-01-01");
     expect(result.errorOutput).toContain(

--- a/eng/tools/typespec-validation/test/multiple-new-api-versions.test.ts
+++ b/eng/tools/typespec-validation/test/multiple-new-api-versions.test.ts
@@ -1,0 +1,218 @@
+import { type TypeSpecMetadata } from "@azure-tools/specs-shared/typespec-metadata";
+import { describe, expect, it, vi } from "vitest";
+import {
+  compareApiVersionsAsc,
+  evaluateApiVersionPolicy,
+  MultipleNewApiVersionsRule,
+} from "../src/rules/multiple-new-api-versions.ts";
+
+function serviceYaml(...versions: string[]) {
+  return `versions:\n${versions
+    .map((version) => `  - version: ${version}\n    source: typespec`)
+    .join("\n")}\n`;
+}
+
+function metadata(apiVersions: Record<string, string | undefined>): TypeSpecMetadata {
+  return {
+    emitterVersion: "0.3.0",
+    generatedAt: "2026-08-18T00:00:00.000Z",
+    typespec: {
+      namespace: "Contoso.Management",
+      type: "management",
+    },
+    languages: Object.fromEntries(
+      Object.entries(apiVersions).map(([emitterName, apiVersion]) => [
+        emitterName,
+        [{ emitterName, apiVersion }],
+      ]),
+    ),
+  };
+}
+
+const pythonEmitter = "@azure-tools/typespec-python";
+const javaEmitter = "@azure-tools/typespec-java";
+
+describe("MultipleNewApiVersionsRule", function () {
+  it("does not generate metadata when no TypeSpec API version was added", async function () {
+    const generateMetadata = vi.fn();
+    const rule = new MultipleNewApiVersionsRule({
+      baseCommitish: "base",
+      headCommitish: "head",
+      readFileAtCommit: vi.fn().mockResolvedValue(serviceYaml("2025-01-01")),
+      generateMetadata,
+    });
+
+    const result = await rule.execute("specification/foo/Foo");
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toContain("No new TypeSpec API versions");
+    expect(generateMetadata).not.toHaveBeenCalled();
+  });
+
+  it("generates metadata when one TypeSpec API version was added", async function () {
+    const generateMetadata = vi.fn().mockResolvedValue(metadata({ [pythonEmitter]: "2026-01-01" }));
+    const readFileAtCommit = vi
+      .fn()
+      .mockResolvedValueOnce(serviceYaml("2025-01-01"))
+      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01"));
+    const rule = new MultipleNewApiVersionsRule({
+      baseCommitish: "base",
+      headCommitish: "head",
+      readFileAtCommit,
+      generateMetadata,
+    });
+
+    const result = await rule.execute("specification/foo/Foo");
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).not.toContain("Warning:");
+    expect(generateMetadata).toHaveBeenCalledOnce();
+  });
+
+  it("ignores swagger-sourced versions when finding newly added versions", async function () {
+    const generateMetadata = vi.fn();
+    const readFileAtCommit = vi
+      .fn()
+      .mockResolvedValueOnce(serviceYaml("2025-01-01"))
+      .mockResolvedValueOnce(
+        `${serviceYaml("2025-01-01")}  - version: 2026-01-01\n    source: swagger\n`,
+      );
+    const rule = new MultipleNewApiVersionsRule({ readFileAtCommit, generateMetadata });
+
+    const result = await rule.execute("specification/foo/Foo");
+
+    expect(result.success).toBe(true);
+    expect(generateMetadata).not.toHaveBeenCalled();
+  });
+
+  it("treats all head TypeSpec versions as new when service.yaml is absent at base", async function () {
+    const generateMetadata = vi.fn().mockResolvedValue(metadata({ [pythonEmitter]: "2026-01-01" }));
+    const readFileAtCommit = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(serviceYaml("2026-01-01"));
+    const rule = new MultipleNewApiVersionsRule({ readFileAtCommit, generateMetadata });
+
+    const result = await rule.execute("specification/foo/Foo");
+
+    expect(result.success).toBe(true);
+    expect(generateMetadata).toHaveBeenCalledOnce();
+  });
+
+  it("skips projects without service.yaml at head", async function () {
+    const generateMetadata = vi.fn();
+    const rule = new MultipleNewApiVersionsRule({
+      readFileAtCommit: vi.fn().mockResolvedValue(undefined),
+      generateMetadata,
+    });
+
+    const result = await rule.execute("specification/foo/Foo");
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toContain("validation skipped");
+    expect(generateMetadata).not.toHaveBeenCalled();
+  });
+
+  it("fails when metadata generation fails", async function () {
+    const readFileAtCommit = vi
+      .fn()
+      .mockResolvedValueOnce(serviceYaml("2025-01-01"))
+      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01"));
+    const rule = new MultipleNewApiVersionsRule({
+      readFileAtCommit,
+      generateMetadata: vi.fn().mockRejectedValue(new Error("metadata failed")),
+    });
+
+    const result = await rule.execute("specification/foo/Foo");
+
+    expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain("metadata failed");
+  });
+});
+
+describe("evaluateApiVersionPolicy", function () {
+  it("warns for each emitter targeting an older version when one version is added", function () {
+    const result = evaluateApiVersionPolicy(
+      metadata({
+        [pythonEmitter]: "2025-01-01",
+        [javaEmitter]: "2026-01-01",
+      }),
+      ["2026-01-01"],
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toContain(`Warning: ${pythonEmitter}`);
+    expect(result.stdOutput).not.toContain(`Warning: ${javaEmitter}`);
+  });
+
+  it("does not compare special metadata API-version values", function () {
+    const result = evaluateApiVersionPolicy(metadata({ [pythonEmitter]: "all" }), ["2026-01-01"]);
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).not.toContain("Warning:");
+  });
+
+  it("skips multiple-service projects when one version is added", function () {
+    const result = evaluateApiVersionPolicy(
+      metadata({ [pythonEmitter]: "multiple-versions", [javaEmitter]: "multiple-versions" }),
+      ["2026-01-01"],
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toContain("does not support multiple-service project");
+  });
+
+  it("skips multiple-service projects instead of failing when multiple versions are added", function () {
+    const result = evaluateApiVersionPolicy(
+      metadata({ [pythonEmitter]: "multiple-versions", [javaEmitter]: "multiple-versions" }),
+      ["2026-02-01-preview", "2026-01-01"],
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toContain("does not support multiple-service project");
+  });
+
+  it("requires all configured SDK emitters to target the oldest newly added version", function () {
+    const result = evaluateApiVersionPolicy(
+      metadata({
+        [pythonEmitter]: "2026-01-01",
+        [javaEmitter]: "2026-02-01-preview",
+      }),
+      ["2026-02-01-preview", "2026-01-01"],
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain(`${javaEmitter}: 2026-02-01-preview`);
+    expect(result.errorOutput).toContain("expected 2026-01-01");
+  });
+
+  it("passes when all configured SDK emitters target the oldest new version", function () {
+    const result = evaluateApiVersionPolicy(
+      metadata({
+        [pythonEmitter]: "2026-01-01",
+        [javaEmitter]: "2026-01-01",
+      }),
+      ["2026-02-01-preview", "2026-01-01"],
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("fails multiple-version validation when no SDK emitters are reported", function () {
+    const result = evaluateApiVersionPolicy(metadata({}), ["2026-02-01-preview", "2026-01-01"]);
+
+    expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain("did not report any configured SDK language emitters");
+  });
+});
+
+describe("compareApiVersionsAsc", function () {
+  it("sorts oldest first and treats preview as older than stable on the same date", function () {
+    const versions = ["2026-01-01", "2025-01-01", "2026-01-01-preview"];
+    expect(versions.sort(compareApiVersionsAsc)).toEqual([
+      "2025-01-01",
+      "2026-01-01-preview",
+      "2026-01-01",
+    ]);
+  });
+});

--- a/eng/tools/typespec-validation/test/sdk-api-version.test.ts
+++ b/eng/tools/typespec-validation/test/sdk-api-version.test.ts
@@ -1,0 +1,186 @@
+import { generateTypeSpecMetadata } from "@azure-tools/specs-shared/typespec-metadata";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { context } from "../src/index.ts";
+import {
+  compareApiVersionsAsc,
+  resolveNewApiVersions,
+  resolveSdkEmitters,
+} from "../src/rules/sdk-api-version.ts";
+import * as utils from "../src/utils.ts";
+import { metadata, pythonEmitter, serviceYaml } from "./api-version-fixtures.ts";
+
+vi.mock("@azure-tools/specs-shared/typespec-metadata", () => ({
+  generateTypeSpecMetadata: vi.fn(),
+}));
+
+describe("resolveNewApiVersions", function () {
+  beforeEach(() => {
+    context.baseCommitish = "base";
+    context.headCommitish = "head";
+    context.checkingAllSpecs = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(generateTypeSpecMetadata).mockReset();
+  });
+
+  it("skips comparison when validating all specs", async function () {
+    context.checkingAllSpecs = true;
+    const readFileAtCommit = vi.spyOn(utils, "readFileAtCommit");
+
+    const resolved = await resolveNewApiVersions("specification/foo/Foo");
+
+    expect(resolved.kind).toBe("skip");
+    expect(resolved.kind === "skip" && resolved.result.stdOutput).toContain("Validating all specs");
+    expect(readFileAtCommit).not.toHaveBeenCalled();
+  });
+
+  it("skips when no commits are provided", async function () {
+    delete context.baseCommitish;
+    delete context.headCommitish;
+    const readFileAtCommit = vi.spyOn(utils, "readFileAtCommit");
+
+    const resolved = await resolveNewApiVersions("specification/foo/Foo");
+
+    expect(resolved.kind).toBe("skip");
+    expect(resolved.kind === "skip" && resolved.result.stdOutput).toContain(
+      `npx tsv specification/foo/Foo '{"baseCommitish":"{commitShaOfMain}","headCommitish":"{headShaOfLocalBranch}"}'`,
+    );
+    expect(readFileAtCommit).not.toHaveBeenCalled();
+  });
+
+  it("skips projects without service.yaml at head", async function () {
+    vi.spyOn(utils, "readFileAtCommit").mockResolvedValue(undefined);
+
+    const resolved = await resolveNewApiVersions("specification/foo/Foo");
+
+    expect(resolved.kind).toBe("skip");
+    expect(resolved.kind === "skip" && resolved.result.stdOutput).toContain(
+      "Warning: service.yaml does not exist at head",
+    );
+  });
+
+  it("skips when no TypeSpec API version was added", async function () {
+    vi.spyOn(utils, "readFileAtCommit").mockResolvedValue(serviceYaml("2025-01-01"));
+
+    const resolved = await resolveNewApiVersions("specification/foo/Foo");
+
+    expect(resolved.kind).toBe("skip");
+    expect(resolved.kind === "skip" && resolved.result.stdOutput).toContain(
+      "No new TypeSpec API versions",
+    );
+  });
+
+  it("ignores swagger-sourced versions when finding newly added versions", async function () {
+    vi.spyOn(utils, "readFileAtCommit")
+      .mockResolvedValueOnce(serviceYaml("2025-01-01"))
+      .mockResolvedValueOnce(
+        `${serviceYaml("2025-01-01")}  - version: 2026-01-01\n    source: swagger\n`,
+      );
+
+    const resolved = await resolveNewApiVersions("specification/foo/Foo");
+
+    expect(resolved.kind).toBe("skip");
+  });
+
+  it("returns newly added versions", async function () {
+    vi.spyOn(utils, "readFileAtCommit")
+      .mockResolvedValueOnce(serviceYaml("2025-01-01"))
+      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01"));
+
+    const resolved = await resolveNewApiVersions("specification/foo/Foo");
+
+    expect(resolved.kind === "versions" && resolved.newApiVersions).toEqual(["2026-01-01"]);
+  });
+
+  it("treats all head TypeSpec versions as new when service.yaml is absent at base", async function () {
+    vi.spyOn(utils, "readFileAtCommit")
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(serviceYaml("2026-01-01"));
+
+    const resolved = await resolveNewApiVersions("specification/foo/Foo");
+
+    expect(resolved.kind === "versions" && resolved.newApiVersions).toEqual(["2026-01-01"]);
+  });
+
+  it("fails when service.yaml cannot be read", async function () {
+    vi.spyOn(utils, "readFileAtCommit").mockRejectedValue(new Error("bad revision"));
+
+    const resolved = await resolveNewApiVersions("specification/foo/Foo");
+
+    expect(resolved.kind === "skip" && resolved.result.success).toBe(false);
+    expect(resolved.kind === "skip" && resolved.result.errorOutput).toContain(
+      "Unable to compare service.yaml",
+    );
+  });
+
+  it("fails when service.yaml is malformed at head", async function () {
+    vi.spyOn(utils, "readFileAtCommit").mockResolvedValue("versions: not-a-list\n");
+
+    const resolved = await resolveNewApiVersions("specification/foo/Foo");
+
+    expect(resolved.kind === "skip" && resolved.result.success).toBe(false);
+    expect(resolved.kind === "skip" && resolved.result.errorOutput).toContain("ERROR: head:");
+  });
+
+  it("fails when service.yaml is malformed at base", async function () {
+    vi.spyOn(utils, "readFileAtCommit")
+      .mockResolvedValueOnce("versions: not-a-list\n")
+      .mockResolvedValueOnce(serviceYaml("2026-01-01"));
+
+    const resolved = await resolveNewApiVersions("specification/foo/Foo");
+
+    expect(resolved.kind === "skip" && resolved.result.success).toBe(false);
+    expect(resolved.kind === "skip" && resolved.result.errorOutput).toContain("ERROR: base:");
+  });
+});
+
+describe("resolveSdkEmitters", function () {
+  it("skips when no SDK language emitters are configured", function () {
+    const resolved = resolveSdkEmitters(metadata({}));
+
+    expect(resolved.kind).toBe("skip");
+    expect(resolved.kind === "skip" && resolved.result.stdOutput).toBe(
+      "Warning: No SDK language emitters are configured; skipping API-version validation.",
+    );
+  });
+
+  it("skips multiple-service projects", function () {
+    const resolved = resolveSdkEmitters(metadata({ [pythonEmitter]: "multiple-versions" }));
+
+    expect(resolved.kind).toBe("skip");
+    expect(resolved.kind === "skip" && resolved.result.stdOutput).toBe(
+      "Warning: This rule does not support multiple-service project scenarios.",
+    );
+  });
+
+  it("ignores emitters that are not SDK language emitters", function () {
+    const resolved = resolveSdkEmitters(
+      metadata({ "@azure-tools/typespec-autorest": "2026-01-01" }),
+    );
+
+    expect(resolved.kind).toBe("skip");
+  });
+
+  it("returns the configured SDK emitters", function () {
+    const resolved = resolveSdkEmitters(metadata({ [pythonEmitter]: "2026-01-01" }));
+
+    expect(resolved.kind === "emitters" && resolved.emitters).toHaveLength(1);
+  });
+});
+
+describe("compareApiVersionsAsc", function () {
+  it("sorts oldest first and treats preview as older than stable on the same date", function () {
+    const versions = ["2026-01-01", "2025-01-01", "2026-01-01-preview"];
+    expect(versions.sort(compareApiVersionsAsc)).toEqual([
+      "2025-01-01",
+      "2026-01-01-preview",
+      "2026-01-01",
+    ]);
+  });
+
+  it("falls back to string comparison for non-date values", function () {
+    expect(compareApiVersionsAsc("all", "2026-01-01")).toBeGreaterThan(0);
+  });
+});

--- a/eng/tools/typespec-validation/test/stale-api-version-pin.test.ts
+++ b/eng/tools/typespec-validation/test/stale-api-version-pin.test.ts
@@ -1,0 +1,145 @@
+import { generateTypeSpecMetadata } from "@azure-tools/specs-shared/typespec-metadata";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { context } from "../src/index.ts";
+import {
+  StaleApiVersionPinRule,
+  evaluateStaleApiVersionPin,
+} from "../src/rules/stale-api-version-pin.ts";
+import * as utils from "../src/utils.ts";
+import { javaEmitter, metadata, pythonEmitter, serviceYaml } from "./api-version-fixtures.ts";
+
+vi.mock("@azure-tools/specs-shared/typespec-metadata", () => ({
+  generateTypeSpecMetadata: vi.fn(),
+}));
+
+describe("StaleApiVersionPinRule", function () {
+  beforeEach(() => {
+    context.baseCommitish = "base";
+    context.headCommitish = "head";
+    context.checkingAllSpecs = false;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.mocked(generateTypeSpecMetadata).mockReset();
+  });
+
+  it("skips when multiple API versions were added", async function () {
+    vi.spyOn(utils, "readFileAtCommit")
+      .mockResolvedValueOnce(serviceYaml("2025-01-01"))
+      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01", "2026-02-01"));
+
+    const result = await new StaleApiVersionPinRule().execute("specification/foo/Foo");
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toContain("Multiple new API versions were added");
+    expect(generateTypeSpecMetadata).not.toHaveBeenCalled();
+  });
+
+  it("passes when no emitter is pinned to an older version", async function () {
+    vi.spyOn(utils, "readFileAtCommit")
+      .mockResolvedValueOnce(serviceYaml("2025-01-01"))
+      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01"));
+    vi.mocked(generateTypeSpecMetadata).mockResolvedValue(
+      metadata({ [pythonEmitter]: "2026-01-01" }),
+    );
+
+    const result = await new StaleApiVersionPinRule().execute("specification/foo/Foo");
+
+    expect(result.success).toBe(true);
+    expect(generateTypeSpecMetadata).toHaveBeenCalledOnce();
+  });
+
+  it("fails and includes the reproduce hint when an emitter is stale", async function () {
+    vi.spyOn(utils, "readFileAtCommit")
+      .mockResolvedValueOnce(serviceYaml("2025-01-01"))
+      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01"));
+    vi.mocked(generateTypeSpecMetadata).mockResolvedValue(
+      metadata({ [pythonEmitter]: "2025-01-01" }),
+    );
+
+    const result = await new StaleApiVersionPinRule().execute("specification/foo/Foo");
+
+    expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain(`  - ${pythonEmitter}: 2025-01-01`);
+    expect(result.errorOutput).toContain("To reproduce locally:");
+  });
+
+  it("fails when metadata generation fails", async function () {
+    vi.spyOn(utils, "readFileAtCommit")
+      .mockResolvedValueOnce(serviceYaml("2025-01-01"))
+      .mockResolvedValueOnce(serviceYaml("2025-01-01", "2026-01-01"));
+    vi.mocked(generateTypeSpecMetadata).mockRejectedValue(new Error("metadata failed"));
+
+    const result = await new StaleApiVersionPinRule().execute("specification/foo/Foo");
+
+    expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain("metadata failed");
+  });
+
+  it("is suppressable", function () {
+    expect(new StaleApiVersionPinRule().suppressable).toBe(true);
+  });
+});
+
+describe("evaluateStaleApiVersionPin", function () {
+  it("reports every emitter pinned to an older version", function () {
+    const result = evaluateStaleApiVersionPin(
+      metadata({ [pythonEmitter]: "2025-01-01", [javaEmitter]: "2025-06-01" }),
+      "2026-01-01",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain(
+      "ERROR: This pull request adds API version 2026-01-01, but the SDK language emitters " +
+        "below are pinned to an older API version, so their SDKs will be generated from the " +
+        "pinned version instead.",
+    );
+    expect(result.errorOutput).toContain(
+      'To generate and release the SDKs from 2026-01-01, remove the "api-version" setting from ' +
+        "these emitters in tspconfig.yaml:",
+    );
+    expect(result.errorOutput).toContain(`  - ${pythonEmitter}: 2025-01-01`);
+    expect(result.errorOutput).toContain(`  - ${javaEmitter}: 2025-06-01`);
+    expect(result.errorOutput).toContain(
+      "https://github.com/Azure/azure-rest-api-specs/wiki/TypeSpec-Validation#staleapiversionpin",
+    );
+  });
+
+  it("ignores emitters targeting the new version", function () {
+    const result = evaluateStaleApiVersionPin(
+      metadata({ [pythonEmitter]: "2025-01-01", [javaEmitter]: "2026-01-01" }),
+      "2026-01-01",
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errorOutput).toContain(pythonEmitter);
+    expect(result.errorOutput).not.toContain(javaEmitter);
+  });
+
+  it("does not compare non-date API-version values", function () {
+    const result = evaluateStaleApiVersionPin(metadata({ [pythonEmitter]: "all" }), "2026-01-01");
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toBe("No SDK emitter targets an API version older than 2026-01-01.");
+  });
+
+  it("does not compare when an emitter reports no API version", function () {
+    const result = evaluateStaleApiVersionPin(
+      metadata({ [pythonEmitter]: undefined }),
+      "2026-01-01",
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("skips multiple-service projects", function () {
+    const result = evaluateStaleApiVersionPin(
+      metadata({ [pythonEmitter]: "multiple-versions" }),
+      "2026-01-01",
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.stdOutput).toContain("does not support multiple-service project");
+  });
+});

--- a/eng/tools/typespec-validation/test/util.test.ts
+++ b/eng/tools/typespec-validation/test/util.test.ts
@@ -4,10 +4,28 @@ mockSimpleGit();
 import { strict as assert } from "node:assert";
 import path from "path";
 import process from "process";
-import { describe, it } from "vitest";
-import { gitDiffTopSpecFolder, normalizePath } from "../src/utils.ts";
+import { simpleGit } from "simple-git";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { gitDiffTopSpecFolder, normalizePath, readFileAtCommit } from "../src/utils.ts";
 
 describe("util", function () {
+  let revparseMock = vi.fn();
+  let showMock = vi.fn();
+
+  beforeEach(() => {
+    revparseMock = vi.fn().mockResolvedValueOnce("abc123").mockResolvedValueOnce("C:/repo\n");
+    showMock = vi.fn().mockResolvedValue("versions: []\n");
+    vi.mocked(simpleGit).mockReturnValue({
+      revparse: revparseMock,
+      show: showMock,
+      status: vi.fn().mockResolvedValue({
+        modified: [],
+        not_added: [],
+        isClean: () => true,
+      }),
+    } as never);
+  });
+
   describe("normalize", function () {
     it("should succeed if normalized . and normalized cwd matches", function () {
       const dotResult = normalizePath(".");
@@ -36,6 +54,35 @@ describe("util", function () {
     it("should succeed if git diff produces no output", async function () {
       const result = await gitDiffTopSpecFolder(mockFolder);
       assert(result.success);
+    });
+  });
+
+  describe("readFileAtCommit", function () {
+    it("reads a repository-relative path from the requested commit", async function () {
+      const content = await readFileAtCommit(
+        "C:/repo/specification/foo/Foo",
+        "base",
+        "C:/repo/specification/foo/Foo/service.yaml",
+      );
+
+      expect(content).toBe("versions: []\n");
+      expect(revparseMock).toHaveBeenNthCalledWith(1, ["--verify", "base^{commit}"]);
+      expect(showMock).toHaveBeenCalledWith(["base:specification/foo/Foo/service.yaml"]);
+    });
+
+    it("returns undefined when the file does not exist at the commit", async function () {
+      vi.mocked(simpleGit).mockReturnValue({
+        revparse: vi.fn().mockResolvedValueOnce("abc123").mockResolvedValueOnce("C:/repo\n"),
+        show: vi.fn().mockRejectedValue(new Error("path does not exist")),
+      } as never);
+
+      await expect(
+        readFileAtCommit(
+          "C:/repo/specification/foo/Foo",
+          "base",
+          "C:/repo/specification/foo/Foo/service.yaml",
+        ),
+      ).resolves.toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
resolves https://github.com/Azure/azure-sdk-tools/issues/16731
## Summary

- add a `multiple-new-api-versions` TypeSpec validation rule: doc is at https://github.com/Azure/azure-rest-api-specs/wiki/TypeSpec-Validation#multiplenewapiversions
- detect and report multiple newly introduced API versions
- add shared TypeSpec metadata support, tests, and documentation
- integrate the rule into TypeSpec validation workflows

## Testing

- added unit tests for the validation rule and metadata utilities