### PR TITLE
Add environment properties to SandboxGroup

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
@@ -23,14 +23,14 @@ model SandboxGroup is TrackedResource<SandboxGroupProperties> {
 
 /** SandboxGroup resource specific properties. */
 model SandboxGroupProperties {
-  /** The resource ID of the Azure Container Apps managed environment to associate with the sandbox group. A sandbox group can be associated after creation, but the association cannot then be changed or removed. For subsequent create-or-update (PUT) requests, specify the same environment ID; omitting or changing it returns 409 Conflict. Omitting it from an update (PATCH) request leaves the existing association unchanged. */
+  /** The resource ID of the Azure Container Apps environment to link to the sandbox group. A sandbox group can be linked after creation, but the link cannot then be changed or removed. For subsequent create-or-update (PUT) requests, specify the same environment ID; omitting or changing it returns 409 Conflict. Omitting it from an update (PATCH) request leaves the existing link unchanged. */
   environmentId?: armResourceIdentifier<[
     {
       type: "Microsoft.App/managedEnvironments";
     }
   ]>;
 
-  /** The default domain of the associated Azure Container Apps managed environment. Sandbox endpoints use subdomains of this domain. This read-only property is populated by the service and is omitted when no managed environment is associated. */
+  /** The default domain of the linked Azure Container Apps environment. Sandbox endpoints use subdomains of this domain. This read-only property is populated by the service and is omitted when no environment is linked. */
   @visibility(Lifecycle.Read)
   defaultDomain?: string;
 

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
@@ -23,6 +23,17 @@ model SandboxGroup is TrackedResource<SandboxGroupProperties> {
 
 /** SandboxGroup resource specific properties. */
 model SandboxGroupProperties {
+  /** The resource ID of the Azure Container Apps managed environment to associate with the sandbox group. A sandbox group can be associated after creation, but the association cannot then be changed or removed. For subsequent create-or-update (PUT) requests, specify the same environment ID; omitting or changing it returns 409 Conflict. Omitting it from an update (PATCH) request leaves the existing association unchanged. */
+  environmentId?: armResourceIdentifier<[
+    {
+      type: "Microsoft.App/managedEnvironments";
+    }
+  ]>;
+
+  /** The default domain of the associated Azure Container Apps managed environment. Sandbox endpoints use subdomains of this domain. This read-only property is populated by the service and is omitted when no managed environment is associated. */
+  @visibility(Lifecycle.Read)
+  defaultDomain?: string;
+
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "Description is on the referenced type to avoid emitting a sibling of $ref."
   @visibility(Lifecycle.Read)
   provisioningState?: SandboxGroupProvisioningState;
@@ -52,7 +63,7 @@ interface SandboxGroups {
   /** Create or update a SandboxGroup. */
   createOrUpdate is ArmResourceCreateOrReplaceAsync<SandboxGroup>;
 
-  /** Patches a SandboxGroup. Only patching of tags is supported. */
+  /** Patches a SandboxGroup. */
   update is ArmCustomPatchAsync<
     SandboxGroup,
     SandboxGroupPatch,
@@ -77,4 +88,12 @@ model SandboxGroupPatch {
   /** Resource tags. */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Resource tags are defined as an open key/value map per ARM contract."
   tags?: Record<string>;
+
+  /** SandboxGroup properties that can be updated. */
+  properties?: SandboxGroupPatchProperties;
+}
+
+/** SandboxGroup resource specific properties for patch requests. */
+model SandboxGroupPatchProperties {
+  ...PickProperties<SandboxGroupProperties, "environmentId">;
 }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_CreateOrUpdate.json
@@ -5,7 +5,10 @@
     "resourceGroupName": "examplerg",
     "sandboxGroupName": "testgroup",
     "resource": {
-      "location": "East US"
+      "location": "East US",
+      "properties": {
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv"
+      }
     }
   },
   "responses": {
@@ -16,6 +19,8 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }
@@ -30,6 +35,8 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "InProgress"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_CreateOrUpdate.json
@@ -5,10 +5,7 @@
     "resourceGroupName": "examplerg",
     "sandboxGroupName": "testgroup",
     "resource": {
-      "location": "East US",
-      "properties": {
-        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv"
-      }
+      "location": "East US"
     }
   },
   "responses": {
@@ -19,8 +16,6 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
-          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }
@@ -35,8 +30,6 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
-          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "InProgress"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Get.json
@@ -13,6 +13,8 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Get.json
@@ -13,8 +13,6 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
-          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_ListByResourceGroup.json
@@ -14,6 +14,8 @@
             "type": "Microsoft.App/sandboxGroups",
             "location": "East US",
             "properties": {
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+              "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_ListByResourceGroup.json
@@ -14,8 +14,6 @@
             "type": "Microsoft.App/sandboxGroups",
             "location": "East US",
             "properties": {
-              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-              "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_ListBySubscription.json
@@ -13,6 +13,8 @@
             "type": "Microsoft.App/sandboxGroups",
             "location": "East US",
             "properties": {
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+              "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_ListBySubscription.json
@@ -13,8 +13,6 @@
             "type": "Microsoft.App/sandboxGroups",
             "location": "East US",
             "properties": {
-              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-              "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Update.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Update.json
@@ -25,7 +25,7 @@
         },
         "properties": {
           "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
+          "defaultDomain": "icycliff-79e92900.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Update.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Update.json
@@ -7,6 +7,9 @@
     "properties": {
       "tags": {
         "environment": "test"
+      },
+      "properties": {
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv"
       }
     }
   },
@@ -21,6 +24,8 @@
           "environment": "test"
         },
         "properties": {
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
@@ -685,7 +685,7 @@
         "environmentId": {
           "type": "string",
           "format": "arm-id",
-          "description": "The resource ID of the Azure Container Apps managed environment to associate with the sandbox group. A sandbox group can be associated after creation, but the association cannot then be changed or removed. For subsequent create-or-update (PUT) requests, specify the same environment ID; omitting or changing it returns 409 Conflict. Omitting it from an update (PATCH) request leaves the existing association unchanged.",
+          "description": "The resource ID of the Azure Container Apps environment to link to the sandbox group. A sandbox group can be linked after creation, but the link cannot then be changed or removed. For subsequent create-or-update (PUT) requests, specify the same environment ID; omitting or changing it returns 409 Conflict. Omitting it from an update (PATCH) request leaves the existing link unchanged.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {
@@ -703,7 +703,7 @@
         "environmentId": {
           "type": "string",
           "format": "arm-id",
-          "description": "The resource ID of the Azure Container Apps managed environment to associate with the sandbox group. A sandbox group can be associated after creation, but the association cannot then be changed or removed. For subsequent create-or-update (PUT) requests, specify the same environment ID; omitting or changing it returns 409 Conflict. Omitting it from an update (PATCH) request leaves the existing association unchanged.",
+          "description": "The resource ID of the Azure Container Apps environment to link to the sandbox group. A sandbox group can be linked after creation, but the link cannot then be changed or removed. For subsequent create-or-update (PUT) requests, specify the same environment ID; omitting or changing it returns 409 Conflict. Omitting it from an update (PATCH) request leaves the existing link unchanged.",
           "x-ms-arm-id-details": {
             "allowedResources": [
               {
@@ -714,7 +714,7 @@
         },
         "defaultDomain": {
           "type": "string",
-          "description": "The default domain of the associated Azure Container Apps managed environment. Sandbox endpoints use subdomains of this domain. This read-only property is populated by the service and is omitted when no managed environment is associated.",
+          "description": "The default domain of the linked Azure Container Apps environment. Sandbox endpoints use subdomains of this domain. This read-only property is populated by the service and is omitted when no environment is linked.",
           "readOnly": true
         },
         "provisioningState": {

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
@@ -251,7 +251,7 @@
         "tags": [
           "SandboxGroups"
         ],
-        "description": "Patches a SandboxGroup. Only patching of tags is supported.",
+        "description": "Patches a SandboxGroup.",
         "parameters": [
           {
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
@@ -671,6 +671,28 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "properties": {
+          "$ref": "#/definitions/SandboxGroupPatchProperties",
+          "description": "SandboxGroup properties that can be updated."
+        }
+      }
+    },
+    "SandboxGroupPatchProperties": {
+      "type": "object",
+      "description": "SandboxGroup resource specific properties for patch requests.",
+      "properties": {
+        "environmentId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the Azure Container Apps managed environment to associate with the sandbox group. A sandbox group can be associated after creation, but the association cannot then be changed or removed. For subsequent create-or-update (PUT) requests, specify the same environment ID; omitting or changing it returns 409 Conflict. Omitting it from an update (PATCH) request leaves the existing association unchanged.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.App/managedEnvironments"
+              }
+            ]
+          }
         }
       }
     },
@@ -678,6 +700,23 @@
       "type": "object",
       "description": "SandboxGroup resource specific properties.",
       "properties": {
+        "environmentId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the Azure Container Apps managed environment to associate with the sandbox group. A sandbox group can be associated after creation, but the association cannot then be changed or removed. For subsequent create-or-update (PUT) requests, specify the same environment ID; omitting or changing it returns 409 Conflict. Omitting it from an update (PATCH) request leaves the existing association unchanged.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.App/managedEnvironments"
+              }
+            ]
+          }
+        },
+        "defaultDomain": {
+          "type": "string",
+          "description": "The default domain of the associated Azure Container Apps managed environment. Sandbox endpoints use subdomains of this domain. This read-only property is populated by the service and is omitted when no managed environment is associated.",
+          "readOnly": true
+        },
         "provisioningState": {
           "$ref": "#/definitions/SandboxGroupProvisioningState",
           "readOnly": true

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_CreateOrUpdate.json
@@ -5,7 +5,10 @@
     "resourceGroupName": "examplerg",
     "sandboxGroupName": "testgroup",
     "resource": {
-      "location": "East US"
+      "location": "East US",
+      "properties": {
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv"
+      }
     }
   },
   "responses": {
@@ -16,6 +19,8 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }
@@ -30,6 +35,8 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "InProgress"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_CreateOrUpdate.json
@@ -5,10 +5,7 @@
     "resourceGroupName": "examplerg",
     "sandboxGroupName": "testgroup",
     "resource": {
-      "location": "East US",
-      "properties": {
-        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv"
-      }
+      "location": "East US"
     }
   },
   "responses": {
@@ -19,8 +16,6 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
-          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }
@@ -35,8 +30,6 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
-          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "InProgress"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Get.json
@@ -13,6 +13,8 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Get.json
@@ -13,8 +13,6 @@
         "type": "Microsoft.App/sandboxGroups",
         "location": "East US",
         "properties": {
-          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_ListByResourceGroup.json
@@ -14,6 +14,8 @@
             "type": "Microsoft.App/sandboxGroups",
             "location": "East US",
             "properties": {
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+              "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_ListByResourceGroup.json
@@ -14,8 +14,6 @@
             "type": "Microsoft.App/sandboxGroups",
             "location": "East US",
             "properties": {
-              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-              "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_ListBySubscription.json
@@ -13,6 +13,8 @@
             "type": "Microsoft.App/sandboxGroups",
             "location": "East US",
             "properties": {
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+              "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_ListBySubscription.json
@@ -13,8 +13,6 @@
             "type": "Microsoft.App/sandboxGroups",
             "location": "East US",
             "properties": {
-              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-              "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
               "provisioningState": "Succeeded"
             }
           }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Update.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Update.json
@@ -25,7 +25,7 @@
         },
         "properties": {
           "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
-          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
+          "defaultDomain": "icycliff-79e92900.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Update.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Update.json
@@ -7,6 +7,9 @@
     "properties": {
       "tags": {
         "environment": "test"
+      },
+      "properties": {
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv"
       }
     }
   },
@@ -21,6 +24,8 @@
           "environment": "test"
         },
         "properties": {
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+          "defaultDomain": "exampleenv-00000000.eastus.azurecontainerapps.io",
           "provisioningState": "Succeeded"
         }
       }


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [ ] New resource provider.
- [ ] New API version for an existing resource provider.
- [ ] Update existing version for a new feature.
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing OpenAPI spec to TypeSpec spec.
- [x] Other, please clarify:
  - This is a minor additive update to the unreleased `2026-07-01` API on its release branch. It adds `environmentId` as a read/write SandboxGroup property for PUT and PATCH requests and adds `defaultDomain` as a read-only, service-populated response property. `publicNetworkAccess` is intentionally not included.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed the [Resource Provider guidelines](https://aka.ms/rpguidelines), including the [ARM resource provider contract](https://aka.ms/azurerpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md).
- [ ] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created.

## Additional information

- Adds clear public descriptions for the environment association's set-once behavior and PUT/PATCH semantics.
- Uses an ARM resource identifier restricted to `Microsoft.App/managedEnvironments`.
- Regenerates the stable OpenAPI document and linked SandboxGroup examples from TypeSpec.
