### PR TITLE
Fix .NET management API review follow-ups

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/client.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/client.tsp
@@ -163,6 +163,12 @@ union OpenIdConnectClientCredentialMethod {
 
 @@alternateType(SourceControlProperties.repoUrl, url, "csharp");
 
+@@alternateType(
+  BlobStorageTokenStore.managedIdentityResourceId,
+  armResourceIdentifier,
+  "csharp"
+);
+
 // C# @@clientName customizations.
 @@clientName(
   AvailableWorkloadProfilesOperationGroup.get,
@@ -172,13 +178,13 @@ union OpenIdConnectClientCredentialMethod {
 
 @@clientName(BillingMetersOperationGroup.get, "GetBillingMeters", "csharp");
 
-@@clientName(BuilderResource, "Builder", "csharp");
+@@clientName(BuilderResource, "ContainerAppBuilder", "csharp");
 
-@@clientName(BuilderCollection, "BuilderList", "csharp");
+@@clientName(BuilderCollection, "ContainerAppBuilderList", "csharp");
 
-@@clientName(BuildResource, "Build", "csharp");
+@@clientName(BuildResource, "ContainerAppBuild", "csharp");
 
-@@clientName(BuildCollection, "BuildList", "csharp");
+@@clientName(BuildCollection, "ContainerAppBuildList", "csharp");
 
 @@clientName(BuildToken.expires, "ExpiresOn", "csharp");
 
@@ -207,6 +213,12 @@ union OpenIdConnectClientCredentialMethod {
 @@clientName(
   ContainerAppsLabelHistory.listLabelHistory,
   "ListLabelHistory",
+  "csharp"
+);
+
+@@clientName(
+  RuntimeDotnet.autoConfigureDataProtection,
+  "IsAutoConfigureDataProtectionEnabled",
   "csharp"
 );
 

--- a/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/client.tsp
+++ b/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/client.tsp
@@ -436,13 +436,88 @@ model ResourcePatchRequestInput {
 // =====================================================================
 @@clientName(
   AdditionalCapabilities.ultraSSDEnabled,
-  "UltraSsdEnabled",
+  "IsUltraSsdEnabled",
   "csharp"
 );
-@@clientName(LinuxConfiguration.provisionVMAgent, "ProvisionVmAgent", "csharp");
+@@clientName(
+  AdditionalCapabilities.hibernationEnabled,
+  "IsHibernationEnabled",
+  "csharp"
+);
+@@clientName(
+  BulkActionVmExtensionProperties.autoUpgradeMinorVersion,
+  "IsAutoUpgradeMinorVersionEnabled",
+  "csharp"
+);
+@@clientName(
+  BulkActionVmExtensionProperties.suppressFailures,
+  "ShouldSuppressFailures",
+  "csharp"
+);
+@@clientName(
+  LinuxConfiguration.provisionVMAgent,
+  "ShouldProvisionVmAgent",
+  "csharp"
+);
 @@clientName(
   WindowsConfiguration.provisionVMAgent,
-  "ProvisionVmAgent",
+  "ShouldProvisionVmAgent",
+  "csharp"
+);
+@@clientName(
+  LinuxVMGuestPatchAutomaticByPlatformSettings.bypassPlatformSafetyChecksOnUserSchedule,
+  "ShouldBypassPlatformSafetyChecksOnUserSchedule",
+  "csharp"
+);
+@@clientName(
+  WindowsVMGuestPatchAutomaticByPlatformSettings.bypassPlatformSafetyChecksOnUserSchedule,
+  "ShouldBypassPlatformSafetyChecksOnUserSchedule",
+  "csharp"
+);
+@@clientName(
+  ProxyAgentSettings.addProxyAgentExtension,
+  "ShouldAddProxyAgentExtension",
+  "csharp"
+);
+@@clientName(
+  SecurityProfile.encryptionAtHost,
+  "IsEncryptionAtHostEnabled",
+  "csharp"
+);
+@@clientName(DataDisk.toBeDetached, "IsToBeDetached", "csharp");
+@@clientName(
+  DataDisk.writeAcceleratorEnabled,
+  "IsWriteAcceleratorEnabled",
+  "csharp"
+);
+@@clientName(
+  OSDisk.writeAcceleratorEnabled,
+  "IsWriteAcceleratorEnabled",
+  "csharp"
+);
+@@clientName(
+  NetworkInterfaceReferenceProperties.primary,
+  "IsPrimary",
+  "csharp"
+);
+@@clientName(
+  VirtualMachineNetworkInterfaceConfigurationProperties.primary,
+  "IsPrimary",
+  "csharp"
+);
+@@clientName(
+  VirtualMachineNetworkInterfaceIPConfigurationProperties.primary,
+  "IsPrimary",
+  "csharp"
+);
+@@clientName(
+  OSProfile.requireGuestProvisionSignal,
+  "IsGuestProvisionSignalRequired",
+  "csharp"
+);
+@@clientName(
+  VMGalleryApplication.treatFailureAsDeploymentFailure,
+  "ShouldTreatFailureAsDeploymentFailure",
   "csharp"
 );
 @@clientName(UefiSettings.secureBootEnabled, "IsSecureBootEnabled", "csharp");
@@ -531,6 +606,10 @@ model ResourcePatchRequestInput {
 );
 @@clientName(FallbackOperationInfo, "ScheduledActionFallbackInfo", "csharp");
 @@clientName(Modes, "HostEndpointSettingsMode", "csharp");
+@@clientName(DeleteOptions, "DeleteConfig", "csharp");
+@@clientName(DiffDiskOptions, "DiffDiskConfig", "csharp");
+@@clientName(Mode, "ProxyAgentMode", "csharp");
+@@clientName(Placement, "VirtualMachinePlacement", "csharp");
 
 // =====================================================================
 // C# enum renames: Singular names to match Compute SDK conventions
@@ -547,7 +626,11 @@ model ResourcePatchRequestInput {
 @@clientName(DomainNameLabelScopeTypes, "DomainNameLabelScopeType", "csharp");
 @@clientName(SecurityEncryptionTypes, "SecurityEncryptionType", "csharp");
 @@clientName(StorageAccountTypes, "StorageAccountType", "csharp");
-@@clientName(SettingNames, "SettingName", "csharp");
+@@clientName(
+  SettingNames,
+  "AdditionalUnattendContentSettingName",
+  "csharp"
+);
 
 // =====================================================================
 // C# property renames: Match Compute SDK property names
@@ -595,6 +678,46 @@ namespace Azure.ResourceManager.Models {
 );
 @@alternateType(
   VaultSecretGroup.sourceVault,
+  Azure.ResourceManager.Models.WritableSubResource,
+  "csharp"
+);
+@@alternateType(
+  VirtualMachineNetworkInterfaceConfigurationProperties.networkSecurityGroup,
+  Azure.ResourceManager.Models.WritableSubResource,
+  "csharp"
+);
+@@alternateType(
+  VirtualMachineNetworkInterfaceConfigurationProperties.dscpConfiguration,
+  Azure.ResourceManager.Models.WritableSubResource,
+  "csharp"
+);
+@@alternateType(
+  VirtualMachineNetworkInterfaceIPConfigurationProperties.subnet,
+  Azure.ResourceManager.Models.WritableSubResource,
+  "csharp"
+);
+@@alternateType(
+  VirtualMachineNetworkInterfaceIPConfigurationProperties.applicationSecurityGroups,
+  Azure.ResourceManager.Models.WritableSubResource[],
+  "csharp"
+);
+@@alternateType(
+  VirtualMachineNetworkInterfaceIPConfigurationProperties.applicationGatewayBackendAddressPools,
+  Azure.ResourceManager.Models.WritableSubResource[],
+  "csharp"
+);
+@@alternateType(
+  VirtualMachineNetworkInterfaceIPConfigurationProperties.loadBalancerBackendAddressPools,
+  Azure.ResourceManager.Models.WritableSubResource[],
+  "csharp"
+);
+@@alternateType(
+  VirtualMachinePublicIPAddressConfigurationProperties.publicIPPrefix,
+  Azure.ResourceManager.Models.WritableSubResource,
+  "csharp"
+);
+@@alternateType(
+  CapacityReservationProfile.capacityReservationGroup,
   Azure.ResourceManager.Models.WritableSubResource,
   "csharp"
 );

--- a/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/client.tsp
+++ b/specification/computeschedule/resource-manager/Microsoft.ComputeSchedule/ComputeSchedule/client.tsp
@@ -626,11 +626,7 @@ model ResourcePatchRequestInput {
 @@clientName(DomainNameLabelScopeTypes, "DomainNameLabelScopeType", "csharp");
 @@clientName(SecurityEncryptionTypes, "SecurityEncryptionType", "csharp");
 @@clientName(StorageAccountTypes, "StorageAccountType", "csharp");
-@@clientName(
-  SettingNames,
-  "AdditionalUnattendContentSettingName",
-  "csharp"
-);
+@@clientName(SettingNames, "AdditionalUnattendContentSettingName", "csharp");
 
 // =====================================================================
 // C# property renames: Match Compute SDK property names


### PR DESCRIPTION
## Summary

- fix .NET boolean and contextual API names for ComputeSchedule
- use framework resource reference types where compatible
- add service context to AppContainers build and builder resources
- use `ResourceIdentifier` for the new managed identity resource ID

## Validation

- generated Azure.ResourceManager.ComputeSchedule successfully
- generated Azure.ResourceManager.AppContainers successfully
- both SDK packages build successfully

\- by copilot
