### PR TITLE
Add ObservabilityConfiguration service group to Microsoft.EdgeOperator ARM lease

### DIFF
--- a/.github/arm-leases/edgeoperator/Microsoft.EdgeOperator/ObservabilityConfiguration/lease.yaml
+++ b/.github/arm-leases/edgeoperator/Microsoft.EdgeOperator/ObservabilityConfiguration/lease.yaml
@@ -1,0 +1,5 @@
+lease:
+  resource-provider: Microsoft.EdgeOperator
+  startdate: 2026-08-19
+  duration: P180D
+  reviewer: "@vikeshi26"


### PR DESCRIPTION
Adds an ARM lease for **Microsoft.EdgeOperator** (service group **ObservabilityConfiguration**) per `.github/arm-leases/README.md`.

- Path: `.github/arm-leases/edgeoperator/Microsoft.EdgeOperator/ObservabilityConfiguration/lease.yaml`
- Resource provider: `Microsoft.EdgeOperator`
- Start date: 2026-08-19
- Duration: P180D
- Reviewer: @vikeshi26