### PR TITLE
Add approvalReference to private endpoint connection in 2026-01-01

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
@@ -3806,7 +3806,11 @@ model ApprovalReference {
   /**
    * The ARM resource id of an existing approved private endpoint whose approval state is inherited by this connection.
    */
-  privateEndpointId?: string;
+  privateEndpointId?: Azure.Core.armResourceIdentifier<[
+    {
+      type: "Microsoft.Network/privateEndpoints";
+    }
+  ]>;
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
@@ -3792,10 +3792,9 @@ model PrivateLinkServiceConnectionProperties {
   privateLinkServiceConnectionState?: PrivateLinkServiceConnectionState;
 
   /**
-   * A reference to an existing approved private endpoint whose connection approval state should be inherited by this connection at creation time. Set at create and cannot be changed afterward.
+   * A reference to an existing approved private endpoint whose connection approval state should be inherited by this connection at creation time.
    */
   @added(Versions.v2026_01_01)
-  @visibility(Lifecycle.Read, Lifecycle.Create)
   approvalReference?: ApprovalReference;
 }
 

--- a/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Common/main.tsp
@@ -3790,6 +3790,24 @@ model PrivateLinkServiceConnectionProperties {
    * A collection of read-only information about the state of the connection to the remote resource.
    */
   privateLinkServiceConnectionState?: PrivateLinkServiceConnectionState;
+
+  /**
+   * A reference to an existing approved private endpoint whose connection approval state should be inherited by this connection at creation time. Set at create and cannot be changed afterward.
+   */
+  @added(Versions.v2026_01_01)
+  @visibility(Lifecycle.Read, Lifecycle.Create)
+  approvalReference?: ApprovalReference;
+}
+
+/**
+ * Reference to an existing approved private endpoint used to inherit its connection approval state.
+ */
+@added(Versions.v2026_01_01)
+model ApprovalReference {
+  /**
+   * The ARM resource id of an existing approved private endpoint whose approval state is inherited by this connection.
+   */
+  privateEndpointId?: string;
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
@@ -3477,11 +3477,7 @@
         },
         "approvalReference": {
           "$ref": "#/definitions/ApprovalReference",
-          "description": "A reference to an existing approved private endpoint whose connection approval state should be inherited by this connection at creation time. Set at create and cannot be changed afterward.",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
+          "description": "A reference to an existing approved private endpoint whose connection approval state should be inherited by this connection at creation time."
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
@@ -734,7 +734,15 @@
       "properties": {
         "privateEndpointId": {
           "type": "string",
-          "description": "The ARM resource id of an existing approved private endpoint whose approval state is inherited by this connection."
+          "format": "arm-id",
+          "description": "The ARM resource id of an existing approved private endpoint whose approval state is inherited by this connection.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/privateEndpoints"
+              }
+            ]
+          }
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2018-10-01/vmssNetwork.json
@@ -728,6 +728,16 @@
         }
       }
     },
+    "ApprovalReference": {
+      "type": "object",
+      "description": "Reference to an existing approved private endpoint used to inherit its connection approval state.",
+      "properties": {
+        "privateEndpointId": {
+          "type": "string",
+          "description": "The ARM resource id of an existing approved private endpoint whose approval state is inherited by this connection."
+        }
+      }
+    },
     "BackendAddressPool": {
       "type": "object",
       "description": "Pool of backend IP addresses.",
@@ -3464,6 +3474,14 @@
         "privateLinkServiceConnectionState": {
           "$ref": "#/definitions/PrivateLinkServiceConnectionState",
           "description": "A collection of read-only information about the state of the connection to the remote resource."
+        },
+        "approvalReference": {
+          "$ref": "#/definitions/ApprovalReference",
+          "description": "A reference to an existing approved private endpoint whose connection approval state should be inherited by this connection at creation time. Set at create and cannot be changed afterward.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
@@ -1402,7 +1402,15 @@
       "properties": {
         "privateEndpointId": {
           "type": "string",
-          "description": "The ARM resource id of an existing approved private endpoint whose approval state is inherited by this connection."
+          "format": "arm-id",
+          "description": "The ARM resource id of an existing approved private endpoint whose approval state is inherited by this connection.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Network/privateEndpoints"
+              }
+            ]
+          }
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
@@ -1396,6 +1396,16 @@
         ]
       }
     },
+    "ApprovalReference": {
+      "type": "object",
+      "description": "Reference to an existing approved private endpoint used to inherit its connection approval state.",
+      "properties": {
+        "privateEndpointId": {
+          "type": "string",
+          "description": "The ARM resource id of an existing approved private endpoint whose approval state is inherited by this connection."
+        }
+      }
+    },
     "AssociationAccessMode": {
       "type": "string",
       "description": "Access mode on the association.",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/virtualNetwork.json
@@ -19116,11 +19116,7 @@
         },
         "approvalReference": {
           "$ref": "./common.json#/definitions/ApprovalReference",
-          "description": "A reference to an existing approved private endpoint whose connection approval state should be inherited by this connection at creation time. Set at create and cannot be changed afterward.",
-          "x-ms-mutability": [
-            "read",
-            "create"
-          ]
+          "description": "A reference to an existing approved private endpoint whose connection approval state should be inherited by this connection at creation time."
         }
       }
     },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/virtualNetwork.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/virtualNetwork.json
@@ -19113,6 +19113,14 @@
         "privateLinkServiceConnectionState": {
           "$ref": "#/definitions/PrivateLinkServiceConnectionState",
           "description": "A collection of read-only information about the state of the connection to the remote resource."
+        },
+        "approvalReference": {
+          "$ref": "./common.json#/definitions/ApprovalReference",
+          "description": "A reference to an existing approved private endpoint whose connection approval state should be inherited by this connection at creation time. Set at create and cannot be changed afterward.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds an optional `approvalReference.privateEndpointId` property to `PrivateLinkServiceConnectionProperties`, gated `@added(Versions.v2026_01_01)`. The property is emitted into the new `stable/2026-01-01` swagger outputs (`common.json`, `virtualNetwork.json`).

`approvalReference` lets a manual private endpoint connection inherit the connection-approval state of an existing, already-approved private endpoint at creation time.

## Notes

- **No mutability restriction.** Per internal design discussion, the property is intentionally a normal read/write property — it does **not** carry `x-ms-mutability`/`@visibility`, and there is no create-only enforcement in the swagger. (An earlier revision of this PR added `@visibility(Lifecycle.Read, Lifecycle.Create)`; that was removed by design.)
- **`stable/2018-10-01/vmssNetwork.json` change is a generated artifact.** The `Vmss` TypeSpec project shares `PrivateLinkServiceConnectionProperties` and pins `@useDependency(Common.Versions.v2026_01_01)`, so `tsp compile` emits this new Common property into its single `2018-10-01` output. This is the same behavior as prior Network releases (e.g. `ddosCustomPolicy`/`disablePeeringRoute` added to the same file in the 2025-07-01 release). The regenerated file is required for TypeSpec Validation to pass; it cannot be hand-trimmed without breaking the compile-parity check.
