### PR TITLE
Fix Security Insights Java migration configuration

### DIFF
--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/tspconfig.yaml
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/tspconfig.yaml
@@ -16,13 +16,8 @@ options:
     namespace: "com.azure.resourcemanager.securityinsights"
     flavor: "azure"
     service-name: "Security Insights"
-    premium: true
-    generate-tests: false
-    client-side-validations: true
-    enable-sync-stack: false
     remove-inner: SecurityAlert,HuntingBookmark,Entity
     use-object-for-unknown: true
-    uuid-as-string: false
     resource-collection-associations:
       - resource: Relation
         collection: IncidentRelations

--- a/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/tspconfig.yaml
+++ b/specification/securityinsights/resource-manager/Microsoft.SecurityInsights/SecurityInsights/tspconfig.yaml
@@ -16,8 +16,16 @@ options:
     namespace: "com.azure.resourcemanager.securityinsights"
     flavor: "azure"
     service-name: "Security Insights"
+    premium: true
+    generate-tests: false
+    client-side-validations: true
+    enable-sync-stack: false
     remove-inner: SecurityAlert,HuntingBookmark,Entity
     use-object-for-unknown: true
+    uuid-as-string: false
+    resource-collection-associations:
+      - resource: Relation
+        collection: IncidentRelations
   "@azure-tools/typespec-python":
     service-dir: "sdk/securityinsight"
     emitter-output-dir: "{output-dir}/{service-dir}/azure-mgmt-securityinsight"


### PR DESCRIPTION
Fix the Java management SDK migration configuration for Security Insights.

- Select `IncidentRelations` as the fluent resource collection for `Relation`.

This should restore the incident relation `define`, by-ID, delete-by-ID, and `withExistingIncident` APIs during regeneration.
