### PR TITLE
Fix Bug 38477992: type computedDisabledRules.rules as integers (2026-01-01)

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafListAllPolicies.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafListAllPolicies.json
@@ -114,7 +114,7 @@
                       {
                         "ruleGroupName": "General",
                         "rules": [
-                          "200003"
+                          200003
                         ]
                       }
                     ],

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafListPolicies.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafListPolicies.json
@@ -115,7 +115,7 @@
                       {
                         "ruleGroupName": "General",
                         "rules": [
-                          "200003"
+                          200003
                         ]
                       }
                     ],

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/WafPolicyGet.json
@@ -207,21 +207,21 @@
                   {
                     "ruleGroupName": "REQUEST-942-APPLICATION-ATTACK-SQLI",
                     "rules": [
-                      "942130",
-                      "942110"
+                      942130,
+                      942110
                     ]
                   },
                   {
                     "ruleGroupName": "REQUEST-920-PROTOCOL-ENFORCEMENT",
                     "rules": [
-                      "920100",
-                      "920120"
+                      920100,
+                      920120
                     ]
                   },
                   {
                     "ruleGroupName": "General",
                     "rules": [
-                      "200003"
+                      200003
                     ]
                   }
                 ],

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -26117,7 +26117,8 @@ model ManagedRuleSetRuleGroup {
   /**
    * List of rules within the rule group
    */
-  rules?: string[];
+  @typeChangedFrom(Versions.v2026_01_01, string[])
+  rules?: int32[];
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/applicationGateway.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/applicationGateway.json
@@ -4705,7 +4705,8 @@
           "type": "array",
           "description": "List of rules within the rule group",
           "items": {
-            "type": "string"
+            "type": "integer",
+            "format": "int32"
           }
         }
       },

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafListAllPolicies.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafListAllPolicies.json
@@ -114,7 +114,7 @@
                       {
                         "ruleGroupName": "General",
                         "rules": [
-                          "200003"
+                          200003
                         ]
                       }
                     ],

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafListPolicies.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafListPolicies.json
@@ -115,7 +115,7 @@
                       {
                         "ruleGroupName": "General",
                         "rules": [
-                          "200003"
+                          200003
                         ]
                       }
                     ],

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafPolicyGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/WafPolicyGet.json
@@ -207,21 +207,21 @@
                   {
                     "ruleGroupName": "REQUEST-942-APPLICATION-ATTACK-SQLI",
                     "rules": [
-                      "942130",
-                      "942110"
+                      942130,
+                      942110
                     ]
                   },
                   {
                     "ruleGroupName": "REQUEST-920-PROTOCOL-ENFORCEMENT",
                     "rules": [
-                      "920100",
-                      "920120"
+                      920100,
+                      920120
                     ]
                   },
                   {
                     "ruleGroupName": "General",
                     "rules": [
-                      "200003"
+                      200003
                     ]
                   }
                 ],


### PR DESCRIPTION
# Fix Bug 38477992: type computedDisabledRules.rules as integers (2026-01-01)

Fixes Bug 38477992. Retypes `managedRuleSet.ruleGroupOverrides[].rules` (computedDisabledRules) from `string[]` to `int32[]` in the 2026-01-01 API version.

Changes:
- `models.tsp`: `rules` -> `int32[]` with `@typeChangedFrom(Versions.v2026_01_01, string[])`.
- `stable/2026-01-01/applicationGateway.json`: items type `string` -> `integer` (`int32`).
- Updated 6 example files to use unquoted integer rule IDs.

Target branch: `Azure/azure-rest-api-specs:release-microsoft-network-2026-01-01`


## Breaking Change Justification — `ManagedRuleSetRuleGroup.rules` items `string` → `integer`

**TL;DR:** This corrects a read-only field that NRP has always serialized as an integer, while the spec has long described it as a string. It fixes that mismatch on a read-only field and breaks no working client. Requesting approval/suppression.

### Details

- **Field:** `ManagedRuleSetRuleGroup.rules` items, used only by `computedDisabledRules` — `readOnly: true`, response-only, shipped in API version `2024-07-01` and later.
- **Mismatch:** NRP serializes rule IDs as JSON numbers (`List<int>`, for example `[931100, 931130]`), but the spec declares `items.type: string`. Clients modeled as strings fail to deserialize.
- **Impact today:** `az … waf-policy managed-rule exception add` crashes on GET with `AAZInvalidValueError: Expect <class 'str'>, got 931100 (<class 'int'>)` on any DRS policy (bug 38477992). No functioning client depends on the string behavior.
- **Why not `anyOf`/`oneOf`:** It is still flagged as breaking and requires the same approval; SDK/CLI code generation does not support scalar unions (it degrades to `any` or fails); and it is semantically false because the service only ever sends an integer.
- **Blast radius:** This is a response-only field, so the change affects deserialization only and has no request-path impact. Switching to integer lets clients parse the existing response for the first time.
