### PR TITLE
Fix Hub virtual network IPv6 peering contract

### DIFF
--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionGet.json
@@ -14,7 +14,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Succeeded",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionList.json
@@ -16,7 +16,7 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
             "properties": {
               "enableInternetSecurity": false,
-              "enableOnlyIpv6Peering": "Disabled",
+              "enableOnlyIPv6Peering": false,
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"
@@ -80,7 +80,7 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection2",
             "properties": {
               "enableInternetSecurity": false,
-              "enableOnlyIpv6Peering": "Disabled",
+              "enableOnlyIPv6Peering": false,
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet2"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2025-09-01/HubVirtualNetworkConnectionPut.json
@@ -5,7 +5,7 @@
     "hubVirtualNetworkConnectionParameters": {
       "properties": {
         "enableInternetSecurity": false,
-        "enableOnlyIpv6Peering": "Disabled",
+        "enableOnlyIPv6Peering": false,
         "remoteVirtualNetwork": {
           "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
         },
@@ -68,7 +68,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
@@ -134,7 +134,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/HubVirtualNetworkConnectionGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/HubVirtualNetworkConnectionGet.json
@@ -14,7 +14,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Succeeded",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/HubVirtualNetworkConnectionList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/HubVirtualNetworkConnectionList.json
@@ -16,7 +16,7 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
             "properties": {
               "enableInternetSecurity": false,
-              "enableOnlyIpv6Peering": "Disabled",
+              "enableOnlyIPv6Peering": false,
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"
@@ -80,7 +80,7 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection2",
             "properties": {
               "enableInternetSecurity": false,
-              "enableOnlyIpv6Peering": "Disabled",
+              "enableOnlyIPv6Peering": false,
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet2"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/HubVirtualNetworkConnectionPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/examples/2026-01-01/HubVirtualNetworkConnectionPut.json
@@ -5,7 +5,7 @@
     "hubVirtualNetworkConnectionParameters": {
       "properties": {
         "enableInternetSecurity": false,
-        "enableOnlyIpv6Peering": "Disabled",
+        "enableOnlyIPv6Peering": false,
         "remoteVirtualNetwork": {
           "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
         },
@@ -68,7 +68,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
@@ -134,7 +134,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -24223,9 +24223,12 @@ model HubVirtualNetworkConnectionProperties {
   /**
    * Enable Only IPv6 Peering for this connection.
    */
+  #suppress "@azure-tools/typespec-azure-core/casing-style" "Matches the NRP wire contract property casing."
   @added(Versions.v2025_09_01)
+  @renamedFrom(Versions.v2026_01_01, "enableOnlyIpv6Peering")
+  @typeChangedFrom(Versions.v2026_01_01, EnableOnlyIpv6PeeringState)
   @visibility(Lifecycle.Read, Lifecycle.Create)
-  enableOnlyIpv6Peering?: EnableOnlyIpv6PeeringState;
+  enableOnlyIPv6Peering?: boolean;
 
   /**
    * The provisioning state of the hub virtual network connection resource.

--- a/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
+++ b/specification/network/resource-manager/Microsoft.Network/Network/Network/models.tsp
@@ -24225,8 +24225,6 @@ model HubVirtualNetworkConnectionProperties {
    */
   #suppress "@azure-tools/typespec-azure-core/casing-style" "Matches the NRP wire contract property casing."
   @added(Versions.v2025_09_01)
-  @renamedFrom(Versions.v2026_01_01, "enableOnlyIpv6Peering")
-  @typeChangedFrom(Versions.v2026_01_01, EnableOnlyIpv6PeeringState)
   @visibility(Lifecycle.Read, Lifecycle.Create)
   enableOnlyIPv6Peering?: boolean;
 
@@ -24235,23 +24233,6 @@ model HubVirtualNetworkConnectionProperties {
    */
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
-}
-
-/**
- * The state of IPv6 peering.
- */
-union EnableOnlyIpv6PeeringState {
-  string,
-
-  /**
-   * IPv6 peering is enabled.
-   */
-  Enabled: "Enabled",
-
-  /**
-   * IPv6 peering is disabled.
-   */
-  Disabled: "Disabled",
 }
 
 /**

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/common.json
@@ -3053,30 +3053,6 @@
         ]
       }
     },
-    "EnableOnlyIpv6PeeringState": {
-      "type": "string",
-      "description": "The state of IPv6 peering.",
-      "enum": [
-        "Enabled",
-        "Disabled"
-      ],
-      "x-ms-enum": {
-        "name": "EnableOnlyIpv6PeeringState",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Enabled",
-            "value": "Enabled",
-            "description": "IPv6 peering is enabled."
-          },
-          {
-            "name": "Disabled",
-            "value": "Disabled",
-            "description": "IPv6 peering is disabled."
-          }
-        ]
-      }
-    },
     "EndpointType": {
       "type": "string",
       "description": "The endpoint type.",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionGet.json
@@ -14,7 +14,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Succeeded",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionList.json
@@ -16,7 +16,7 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
             "properties": {
               "enableInternetSecurity": false,
-              "enableOnlyIpv6Peering": "Disabled",
+              "enableOnlyIPv6Peering": false,
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"
@@ -80,7 +80,7 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection2",
             "properties": {
               "enableInternetSecurity": false,
-              "enableOnlyIpv6Peering": "Disabled",
+              "enableOnlyIPv6Peering": false,
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet2"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/examples/HubVirtualNetworkConnectionPut.json
@@ -5,7 +5,7 @@
     "hubVirtualNetworkConnectionParameters": {
       "properties": {
         "enableInternetSecurity": false,
-        "enableOnlyIpv6Peering": "Disabled",
+        "enableOnlyIPv6Peering": false,
         "remoteVirtualNetwork": {
           "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
         },
@@ -68,7 +68,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
@@ -134,7 +134,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2025-09-01/virtualWan.json
@@ -8540,8 +8540,8 @@
           "$ref": "#/definitions/RoutingConfiguration",
           "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
         },
-        "enableOnlyIpv6Peering": {
-          "$ref": "./common.json#/definitions/EnableOnlyIpv6PeeringState",
+        "enableOnlyIPv6Peering": {
+          "type": "boolean",
           "description": "Enable Only IPv6 Peering for this connection.",
           "x-ms-mutability": [
             "read",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/common.json
@@ -3053,30 +3053,6 @@
         ]
       }
     },
-    "EnableOnlyIpv6PeeringState": {
-      "type": "string",
-      "description": "The state of IPv6 peering.",
-      "enum": [
-        "Enabled",
-        "Disabled"
-      ],
-      "x-ms-enum": {
-        "name": "EnableOnlyIpv6PeeringState",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Enabled",
-            "value": "Enabled",
-            "description": "IPv6 peering is enabled."
-          },
-          {
-            "name": "Disabled",
-            "value": "Disabled",
-            "description": "IPv6 peering is disabled."
-          }
-        ]
-      }
-    },
     "EndpointType": {
       "type": "string",
       "description": "The endpoint type.",

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/HubVirtualNetworkConnectionGet.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/HubVirtualNetworkConnectionGet.json
@@ -14,7 +14,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Succeeded",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/HubVirtualNetworkConnectionList.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/HubVirtualNetworkConnectionList.json
@@ -16,7 +16,7 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
             "properties": {
               "enableInternetSecurity": false,
-              "enableOnlyIpv6Peering": "Disabled",
+              "enableOnlyIPv6Peering": false,
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet1"
@@ -80,7 +80,7 @@
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection2",
             "properties": {
               "enableInternetSecurity": false,
-              "enableOnlyIpv6Peering": "Disabled",
+              "enableOnlyIPv6Peering": false,
               "provisioningState": "Succeeded",
               "remoteVirtualNetwork": {
                 "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/vnet2"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/HubVirtualNetworkConnectionPut.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/examples/HubVirtualNetworkConnectionPut.json
@@ -5,7 +5,7 @@
     "hubVirtualNetworkConnectionParameters": {
       "properties": {
         "enableInternetSecurity": false,
-        "enableOnlyIpv6Peering": "Disabled",
+        "enableOnlyIPv6Peering": false,
         "remoteVirtualNetwork": {
           "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
         },
@@ -68,7 +68,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"
@@ -134,7 +134,7 @@
         "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualHubs/virtualHub1/hubVirtualNetworkConnections/connection1",
         "properties": {
           "enableInternetSecurity": false,
-          "enableOnlyIpv6Peering": "Disabled",
+          "enableOnlyIPv6Peering": false,
           "provisioningState": "Updating",
           "remoteVirtualNetwork": {
             "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.Network/virtualNetworks/SpokeVnet1"

--- a/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/virtualWan.json
+++ b/specification/network/resource-manager/Microsoft.Network/Network/stable/2026-01-01/virtualWan.json
@@ -8540,8 +8540,8 @@
           "$ref": "#/definitions/RoutingConfiguration",
           "description": "The Routing Configuration indicating the associated and propagated route tables on this connection."
         },
-        "enableOnlyIpv6Peering": {
-          "$ref": "./common.json#/definitions/EnableOnlyIpv6PeeringState",
+        "enableOnlyIPv6Peering": {
+          "type": "boolean",
           "description": "Enable Only IPv6 Peering for this connection.",
           "x-ms-mutability": [
             "read",


### PR DESCRIPTION
## Summary

- correct `HubVirtualNetworkConnectionProperties.enableOnlyIPv6Peering` to match the deployed NRP JSON contract
- model the property as `boolean` instead of the `Enabled`/`Disabled` string union
- regenerate the 2025-09-01 and 2026-01-01 Swagger and examples from TypeSpec

## Versioning rationale

The property was introduced in API version 2025-09-01, so both 2025-09-01 and 2026-01-01 must describe the same deployed wire contract. The PR targets the `release-microsoft-network-2026-01-01` branch while correcting both generated stable projections on that branch.

## Validation

- `npx tsp compile .`
- generated `virtualWan.json` uses `enableOnlyIPv6Peering` with `type: boolean` in both versions
- generated examples use `true`/`false`
- pre-2025-09-01 API-version files are unchanged
- `git diff --check`