### PR TITLE
[Network] Refine C# management SDK API surface

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -1701,6 +1701,51 @@ union ProvisioningStateUnion {
   "ResourceType",
   "csharp"
 );
+@@clientName(
+  Microsoft.Network.FirewallPolicyPropertiesFormat.afcManaged,
+  "IsAfcManaged",
+  "csharp"
+);
+@@clientName(
+  Common.PublicIPAddressPropertiesFormat.upgradedToV2,
+  "IsUpgradedToV2",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.PublicIPPrefixPropertiesFormat.upgradedToV2,
+  "IsUpgradedToV2",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.ConnectivityCheckSettings.generatePath,
+  "ShouldGeneratePath",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.MoveIpConfigurationsRequest,
+  "MoveIpConfigurationsContent",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.NetworkVirtualApplianceCommitMigrationRequest,
+  "NetworkVirtualApplianceCommitMigrationContent",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.NetworkVirtualAppliancePrepareMigrationRequest,
+  "NetworkVirtualAppliancePrepareMigrationContent",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.NetworkVirtualApplianceExecuteMigrationRequest,
+  "NetworkVirtualApplianceExecuteMigrationContent",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.GenerateExpressRouteLagsLOARequest,
+  "GenerateExpressRouteLagsLoaContent",
+  "csharp"
+);
 @@clientName(Commit, "NetworkManagerConfigurationCommit", "csharp");
 @@clientName(Subgroup, "InterconnectGroupSubgroup", "csharp");
 @@clientName(VM, "BastionShareableLinkVirtualMachine", "csharp");

--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -1746,6 +1746,11 @@ union ProvisioningStateUnion {
   "GenerateExpressRouteLagsLoaContent",
   "csharp"
 );
+@@clientName(
+  Microsoft.Network.GenerateExpressRouteLagsLOAResult,
+  "GenerateExpressRouteLagsLoaResult",
+  "csharp"
+);
 @@clientName(Commit, "NetworkManagerConfigurationCommit", "csharp");
 @@clientName(Subgroup, "InterconnectGroupSubgroup", "csharp");
 @@clientName(VM, "BastionShareableLinkVirtualMachine", "csharp");

--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -5531,6 +5531,12 @@ op replaceprivateDnsZoneGroupsList(
 );
 
 @@alternateType(
+  Microsoft.Network.ExpressRouteLag.identity,
+  Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
+  "csharp"
+);
+
+@@alternateType(
   Common.LoadBalancer.extendedLocation,
   Azure.ResourceManager.CommonTypes.ExtendedLocation,
   "csharp"

--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -5537,6 +5537,12 @@ op replaceprivateDnsZoneGroupsList(
 );
 
 @@alternateType(
+  Microsoft.Network.ExpressRouteLagUpdateTagsOrIdentityRequest.identity,
+  Azure.ResourceManager.CommonTypes.ManagedServiceIdentity,
+  "csharp"
+);
+
+@@alternateType(
   Common.LoadBalancer.extendedLocation,
   Azure.ResourceManager.CommonTypes.ExtendedLocation,
   "csharp"

--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -1751,6 +1751,66 @@ union ProvisioningStateUnion {
   "GenerateExpressRouteLagsLoaResult",
   "csharp"
 );
+@@clientName(
+  Microsoft.Network.ConnectionAnalyzerQueryStatusResult.expiryInUtc,
+  "ExpiresOn",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.DiagnosticOperation,
+  "ConnectionAnalyzerDiagnosticOperation",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.DiagnosticOperationResult,
+  "ConnectionAnalyzerDiagnosticOperationResult",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.DiagnosticOperationsSettings,
+  "ConnectionAnalyzerDiagnosticOperationsSettings",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.ProtocolSettings,
+  "ConnectionAnalyzerProtocolSettings",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.StorageAccountSettings,
+  "ConnectionAnalyzerStorageAccountSettings",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.KubeLabelSelector,
+  "FirewallPolicyKubeLabelSelector",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.LabelSelectorExpression,
+  "FirewallPolicyLabelSelectorExpression",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.LabelSelectorOperator,
+  "FirewallPolicyLabelSelectorOperator",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.MigrationType,
+  "NetworkVirtualApplianceMigrationType",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.ResiliencyLevel,
+  "ExpressRouteCircuitResiliencyLevel",
+  "csharp"
+);
+@@clientName(
+  Microsoft.Network.ServiceGatewayActionOkResponseBody,
+  "ServiceGatewayActionResult",
+  "csharp"
+);
 @@clientName(Commit, "NetworkManagerConfigurationCommit", "csharp");
 @@clientName(Subgroup, "InterconnectGroupSubgroup", "csharp");
 @@clientName(VM, "BastionShareableLinkVirtualMachine", "csharp");

--- a/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/client.tsp
@@ -1696,6 +1696,11 @@ union ProvisioningStateUnion {
 @@clientName(AzureFirewallSkuName.AZFW_VNet, "AZFWVnet", "go");
 
 // C# management-plane migration naming compatibility.
+@@clientName(
+  Microsoft.Network.ConnectionAnalyzer.type,
+  "ResourceType",
+  "csharp"
+);
 @@clientName(Commit, "NetworkManagerConfigurationCommit", "csharp");
 @@clientName(Subgroup, "InterconnectGroupSubgroup", "csharp");
 @@clientName(VM, "BastionShareableLinkVirtualMachine", "csharp");


### PR DESCRIPTION
Restores the Network-only TypeSpec customizations from #45576 after that PR was accidentally merged into the unrelated HCI branch.

This PR contains only `Microsoft.Network/Network/client.tsp` changes for ConnectionAnalyzer resource type handling and the review feedback from Azure/azure-sdk-for-net#62083.