### PR TITLE
Fix Security Insights .NET API design follow-ups

### DIFF
--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/client.tsp
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/client.tsp
@@ -416,7 +416,7 @@ using Azure.ClientGenerator.Core.Legacy;
 );
 @@clientName(ElevationToken, "SecurityInsightsProcessElevationToken", "csharp");
 @@clientName(EnrichmentDomainBody, "EnrichmentDomainContent", "csharp");
-@@clientName(EnrichmentDomainWhois.expires, "ExpireOn", "csharp");
+@@clientName(EnrichmentDomainWhois.expires, "ExpiresOn", "csharp");
 @@clientName(EnrichmentDomainWhois.created, "CreatedOn", "csharp");
 @@clientName(EnrichmentDomainWhois.updated, "UpdatedOn", "csharp");
 @@clientName(EnrichmentIpAddressBody, "EnrichmentIPAddressContent", "csharp");

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/client.tsp
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/client.tsp
@@ -1631,11 +1631,7 @@ using Azure.ClientGenerator.Core.Legacy;
   Azure.Core.armResourceIdentifier,
   "csharp"
 );
-@@alternateType(
-  JobItem.resourceId,
-  Azure.Core.armResourceIdentifier,
-  "csharp"
-);
+@@alternateType(JobItem.resourceId, Azure.Core.armResourceIdentifier, "csharp");
 @@alternateType(
   AssignmentItem.resourceId,
   Azure.Core.armResourceIdentifier,

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/client.tsp
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/client.tsp
@@ -417,6 +417,7 @@ using Azure.ClientGenerator.Core.Legacy;
 @@clientName(ElevationToken, "SecurityInsightsProcessElevationToken", "csharp");
 @@clientName(EnrichmentDomainBody, "EnrichmentDomainContent", "csharp");
 @@clientName(EnrichmentDomainWhois.expires, "ExpireOn", "csharp");
+@@clientName(EnrichmentDomainWhois.created, "CreatedOn", "csharp");
 @@clientName(EnrichmentDomainWhois.updated, "UpdatedOn", "csharp");
 @@clientName(EnrichmentIpAddressBody, "EnrichmentIPAddressContent", "csharp");
 @@clientName(Entity, "SecurityInsightsEntity", "csharp");
@@ -465,12 +466,12 @@ using Azure.ClientGenerator.Core.Legacy;
 @@clientName(FileImportProperties.createdTimeUTC, "CreatedOn", "csharp");
 @@clientName(
   FileImportProperties.filesValidUntilTimeUTC,
-  "FilesValidUntil",
+  "FilesExpireOn",
   "csharp"
 );
 @@clientName(
   FileImportProperties.importValidUntilTimeUTC,
-  "ImportValidUntil",
+  "ImportExpiresOn",
   "csharp"
 );
 @@clientName(FileImport, "SecurityInsightsFileImport", "csharp");
@@ -1143,6 +1144,7 @@ using Azure.ClientGenerator.Core.Legacy;
   "csharp"
 );
 @@clientName(SupportTier, "SecurityInsightsSupportTier", "csharp");
+@@clientName(TeamInformation.teamCreationTimeUtc, "CreatedOn", "csharp");
 @@clientName(TemplateModel, "SecurityInsightsTemplate", "csharp");
 @@clientName(
   TemplateProperties,
@@ -1269,6 +1271,11 @@ using Azure.ClientGenerator.Core.Legacy;
 @@clientName(
   TIDataConnectorProperties.tipLookbackPeriod,
   "TipLookbackOn",
+  "csharp"
+);
+@@clientName(
+  TiTaxiiDataConnectorProperties.taxiiLookbackPeriod,
+  "TaxiiLookbackOn",
   "csharp"
 );
 @@clientName(TIDataConnector, "SecurityInsightsTIDataConnector", "csharp");
@@ -1611,6 +1618,26 @@ using Azure.ClientGenerator.Core.Legacy;
 
 @@alternateType(
   ActionPropertiesBase.logicAppResourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  RecommendationProperties.resourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  WorkspaceManagerMemberProperties.targetWorkspaceResourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  JobItem.resourceId,
+  Azure.Core.armResourceIdentifier,
+  "csharp"
+);
+@@alternateType(
+  AssignmentItem.resourceId,
   Azure.Core.armResourceIdentifier,
   "csharp"
 );

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/client.tsp
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/client.tsp
@@ -466,12 +466,12 @@ using Azure.ClientGenerator.Core.Legacy;
 @@clientName(FileImportProperties.createdTimeUTC, "CreatedOn", "csharp");
 @@clientName(
   FileImportProperties.filesValidUntilTimeUTC,
-  "FilesExpireOn",
+  "FilesExpirationOn",
   "csharp"
 );
 @@clientName(
   FileImportProperties.importValidUntilTimeUTC,
-  "ImportExpiresOn",
+  "ImportExpirationOn",
   "csharp"
 );
 @@clientName(FileImport, "SecurityInsightsFileImport", "csharp");


### PR DESCRIPTION
Adds C# client customizations for date/time naming and ARM resource identifier types in Security Insights. The changes are based on the latest spec main and retain the 2025-10-01-preview API version.

&#8203;&#45; by copilot