### PR TITLE
Microsoft.App 2026-03-02-preview: add AvailableEnvironmentModes API

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/back-compatible.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/back-compatible.tsp
@@ -188,6 +188,10 @@ using Microsoft.App;
   "AvailableWorkloadProfiles"
 );
 
+@@clientLocation(AvailableEnvironmentModesOperationGroup.list,
+  "AvailableEnvironmentModes"
+);
+
 @@clientLocation(BillingMetersOperationGroup.get, "BillingMeters");
 
 #suppress "@azure-tools/typespec-azure-core/no-legacy-usage" "FIXME: Update justification, follow aka.ms/tsp/conversion-fix for details"

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AppResiliency_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AppResiliency_CreateOrUpdate.json
@@ -1,0 +1,178 @@
+{
+  "parameters": {
+    "name": "resiliency-policy-1",
+    "api-version": "2026-03-02-preview",
+    "appName": "testcontainerApp0",
+    "resiliencyEnvelope": {
+      "properties": {
+        "circuitBreakerPolicy": {
+          "consecutiveErrors": 5,
+          "intervalInSeconds": 10,
+          "maxEjectionPercent": 50
+        },
+        "httpConnectionPool": {
+          "http1MaxPendingRequests": 1024,
+          "http2MaxRequests": 1024
+        },
+        "httpRetryPolicy": {
+          "matches": {
+            "errors": [
+              "5xx",
+              "connect-failure",
+              "reset",
+              "retriable-headers",
+              "retriable-status-codes"
+            ],
+            "headers": [
+              {
+                "header": "X-Content-Type",
+                "match": {
+                  "prefixMatch": "GOATS"
+                }
+              }
+            ],
+            "httpStatusCodes": [
+              502,
+              503
+            ]
+          },
+          "maxRetries": 5,
+          "retryBackOff": {
+            "initialDelayInMilliseconds": 1000,
+            "maxIntervalInMilliseconds": 10000
+          }
+        },
+        "tcpConnectionPool": {
+          "maxConnections": 100
+        },
+        "tcpRetryPolicy": {
+          "maxConnectAttempts": 3
+        },
+        "timeoutPolicy": {
+          "connectionTimeoutInSeconds": 5,
+          "responseTimeoutInSeconds": 15
+        }
+      }
+    },
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "resiliency-policy-1",
+        "type": "Microsoft.App/containerApps/resiliencyPolicies",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/resiliencyPolicies/resiliency-policy-1",
+        "properties": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 5,
+            "intervalInSeconds": 10,
+            "maxEjectionPercent": 50
+          },
+          "httpConnectionPool": {
+            "http1MaxPendingRequests": 1024,
+            "http2MaxRequests": 1024
+          },
+          "httpRetryPolicy": {
+            "matches": {
+              "errors": [
+                "5xx",
+                "connect-failure",
+                "reset",
+                "retriable-headers",
+                "retriable-status-codes"
+              ],
+              "headers": [
+                {
+                  "header": "X-Content-Type",
+                  "match": {
+                    "prefixMatch": "GOATS"
+                  }
+                }
+              ],
+              "httpStatusCodes": [
+                502,
+                503
+              ]
+            },
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 1000,
+              "maxIntervalInMilliseconds": 10000
+            }
+          },
+          "tcpConnectionPool": {
+            "maxConnections": 100
+          },
+          "tcpRetryPolicy": {
+            "maxConnectAttempts": 3
+          },
+          "timeoutPolicy": {
+            "connectionTimeoutInSeconds": 5,
+            "responseTimeoutInSeconds": 15
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "resiliency-policy-1",
+        "type": "Microsoft.App/containerApps/resiliencyPolicies",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/resiliencyPolicies/resiliency-policy-1",
+        "properties": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 5,
+            "intervalInSeconds": 10,
+            "maxEjectionPercent": 50
+          },
+          "httpConnectionPool": {
+            "http1MaxPendingRequests": 1024,
+            "http2MaxRequests": 1024
+          },
+          "httpRetryPolicy": {
+            "matches": {
+              "errors": [
+                "5xx",
+                "connect-failure",
+                "reset",
+                "retriable-headers",
+                "retriable-status-codes"
+              ],
+              "headers": [
+                {
+                  "header": "X-Content-Type",
+                  "match": {
+                    "prefixMatch": "GOATS"
+                  }
+                }
+              ],
+              "httpStatusCodes": [
+                502,
+                503
+              ]
+            },
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 1000,
+              "maxIntervalInMilliseconds": 10000
+            }
+          },
+          "tcpConnectionPool": {
+            "maxConnections": 100
+          },
+          "tcpRetryPolicy": {
+            "maxConnectAttempts": 3
+          },
+          "timeoutPolicy": {
+            "connectionTimeoutInSeconds": 5,
+            "responseTimeoutInSeconds": 15
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AppResiliency_CreateOrUpdate",
+  "title": "Create or Update App Resiliency"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AppResiliency_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AppResiliency_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "resiliency-policy-1",
+    "api-version": "2026-03-02-preview",
+    "appName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "AppResiliency_Delete",
+  "title": "Delete App Resiliency"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AppResiliency_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AppResiliency_Get.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "name": "resiliency-policy-1",
+    "api-version": "2026-03-02-preview",
+    "appName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "resiliency-policy-1",
+        "type": "Microsoft.App/containerApps/resiliencyPolicies",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/resiliencyPolicies/resiliency-policy-1",
+        "properties": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 5,
+            "intervalInSeconds": 10,
+            "maxEjectionPercent": 50
+          },
+          "httpConnectionPool": {
+            "http1MaxPendingRequests": 1024,
+            "http2MaxRequests": 1024
+          },
+          "httpRetryPolicy": {
+            "matches": {
+              "errors": [
+                "5xx",
+                "connect-failure",
+                "reset",
+                "retriable-headers",
+                "retriable-status-codes"
+              ],
+              "headers": [
+                {
+                  "header": "X-Content-Type",
+                  "match": {
+                    "prefixMatch": "GOATS"
+                  }
+                }
+              ],
+              "httpStatusCodes": [
+                502,
+                503
+              ]
+            },
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 1000,
+              "maxIntervalInMilliseconds": 10000
+            }
+          },
+          "tcpConnectionPool": {
+            "maxConnections": 100
+          },
+          "tcpRetryPolicy": {
+            "maxConnectAttempts": 3
+          },
+          "timeoutPolicy": {
+            "connectionTimeoutInSeconds": 5,
+            "responseTimeoutInSeconds": 15
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AppResiliency_Get",
+  "title": "Get App Resiliency"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AppResiliency_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AppResiliency_List.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "appName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "resiliency-policy-1",
+            "type": "Microsoft.App/containerApps/resiliencyPolicies",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/resiliencyPolicies/resiliency-policy-1",
+            "properties": {
+              "circuitBreakerPolicy": {
+                "consecutiveErrors": 5,
+                "intervalInSeconds": 10,
+                "maxEjectionPercent": 50
+              },
+              "httpConnectionPool": {
+                "http1MaxPendingRequests": 1024,
+                "http2MaxRequests": 1024
+              },
+              "httpRetryPolicy": {
+                "matches": {
+                  "errors": [
+                    "5xx",
+                    "connect-failure",
+                    "reset",
+                    "retriable-headers",
+                    "retriable-status-codes"
+                  ],
+                  "headers": [
+                    {
+                      "header": "X-Content-Type",
+                      "match": {
+                        "prefixMatch": "GOATS"
+                      }
+                    }
+                  ],
+                  "httpStatusCodes": [
+                    502,
+                    503
+                  ]
+                },
+                "maxRetries": 5,
+                "retryBackOff": {
+                  "initialDelayInMilliseconds": 1000,
+                  "maxIntervalInMilliseconds": 10000
+                }
+              },
+              "tcpConnectionPool": {
+                "maxConnections": 100
+              },
+              "tcpRetryPolicy": {
+                "maxConnectAttempts": 3
+              },
+              "timeoutPolicy": {
+                "connectionTimeoutInSeconds": 5,
+                "responseTimeoutInSeconds": 15
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AppResiliency_List",
+  "title": "List App Resiliency"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AppResiliency_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AppResiliency_Patch.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "name": "resiliency-policy-1",
+    "api-version": "2026-03-02-preview",
+    "appName": "testcontainerApp0",
+    "resiliencyEnvelope": {
+      "properties": {
+        "timeoutPolicy": {
+          "connectionTimeoutInSeconds": 40,
+          "responseTimeoutInSeconds": 30
+        }
+      }
+    },
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "resiliency-policy-1",
+        "type": "Microsoft.App/containerApps/resiliencyPolicies",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/resiliencyPolicies/resiliency-policy-1",
+        "properties": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 5,
+            "intervalInSeconds": 10,
+            "maxEjectionPercent": 50
+          },
+          "httpConnectionPool": {
+            "http1MaxPendingRequests": 1024,
+            "http2MaxRequests": 1024
+          },
+          "httpRetryPolicy": {
+            "matches": {
+              "errors": [
+                "5xx",
+                "connect-failure",
+                "reset",
+                "retriable-headers",
+                "retriable-status-codes"
+              ],
+              "headers": [
+                {
+                  "header": "X-Content-Type",
+                  "match": {
+                    "prefixMatch": "GOATS"
+                  }
+                }
+              ],
+              "httpStatusCodes": [
+                502,
+                503
+              ]
+            },
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 1000,
+              "maxIntervalInMilliseconds": 10000
+            }
+          },
+          "tcpConnectionPool": {
+            "maxConnections": 100
+          },
+          "tcpRetryPolicy": {
+            "maxConnectAttempts": 3
+          },
+          "timeoutPolicy": {
+            "connectionTimeoutInSeconds": 40,
+            "responseTimeoutInSeconds": 30
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AppResiliency_Update",
+  "title": "Update App Resiliency"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_BlobStorageTokenStore_ClientId_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_BlobStorageTokenStore_ClientId_CreateOrUpdate.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "authConfigEnvelope": {
+      "properties": {
+        "encryptionSettings": {
+          "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+          "containerAppAuthSigningSecretName": "testSigningSecretName"
+        },
+        "globalValidation": {
+          "unauthenticatedClientAction": "AllowAnonymous"
+        },
+        "identityProviders": {
+          "facebook": {
+            "registration": {
+              "appId": "123",
+              "appSecretSettingName": "facebook-secret"
+            }
+          }
+        },
+        "login": {
+          "tokenStore": {
+            "azureBlobStorage": {
+              "blobContainerUri": "https://test.blob.core.windows.net/container1",
+              "clientId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "platform": {
+          "enabled": true
+        }
+      }
+    },
+    "authConfigName": "current",
+    "containerAppName": "myapp",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/authconfigs",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.App/containerApps/myapp/authconfigs/current",
+        "properties": {
+          "encryptionSettings": {
+            "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+            "containerAppAuthSigningSecretName": "testSigningSecretName"
+          },
+          "globalValidation": {
+            "unauthenticatedClientAction": "AllowAnonymous"
+          },
+          "identityProviders": {
+            "facebook": {
+              "registration": {
+                "appId": "123",
+                "appSecretSettingName": "facebook-secret"
+              }
+            }
+          },
+          "login": {
+            "tokenStore": {
+              "azureBlobStorage": {
+                "blobContainerUri": "https://test.blob.core.windows.net/container1",
+                "clientId": "00000000-0000-0000-0000-000000000000"
+              }
+            }
+          },
+          "platform": {
+            "enabled": true
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsAuthConfigs_CreateOrUpdate",
+  "title": "Create or Update Container App AuthConfig with msi clientID blob storage token store"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_BlobStorageTokenStore_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_BlobStorageTokenStore_CreateOrUpdate.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "authConfigEnvelope": {
+      "properties": {
+        "encryptionSettings": {
+          "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+          "containerAppAuthSigningSecretName": "testSigningSecretName"
+        },
+        "globalValidation": {
+          "unauthenticatedClientAction": "AllowAnonymous"
+        },
+        "identityProviders": {
+          "facebook": {
+            "registration": {
+              "appId": "123",
+              "appSecretSettingName": "facebook-secret"
+            }
+          }
+        },
+        "login": {
+          "tokenStore": {
+            "azureBlobStorage": {
+              "blobContainerUri": "https://test.blob.core.windows.net/container1",
+              "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            }
+          }
+        },
+        "platform": {
+          "enabled": true
+        }
+      }
+    },
+    "authConfigName": "current",
+    "containerAppName": "myapp",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/authconfigs",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.App/containerApps/myapp/authconfigs/current",
+        "properties": {
+          "encryptionSettings": {
+            "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+            "containerAppAuthSigningSecretName": "testSigningSecretName"
+          },
+          "globalValidation": {
+            "unauthenticatedClientAction": "AllowAnonymous"
+          },
+          "identityProviders": {
+            "facebook": {
+              "registration": {
+                "appId": "123",
+                "appSecretSettingName": "facebook-secret"
+              }
+            }
+          },
+          "login": {
+            "tokenStore": {
+              "azureBlobStorage": {
+                "blobContainerUri": "https://test.blob.core.windows.net/container1",
+                "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+              }
+            }
+          },
+          "platform": {
+            "enabled": true
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsAuthConfigs_CreateOrUpdate",
+  "title": "Create or Update Container App AuthConfig with msi managedIdentityResourceId blob storage token store"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_CreateOrUpdate.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "authConfigEnvelope": {
+      "properties": {
+        "encryptionSettings": {
+          "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+          "containerAppAuthSigningSecretName": "testSigningSecretName"
+        },
+        "globalValidation": {
+          "unauthenticatedClientAction": "AllowAnonymous"
+        },
+        "identityProviders": {
+          "facebook": {
+            "registration": {
+              "appId": "123",
+              "appSecretSettingName": "facebook-secret"
+            }
+          }
+        },
+        "platform": {
+          "enabled": true
+        }
+      }
+    },
+    "authConfigName": "current",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/authconfigs",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/authconfigs/current",
+        "properties": {
+          "encryptionSettings": {
+            "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+            "containerAppAuthSigningSecretName": "testSigningSecretName"
+          },
+          "globalValidation": {
+            "unauthenticatedClientAction": "AllowAnonymous"
+          },
+          "identityProviders": {
+            "facebook": {
+              "registration": {
+                "appId": "123",
+                "appSecretSettingName": "facebook-secret"
+              }
+            }
+          },
+          "platform": {
+            "enabled": true
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsAuthConfigs_CreateOrUpdate",
+  "title": "Create or Update Container App AuthConfig"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "authConfigName": "current",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ContainerAppsAuthConfigs_Delete",
+  "title": "Delete Container App AuthConfig"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_Get.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "authConfigName": "current",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/authconfigs",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/testcanadacentral/authconfigs/current",
+        "properties": {
+          "encryptionSettings": {
+            "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+            "containerAppAuthSigningSecretName": "testSigningSecretName"
+          },
+          "globalValidation": {
+            "unauthenticatedClientAction": "AllowAnonymous"
+          },
+          "identityProviders": {
+            "facebook": {
+              "registration": {
+                "appId": "123",
+                "appSecretSettingName": "facebook-secret"
+              }
+            }
+          },
+          "platform": {
+            "enabled": true
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsAuthConfigs_Get",
+  "title": "Get Container App's AuthConfig"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_ListByContainer.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AuthConfigs_ListByContainer.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "current",
+            "type": "Microsoft.App/containerapps/authconfigs",
+            "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/testcanadacentral/authconfigs/current",
+            "properties": {
+              "encryptionSettings": {
+                "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+                "containerAppAuthSigningSecretName": "testSigningSecretName"
+              },
+              "globalValidation": {
+                "unauthenticatedClientAction": "AllowAnonymous"
+              },
+              "identityProviders": {
+                "facebook": {
+                  "registration": {
+                    "appId": "123",
+                    "appSecretSettingName": "facebook-secret"
+                  }
+                }
+              },
+              "platform": {
+                "enabled": true
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsAuthConfigs_ListByContainerApp",
+  "title": "List Auth Configs by Container Apps"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AvailableEnvironmentModes_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AvailableEnvironmentModes_List.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "location": "East US",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsModes/ConsumptionOnly",
+            "name": "ConsumptionOnly",
+            "type": "Microsoft.App/availableManagedEnvironmentsModes",
+            "location": "East US",
+            "properties": {
+              "displayName": "Consumption Only",
+              "description": "Serverless consumption-based environment without dedicated workload profiles."
+            }
+          },
+          {
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsModes/WorkloadProfiles",
+            "name": "WorkloadProfiles",
+            "type": "Microsoft.App/availableManagedEnvironmentsModes",
+            "location": "East US",
+            "properties": {
+              "displayName": "Workload Profiles",
+              "description": "Environment with configurable workload profiles including consumption and dedicated compute."
+            }
+          },
+          {
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsModes/Archived",
+            "name": "Archived",
+            "type": "Microsoft.App/availableManagedEnvironmentsModes",
+            "location": "East US",
+            "properties": {
+              "displayName": "Archived",
+              "description": "Deprovisioned environment in archived state."
+            }
+          },
+          {
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsModes/Express",
+            "name": "Express",
+            "type": "Microsoft.App/availableManagedEnvironmentsModes",
+            "location": "East US",
+            "properties": {
+              "displayName": "Express",
+              "description": "Multi-tenant express environment with simplified configuration."
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AvailableEnvironmentModes_List",
+  "title": "AvailableEnvironmentModes_List"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AvailableEnvironmentModes_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AvailableEnvironmentModes_List.json
@@ -53,5 +53,5 @@
     }
   },
   "operationId": "AvailableEnvironmentModes_List",
-  "title": "AvailableEnvironmentModes_List"
+  "title": "List available environment modes by location"
 }

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AvailableWorkloadProfiles_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/AvailableWorkloadProfiles_Get.json
@@ -1,0 +1,161 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "location": "East US",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Dedicated-D4",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-D4",
+            "location": "East US",
+            "properties": {
+              "applicability": "LocationDefault",
+              "category": "General purpose D-series",
+              "cores": 4,
+              "displayName": "Dedicated-D4",
+              "memoryGiB": 16
+            }
+          },
+          {
+            "name": "Dedicated-D4",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-D8",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "General purpose D-series",
+              "cores": 8,
+              "displayName": "Dedicated-D8",
+              "memoryGiB": 32
+            }
+          },
+          {
+            "name": "Dedicated-D16",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-D16",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "General purpose D-series",
+              "cores": 16,
+              "displayName": "Dedicated-D16",
+              "memoryGiB": 64
+            }
+          },
+          {
+            "name": "Dedicated-E4",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-E4",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Memory optimized E-series",
+              "cores": 4,
+              "displayName": "Dedicated-E4",
+              "memoryGiB": 32
+            }
+          },
+          {
+            "name": "Dedicated-E8",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-E8",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Memory optimized E-series",
+              "cores": 8,
+              "displayName": "Dedicated-E8",
+              "memoryGiB": 64
+            }
+          },
+          {
+            "name": "Dedicated-E16",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-E16",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Memory optimized E-series",
+              "cores": 16,
+              "displayName": "Dedicated-E16",
+              "memoryGiB": 128
+            }
+          },
+          {
+            "name": "Dedicated-F4",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-F4",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Compute optimized F-series",
+              "cores": 4,
+              "displayName": "Dedicated-F4",
+              "memoryGiB": 8
+            }
+          },
+          {
+            "name": "Dedicated-F8",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-F8",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Compute optimized F-series",
+              "cores": 8,
+              "displayName": "Dedicated-F8",
+              "memoryGiB": 16
+            }
+          },
+          {
+            "name": "Dedicated-F16",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-F16",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Compute optimized F-series",
+              "cores": 16,
+              "displayName": "Dedicated-F16",
+              "memoryGiB": 32
+            }
+          },
+          {
+            "name": "NC48-A100",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/NC48-A100",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "GPU-NC-A100",
+              "cores": 48,
+              "displayName": "Dedicated-NC48-A100",
+              "gpus": 2,
+              "memoryGiB": 440
+            }
+          },
+          {
+            "name": "Consumption",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Consumption",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Consumption",
+              "cores": 3,
+              "displayName": "Consumption",
+              "memoryGiB": 3
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AvailableWorkloadProfiles_Get",
+  "title": "BillingMeters_Get"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/BillingMeters_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/BillingMeters_Get.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "location": "East US",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "GeneralPurposeDseriesCPU",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/GeneralPurposeDseriesCPU",
+            "location": "East US",
+            "properties": {
+              "category": "General purpose D-series",
+              "displayName": "General Purpose Cores per Second",
+              "meterType": "CPU"
+            }
+          },
+          {
+            "name": "GeneralPurposeDseriesMemory",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/GeneralPurposeDseriesMemory",
+            "location": "East US",
+            "properties": {
+              "category": "General purpose D-series",
+              "displayName": "General Purpose Memory GiB per Second",
+              "meterType": "Memory"
+            }
+          },
+          {
+            "name": "MemoryOptimizedEseriesCPU",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/MemoryOptimizedEseriesCPU",
+            "location": "East US",
+            "properties": {
+              "category": "Memory optimized E-series",
+              "displayName": "Memory Optimized Cores per Second",
+              "meterType": "CPU"
+            }
+          },
+          {
+            "name": "MemoryOptimizedEseriesMemory",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/MemoryOptimizedEseriesMemory",
+            "location": "East US",
+            "properties": {
+              "category": "Memory optimized E-series",
+              "displayName": "Memory Optimized Memory GiB per Second",
+              "meterType": "Memory"
+            }
+          },
+          {
+            "name": "ComputeOptimizedFseriesCPU",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/ComputeOptimizedFseriesCPU",
+            "location": "East US",
+            "properties": {
+              "category": "Compute optimized F-series",
+              "displayName": "Compute Optimized Cores per Second",
+              "meterType": "CPU"
+            }
+          },
+          {
+            "name": "GeneralComputeMemory",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/GeneralComputeMemory",
+            "location": "East US",
+            "properties": {
+              "category": "Compute optimized F-series",
+              "displayName": "Compute Optimized Memory GiB per Second",
+              "meterType": "Memory"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BillingMeters_Get",
+  "title": "BillingMeters_Get"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_CreateOrUpdate.json
@@ -1,0 +1,128 @@
+{
+  "operationId": "Builders_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "builderEnvelope": {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {}
+        }
+      },
+      "location": "eastus",
+      "properties": {
+        "containerRegistries": [
+          {
+            "containerRegistryServer": "test.azurecr.io",
+            "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+          },
+          {
+            "containerRegistryServer": "test2.azurecr.io",
+            "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+          }
+        ],
+        "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv"
+      },
+      "tags": {
+        "company": "Microsoft"
+      }
+    },
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_CreateOrUpdate_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuilder",
+        "type": "Microsoft.App/builders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "containerRegistries": [
+            {
+              "containerRegistryServer": "test.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            },
+            {
+              "containerRegistryServer": "test2.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            }
+          ],
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        },
+        "tags": {
+          "company": "Microsoft"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testBuilder",
+        "type": "Microsoft.App/builders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "containerRegistries": [
+            {
+              "containerRegistryServer": "test.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            },
+            {
+              "containerRegistryServer": "test2.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            }
+          ],
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        },
+        "tags": {
+          "company": "Microsoft"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_Delete.json
@@ -1,0 +1,18 @@
+{
+  "operationId": "Builders_Delete",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_Delete_0",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_Get.json
@@ -1,0 +1,56 @@
+{
+  "operationId": "Builders_Get",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_Get_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuilder",
+        "type": "Microsoft.App/builders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "containerRegistries": [
+            {
+              "containerRegistryServer": "test.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            },
+            {
+              "containerRegistryServer": "test2.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            }
+          ],
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        },
+        "tags": {
+          "key": "value"
+        }
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_ListByResourceGroup.json
@@ -1,0 +1,102 @@
+{
+  "operationId": "Builders_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_ListByResourceGroup_0",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testBuilder1",
+            "type": "Microsoft.App/builders",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder1",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+                  "clientId": "00000000-0000-0000-0000-000000000000",
+                  "principalId": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "containerRegistries": [
+                {
+                  "containerRegistryServer": "test.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                },
+                {
+                  "containerRegistryServer": "test2.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                }
+              ],
+              "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            },
+            "tags": {
+              "key": "value"
+            }
+          },
+          {
+            "name": "testBuilder2",
+            "type": "Microsoft.App/builders",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder2",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+                  "clientId": "00000000-0000-0000-0000-000000000000",
+                  "principalId": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "containerRegistries": [
+                {
+                  "containerRegistryServer": "test.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                },
+                {
+                  "containerRegistryServer": "test2.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                }
+              ],
+              "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            },
+            "tags": {
+              "key": "value"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_ListBySubscription.json
@@ -1,0 +1,101 @@
+{
+  "operationId": "Builders_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_ListBySubscription_0",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testBuilder1",
+            "type": "Microsoft.App/builders",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg1/providers/Microsoft.App/builders/testBuilder1",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+                  "clientId": "00000000-0000-0000-0000-000000000000",
+                  "principalId": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "containerRegistries": [
+                {
+                  "containerRegistryServer": "test.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                },
+                {
+                  "containerRegistryServer": "test2.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                }
+              ],
+              "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            },
+            "tags": {
+              "key": "value"
+            }
+          },
+          {
+            "name": "testBuilder2",
+            "type": "Microsoft.App/builders",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg2/providers/Microsoft.App/builders/testBuilder2",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+                  "clientId": "00000000-0000-0000-0000-000000000000",
+                  "principalId": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "containerRegistries": [
+                {
+                  "containerRegistryServer": "test.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                },
+                {
+                  "containerRegistryServer": "test2.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                }
+              ],
+              "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            },
+            "tags": {
+              "key": "value"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_Update.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builders_Update.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "Builders_Update",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "builderEnvelope": {
+      "tags": {
+        "mytag1": "myvalue1"
+      }
+    },
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_Update_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuilder",
+        "type": "Microsoft.App/builders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "containerRegistries": [
+            {
+              "containerRegistryServer": "test.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            },
+            {
+              "containerRegistryServer": "test2.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            }
+          ],
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        },
+        "tags": {
+          "mytag1": "myvalue1"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_CreateOrUpdate.json
@@ -1,0 +1,214 @@
+{
+  "operationId": "Builds_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildEnvelope": {
+      "properties": {
+        "configuration": {
+          "baseOs": "DebianBullseye",
+          "environmentVariables": [
+            {
+              "name": "foo1",
+              "value": "bar1"
+            },
+            {
+              "name": "foo2",
+              "value": "bar2"
+            }
+          ],
+          "platform": "dotnetcore",
+          "platformVersion": "7.0",
+          "preBuildSteps": [
+            {
+              "description": "First pre build step.",
+              "httpGet": {
+                "fileName": "output.txt",
+                "headers": [
+                  "foo",
+                  "bar"
+                ],
+                "url": "https://microsoft.com"
+              },
+              "scripts": [
+                "echo 'hello'",
+                "echo 'world'"
+              ]
+            },
+            {
+              "description": "Second pre build step.",
+              "httpGet": {
+                "fileName": "output.txt",
+                "headers": [
+                  "foo"
+                ],
+                "url": "https://microsoft.com"
+              },
+              "scripts": [
+                "echo 'hello'",
+                "echo 'again'"
+              ]
+            }
+          ]
+        },
+        "destinationContainerRegistry": {
+          "image": "test.azurecr.io/repo:tag",
+          "server": "test.azurecr.io"
+        }
+      }
+    },
+    "buildName": "testBuild-123456789az",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builds_CreateOrUpdate_WithConfig",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuild-123456789az",
+        "type": "Microsoft.App/builders/builds",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild-123456789az",
+        "properties": {
+          "buildStatus": "InProgress",
+          "configuration": {
+            "baseOs": "DebianBullseye",
+            "environmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "platform": "dotnetcore",
+            "platformVersion": "7.0",
+            "preBuildSteps": [
+              {
+                "description": "First pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo",
+                    "bar"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'world'"
+                ]
+              },
+              {
+                "description": "Second pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'again'"
+                ]
+              }
+            ]
+          },
+          "destinationContainerRegistry": {
+            "image": "test.azurecr.io/repo:tag",
+            "server": "test.azurecr.io"
+          },
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Succeeded",
+          "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+          "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testBuild",
+        "type": "Microsoft.App/build",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild",
+        "properties": {
+          "buildStatus": "NotStarted",
+          "configuration": {
+            "baseOs": "DebianBullseye",
+            "environmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "platform": "dotnetcore",
+            "platformVersion": "7.0",
+            "preBuildSteps": [
+              {
+                "description": "First pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo",
+                    "bar"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'world'"
+                ]
+              },
+              {
+                "description": "Second pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'again'"
+                ]
+              }
+            ]
+          },
+          "destinationContainerRegistry": {
+            "image": "test.azurecr.io/repo:tag",
+            "server": "test.azurecr.io"
+          },
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Creating",
+          "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+          "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_CreateOrUpdate_NoConfig.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_CreateOrUpdate_NoConfig.json
@@ -1,0 +1,61 @@
+{
+  "operationId": "Builds_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildEnvelope": {},
+    "buildName": "testBuild",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builds_CreateOrUpdate_NoConfig",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuild",
+        "type": "Microsoft.App/builders/builds",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild",
+        "properties": {
+          "buildStatus": "InProgress",
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Succeeded",
+          "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+          "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testBuild",
+        "type": "Microsoft.App/build",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild",
+        "properties": {
+          "buildStatus": "InProgress",
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Creating",
+          "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+          "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_Delete.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "Builds_Delete",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildName": "testBuild",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builds_Delete_0",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_Get.json
@@ -1,0 +1,85 @@
+{
+  "operationId": "Builds_Get",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildName": "testBuild",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builds_Get_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuild",
+        "type": "Microsoft.App/builders/builds",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild",
+        "properties": {
+          "buildStatus": "InProgress",
+          "configuration": {
+            "baseOs": "DebianBullseye",
+            "environmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "platform": "dotnetcore",
+            "platformVersion": "7.0",
+            "preBuildSteps": [
+              {
+                "description": "First pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo",
+                    "bar"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'world'"
+                ]
+              },
+              {
+                "description": "Second pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'again'"
+                ]
+              }
+            ]
+          },
+          "destinationContainerRegistry": {
+            "image": "test.azurecr.io/repo:tag",
+            "server": "test.azurecr.io"
+          },
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Succeeded",
+          "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+          "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_ListAuthToken.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_ListAuthToken.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "BuildAuthToken_List",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildName": "testBuild",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get Build Auth Token",
+  "responses": {
+    "200": {
+      "body": {
+        "expires": "2022-07-14T19:22:50.3080223Z",
+        "token": "foobartoken"
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_ListByBuilderResource.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Builds_ListByBuilderResource.json
@@ -1,0 +1,159 @@
+{
+  "operationId": "BuildsByBuilderResource_List",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builds_ListByBuilderResource_0",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testBuild1",
+            "type": "Microsoft.App/builders/builds",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild1",
+            "properties": {
+              "buildStatus": "InProgress",
+              "configuration": {
+                "baseOs": "DebianBullseye",
+                "environmentVariables": [
+                  {
+                    "name": "foo1",
+                    "value": "bar1"
+                  },
+                  {
+                    "name": "foo2",
+                    "value": "bar2"
+                  }
+                ],
+                "platform": "dotnetcore",
+                "platformVersion": "7.0",
+                "preBuildSteps": [
+                  {
+                    "description": "First pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo",
+                        "bar"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'world'"
+                    ]
+                  },
+                  {
+                    "description": "Second pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'again'"
+                    ]
+                  }
+                ]
+              },
+              "destinationContainerRegistry": {
+                "image": "test.azurecr.io/repo:tag",
+                "server": "test.azurecr.io"
+              },
+              "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+              "provisioningState": "Succeeded",
+              "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+              "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "testBuild2",
+            "type": "Microsoft.App/builders/builds",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild2",
+            "properties": {
+              "buildStatus": "InProgress",
+              "configuration": {
+                "baseOs": "DebianBullseye",
+                "environmentVariables": [
+                  {
+                    "name": "foo1",
+                    "value": "bar1"
+                  },
+                  {
+                    "name": "foo2",
+                    "value": "bar2"
+                  }
+                ],
+                "platform": "dotnetcore",
+                "platformVersion": "7.0",
+                "preBuildSteps": [
+                  {
+                    "description": "First pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo",
+                        "bar"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'world'"
+                    ]
+                  },
+                  {
+                    "description": "Second pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'again'"
+                    ]
+                  }
+                ]
+              },
+              "destinationContainerRegistry": {
+                "image": "test.azurecr.io/repo:tag",
+                "server": "test.azurecr.io"
+              },
+              "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+              "provisioningState": "Succeeded",
+              "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+              "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificate_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificate_CreateOrUpdate.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateEnvelope": {
+      "location": "East US",
+      "properties": {
+        "certificateType": "ImagePullTrustedCA",
+        "password": "private key password",
+        "value": "Y2VydA=="
+      }
+    },
+    "certificateName": "certificate-firendly-name",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "certificateType": "ImagePullTrustedCA",
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Certificates_CreateOrUpdate",
+  "title": "Create or Update Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificate_CreateOrUpdate_FromKeyVault.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificate_CreateOrUpdate_FromKeyVault.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateEnvelope": {
+      "location": "East US",
+      "properties": {
+        "certificateKeyVaultProperties": {
+          "identity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.managedidentity/userassignedidentities/test-user-mi",
+          "keyVaultUrl": "https://xxxxxxxx.vault.azure.net/certificates/certName"
+        },
+        "certificateType": "ServerSSLCertificate"
+      }
+    },
+    "certificateName": "certificate-firendly-name",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "certificateKeyVaultProperties": {
+            "identity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.managedidentity/userassignedidentities/test-user-mi",
+            "keyVaultUrl": "https://xxxxxxxx.vault.azure.net/certificates/certName"
+          },
+          "certificateType": "ServerSSLCertificate",
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Certificates_CreateOrUpdate",
+  "title": "Create or Update Certificate using Managed Identity"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificate_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificate_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateName": "certificate-firendly-name",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Certificates_Delete",
+  "title": "Delete Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificate_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificate_Get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateName": "certificate-firendly-name",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "certificate-firendly-name",
+        "type": "Microsoft.App/ManagedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "certificateType": "ServerSSLCertificate",
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Certificates_Get",
+  "title": "Get Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificates_CheckNameAvailability.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificates_CheckNameAvailability.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "checkNameAvailabilityRequest": {
+      "name": "testcertificatename",
+      "type": "Microsoft.App/managedEnvironments/certificates"
+    },
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "Namespaces_CheckNameAvailability",
+  "title": "Certificates_CheckNameAvailability"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificates_ListByManagedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificates_ListByManagedEnvironment.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "certificate-firendly-name",
+            "type": "Microsoft.App/ManagedEnvironments/Certificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+            "location": "East US",
+            "properties": {
+              "certificateType": "ImagePullTrustedCA",
+              "expirationDate": "2022-11-06T04:00:00Z",
+              "issueDate": "2021-11-06T04:00:00Z",
+              "issuer": "Issuer Name",
+              "provisioningState": "Succeeded",
+              "subjectAlternativeNames": [
+                "CN=my-subject-name.com"
+              ],
+              "subjectName": "my-subject-name.company.country.net",
+              "thumbprint": "CERTIFICATE_THUMBPRINT",
+              "valid": true
+            }
+          },
+          {
+            "name": "certificate-firendly-name",
+            "type": "Microsoft.App/ManagedEnvironments/Certificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+            "location": "East US",
+            "properties": {
+              "certificateType": "ServerSSLCertificate",
+              "expirationDate": "2022-11-06T04:00:00Z",
+              "issueDate": "2021-11-06T04:00:00Z",
+              "issuer": "Issuer Name",
+              "provisioningState": "Succeeded",
+              "subjectAlternativeNames": [
+                "CN=my-subject-name.com"
+              ],
+              "subjectName": "my-subject-name.company.country.net",
+              "thumbprint": "CERTIFICATE_THUMBPRINT",
+              "valid": true
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Certificates_List",
+  "title": "List Certificates by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificates_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Certificates_Patch.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateEnvelope": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "certificateName": "certificate-firendly-name",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "certificateType": "ServerSSLCertificate",
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Certificates_Update",
+  "title": "Patch Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificate_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificate_CreateOrUpdate.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateEnvelope": {
+      "location": "East US",
+      "properties": {
+        "password": "private key password",
+        "value": "Y2VydA=="
+      }
+    },
+    "certificateName": "certificate-firendly-name",
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certififcates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "deploymentErrors": null,
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testenv",
+        "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certififcates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "InProgress",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsCertificates_CreateOrUpdate",
+  "title": "Create or Update Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificate_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificate_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateName": "certificate-firendly-name",
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/connectedOperationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectedEnvironmentsCertificates_Delete",
+  "title": "Delete Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificate_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificate_Get.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateName": "certificate-firendly-name",
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "certificate-firendly-name",
+        "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectedEnvironmentsCertificates_Get",
+  "title": "Get Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificates_CheckNameAvailability.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificates_CheckNameAvailability.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "checkNameAvailabilityRequest": {
+      "name": "testcertificatename",
+      "type": "Microsoft.App/connectedEnvironments/certificates"
+    },
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_CheckNameAvailability",
+  "title": "Certificates_CheckNameAvailability"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificates_ListByConnectedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificates_ListByConnectedEnvironment.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "certificate-firendly-name",
+            "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+            "location": "East US",
+            "properties": {
+              "expirationDate": "2022-11-06T04:00:00Z",
+              "issueDate": "2021-11-06T04:00:00Z",
+              "issuer": "Issuer Name",
+              "provisioningState": "Succeeded",
+              "subjectAlternativeNames": [
+                "CN=my-subject-name.com"
+              ],
+              "subjectName": "my-subject-name.company.country.net",
+              "thumbprint": "CERTIFICATE_THUMBPRINT",
+              "valid": true
+            }
+          },
+          {
+            "name": "certificate-firendly-name",
+            "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+            "location": "East US",
+            "properties": {
+              "expirationDate": "2022-11-06T04:00:00Z",
+              "issueDate": "2021-11-06T04:00:00Z",
+              "issuer": "Issuer Name",
+              "provisioningState": "Succeeded",
+              "subjectAlternativeNames": [
+                "CN=my-subject-name.com"
+              ],
+              "subjectName": "my-subject-name.company.country.net",
+              "thumbprint": "CERTIFICATE_THUMBPRINT",
+              "valid": true
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectedEnvironmentsCertificates_List",
+  "title": "List Certificates by Connected Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificates_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsCertificates_Patch.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateEnvelope": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "certificateName": "certificate-firendly-name",
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/connectedOperationResults/00000"
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsCertificates_Update",
+  "title": "Patch Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsDaprComponents_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsDaprComponents_CreateOrUpdate.json
@@ -1,0 +1,162 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "connectedEnvironmentName": "myenvironment",
+    "daprComponentEnvelope": {
+      "properties": {
+        "componentType": "state.azure.cosmosdb",
+        "ignoreErrors": false,
+        "initTimeout": "50s",
+        "metadata": [
+          {
+            "name": "url",
+            "value": "<COSMOS-URL>"
+          },
+          {
+            "name": "database",
+            "value": "itemsDB"
+          },
+          {
+            "name": "collection",
+            "value": "items"
+          },
+          {
+            "name": "masterkey",
+            "secretRef": "masterkey"
+          }
+        ],
+        "scopes": [
+          "container-app-1",
+          "container-app-2"
+        ],
+        "secrets": [
+          {
+            "name": "masterkey",
+            "value": "keyvalue"
+          }
+        ],
+        "serviceComponentBind": [
+          {
+            "name": "statestore",
+            "metadata": {
+              "name": "daprcomponentBind",
+              "value": "redis-bind"
+            },
+            "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+          }
+        ],
+        "version": "v1"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/connectedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "deploymentErrors": null,
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secrets": [
+            {
+              "name": "masterkey"
+            }
+          ],
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/connectedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "provisioningState": "InProgress",
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secrets": [
+            {
+              "name": "masterkey"
+            }
+          ],
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsDaprComponents_CreateOrUpdate",
+  "title": "Create or update dapr component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsDaprComponents_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsDaprComponents_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "connectedEnvironmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/connectedOperationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectedEnvironmentsDaprComponents_Delete",
+  "title": "Delete dapr component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsDaprComponents_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsDaprComponents_Get.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "connectedEnvironmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/connectedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "deploymentErrors": null,
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secrets": [
+            {
+              "name": "masterkey"
+            }
+          ],
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsDaprComponents_Get",
+  "title": "Get Dapr Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsDaprComponents_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsDaprComponents_List.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "reddog",
+            "type": "Microsoft.App/connectedEnvironments/daprcomponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/myenvironment/daprcomponents/reddog",
+            "properties": {
+              "componentType": "state.azure.cosmosdb",
+              "deploymentErrors": null,
+              "ignoreErrors": false,
+              "initTimeout": "50s",
+              "metadata": [
+                {
+                  "name": "url",
+                  "value": "<COSMOS-URL>"
+                },
+                {
+                  "name": "database",
+                  "value": "itemsDB"
+                },
+                {
+                  "name": "collection",
+                  "value": "items"
+                },
+                {
+                  "name": "masterkey",
+                  "secretRef": "masterkey"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "scopes": [
+                "container-app-1",
+                "container-app-2"
+              ],
+              "secrets": [
+                {
+                  "name": "masterkey"
+                }
+              ],
+              "serviceComponentBind": [
+                {
+                  "name": "statestore",
+                  "metadata": {
+                    "name": "daprcomponentBind",
+                    "value": "redis-bind"
+                  },
+                  "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+                }
+              ],
+              "version": "v1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsDaprComponents_List",
+  "title": "List Dapr Components"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsDaprComponents_ListSecrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsDaprComponents_ListSecrets.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "connectedEnvironmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "secret1",
+            "value": "value1"
+          },
+          {
+            "name": "secret2",
+            "value": "value2"
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectedEnvironmentsDaprComponents_ListSecrets",
+  "title": "List Container Apps Secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsStorages_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsStorages_CreateOrUpdate.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "env",
+    "resourceGroupName": "examplerg",
+    "storageEnvelope": {
+      "properties": {
+        "azureFile": {
+          "accessMode": "ReadOnly",
+          "accountKey": "key",
+          "accountName": "account1",
+          "shareName": "share1"
+        }
+      }
+    },
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/connectedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/env/storages/jlaw-demo1",
+        "properties": {
+          "azureFile": {
+            "accessMode": "ReadOnly",
+            "accountName": "account1",
+            "shareName": "share1"
+          },
+          "deploymentErrors": null,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/connectedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/env/storages/jlaw-demo1",
+        "properties": {
+          "azureFile": {
+            "accessMode": "ReadOnly",
+            "accountName": "account1",
+            "shareName": "share1"
+          },
+          "provisioningState": "InProgress"
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsStorages_CreateOrUpdate",
+  "title": "Create or update environments storage"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsStorages_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsStorages_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "env",
+    "resourceGroupName": "examplerg",
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/connectedOperationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectedEnvironmentsStorages_Delete",
+  "title": "List environments storages by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsStorages_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsStorages_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "env",
+    "resourceGroupName": "examplerg",
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/connectedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/env/storages/jlaw-demo1",
+        "properties": {
+          "azureFile": {
+            "accessMode": "ReadOnly",
+            "accountName": "account1",
+            "shareName": "share1"
+          },
+          "deploymentErrors": null,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsStorages_Get",
+  "title": "get a environments storage properties by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsStorages_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironmentsStorages_List.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "jlaw-demo1",
+            "type": "Microsoft.App/connectedEnvironments/storages",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/managedEnv/storages/jlaw-demo1",
+            "properties": {
+              "azureFile": {
+                "accessMode": "ReadOnly",
+                "accountName": "account1",
+                "shareName": "share1"
+              },
+              "deploymentErrors": null,
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsStorages_List",
+  "title": "List environments storages by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_CreateOrUpdate.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "testenv",
+    "environmentEnvelope": {
+      "location": "East US",
+      "properties": {
+        "customDomainConfiguration": {
+          "certificatePassword": "private key password",
+          "certificateValue": "Y2VydA==",
+          "dnsSuffix": "www.my-name.com"
+        },
+        "daprAIConnectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://northcentralus-0.in.applicationinsights.azure.com/",
+        "staticIp": "1.2.3.4"
+      }
+    },
+    "extendedLocation": {
+      "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+      "type": "CustomLocation"
+    },
+    "kind": "kubernetes",
+    "location": "East US",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testenv",
+        "type": "Microsoft.App/connectedEnvironments",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testenv",
+        "location": "East US",
+        "properties": {
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testenv.k4apps.io",
+          "deploymentErrors": null,
+          "provisioningState": "Succeeded",
+          "staticIp": "1.2.3.4"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testenv",
+        "type": "Microsoft.App/connectedEnvironments",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testenv",
+        "location": "East US",
+        "properties": {
+          "defaultDomain": "testenv.k4apps.io",
+          "deploymentErrors": null,
+          "provisioningState": "Waiting",
+          "staticIp": "1.2.3.4"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_CreateOrUpdate",
+  "title": "Create kube environments"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_Delete.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "examplekenv",
+    "extendedLocation": {
+      "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+      "type": "CustomLocation"
+    },
+    "kind": "kubernetes",
+    "location": "East US",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/operationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectedEnvironments_Delete",
+  "title": "Delete connected environment by connectedEnvironmentName"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_Get.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "examplekenv",
+    "extendedLocation": {
+      "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+      "type": "CustomLocation"
+    },
+    "kind": "kubernetes",
+    "location": "East US",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplekenv",
+        "type": "Microsoft.App/connectedEnvironments",
+        "extendedLocation": {
+          "name": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/examplekenv",
+        "location": "North Central US",
+        "properties": {
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "examplekenv.k4apps.io",
+          "deploymentErrors": null,
+          "provisioningState": "Succeeded",
+          "staticIp": "20.42.33.145"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_Get",
+  "title": "Get connected environment by connectedEnvironmentName"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_ListByResourceGroup.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sample1",
+            "type": "Microsoft.App/connectedEnvironments",
+            "extendedLocation": {
+              "name": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/sample1",
+            "location": "North Central US",
+            "properties": {
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "sample1.k4apps.io",
+              "deploymentErrors": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "20.42.33.145"
+            },
+            "tags": {}
+          },
+          {
+            "name": "sample2",
+            "type": "Microsoft.App/connectedEnvironments",
+            "extendedLocation": {
+              "name": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/sample2",
+            "location": "North Central US",
+            "properties": {
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name2.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name2.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "sample2.k4apps.io",
+              "deploymentErrors": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "52.142.21.61"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_ListByResourceGroup",
+  "title": "List environments by resource group"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_ListBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sample1",
+            "type": "Microsoft.App/connectedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/sample1",
+            "location": "North Central US",
+            "properties": {
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "sample1.k4apps.io",
+              "deploymentErrors": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "20.42.33.145"
+            },
+            "tags": {}
+          },
+          {
+            "name": "sample2",
+            "type": "Microsoft.App/connectedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/DemoRG/providers/Microsoft.App/connectedEnvironments/sample2",
+            "location": "North Central US",
+            "properties": {
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name2.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name2.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "sample2.k4apps.io",
+              "deploymentErrors": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "52.142.21.61"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_ListBySubscription",
+  "title": "List connected environments by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ConnectedEnvironments_Patch.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "testenv",
+    "environmentEnvelope": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testenv",
+        "type": "Microsoft.App/connectedEnvironments",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testenv",
+        "location": "East US",
+        "properties": {
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testenv.k4apps.io",
+          "deploymentErrors": null,
+          "provisioningState": "Succeeded",
+          "staticIp": "20.42.33.145"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_Update",
+  "title": "Patch Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsBuilds_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsBuilds_Delete.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "ContainerAppsBuilds_Delete",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildName": "testBuild",
+    "containerAppName": "testCapp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsBuilds_Delete_0",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsBuilds_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsBuilds_Get.json
@@ -1,0 +1,83 @@
+{
+  "operationId": "ContainerAppsBuilds_Get",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildName": "testBuild",
+    "containerAppName": "testCapp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsBuilds_Get_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuild",
+        "type": "Microsoft.App/containerApps/builds",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/containerApps/testCapp/builds/testBuild",
+        "properties": {
+          "buildStatus": "InProgress",
+          "configuration": {
+            "baseOs": "DebianBullseye",
+            "environmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "platform": "dotnetcore",
+            "platformVersion": "7.0",
+            "preBuildSteps": [
+              {
+                "description": "First pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo",
+                    "bar"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'world'"
+                ]
+              },
+              {
+                "description": "Second pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'again'"
+                ]
+              }
+            ]
+          },
+          "destinationContainerRegistry": {
+            "image": "test.azurecr.io/repo:tag",
+            "server": "test.azurecr.io"
+          },
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsBuilds_ListByContainerApp.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsBuilds_ListByContainerApp.json
@@ -1,0 +1,155 @@
+{
+  "operationId": "ContainerAppsBuildsByContainerApp_List",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testCapp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsBuilds_ListByContainerApp_0",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testBuild1",
+            "type": "Microsoft.App/containerApps/builds",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/containerApps/testCapp/builds/testBuild1",
+            "properties": {
+              "buildStatus": "InProgress",
+              "configuration": {
+                "baseOs": "DebianBullseye",
+                "environmentVariables": [
+                  {
+                    "name": "foo1",
+                    "value": "bar1"
+                  },
+                  {
+                    "name": "foo2",
+                    "value": "bar2"
+                  }
+                ],
+                "platform": "dotnetcore",
+                "platformVersion": "7.0",
+                "preBuildSteps": [
+                  {
+                    "description": "First pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo",
+                        "bar"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'world'"
+                    ]
+                  },
+                  {
+                    "description": "Second pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'again'"
+                    ]
+                  }
+                ]
+              },
+              "destinationContainerRegistry": {
+                "image": "test.azurecr.io/repo:tag",
+                "server": "test.azurecr.io"
+              },
+              "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "testBuild2",
+            "type": "Microsoft.App/containerApps/builds",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/containerApps/testCapp/builds/testBuild2",
+            "properties": {
+              "buildStatus": "InProgress",
+              "configuration": {
+                "baseOs": "DebianBullseye",
+                "environmentVariables": [
+                  {
+                    "name": "foo1",
+                    "value": "bar1"
+                  },
+                  {
+                    "name": "foo2",
+                    "value": "bar2"
+                  }
+                ],
+                "platform": "dotnetcore",
+                "platformVersion": "7.0",
+                "preBuildSteps": [
+                  {
+                    "description": "First pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo",
+                        "bar"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'world'"
+                    ]
+                  },
+                  {
+                    "description": "Second pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'again'"
+                    ]
+                  }
+                ]
+              },
+              "destinationContainerRegistry": {
+                "image": "test.azurecr.io/repo:tag",
+                "server": "test.azurecr.io"
+              },
+              "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsDiagnostics_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsDiagnostics_Get.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "containerAppName": "mikono-capp-stage1",
+    "detectorName": "cappcontainerappnetworkIO",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/containerApps/mikono-capp-stage1/detectors/cappcontainerappnetworkIO",
+        "name": "cappcontainerappnetworkIO",
+        "type": "Microsoft.App/containerapps/detectors",
+        "properties": {
+          "metadata": {
+            "id": "cappcontainerappnetworkIO",
+            "name": "Container App Network Inbound and Outbound",
+            "description": "This detector shows the Container App Network Inbound and Outbound.",
+            "author": "",
+            "category": "Availability and Performance",
+            "supportTopicList": [],
+            "type": "Detector",
+            "score": 0
+          },
+          "dataset": [
+            {
+              "table": {
+                "tableName": "",
+                "columns": [
+                  {
+                    "columnName": "TimeStamp",
+                    "dataType": "DateTime"
+                  },
+                  {
+                    "columnName": "Metric",
+                    "dataType": "String"
+                  },
+                  {
+                    "columnName": "Average",
+                    "dataType": "Double"
+                  }
+                ],
+                "rows": [
+                  [
+                    "2022-03-15T21:35:00",
+                    "RxBytes",
+                    0
+                  ]
+                ]
+              },
+              "renderingProperties": {
+                "type": 8,
+                "title": "Container Apps Network Inbound ",
+                "description": "",
+                "isVisible": true
+              }
+            }
+          ],
+          "status": {
+            "statusId": 3
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ContainerAppsDiagnostics_GetDetector",
+  "title": "Get Container App's diagnostics info"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsDiagnostics_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsDiagnostics_List.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "containerAppName": "mikono-capp-stage1",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/containerApps/mikono-capp-stage1/detectors/cappContainerAppAvailabilityMetrics",
+            "name": "cappContainerAppAvailabilityMetrics",
+            "type": "Microsoft.App/containerapps/detectors",
+            "properties": {
+              "metadata": {
+                "id": "cappContainerAppAvailabilityMetrics",
+                "name": "Availability Metrics for Container Apps",
+                "author": "",
+                "category": "Availability and Performance",
+                "supportTopicList": [],
+                "type": "Analysis",
+                "score": 0
+              },
+              "dataset": [],
+              "status": {
+                "statusId": 4
+              }
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  },
+  "operationId": "ContainerAppsDiagnostics_ListDetectors",
+  "title": "Get the list of available diagnostics for a given Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsFunctions_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsFunctions_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myContainerApp",
+    "functionName": "HttpExample",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "12345678-1234-1234-1234-123456789abc"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myContainerApp/HttpExample",
+        "type": "Microsoft.App/containerApps/functions",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/functions/HttpExample",
+        "properties": {
+          "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/HttpExample",
+          "isDisabled": false,
+          "triggerType": "httpTrigger",
+          "language": "dotnet-isolated"
+        }
+      }
+    }
+  },
+  "operationId": "ContainerAppsFunctions_Get",
+  "title": "Get Container App's function"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsFunctions_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsFunctions_List.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myContainerApp",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "12345678-1234-1234-1234-123456789abc"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "myContainerApp/HttpExample",
+            "type": "Microsoft.App/containerApps/functions",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/functions/HttpExample",
+            "properties": {
+              "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/HttpExample",
+              "isDisabled": false,
+              "triggerType": "httpTrigger",
+              "language": "dotnet-isolated"
+            }
+          },
+          {
+            "name": "myContainerApp/TimerFunction",
+            "type": "Microsoft.App/containerApps/functions",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/functions/TimerFunction",
+            "properties": {
+              "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/TimerFunction",
+              "isDisabled": false,
+              "triggerType": "timerTrigger",
+              "language": "dotnet-isolated"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ContainerAppsFunctions_List",
+  "title": "List Container App's functions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsPatches_Apply.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsPatches_Apply.json
@@ -1,0 +1,53 @@
+{
+  "operationId": "ContainerAppsPatches_Apply",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "test-app",
+    "patchName": "testPatch-25fe4b",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsPatches_Apply_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPatch-25fe4b",
+        "type": "Microsoft.App/containerApps/patches",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app/patches/testPatch-25fe4b",
+        "properties": {
+          "createdAt": "2022-10-10T12:06:20.3421+00:00",
+          "lastModifiedAt": "2022-10-10T12:06:20.3421+00:00",
+          "patchApplyStatus": "Succeeded",
+          "patchDetails": [
+            {
+              "detectionStatus": "Succeeded",
+              "lastDetectionTime": "2022-10-10T12:06:19.5241+00:00",
+              "newImageName": "testregistry.azurecr.io/test-image:latest-patched-202210101206",
+              "newLayer": {
+                "name": "mcr.microsoft.com/dotnet/aspnet:7.0.7-cbl-mariner2.0",
+                "frameworkAndVersion": "dotnet:7.0.7",
+                "osAndVersion": "cbl-mariner2.0"
+              },
+              "oldLayer": {
+                "name": "mcr.microsoft.com/dotnet/aspnet:7.0.5-cbl-mariner2.0",
+                "frameworkAndVersion": "dotnet:7.0.5",
+                "osAndVersion": "cbl-mariner2.0"
+              },
+              "patchType": "FrameworkSecurity",
+              "targetContainerName": "test-container",
+              "targetImage": "testregistry.azurecr.io/test-image:latest"
+            }
+          ],
+          "targetContainerAppId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app",
+          "targetEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/test-env",
+          "targetRevisionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/apps/test-app/revisions/test-app--jm3vvry"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsPatches_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsPatches_Delete.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "ContainerAppsPatches_Delete",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "test-app",
+    "patchName": "testPatch-25fe4b",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsPatches_Delete_0",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsPatches_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsPatches_Get.json
@@ -1,0 +1,48 @@
+{
+  "operationId": "ContainerAppsPatches_Get",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "test-app",
+    "patchName": "testPatch-25fe4b",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsPatches_Get_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPatch-25fe4b",
+        "type": "Microsoft.App/containerApps/patches",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app/patches/testPatch-25fe4b",
+        "properties": {
+          "createdAt": "2022-10-10T12:06:20.3421+00:00",
+          "lastModifiedAt": "2022-10-10T12:06:20.3421+00:00",
+          "patchApplyStatus": "NotStarted",
+          "patchDetails": [
+            {
+              "detectionStatus": "Succeeded",
+              "lastDetectionTime": "2022-10-10T12:06:19.5241+00:00",
+              "newImageName": "testregistry.azurecr.io/test-image:latest-patched-202210101206",
+              "newLayer": {
+                "name": "mcr.microsoft.com/dotnet/aspnet:7.0.7-cbl-mariner2.0",
+                "frameworkAndVersion": "dotnet:7.0.7",
+                "osAndVersion": "cbl-mariner2.0"
+              },
+              "oldLayer": {
+                "name": "mcr.microsoft.com/dotnet/aspnet:7.0.5-cbl-mariner2.0",
+                "frameworkAndVersion": "dotnet:7.0.5",
+                "osAndVersion": "cbl-mariner2.0"
+              },
+              "patchType": "FrameworkSecurity",
+              "targetContainerName": "test-container",
+              "targetImage": "testregistry.azurecr.io/test-image:latest"
+            }
+          ],
+          "targetContainerAppId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app",
+          "targetEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/test-env",
+          "targetRevisionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/apps/test-app/revisions/test-app--jm3vvry"
+        }
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsPatches_ListByContainerApp.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsPatches_ListByContainerApp.json
@@ -1,0 +1,103 @@
+{
+  "operationId": "ContainerAppsPatches_ListByContainerApp",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "test-app",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsPatches_ListByContainerApp_0",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testPatch-25fe4b",
+            "type": "Microsoft.App/containerApps/patches",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app/patches/testPatch-25fe4b",
+            "properties": {
+              "createdAt": "2022-10-10T12:06:20.3421+00:00",
+              "lastModifiedAt": "2022-10-10T12:06:20.3421+00:00",
+              "patchApplyStatus": "NotStarted",
+              "patchDetails": [
+                {
+                  "detectionStatus": "Succeeded",
+                  "lastDetectionTime": "2022-10-10T12:06:19.5241+00:00",
+                  "newImageName": "testregistry.azurecr.io/test-image:release-1-patched-202210101206185241",
+                  "newLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.9-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.9",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "oldLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.7-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.7",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "patchType": "FrameworkSecurity",
+                  "targetContainerName": "test-container",
+                  "targetImage": "testregistry.azurecr.io/test-image:release-1-patched-202209101206203421"
+                }
+              ],
+              "targetContainerAppId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app",
+              "targetEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/test-env",
+              "targetRevisionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/apps/test-app/revisions/test-app--jm3vvry"
+            }
+          },
+          {
+            "name": "testPatch-27c3d5",
+            "type": "Microsoft.App/containerApps/patches",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app/patches/testPatch-27c3d5",
+            "properties": {
+              "createdAt": "2022-09-10T12:06:20.3421+00:00",
+              "lastModifiedAt": "2022-09-20T12:06:20.3421+00:00",
+              "patchApplyStatus": "Succeeded",
+              "patchDetails": [
+                {
+                  "detectionStatus": "Succeeded",
+                  "lastDetectionTime": "2022-09-21T12:06:19.5241+00:00",
+                  "newImageName": "testregistry.azurecr.io/test-image:release-1-patched-202209101206203421",
+                  "newLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.7-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.7",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "oldLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.5-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.5",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "patchType": "FrameworkSecurity",
+                  "targetContainerName": "test-container",
+                  "targetImage": "testregistry.azurecr.io/test-image:release-1"
+                },
+                {
+                  "detectionStatus": "Succeeded",
+                  "lastDetectionTime": "2022-09-21T12:06:19.5241+00:00",
+                  "newImageName": "testregistry.azurecr.io/test-image:release-2-patched-202209101206203421",
+                  "newLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.7-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.7",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "oldLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.0-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.0",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "patchType": "FrameworkSecurity",
+                  "targetContainerName": "test-container-2",
+                  "targetImage": "testregistry.azurecr.io/test-image:release-2"
+                }
+              ],
+              "targetContainerAppId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app",
+              "targetEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/test-env",
+              "targetRevisionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app2/revisions/test-app--z79h4oc"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsPatches_Skip_Configure.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsPatches_Skip_Configure.json
@@ -1,0 +1,21 @@
+{
+  "operationId": "ContainerAppsPatches_SkipConfigure",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "test-app",
+    "patchName": "testPatch-25fe4b",
+    "patchSkipConfig": {
+      "skip": true
+    },
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsPatches_Skip_Configure_0",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsRevisionFunctions_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsRevisionFunctions_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myContainerApp",
+    "functionName": "HttpExample",
+    "resourceGroupName": "myResourceGroup",
+    "revisionName": "myContainerApp-abc123",
+    "subscriptionId": "12345678-1234-1234-1234-123456789abc"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myContainerApp/myContainerApp-abc123/HttpExample",
+        "type": "Microsoft.App/containerApps/revisions/functions",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/revisions/myContainerApp-abc123/functions/HttpExample",
+        "properties": {
+          "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/HttpExample",
+          "isDisabled": false,
+          "triggerType": "httpTrigger",
+          "language": "dotnet-isolated"
+        }
+      }
+    }
+  },
+  "operationId": "ContainerAppsRevisionFunctions_Get",
+  "title": "Get Container App Revision's function"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsRevisionFunctions_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerAppsRevisionFunctions_List.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myContainerApp",
+    "resourceGroupName": "myResourceGroup",
+    "revisionName": "myContainerApp-abc123",
+    "subscriptionId": "12345678-1234-1234-1234-123456789abc"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "myContainerApp/myContainerApp-abc123/HttpExample",
+            "type": "Microsoft.App/containerApps/revisions/functions",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/revisions/myContainerApp-abc123/functions/HttpExample",
+            "properties": {
+              "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/HttpExample",
+              "isDisabled": false,
+              "triggerType": "httpTrigger",
+              "language": "dotnet-isolated"
+            }
+          },
+          {
+            "name": "myContainerApp/myContainerApp-abc123/TimerFunction",
+            "type": "Microsoft.App/containerApps/revisions/functions",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/revisions/myContainerApp-abc123/functions/TimerFunction",
+            "properties": {
+              "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/TimerFunction",
+              "isDisabled": false,
+              "triggerType": "timerTrigger",
+              "language": "dotnet-isolated"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ContainerAppsRevisionFunctions_List",
+  "title": "List Container App Revision's functions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_CheckNameAvailability.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_CheckNameAvailability.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "checkNameAvailabilityRequest": {
+      "name": "testcappname",
+      "type": "Microsoft.App/containerApps"
+    },
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "Namespaces_CheckNameAvailability",
+  "title": "ContainerApps_CheckNameAvailability"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_CreateOrUpdate.json
@@ -1,0 +1,692 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "dapr": {
+            "appHealth": {
+              "path": "/health",
+              "enabled": true,
+              "probeIntervalSeconds": 3,
+              "probeTimeoutMilliseconds": 1000,
+              "threshold": 3
+            },
+            "appPort": 3000,
+            "appProtocol": "http",
+            "enableApiLogging": true,
+            "enabled": true,
+            "httpMaxRequestSize": 10,
+            "httpReadBufferSize": 30,
+            "logLevel": "debug",
+            "maxConcurrency": 10
+          },
+          "identitySettings": [
+            {
+              "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+              "lifecycle": "All"
+            },
+            {
+              "identity": "system",
+              "lifecycle": "Init"
+            }
+          ],
+          "ingress": {
+            "additionalPortMappings": [
+              {
+                "external": true,
+                "targetPort": 1234
+              },
+              {
+                "exposedPort": 3456,
+                "external": false,
+                "targetPort": 2345
+              }
+            ],
+            "clientCertificateMode": "accept",
+            "corsPolicy": {
+              "allowCredentials": true,
+              "allowedHeaders": [
+                "HEADER1",
+                "HEADER2"
+              ],
+              "allowedMethods": [
+                "GET",
+                "POST"
+              ],
+              "allowedOrigins": [
+                "https://a.test.com",
+                "https://b.test.com"
+              ],
+              "exposeHeaders": [
+                "HEADER3",
+                "HEADER4"
+              ],
+              "maxAge": 1234
+            },
+            "customDomains": [
+              {
+                "name": "www.my-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+              },
+              {
+                "name": "www.my-other-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+              }
+            ],
+            "external": true,
+            "ipSecurityRestrictions": [
+              {
+                "name": "Allow work IP A subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/32"
+              },
+              {
+                "name": "Allow work IP B subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/8"
+              }
+            ],
+            "stickySessions": {
+              "affinity": "sticky"
+            },
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "label": "production",
+                "revisionName": "testcontainerApp0-ab1234",
+                "weight": 100
+              }
+            ]
+          },
+          "maxInactiveRevisions": 10,
+          "revisionTransitionThreshold": 100,
+          "runtime": {
+            "dotnet": {
+              "autoConfigureDataProtection": true
+            },
+            "java": {
+              "enableMetrics": true,
+              "javaAgent": {
+                "enabled": true,
+                "logging": {
+                  "loggerSettings": [
+                    {
+                      "level": "debug",
+                      "logger": "org.springframework.boot"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "service": {
+            "type": "redis"
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerApp0",
+              "image": "repo/testcontainerApp0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "mountPath": "/mnt/path1",
+                  "subPath": "subPath1",
+                  "volumeName": "azurefile"
+                },
+                {
+                  "mountPath": "/mnt/path2",
+                  "subPath": "subPath2",
+                  "volumeName": "nfsazurefile"
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerApp0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerApp0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "gpu": 1,
+                "memory": "100Mi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "httpscalingrule",
+                "custom": {
+                  "type": "http",
+                  "metadata": {
+                    "concurrentRequests": "50"
+                  }
+                }
+              },
+              {
+                "name": "servicebus",
+                "custom": {
+                  "type": "azure-servicebus",
+                  "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                  "metadata": {
+                    "messageCount": "5",
+                    "namespace": "mynamespace",
+                    "queueName": "myqueue"
+                  }
+                }
+              },
+              {
+                "name": "azure-queue",
+                "azureQueue": {
+                  "accountName": "account1",
+                  "identity": "system",
+                  "queueLength": 1,
+                  "queueName": "queue1"
+                }
+              }
+            ]
+          },
+          "serviceBinds": [
+            {
+              "name": "redisService",
+              "clientType": "dotnet",
+              "customizedKeys": {
+                "DesiredKey": "defaultKey"
+              },
+              "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/redisService"
+            }
+          ],
+          "volumes": [
+            {
+              "name": "azurefile",
+              "storageName": "storage",
+              "storageType": "AzureFile"
+            },
+            {
+              "name": "nfsazurefile",
+              "storageName": "nfsStorage",
+              "storageType": "NfsAzureFile"
+            }
+          ]
+        },
+        "workloadProfileName": "My-GP-01"
+      }
+    },
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30,
+              "maxConcurrency": 10
+            },
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my-other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "stickySessions": {
+                "affinity": "sticky"
+              },
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "gpu": 1,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                },
+                {
+                  "name": "servicebus",
+                  "custom": {
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "messageCount": "5",
+                      "namespace": "mynamespace",
+                      "queueName": "myqueue"
+                    }
+                  }
+                },
+                {
+                  "name": "azure-queue",
+                  "azureQueue": {
+                    "accountName": "account1",
+                    "identity": "system",
+                    "queueLength": 1,
+                    "queueName": "queue1"
+                  }
+                }
+              ]
+            },
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30,
+              "maxConcurrency": 10
+            },
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "ingress": {
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "gpu": 1,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                },
+                {
+                  "name": "servicebus",
+                  "custom": {
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "messageCount": "5",
+                      "namespace": "mynamespace",
+                      "queueName": "myqueue"
+                    }
+                  }
+                },
+                {
+                  "name": "azure-queue",
+                  "azureQueue": {
+                    "accountName": "account1",
+                    "identity": "system",
+                    "queueLength": 1,
+                    "queueName": "queue1"
+                  }
+                }
+              ]
+            },
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_CreateOrUpdate_ConnectedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_CreateOrUpdate_ConnectedEnvironment.json
@@ -1,0 +1,469 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "extendedLocation": {
+        "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+        "type": "CustomLocation"
+      },
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "dapr": {
+            "appPort": 3000,
+            "appProtocol": "http",
+            "enableApiLogging": true,
+            "enabled": true,
+            "httpMaxRequestSize": 10,
+            "httpReadBufferSize": 30,
+            "logLevel": "debug"
+          },
+          "ingress": {
+            "additionalPortMappings": [
+              {
+                "external": true,
+                "targetPort": 1234
+              },
+              {
+                "exposedPort": 3456,
+                "external": false,
+                "targetPort": 2345
+              }
+            ],
+            "clientCertificateMode": "accept",
+            "corsPolicy": {
+              "allowCredentials": true,
+              "allowedHeaders": [
+                "HEADER1",
+                "HEADER2"
+              ],
+              "allowedMethods": [
+                "GET",
+                "POST"
+              ],
+              "allowedOrigins": [
+                "https://a.test.com",
+                "https://b.test.com"
+              ],
+              "exposeHeaders": [
+                "HEADER3",
+                "HEADER4"
+              ],
+              "maxAge": 1234
+            },
+            "customDomains": [
+              {
+                "name": "www.my-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+              },
+              {
+                "name": "www.my-other-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+              }
+            ],
+            "external": true,
+            "ipSecurityRestrictions": [
+              {
+                "name": "Allow work IP A subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/32"
+              },
+              {
+                "name": "Allow work IP B subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/8"
+              }
+            ],
+            "stickySessions": {
+              "affinity": "sticky"
+            },
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "label": "production",
+                "revisionName": "testcontainerApp0-ab1234",
+                "weight": 100
+              }
+            ]
+          },
+          "maxInactiveRevisions": 10,
+          "revisionTransitionThreshold": 100,
+          "runtime": {
+            "dotnet": {
+              "autoConfigureDataProtection": true
+            },
+            "java": {
+              "enableMetrics": true,
+              "javaAgent": {
+                "enabled": true,
+                "logging": {
+                  "loggerSettings": [
+                    {
+                      "level": "debug",
+                      "logger": "org.springframework.boot"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerApp0",
+              "image": "repo/testcontainerApp0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerApp0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerApp0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "httpscalingrule",
+                "custom": {
+                  "type": "http",
+                  "metadata": {
+                    "concurrentRequests": "50"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30
+            },
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my-other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "stickySessions": {
+                "affinity": "sticky"
+              },
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30
+            },
+            "ingress": {
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update App On A Connected Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testWorkerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/containerApps/testWorkerApp0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ContainerApps_Delete",
+  "title": "Delete Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Get.json
@@ -1,0 +1,226 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enableApiLogging": true,
+              "enabled": true,
+              "httpMaxRequestSize": 10,
+              "httpReadBufferSize": 30,
+              "logLevel": "debug",
+              "maxConcurrency": 10
+            },
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my--other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "stickySessions": {
+                "affinity": "sticky"
+              },
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "maxInactiveRevisions": 10,
+            "revisionTransitionThreshold": 100,
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "service": {
+              "type": "redis"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                },
+                {
+                  "name": "servicebus",
+                  "custom": {
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "messageCount": "5",
+                      "namespace": "mynamespace",
+                      "queueName": "myqueue"
+                    }
+                  }
+                }
+              ]
+            },
+            "serviceBinds": [
+              {
+                "name": "service",
+                "clientType": "dotnet",
+                "customizedKeys": {
+                  "DesiredKey": "defaultKey"
+                },
+                "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/service"
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "404": {}
+  },
+  "operationId": "ContainerApps_Get",
+  "title": "Get Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Get1.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Get1.json
@@ -1,0 +1,226 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enableApiLogging": true,
+              "enabled": true,
+              "httpMaxRequestSize": 10,
+              "httpReadBufferSize": 30,
+              "logLevel": "debug",
+              "maxConcurrency": 10
+            },
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my--other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "stickySessions": {
+                "affinity": "sticky"
+              },
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "maxInactiveRevisions": 10,
+            "revisionTransitionThreshold": 100,
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "service": {
+              "type": "redis"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                },
+                {
+                  "name": "servicebus",
+                  "custom": {
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "messageCount": "5",
+                      "namespace": "mynamespace",
+                      "queueName": "myqueue"
+                    }
+                  }
+                }
+              ]
+            },
+            "serviceBinds": [
+              {
+                "name": "service",
+                "clientType": "dotnet",
+                "customizedKeys": {
+                  "DesiredKey": "defaultKey"
+                },
+                "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/service"
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "404": {}
+  },
+  "operationId": "ContainerAppsDiagnostics_GetRoot",
+  "title": "Get Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_GetAuthToken.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_GetAuthToken.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps/accesstoken",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "expires": "2022-07-14T19:22:50.3080223Z",
+          "token": "testToken"
+        }
+      },
+      "headers": {}
+    },
+    "404": {}
+  },
+  "operationId": "ContainerApps_GetAuthToken",
+  "title": "Get Container App Auth Token"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Kind_FunctionApp_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Kind_FunctionApp_CreateOrUpdate.json
@@ -1,0 +1,213 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "kind": "functionapp",
+      "location": "East Us",
+      "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppFunctionKind",
+      "properties": {
+        "configuration": {
+          "activeRevisionsMode": "Single",
+          "ingress": {
+            "allowInsecure": false,
+            "external": true,
+            "targetPort": 80
+          }
+        },
+        "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+        "template": {
+          "containers": [
+            {
+              "name": "function-app-container",
+              "env": [
+                {
+                  "name": "AzureWebJobsStorage",
+                  "value": "DefaultEndpointsProtocol=https;AccountName=mystorageaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
+                },
+                {
+                  "name": "FUNCTIONS_WORKER_RUNTIME",
+                  "value": "dotnet"
+                },
+                {
+                  "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+                  "value": "false"
+                }
+              ],
+              "image": "mcr.microsoft.com/azure-functions/dotnet:4",
+              "resources": {
+                "cpu": 0.5,
+                "memory": "1.0Gi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 300,
+            "maxReplicas": 10,
+            "minReplicas": 0,
+            "pollingInterval": 30
+          }
+        }
+      }
+    },
+    "containerAppName": "testcontainerAppFunctionKind",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppFunctionKind",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerapps/testcontainerAppFunctionKind",
+        "identity": {
+          "type": "None"
+        },
+        "kind": "functionapp",
+        "location": "East US",
+        "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppFunctionKind",
+        "properties": {
+          "configuration": {
+            "activeRevisionsMode": "Single",
+            "ingress": {
+              "exposedPort": 0,
+              "external": true,
+              "fqdn": "testcontainerAppFunctionKind.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+              "targetPort": 80,
+              "traffic": [
+                {
+                  "latestRevision": true,
+                  "weight": 100
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "eventStreamEndpoint": "https://azurecontainerapps-test.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/containerApps/testcontainerAppFunctionKind/eventstream",
+          "latestReadyRevisionName": "testcontainerAppFunctionKind--abc123",
+          "latestRevisionFqdn": "testcontainerAppFunctionKind--abc123.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+          "latestRevisionName": "testcontainerAppFunctionKind--abc123",
+          "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "function-app-container",
+                "env": [
+                  {
+                    "name": "AzureWebJobsStorage",
+                    "value": "DefaultEndpointsProtocol=https;AccountName=mystorageaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
+                  },
+                  {
+                    "name": "FUNCTIONS_WORKER_RUNTIME",
+                    "value": "dotnet"
+                  },
+                  {
+                    "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+                    "value": "false"
+                  }
+                ],
+                "image": "mcr.microsoft.com/azure-functions/dotnet:4",
+                "resources": {
+                  "cpu": 0.5,
+                  "ephemeralStorage": "2Gi",
+                  "memory": "1Gi"
+                }
+              }
+            ],
+            "initContainers": null,
+            "revisionSuffix": "",
+            "scale": {
+              "cooldownPeriod": 300,
+              "maxReplicas": 10,
+              "minReplicas": 0,
+              "pollingInterval": 30
+            },
+            "terminationGracePeriodSeconds": null
+          },
+          "workloadProfileName": null
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppFunctionKind",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerapps/testcontainerAppFunctionKind",
+        "identity": {
+          "type": "None"
+        },
+        "kind": "functionapp",
+        "location": "East US",
+        "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppFunctionKind",
+        "properties": {
+          "configuration": {
+            "activeRevisionsMode": "Single",
+            "ingress": {
+              "exposedPort": 0,
+              "external": true,
+              "fqdn": "testcontainerAppFunctionKind.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+              "targetPort": 80,
+              "traffic": [
+                {
+                  "latestRevision": true,
+                  "weight": 100
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "eventStreamEndpoint": "https://azurecontainerapps-test.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/containerApps/testcontainerAppFunctionKind/eventstream",
+          "latestReadyRevisionName": "testcontainerAppFunctionKind--abc123",
+          "latestRevisionFqdn": "testcontainerAppFunctionKind--abc123.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+          "latestRevisionName": "testcontainerAppFunctionKind--abc123",
+          "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "function-app-container",
+                "env": [
+                  {
+                    "name": "AzureWebJobsStorage",
+                    "value": "DefaultEndpointsProtocol=https;AccountName=mystorageaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
+                  },
+                  {
+                    "name": "FUNCTIONS_WORKER_RUNTIME",
+                    "value": "dotnet"
+                  },
+                  {
+                    "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+                    "value": "false"
+                  }
+                ],
+                "image": "mcr.microsoft.com/azure-functions/dotnet:4",
+                "resources": {
+                  "cpu": 0.5,
+                  "ephemeralStorage": "2Gi",
+                  "memory": "1Gi"
+                }
+              }
+            ],
+            "revisionSuffix": "",
+            "scale": {
+              "cooldownPeriod": 300,
+              "maxReplicas": 10,
+              "minReplicas": 0,
+              "pollingInterval": 30
+            },
+            "terminationGracePeriodSeconds": null
+          },
+          "workloadProfileName": null
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update FunctionApp Kind"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Kind_WorkflowApp_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Kind_WorkflowApp_CreateOrUpdate.json
@@ -1,0 +1,171 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "kind": "workflowapp",
+      "location": "East Us",
+      "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppKind",
+      "properties": {
+        "configuration": {
+          "activeRevisionsMode": "Single",
+          "ingress": {
+            "allowInsecure": false,
+            "external": true,
+            "targetPort": 443
+          }
+        },
+        "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+        "template": {
+          "containers": [
+            {
+              "name": "logicapps-container",
+              "image": "default/logicapps-base:latest",
+              "resources": {
+                "cpu": 1,
+                "memory": "2.0Gi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 30,
+            "minReplicas": 1,
+            "pollingInterval": 35
+          }
+        }
+      }
+    },
+    "containerAppName": "testcontainerAppKind",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppKind",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerapps/testcontainerAppKind",
+        "identity": {
+          "type": "None"
+        },
+        "kind": "workflowapp",
+        "location": "East US",
+        "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppKind",
+        "properties": {
+          "configuration": {
+            "activeRevisionsMode": "Single",
+            "ingress": {
+              "exposedPort": 0,
+              "external": true,
+              "fqdn": "testcontainerAppKind.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+              "targetPort": 80,
+              "traffic": [
+                {
+                  "latestRevision": true,
+                  "weight": 100
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "eventStreamEndpoint": "https://azurecontainerapps-test.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/containerApps/testcontainerAppKind/eventstream",
+          "latestReadyRevisionName": "testcontainerAppKind--2rltv14",
+          "latestRevisionFqdn": "testcontainerAppKind--2rltv14.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+          "latestRevisionName": "testcontainerAppKind--2rltv14",
+          "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "logicapps-container",
+                "image": "default/logicapps-base:latest",
+                "resources": {
+                  "cpu": 1,
+                  "ephemeralStorage": "4Gi",
+                  "memory": "2Gi"
+                }
+              }
+            ],
+            "initContainers": null,
+            "revisionSuffix": "",
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 30,
+              "minReplicas": 1,
+              "pollingInterval": 35
+            },
+            "terminationGracePeriodSeconds": null
+          },
+          "workloadProfileName": null
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppKind",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerapps/testcontainerAppKind",
+        "identity": {
+          "type": "None"
+        },
+        "kind": "workflowapp",
+        "location": "East US",
+        "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppKind",
+        "properties": {
+          "configuration": {
+            "activeRevisionsMode": "Single",
+            "ingress": {
+              "exposedPort": 0,
+              "external": true,
+              "fqdn": "testcontainerAppKind.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+              "targetPort": 80,
+              "traffic": [
+                {
+                  "latestRevision": true,
+                  "weight": 100
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "eventStreamEndpoint": "https://azurecontainerapps-test.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/containerApps/testcontainerAppKind/eventstream",
+          "latestReadyRevisionName": "testcontainerAppKind--2rltv14",
+          "latestRevisionFqdn": "testcontainerAppKind--2rltv14.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+          "latestRevisionName": "testcontainerAppKind--2rltv14",
+          "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "logicapps-container",
+                "image": "default/logicapps-base:latest",
+                "resources": {
+                  "cpu": 1,
+                  "ephemeralStorage": "4Gi",
+                  "memory": "2Gi"
+                }
+              }
+            ],
+            "revisionSuffix": "",
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 30,
+              "minReplicas": 1,
+              "pollingInterval": 35
+            },
+            "terminationGracePeriodSeconds": null
+          },
+          "workloadProfileName": null
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update WorkflowApp Kind"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_ListByResourceGroup.json
@@ -1,0 +1,213 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerApp0",
+            "type": "Microsoft.App/containerApps",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "dapr": {
+                  "appHealth": {
+                    "path": "/health",
+                    "enabled": true,
+                    "probeIntervalSeconds": 3,
+                    "probeTimeoutMilliseconds": 1000,
+                    "threshold": 3
+                  },
+                  "appPort": 3000,
+                  "appProtocol": "http",
+                  "enableApiLogging": true,
+                  "enabled": true,
+                  "httpMaxRequestSize": 10,
+                  "httpReadBufferSize": 30,
+                  "logLevel": "debug",
+                  "maxConcurrency": 10
+                },
+                "ingress": {
+                  "customDomains": [
+                    {
+                      "name": "www.my-name.com",
+                      "bindingType": "SniEnabled",
+                      "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                    },
+                    {
+                      "name": "www.my--other-name.com",
+                      "bindingType": "SniEnabled",
+                      "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                    }
+                  ],
+                  "external": true,
+                  "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+                  "ipSecurityRestrictions": [
+                    {
+                      "name": "Allow work IP A subnet",
+                      "description": "Allowing all IP's within the subnet below to access containerapp",
+                      "action": "Allow",
+                      "ipAddressRange": "192.168.1.1/32"
+                    },
+                    {
+                      "name": "Allow work IP B subnet",
+                      "description": "Allowing all IP's within the subnet below to access containerapp",
+                      "action": "Allow",
+                      "ipAddressRange": "192.168.1.1/8"
+                    }
+                  ],
+                  "stickySessions": {
+                    "affinity": "sticky"
+                  },
+                  "targetPort": 3000,
+                  "targetPortHttpScheme": "http",
+                  "traffic": [
+                    {
+                      "revisionName": "testcontainerApp0-ab1234",
+                      "weight": 80
+                    },
+                    {
+                      "label": "staging",
+                      "revisionName": "testcontainerApp0-ab4321",
+                      "weight": 20
+                    }
+                  ],
+                  "transport": "auto"
+                },
+                "maxInactiveRevisions": 10,
+                "revisionTransitionThreshold": 100,
+                "runtime": {
+                  "dotnet": {
+                    "autoConfigureDataProtection": true
+                  },
+                  "java": {
+                    "enableMetrics": true,
+                    "javaAgent": {
+                      "enabled": true,
+                      "logging": {
+                        "loggerSettings": [
+                          {
+                            "level": "debug",
+                            "logger": "org.springframework.boot"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              "eventStreamEndpoint": "testEndpoint",
+              "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+              "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "runningStatus": "Running",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp0",
+                    "image": "repo/testcontainerApp0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerApp0",
+                    "image": "repo/testcontainerApp0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "scale": {
+                  "cooldownPeriod": 350,
+                  "maxReplicas": 5,
+                  "minReplicas": 1,
+                  "pollingInterval": 35,
+                  "rules": [
+                    {
+                      "name": "httpscalingrule",
+                      "http": {
+                        "metadata": {
+                          "concurrentRequests": "50"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "workloadProfileName": "My-GP-01"
+            }
+          },
+          {
+            "name": "testcontainerApp1",
+            "type": "Microsoft.App/containerApps",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp1",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "ingress": {
+                  "external": true,
+                  "fqdn": "testcontainerApp1.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+                  "targetPort": 3000,
+                  "targetPortHttpScheme": "http",
+                  "transport": "auto"
+                },
+                "maxInactiveRevisions": 10,
+                "revisionTransitionThreshold": 100
+              },
+              "deploymentErrors": "Code: ContainerAppImagePullProvisionError, Message: Error pulling the container image. Please check the image name or any registry credentials to access if required.",
+              "eventStreamEndpoint": "testEndpoint",
+              "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+              "latestRevisionFqdn": "testcontainerApp1-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Failed",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp1",
+                    "image": "repo/testcontainerApp1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testcontainerApp1",
+                    "image": "repo/testcontainerApp1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "scale": {
+                  "cooldownPeriod": 350,
+                  "maxReplicas": 5,
+                  "minReplicas": 1,
+                  "pollingInterval": 35
+                }
+              },
+              "workloadProfileName": "Consumption"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_ListByResourceGroup",
+  "title": "List Container Apps by resource group"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_ListBySubscription.json
@@ -1,0 +1,170 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerApp0",
+            "type": "Microsoft.App/containerApps",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "dapr": {
+                  "appHealth": {
+                    "path": "/health",
+                    "enabled": true,
+                    "probeIntervalSeconds": 3,
+                    "probeTimeoutMilliseconds": 1000,
+                    "threshold": 3
+                  },
+                  "appPort": 3000,
+                  "appProtocol": "http",
+                  "enableApiLogging": true,
+                  "enabled": true,
+                  "httpMaxRequestSize": 10,
+                  "httpReadBufferSize": 30,
+                  "logLevel": "debug"
+                },
+                "ingress": {
+                  "customDomains": [
+                    {
+                      "name": "www.my-name.com",
+                      "bindingType": "SniEnabled",
+                      "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                    },
+                    {
+                      "name": "www.my--other-name.com",
+                      "bindingType": "SniEnabled",
+                      "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                    }
+                  ],
+                  "external": true,
+                  "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+                  "ipSecurityRestrictions": [
+                    {
+                      "name": "Allow work IP A subnet",
+                      "description": "Allowing all IP's within the subnet below to access containerapp",
+                      "action": "Allow",
+                      "ipAddressRange": "192.168.1.1/32"
+                    },
+                    {
+                      "name": "Allow work IP B subnet",
+                      "description": "Allowing all IP's within the subnet below to access containerapp",
+                      "action": "Allow",
+                      "ipAddressRange": "192.168.1.1/8"
+                    }
+                  ],
+                  "stickySessions": {
+                    "affinity": "sticky"
+                  },
+                  "targetPort": 3000,
+                  "targetPortHttpScheme": "http",
+                  "traffic": [
+                    {
+                      "revisionName": "testcontainerApp0-ab1234",
+                      "weight": 80
+                    },
+                    {
+                      "label": "staging",
+                      "revisionName": "testcontainerApp0-ab4321",
+                      "weight": 20
+                    }
+                  ],
+                  "transport": "auto"
+                },
+                "maxInactiveRevisions": 10,
+                "revisionTransitionThreshold": 100,
+                "runtime": {
+                  "dotnet": {
+                    "autoConfigureDataProtection": true
+                  },
+                  "java": {
+                    "enableMetrics": true,
+                    "javaAgent": {
+                      "enabled": true,
+                      "logging": {
+                        "loggerSettings": [
+                          {
+                            "level": "debug",
+                            "logger": "org.springframework.boot"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                "service": {
+                  "type": "redis"
+                }
+              },
+              "eventStreamEndpoint": "testEndpoint",
+              "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+              "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "runningStatus": "Running",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp0",
+                    "image": "repo/testcontainerApp0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerApp0",
+                    "image": "repo/testcontainerApp0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "scale": {
+                  "cooldownPeriod": 350,
+                  "maxReplicas": 5,
+                  "minReplicas": 1,
+                  "pollingInterval": 35,
+                  "rules": [
+                    {
+                      "name": "httpscalingrule",
+                      "http": {
+                        "metadata": {
+                          "concurrentRequests": "50"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "serviceBinds": [
+                  {
+                    "name": "service",
+                    "clientType": "dotnet",
+                    "customizedKeys": {
+                      "DesiredKey": "defaultKey"
+                    },
+                    "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/service"
+                  }
+                ]
+              },
+              "workloadProfileName": "My-GP-01"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_ListBySubscription",
+  "title": "List Container Apps by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_ListCustomHostNameAnalysis.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_ListCustomHostNameAnalysis.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "customHostname": "my.name.corp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "aRecords": [
+          "aRecord1",
+          "aRecord2"
+        ],
+        "alternateCNameRecords": [
+          "cNameRecord1",
+          "cNameRecord2"
+        ],
+        "alternateTxtRecords": [
+          "txtRecord1",
+          "txtRecord2"
+        ],
+        "cNameRecords": [
+          "cNameRecord1",
+          "cNameRecord2"
+        ],
+        "conflictingContainerAppResourceId": "",
+        "customDomainVerificationFailureInfo": {},
+        "customDomainVerificationTest": "Passed",
+        "hasConflictOnManagedEnvironment": false,
+        "hostName": "my.name.corp",
+        "isHostnameAlreadyVerified": true,
+        "txtRecords": [
+          "txtRecord1",
+          "txtRecord2"
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_ListCustomHostNameAnalysis",
+  "title": "Analyze Custom Hostname"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_ListSecrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_ListSecrets.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "secret1"
+          },
+          {
+            "name": "secret2"
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_ListSecrets",
+  "title": "List Container Apps Secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_ManagedBy_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_ManagedBy_CreateOrUpdate.json
@@ -1,0 +1,214 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "location": "East US",
+      "managedBy": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.AppPlatform/Spring/springapp",
+      "properties": {
+        "configuration": {
+          "ingress": {
+            "exposedPort": 4000,
+            "external": true,
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "revisionName": "testcontainerAppManagedBy-ab1234",
+                "weight": 100
+              }
+            ],
+            "transport": "tcp"
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppManagedBy",
+              "image": "repo/testcontainerAppManagedBy:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3,
+                  "tcpSocket": {
+                    "port": 8080
+                  }
+                }
+              ]
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "tcpscalingrule",
+                "tcp": {
+                  "metadata": {
+                    "concurrentConnections": "50"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "containerAppName": "testcontainerAppManagedBy",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppManagedBy",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerAppManagedBy",
+        "location": "East US",
+        "managedBy": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.AppPlatform/Spring/springapp",
+        "properties": {
+          "configuration": {
+            "ingress": {
+              "exposedPort": 4000,
+              "external": true,
+              "fqdn": "testcontainerAppManagedBy.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "traffic": [
+                {
+                  "revisionName": "testcontainerAppManagedBy-ab1234",
+                  "weight": 80
+                },
+                {
+                  "revisionName": "testcontainerAppManagedBy-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "tcp"
+            }
+          },
+          "latestReadyRevisionName": "testcontainerAppManagedBy-pjxhsye",
+          "latestRevisionFqdn": "testcontainerAppManagedBy-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppManagedBy",
+                "image": "repo/testcontainerAppManagedBy:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3,
+                    "tcpSocket": {
+                      "port": 8080
+                    }
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "tcpscalingrule",
+                  "tcp": {
+                    "metadata": {
+                      "concurrentConnections": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppManagedBy",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerAppManagedBy",
+        "location": "East US",
+        "managedBy": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.AppPlatform/Spring/springapp",
+        "properties": {
+          "configuration": {
+            "ingress": {
+              "exposedPort": 4000,
+              "external": true,
+              "fqdn": "testcontainerAppManagedBy.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "traffic": [
+                {
+                  "revisionName": "testcontainerAppManagedBy-ab1234",
+                  "weight": 80
+                },
+                {
+                  "revisionName": "testcontainerAppManagedBy-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "tcp"
+            }
+          },
+          "latestRevisionFqdn": "testcontainerAppManagedBy-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppManagedBy",
+                "image": "repo/testcontainerAppManagedBy:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3,
+                    "tcpSocket": {
+                      "port": 8080
+                    }
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "tcpscalingrule",
+                  "tcp": {
+                    "metadata": {
+                      "concurrentConnections": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update ManagedBy App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Patch.json
@@ -1,0 +1,311 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "dapr": {
+            "appHealth": {
+              "path": "/health",
+              "enabled": true,
+              "probeIntervalSeconds": 3,
+              "probeTimeoutMilliseconds": 1000,
+              "threshold": 3
+            },
+            "appPort": 3000,
+            "appProtocol": "http",
+            "enableApiLogging": true,
+            "enabled": true,
+            "httpMaxRequestSize": 10,
+            "httpReadBufferSize": 30,
+            "logLevel": "debug",
+            "maxConcurrency": 10
+          },
+          "ingress": {
+            "customDomains": [
+              {
+                "name": "www.my-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+              },
+              {
+                "name": "www.my-other-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+              }
+            ],
+            "external": true,
+            "ipSecurityRestrictions": [
+              {
+                "name": "Allow work IP A subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/32"
+              },
+              {
+                "name": "Allow work IP B subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/8"
+              }
+            ],
+            "stickySessions": {
+              "affinity": "sticky"
+            },
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "label": "production",
+                "revisionName": "testcontainerApp0-ab1234",
+                "weight": 100
+              }
+            ]
+          },
+          "maxInactiveRevisions": 10,
+          "revisionTransitionThreshold": 100,
+          "runtime": {
+            "dotnet": {
+              "autoConfigureDataProtection": true
+            },
+            "java": {
+              "enableMetrics": true,
+              "javaAgent": {
+                "enabled": true,
+                "logging": {
+                  "loggerSettings": [
+                    {
+                      "level": "debug",
+                      "logger": "org.springframework.boot"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "service": {
+            "type": "redis"
+          }
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerApp0",
+              "image": "repo/testcontainerApp0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerApp0",
+              "image": "repo/testcontainerApp0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "httpscalingrule",
+                "custom": {
+                  "type": "http",
+                  "metadata": {
+                    "concurrentRequests": "50"
+                  }
+                }
+              }
+            ]
+          },
+          "serviceBinds": [
+            {
+              "name": "service",
+              "clientType": "dotnet",
+              "customizedKeys": {
+                "DesiredKey": "defaultKey"
+              },
+              "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/service"
+            }
+          ]
+        }
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enableApiLogging": true,
+              "enabled": true,
+              "httpMaxRequestSize": 10,
+              "httpReadBufferSize": 30,
+              "logLevel": "debug",
+              "maxConcurrency": 10
+            },
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my--other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "maxInactiveRevisions": 10,
+            "revisionTransitionThreshold": 100,
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/locations/eastus/containerappOperationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "ContainerApps_Update",
+  "title": "Patch Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_SourceToCloudApp_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_SourceToCloudApp_CreateOrUpdate.json
@@ -1,0 +1,495 @@
+{
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "dapr": {
+            "appPort": 3000,
+            "appProtocol": "http",
+            "enableApiLogging": true,
+            "enabled": true,
+            "httpMaxRequestSize": 10,
+            "httpReadBufferSize": 30,
+            "logLevel": "debug"
+          },
+          "ingress": {
+            "additionalPortMappings": [
+              {
+                "external": true,
+                "targetPort": 1234
+              },
+              {
+                "exposedPort": 3456,
+                "external": false,
+                "targetPort": 2345
+              }
+            ],
+            "clientCertificateMode": "accept",
+            "corsPolicy": {
+              "allowCredentials": true,
+              "allowedHeaders": [
+                "HEADER1",
+                "HEADER2"
+              ],
+              "allowedMethods": [
+                "GET",
+                "POST"
+              ],
+              "allowedOrigins": [
+                "https://a.test.com",
+                "https://b.test.com"
+              ],
+              "exposeHeaders": [
+                "HEADER3",
+                "HEADER4"
+              ],
+              "maxAge": 1234
+            },
+            "customDomains": [
+              {
+                "name": "www.my-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+              },
+              {
+                "name": "www.my-other-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+              }
+            ],
+            "external": true,
+            "ipSecurityRestrictions": [
+              {
+                "name": "Allow work IP A subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/32"
+              },
+              {
+                "name": "Allow work IP B subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/8"
+              }
+            ],
+            "stickySessions": {
+              "affinity": "sticky"
+            },
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "label": "production",
+                "revisionName": "testcontainerApp0-ab1234",
+                "weight": 100
+              }
+            ]
+          },
+          "maxInactiveRevisions": 10,
+          "revisionTransitionThreshold": 100,
+          "service": {
+            "type": "redis"
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "patchingConfiguration": {
+          "patchingMode": "Automatic"
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerApp0",
+              "image": "",
+              "imageType": "CloudBuild",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "mountPath": "/mnt/path1",
+                  "subPath": "subPath1",
+                  "volumeName": "azurefile"
+                },
+                {
+                  "mountPath": "/mnt/path2",
+                  "subPath": "subPath2",
+                  "volumeName": "nfsazurefile"
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerApp0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerApp0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "httpscalingrule",
+                "custom": {
+                  "type": "http",
+                  "metadata": {
+                    "concurrentRequests": "50"
+                  }
+                }
+              }
+            ]
+          },
+          "serviceBinds": [
+            {
+              "name": "redisService",
+              "clientType": "dotnet",
+              "customizedKeys": {
+                "DesiredKey": "defaultKey"
+              },
+              "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/redisService"
+            }
+          ],
+          "volumes": [
+            {
+              "name": "azurefile",
+              "storageName": "storage",
+              "storageType": "AzureFile"
+            },
+            {
+              "name": "nfsazurefile",
+              "storageName": "nfsStorage",
+              "storageType": "NfsAzureFile"
+            }
+          ]
+        },
+        "workloadProfileName": "My-GP-01"
+      }
+    },
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "title": "Create or Update SourceToCloud App",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30
+            },
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my-other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "stickySessions": {
+                "affinity": "sticky"
+              },
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "patchingConfiguration": {
+            "patchingMode": "Automatic"
+          },
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "mcr.microsoft.com/k8se/cloudbuild-waiting-upload:latest",
+                "imageType": "CloudBuild",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            },
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30
+            },
+            "ingress": {
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "patchingConfiguration": {
+            "patchingMode": "Automatic"
+          },
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "mcr.microsoft.com/k8se/cloudbuild-waiting-upload:latest",
+                "imageType": "CloudBuild",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            },
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Start.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Start.json
@@ -1,0 +1,149 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testWorkerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enableApiLogging": true,
+              "enabled": true,
+              "httpMaxRequestSize": 10,
+              "httpReadBufferSize": 30,
+              "logLevel": "debug"
+            },
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my--other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "maxInactiveRevisions": 10,
+            "revisionTransitionThreshold": 100,
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/containerApps/testWorkerApp0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "ContainerApps_Start",
+  "title": "Start Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Stop.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_Stop.json
@@ -1,0 +1,155 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testWorkerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enableApiLogging": true,
+              "enabled": true,
+              "httpMaxRequestSize": 10,
+              "httpReadBufferSize": 30,
+              "logLevel": "debug",
+              "maxConcurrency": 10
+            },
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my--other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "maxInactiveRevisions": 10,
+            "revisionTransitionThreshold": 100,
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/containerApps/testWorkerApp0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "ContainerApps_Stop",
+  "title": "Stop Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_TcpApp_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ContainerApps_TcpApp_CreateOrUpdate.json
@@ -1,0 +1,211 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "ingress": {
+            "exposedPort": 4000,
+            "external": true,
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "revisionName": "testcontainerAppTcp-ab1234",
+                "weight": 100
+              }
+            ],
+            "transport": "tcp"
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppTcp",
+              "image": "repo/testcontainerAppTcp:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3,
+                  "tcpSocket": {
+                    "port": 8080
+                  }
+                }
+              ]
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "tcpscalingrule",
+                "tcp": {
+                  "metadata": {
+                    "concurrentConnections": "50"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "containerAppName": "testcontainerAppTcp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppTcp",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerAppTcp",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "ingress": {
+              "exposedPort": 4000,
+              "external": true,
+              "fqdn": "testcontainerAppTcp.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "traffic": [
+                {
+                  "revisionName": "testcontainerAppTcp-ab1234",
+                  "weight": 80
+                },
+                {
+                  "revisionName": "testcontainerAppTcp-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "tcp"
+            }
+          },
+          "latestReadyRevisionName": "testcontainerAppTcp-pjxhsye",
+          "latestRevisionFqdn": "testcontainerAppTcp-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppTcp",
+                "image": "repo/testcontainerAppTcp:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3,
+                    "tcpSocket": {
+                      "port": 8080
+                    }
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "tcpscalingrule",
+                  "tcp": {
+                    "metadata": {
+                      "concurrentConnections": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppTcp",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerAppTcp",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "ingress": {
+              "exposedPort": 4000,
+              "external": true,
+              "fqdn": "testcontainerAppTcp.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "traffic": [
+                {
+                  "revisionName": "testcontainerAppTcp-ab1234",
+                  "weight": 80
+                },
+                {
+                  "revisionName": "testcontainerAppTcp-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "tcp"
+            }
+          },
+          "latestRevisionFqdn": "testcontainerAppTcp-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppTcp",
+                "image": "repo/testcontainerAppTcp:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3,
+                    "tcpSocket": {
+                      "port": 8080
+                    }
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "tcpscalingrule",
+                  "tcp": {
+                    "metadata": {
+                      "concurrentConnections": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update Tcp App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicies_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicies_Delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "myresiliencypolicy",
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DaprComponentResiliencyPolicies_Delete",
+  "title": "Delete dapr component resiliency policy"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicies_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicies_Get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "name": "myresiliencypolicy",
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "inboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 5,
+              "timeoutInSeconds": 10
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 15,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 2000,
+                "maxIntervalInMilliseconds": 5500
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 30
+            }
+          },
+          "outboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "intervalInSeconds": 60,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 100,
+                "maxIntervalInMilliseconds": 30000
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponentResiliencyPolicies_Get",
+  "title": "Get Dapr component resiliency policy"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicies_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicies_List.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "something",
+            "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+            "properties": {
+              "inboundPolicy": {
+                "circuitBreakerPolicy": {
+                  "consecutiveErrors": 5,
+                  "timeoutInSeconds": 10
+                },
+                "httpRetryPolicy": {
+                  "maxRetries": 15,
+                  "retryBackOff": {
+                    "initialDelayInMilliseconds": 2000,
+                    "maxIntervalInMilliseconds": 5500
+                  }
+                },
+                "timeoutPolicy": {
+                  "responseTimeoutInSeconds": 30
+                }
+              },
+              "outboundPolicy": {
+                "circuitBreakerPolicy": {
+                  "consecutiveErrors": 3,
+                  "intervalInSeconds": 60,
+                  "timeoutInSeconds": 20
+                },
+                "httpRetryPolicy": {
+                  "maxRetries": 5,
+                  "retryBackOff": {
+                    "initialDelayInMilliseconds": 100,
+                    "maxIntervalInMilliseconds": 30000
+                  }
+                },
+                "timeoutPolicy": {
+                  "responseTimeoutInSeconds": 12
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DaprComponentResiliencyPolicies_List",
+  "title": "List Dapr component resiliency policies"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicy_CreateOrUpdate_AllOptions.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicy_CreateOrUpdate_AllOptions.json
@@ -1,0 +1,138 @@
+{
+  "parameters": {
+    "name": "myresiliencypolicy",
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "daprComponentResiliencyPolicyEnvelope": {
+      "properties": {
+        "inboundPolicy": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 5,
+            "intervalInSeconds": 4,
+            "timeoutInSeconds": 10
+          },
+          "httpRetryPolicy": {
+            "maxRetries": 15,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 2000,
+              "maxIntervalInMilliseconds": 5500
+            }
+          },
+          "timeoutPolicy": {
+            "responseTimeoutInSeconds": 30
+          }
+        },
+        "outboundPolicy": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 3,
+            "intervalInSeconds": 60,
+            "timeoutInSeconds": 20
+          },
+          "httpRetryPolicy": {
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 100,
+              "maxIntervalInMilliseconds": 30000
+            }
+          },
+          "timeoutPolicy": {
+            "responseTimeoutInSeconds": 12
+          }
+        }
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "inboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 5,
+              "intervalInSeconds": 4,
+              "timeoutInSeconds": 10
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 15,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 2000,
+                "maxIntervalInMilliseconds": 5500
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 30
+            }
+          },
+          "outboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "intervalInSeconds": 60,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 100,
+                "maxIntervalInMilliseconds": 30000
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "inboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 5,
+              "intervalInSeconds": 4,
+              "timeoutInSeconds": 10
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 15,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 2000,
+                "maxIntervalInMilliseconds": 5500
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 30
+            }
+          },
+          "outboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "intervalInSeconds": 60,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 100,
+                "maxIntervalInMilliseconds": 30000
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponentResiliencyPolicies_CreateOrUpdate",
+  "title": "Create or update dapr component resiliency policy with all options"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicy_CreateOrUpdate_OutboundOnly.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicy_CreateOrUpdate_OutboundOnly.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "name": "myresiliencypolicy",
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "daprComponentResiliencyPolicyEnvelope": {
+      "properties": {
+        "outboundPolicy": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 3,
+            "intervalInSeconds": 60,
+            "timeoutInSeconds": 20
+          },
+          "httpRetryPolicy": {
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 100,
+              "maxIntervalInMilliseconds": 30000
+            }
+          },
+          "timeoutPolicy": {
+            "responseTimeoutInSeconds": 12
+          }
+        }
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "outboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "intervalInSeconds": 60,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 100,
+                "maxIntervalInMilliseconds": 30000
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "outboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "intervalInSeconds": 60,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 100,
+                "maxIntervalInMilliseconds": 30000
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponentResiliencyPolicies_CreateOrUpdate",
+  "title": "Create or update dapr component resiliency policy with outbound policy only"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicy_CreateOrUpdate_SparseOptions.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponentResiliencyPolicy_CreateOrUpdate_SparseOptions.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "name": "myresiliencypolicy",
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "daprComponentResiliencyPolicyEnvelope": {
+      "properties": {
+        "inboundPolicy": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 3,
+            "timeoutInSeconds": 20
+          },
+          "httpRetryPolicy": {
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 2000,
+              "maxIntervalInMilliseconds": 5500
+            }
+          }
+        },
+        "outboundPolicy": {
+          "timeoutPolicy": {
+            "responseTimeoutInSeconds": 12
+          }
+        }
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "inboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 2000,
+                "maxIntervalInMilliseconds": 5500
+              }
+            }
+          },
+          "outboundPolicy": {
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "inboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 2000,
+                "maxIntervalInMilliseconds": 5500
+              }
+            }
+          },
+          "outboundPolicy": {
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponentResiliencyPolicies_CreateOrUpdate",
+  "title": "Create or update dapr component resiliency policy with sparse options"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_CreateOrUpdate_SecretStoreComponent.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_CreateOrUpdate_SecretStoreComponent.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "daprComponentEnvelope": {
+      "properties": {
+        "componentType": "state.azure.cosmosdb",
+        "ignoreErrors": false,
+        "initTimeout": "50s",
+        "metadata": [
+          {
+            "name": "url",
+            "value": "<COSMOS-URL>"
+          },
+          {
+            "name": "database",
+            "value": "itemsDB"
+          },
+          {
+            "name": "collection",
+            "value": "items"
+          },
+          {
+            "name": "masterkey",
+            "secretRef": "masterkey"
+          }
+        ],
+        "scopes": [
+          "container-app-1",
+          "container-app-2"
+        ],
+        "secretStoreComponent": "my-secret-store",
+        "serviceComponentBind": [
+          {
+            "name": "statestore",
+            "metadata": {
+              "name": "daprcomponentBind",
+              "value": "redis-bind"
+            },
+            "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+          }
+        ],
+        "version": "v1"
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/managedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secretStoreComponent": "my-secret-store",
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponents_CreateOrUpdate",
+  "title": "Create or update dapr component with secret store component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_CreateOrUpdate_Secrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_CreateOrUpdate_Secrets.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "daprComponentEnvelope": {
+      "properties": {
+        "componentType": "state.azure.cosmosdb",
+        "ignoreErrors": false,
+        "initTimeout": "50s",
+        "metadata": [
+          {
+            "name": "url",
+            "value": "<COSMOS-URL>"
+          },
+          {
+            "name": "database",
+            "value": "itemsDB"
+          },
+          {
+            "name": "collection",
+            "value": "items"
+          },
+          {
+            "name": "masterkey",
+            "secretRef": "masterkey"
+          }
+        ],
+        "scopes": [
+          "container-app-1",
+          "container-app-2"
+        ],
+        "secrets": [
+          {
+            "name": "masterkey",
+            "value": "keyvalue"
+          }
+        ],
+        "serviceComponentBind": [
+          {
+            "name": "statestore",
+            "metadata": {
+              "name": "daprcomponentBind",
+              "value": "redis-bind"
+            },
+            "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+          }
+        ],
+        "version": "v1"
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/managedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secrets": [
+            {
+              "name": "masterkey"
+            }
+          ],
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponents_CreateOrUpdate",
+  "title": "Create or update dapr component with secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DaprComponents_Delete",
+  "title": "Delete dapr component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_Get_SecretStoreComponent.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_Get_SecretStoreComponent.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/managedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secretStoreComponent": "my-secret-store",
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponents_Get",
+  "title": "Get Dapr Component with secret store component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_Get_Secrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_Get_Secrets.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/managedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secrets": [
+            {
+              "name": "masterkey"
+            }
+          ],
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponents_Get",
+  "title": "Get Dapr Component with secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_List.json
@@ -1,0 +1,154 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "reddog",
+            "type": "Microsoft.App/managedEnvironments/daprcomponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprcomponents/reddog",
+            "properties": {
+              "componentType": "state.azure.cosmosdb",
+              "ignoreErrors": false,
+              "initTimeout": "50s",
+              "metadata": [
+                {
+                  "name": "url",
+                  "value": "<COSMOS-URL>"
+                },
+                {
+                  "name": "database",
+                  "value": "itemsDB"
+                },
+                {
+                  "name": "collection",
+                  "value": "items"
+                },
+                {
+                  "name": "masterkey",
+                  "secretRef": "masterkey"
+                }
+              ],
+              "scopes": [
+                "container-app-1",
+                "container-app-2"
+              ],
+              "secrets": [
+                {
+                  "name": "masterkey"
+                }
+              ],
+              "serviceComponentBind": [
+                {
+                  "name": "statestore",
+                  "metadata": {
+                    "name": "daprcomponentBind",
+                    "value": "redis-bind"
+                  },
+                  "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+                }
+              ],
+              "version": "v1"
+            }
+          },
+          {
+            "name": "vaultdog",
+            "type": "Microsoft.App/managedEnvironments/daprcomponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprcomponents/vaultdog",
+            "properties": {
+              "componentType": "state.azure.cosmosdb",
+              "ignoreErrors": false,
+              "initTimeout": "50s",
+              "metadata": [
+                {
+                  "name": "url",
+                  "value": "<COSMOS-URL>"
+                },
+                {
+                  "name": "database",
+                  "value": "itemsDB"
+                },
+                {
+                  "name": "collection",
+                  "value": "items"
+                },
+                {
+                  "name": "masterkey",
+                  "secretRef": "masterkey"
+                }
+              ],
+              "scopes": [
+                "container-app-1",
+                "container-app-2"
+              ],
+              "secretStoreComponent": "my-secret-store",
+              "serviceComponentBind": [
+                {
+                  "name": "statestore",
+                  "metadata": {
+                    "name": "daprcomponentBind",
+                    "value": "redis-bind"
+                  },
+                  "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+                }
+              ],
+              "version": "v1"
+            }
+          },
+          {
+            "name": "vaultdog",
+            "type": "Microsoft.App/managedEnvironments/daprcomponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprcomponents/vaultdog",
+            "properties": {
+              "componentType": "state.azure.cosmosdb",
+              "ignoreErrors": false,
+              "initTimeout": "50s",
+              "metadata": [
+                {
+                  "name": "url",
+                  "secretRef": "cosmosdb/url"
+                },
+                {
+                  "name": "database",
+                  "value": "itemsDB"
+                },
+                {
+                  "name": "collection",
+                  "value": "items"
+                },
+                {
+                  "name": "masterkey",
+                  "secretRef": "cosmosdb/masterkey"
+                }
+              ],
+              "scopes": [
+                "container-app-1",
+                "container-app-2"
+              ],
+              "secretStoreComponent": "my-secret-store",
+              "serviceComponentBind": [
+                {
+                  "name": "statestore",
+                  "metadata": {
+                    "name": "daprcomponentBind",
+                    "value": "redis-bind"
+                  },
+                  "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+                }
+              ],
+              "version": "v1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DaprComponents_List",
+  "title": "List Dapr Components"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_ListSecrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprComponents_ListSecrets.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "secret1"
+          },
+          {
+            "name": "secret2"
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DaprComponents_ListSecrets",
+  "title": "List Container Apps Secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_CreateOrUpdate_BulkSubscribeAndScopes.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_CreateOrUpdate_BulkSubscribeAndScopes.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "name": "mysubscription",
+    "api-version": "2026-03-02-preview",
+    "daprSubscriptionEnvelope": {
+      "properties": {
+        "bulkSubscribe": {
+          "enabled": true,
+          "maxAwaitDurationMs": 500,
+          "maxMessagesCount": 123
+        },
+        "pubsubName": "mypubsubcomponent",
+        "routes": {
+          "default": "/products"
+        },
+        "scopes": [
+          "warehouseapp",
+          "customersupportapp"
+        ],
+        "topic": "inventory"
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "bulkSubscribe": {
+            "enabled": true,
+            "maxAwaitDurationMs": 500,
+            "maxMessagesCount": 123
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "scopes": [
+            "warehouseapp",
+            "customersupportapp"
+          ],
+          "topic": "inventory"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "bulkSubscribe": {
+            "enabled": true,
+            "maxAwaitDurationMs": 500,
+            "maxMessagesCount": 123
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "scopes": [
+            "warehouseapp",
+            "customersupportapp"
+          ],
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_CreateOrUpdate",
+  "title": "Create or update dapr subscription with bulk subscribe configuration and scopes"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_CreateOrUpdate_DefaultRoute.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_CreateOrUpdate_DefaultRoute.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "name": "mysubscription",
+    "api-version": "2026-03-02-preview",
+    "daprSubscriptionEnvelope": {
+      "properties": {
+        "pubsubName": "mypubsubcomponent",
+        "routes": {
+          "default": "/products"
+        },
+        "topic": "inventory"
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "topic": "inventory"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_CreateOrUpdate",
+  "title": "Create or update dapr subscription with default route only"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_CreateOrUpdate_RouteRulesAndMetadata.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_CreateOrUpdate_RouteRulesAndMetadata.json
@@ -1,0 +1,92 @@
+{
+  "parameters": {
+    "name": "mysubscription",
+    "api-version": "2026-03-02-preview",
+    "daprSubscriptionEnvelope": {
+      "properties": {
+        "metadata": {
+          "foo": "bar",
+          "hello": "world"
+        },
+        "pubsubName": "mypubsubcomponent",
+        "routes": {
+          "default": "/products",
+          "rules": [
+            {
+              "path": "/widgets",
+              "match": "event.type == 'widget'"
+            },
+            {
+              "path": "/gadgets",
+              "match": "event.type == 'gadget'"
+            }
+          ]
+        },
+        "topic": "inventory"
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "metadata": {
+            "foo": "bar",
+            "hello": "world"
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": [
+              {
+                "path": "/widgets",
+                "match": "event.type == 'widget'"
+              },
+              {
+                "path": "/gadgets",
+                "match": "event.type == 'gadget'"
+              }
+            ]
+          },
+          "topic": "inventory"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "metadata": {
+            "foo": "bar",
+            "hello": "world"
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": [
+              {
+                "path": "/widgets",
+                "match": "event.type == 'widget'"
+              },
+              {
+                "path": "/gadgets",
+                "match": "event.type == 'gadget'"
+              }
+            ]
+          },
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_CreateOrUpdate",
+  "title": "Create or update dapr subscription with route rules and metadata"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "mysubscription",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DaprSubscriptions_Delete",
+  "title": "Delete dapr subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_Get_BulkSubscribeAndScopes.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_Get_BulkSubscribeAndScopes.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "name": "mypubsubcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "bulkSubscribe": {
+            "enabled": true,
+            "maxAwaitDurationMs": 500,
+            "maxMessagesCount": 123
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "scopes": [
+            "warehouseapp",
+            "customersupportapp"
+          ],
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_Get",
+  "title": "Get Dapr subscription with default route only"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_Get_DefaultRoute.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_Get_DefaultRoute.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "name": "mypubsubcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_Get",
+  "title": "Get Dapr subscription with bulk subscribe configuration and scopes"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_Get_RouteRulesAndMetadata.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_Get_RouteRulesAndMetadata.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "name": "mypubsubcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "metadata": {
+            "foo": "bar",
+            "hello": "world"
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": [
+              {
+                "path": "/widgets",
+                "match": "event.type == 'widget'"
+              },
+              {
+                "path": "/gadgets",
+                "match": "event.type == 'gadget'"
+              }
+            ]
+          },
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_Get",
+  "title": "GetDapr subscription with route rules and metadata"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DaprSubscriptions_List.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "mybulksubscription",
+            "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mybulksubscription",
+            "properties": {
+              "bulkSubscribe": {
+                "enabled": true,
+                "maxAwaitDurationMs": 500,
+                "maxMessagesCount": 123
+              },
+              "pubsubName": "mypubsubcomponent",
+              "routes": {
+                "default": "/products",
+                "rules": []
+              },
+              "topic": "inventory"
+            }
+          },
+          {
+            "name": "mydefaultsubscription",
+            "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mydefaultsubscription",
+            "properties": {
+              "pubsubName": "mypubsubcomponent",
+              "routes": {
+                "default": "/products",
+                "rules": []
+              },
+              "topic": "inventory"
+            }
+          },
+          {
+            "name": "myroutingsubscription",
+            "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/myroutingsubscription",
+            "properties": {
+              "metadata": {
+                "foo": "bar",
+                "hello": "world"
+              },
+              "pubsubName": "mypubsubcomponent",
+              "routes": {
+                "default": "/products",
+                "rules": [
+                  {
+                    "path": "/widgets",
+                    "match": "event.type == 'widget'"
+                  },
+                  {
+                    "path": "/gadgets",
+                    "match": "event.type == 'gadget'"
+                  }
+                ]
+              },
+              "topic": "inventory"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_List",
+  "title": "List Dapr subscriptions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_CreateOrUpdate.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "dotNetComponentEnvelope": {
+      "properties": {
+        "componentType": "AspireDashboard",
+        "configurations": [
+          {
+            "propertyName": "dashboard-theme",
+            "value": "dark"
+          }
+        ]
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "InProgress"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DotNetComponents_CreateOrUpdate",
+  "title": "Create or Update .NET Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_CreateOrUpdate_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_CreateOrUpdate_ServiceBind.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "dotNetComponentEnvelope": {
+      "properties": {
+        "componentType": "AspireDashboard",
+        "configurations": [
+          {
+            "propertyName": "dashboard-theme",
+            "value": "dark"
+          }
+        ],
+        "serviceBinds": [
+          {
+            "name": "yellowcat",
+            "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+          }
+        ]
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "InProgress",
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DotNetComponents_CreateOrUpdate",
+  "title": "Create or Update .NET Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "DotNetComponents_Delete",
+  "title": "Delete .NET Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_Get.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DotNetComponents_Get",
+  "title": "Get .NET Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_Get_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_Get_ServiceBind.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DotNetComponents_Get",
+  "title": "Get .NET Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_List.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blueshark",
+            "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/blueshark",
+            "properties": {
+              "componentType": "AspireDashboard",
+              "configurations": [
+                {
+                  "propertyName": "dashboard-theme",
+                  "value": "dark"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "yellowcat",
+            "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat",
+            "properties": {
+              "componentType": "MyOtherDotNetComponentType",
+              "configurations": [
+                {
+                  "propertyName": "timeout-value",
+                  "value": "10000ms"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DotNetComponents_List",
+  "title": "List .NET Components"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_List_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_List_ServiceBind.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blueshark",
+            "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/blueshark",
+            "properties": {
+              "componentType": "AspireDashboard",
+              "configurations": [
+                {
+                  "propertyName": "dashboard-theme",
+                  "value": "dark"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "serviceBinds": [
+                {
+                  "name": "yellowcat",
+                  "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+                }
+              ]
+            }
+          },
+          {
+            "name": "yellowcat",
+            "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat",
+            "properties": {
+              "componentType": "MyOtherDotNetComponentType",
+              "configurations": [
+                {
+                  "propertyName": "timeout-value",
+                  "value": "10000ms"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "serviceBinds": [
+                {
+                  "name": "blueshark",
+                  "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/blueshark"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DotNetComponents_List",
+  "title": "List .NET Components with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_Patch.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "dotNetComponentEnvelope": {
+      "properties": {
+        "componentType": "AspireDashboard",
+        "configurations": [
+          {
+            "propertyName": "dashboard-theme",
+            "value": "dark"
+          }
+        ]
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "DotNetComponents_Update",
+  "title": "Patch .NET Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_Patch_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/DotNetComponents_Patch_ServiceBind.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "dotNetComponentEnvelope": {
+      "properties": {
+        "componentType": "AspireDashboard",
+        "configurations": [
+          {
+            "propertyName": "dashboard-theme",
+            "value": "dark"
+          }
+        ],
+        "serviceBinds": [
+          {
+            "name": "yellowcat",
+            "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+          }
+        ]
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "DotNetComponents_Update",
+  "title": "Patch .NET Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/FunctionsExtension_Post.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/FunctionsExtension_Post.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "functionAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": "{\"status\":\"success\"}"
+    }
+  },
+  "operationId": "FunctionsExtension_InvokeFunctionsHost",
+  "title": "Invoke Functions host using Functions Extension API"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_CreateOrUpdate.json
@@ -1,0 +1,129 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteConfigEnvelope": {
+      "properties": {
+        "customDomains": [
+          {
+            "name": "example.com",
+            "bindingType": "SniEnabled",
+            "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+          }
+        ],
+        "rules": [
+          {
+            "description": "random-description",
+            "routes": [
+              {
+                "action": {
+                  "prefixRewrite": "/v1/api"
+                },
+                "match": {
+                  "path": "/v1",
+                  "caseSensitive": true
+                }
+              }
+            ],
+            "targets": [
+              {
+                "containerApp": "capp-1",
+                "revision": "rev-1",
+                "weight": 100
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "SniEnabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "InProgress",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "path": "/v1",
+                    "caseSensitive": true
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "revision": "rev-1",
+                  "weight": 100
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "SniEnabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "Succeeded",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "path": "/v1",
+                    "caseSensitive": true
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "revision": "rev-1",
+                  "weight": 100
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_CreateOrUpdate",
+  "title": "Create or Update Http Route"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_CreateOrUpdatePrefix.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_CreateOrUpdatePrefix.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteConfigEnvelope": {
+      "properties": {
+        "customDomains": [
+          {
+            "name": "example.com",
+            "bindingType": "Disabled",
+            "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+          }
+        ],
+        "rules": [
+          {
+            "description": "random-description",
+            "routes": [
+              {
+                "action": {
+                  "prefixRewrite": "/v1/api"
+                },
+                "match": {
+                  "caseSensitive": true,
+                  "prefix": "/v1"
+                }
+              }
+            ],
+            "targets": [
+              {
+                "containerApp": "capp-1",
+                "label": "label-1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "Disabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "InProgress",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "caseSensitive": true,
+                    "prefix": "/v1"
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "label": "label-1"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "Disabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "Succeeded",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "caseSensitive": true,
+                    "prefix": "/v1"
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "label": "label-1"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_CreateOrUpdate",
+  "title": "Create or Update Http Route Prefix Rule"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_CreateOrUpdate_PathSepPrefix.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_CreateOrUpdate_PathSepPrefix.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteConfigEnvelope": {
+      "properties": {
+        "customDomains": [
+          {
+            "name": "example.com",
+            "bindingType": "Disabled",
+            "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+          }
+        ],
+        "rules": [
+          {
+            "description": "random-description",
+            "routes": [
+              {
+                "action": {
+                  "prefixRewrite": "/v1/api"
+                },
+                "match": {
+                  "caseSensitive": true,
+                  "pathSeparatedPrefix": "/v1"
+                }
+              }
+            ],
+            "targets": [
+              {
+                "containerApp": "capp-1",
+                "label": "label-1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "Disabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "InProgress",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "caseSensitive": true,
+                    "pathSeparatedPrefix": "/v1"
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "label": "label-1"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "Disabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "Succeeded",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "caseSensitive": true,
+                    "pathSeparatedPrefix": "/v1"
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "label": "label-1"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_CreateOrUpdate",
+  "title": "Create or Update Http Route Path Separated Prefix Rule"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/containerApps/testworkerapp0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2025-07-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "HttpRouteConfig_Delete",
+  "title": "Delete Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_Get.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "SniEnabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "Succeeded",
+          "rules": [
+            {
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "caseSensitive": true,
+                    "prefix": "/api"
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "revision": "rev-1",
+                  "weight": 100
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_Get",
+  "title": "Get HttpRoute"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_ListByManagedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_ListByManagedEnvironment.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+            "properties": {
+              "customDomains": [
+                {
+                  "name": "example.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+                }
+              ],
+              "fqdn": "app1.example.com",
+              "provisioningState": "Succeeded",
+              "rules": [
+                {
+                  "routes": [
+                    {
+                      "action": {
+                        "prefixRewrite": "/v1/api"
+                      },
+                      "match": {
+                        "caseSensitive": true,
+                        "prefix": "/api"
+                      }
+                    }
+                  ],
+                  "targets": [
+                    {
+                      "containerApp": "containerApp1"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-2",
+            "properties": {
+              "customDomains": [
+                {
+                  "name": "example.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-2"
+                }
+              ],
+              "fqdn": "app2.example.com",
+              "provisioningState": "Succeeded",
+              "rules": [
+                {
+                  "routes": [
+                    {
+                      "action": {
+                        "prefixRewrite": "/v2/api"
+                      },
+                      "match": {
+                        "caseSensitive": false,
+                        "prefix": "/api"
+                      }
+                    }
+                  ],
+                  "targets": [
+                    {
+                      "containerApp": "containerApp2",
+                      "revision": "rev-2",
+                      "weight": 50
+                    },
+                    {
+                      "containerApp": "containerApp2",
+                      "revision": "rev-3",
+                      "weight": 50
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_List",
+  "title": "List Managed Http Routes by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/HttpRouteConfig_Patch.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteConfigEnvelope": {
+      "properties": {
+        "customDomains": [
+          {
+            "name": "example.com",
+            "bindingType": "SniEnabled",
+            "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+          }
+        ],
+        "rules": [
+          {
+            "description": "random-description",
+            "routes": [
+              {
+                "action": {
+                  "prefixRewrite": "/v1/api"
+                },
+                "match": {
+                  "path": "/v1",
+                  "caseSensitive": true
+                }
+              }
+            ],
+            "targets": [
+              {
+                "containerApp": "capp-1",
+                "revision": "rev-1",
+                "weight": 100
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "SniEnabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "InProgress",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "path": "/v1",
+                    "caseSensitive": true
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "revision": "rev-1",
+                  "weight": 100
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_Update",
+  "title": "Patch Managed Http Route"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_CreateOrUpdate.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "javaComponentEnvelope": {
+      "properties": {
+        "componentType": "SpringBootAdmin",
+        "configurations": [
+          {
+            "propertyName": "spring.boot.admin.ui.enable-toasts",
+            "value": "true"
+          },
+          {
+            "propertyName": "spring.boot.admin.monitor.status-interval",
+            "value": "10000ms"
+          }
+        ],
+        "scale": {
+          "maxReplicas": 1,
+          "minReplicas": 1
+        }
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "ingress": {
+            "fqdn": "myjavacomponent.myenvironment.test.net"
+          },
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "ingress": {
+            "fqdn": "myjavacomponent.myenvironment.test.net"
+          },
+          "provisioningState": "InProgress",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JavaComponents_CreateOrUpdate",
+  "title": "Create or Update Java Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_CreateOrUpdate_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_CreateOrUpdate_ServiceBind.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "javaComponentEnvelope": {
+      "properties": {
+        "componentType": "SpringBootAdmin",
+        "configurations": [
+          {
+            "propertyName": "spring.boot.admin.ui.enable-toasts",
+            "value": "true"
+          },
+          {
+            "propertyName": "spring.boot.admin.monitor.status-interval",
+            "value": "10000ms"
+          }
+        ],
+        "scale": {
+          "maxReplicas": 1,
+          "minReplicas": 1
+        },
+        "serviceBinds": [
+          {
+            "name": "yellowcat",
+            "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          },
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "provisioningState": "InProgress",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          },
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JavaComponents_CreateOrUpdate",
+  "title": "Create or Update Java Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "JavaComponents_Delete",
+  "title": "Delete Java Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_Get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "ingress": {
+            "fqdn": "myjavacomponent.myenvironment.test.net"
+          },
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JavaComponents_Get",
+  "title": "Get Java Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_Get_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_Get_ServiceBind.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          },
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JavaComponents_Get",
+  "title": "Get Java Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_List.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blueshark",
+            "type": "Microsoft.App/managedEnvironments/javaComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/blueshark",
+            "properties": {
+              "componentType": "SpringBootAdmin",
+              "configurations": [
+                {
+                  "propertyName": "spring.boot.admin.ui.enable-toasts",
+                  "value": "true"
+                },
+                {
+                  "propertyName": "spring.boot.admin.monitor.status-interval",
+                  "value": "10000ms"
+                }
+              ],
+              "ingress": {
+                "fqdn": "myjavacomponent.myenvironment.test.net"
+              },
+              "provisioningState": "Succeeded",
+              "scale": {
+                "maxReplicas": 1,
+                "minReplicas": 1
+              }
+            }
+          },
+          {
+            "name": "yellowcat",
+            "type": "Microsoft.App/managedEnvironments/javaComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat",
+            "properties": {
+              "componentType": "SpringCloudEureka",
+              "configurations": [
+                {
+                  "propertyName": "spring.cloud.config.server.git.uri",
+                  "value": "<GIT-URL>"
+                }
+              ],
+              "ingress": {
+                "fqdn": "myjavacomponent.myenvironment.test.net"
+              },
+              "provisioningState": "Succeeded",
+              "scale": {
+                "maxReplicas": 1,
+                "minReplicas": 1
+              }
+            }
+          },
+          {
+            "name": "reddog",
+            "type": "Microsoft.App/managedEnvironments/javaComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/reddog",
+            "properties": {
+              "componentType": "SpringCloudGateway",
+              "configurations": [
+                {
+                  "propertyName": "spring.cloud.gateway.enabled",
+                  "value": "true"
+                }
+              ],
+              "ingress": {
+                "fqdn": "myjavacomponent.myenvironment.test.net"
+              },
+              "provisioningState": "Succeeded",
+              "scale": {
+                "maxReplicas": 1,
+                "minReplicas": 1
+              },
+              "springCloudGatewayRoutes": [
+                {
+                  "filters": [
+                    "SetPath=/{path}"
+                  ],
+                  "id": "route1",
+                  "predicates": [
+                    "Path=/v1/{path}",
+                    "After=2024-01-20T17:42:47.789-07:00[America/Denver]"
+                  ],
+                  "uri": "https://otherjavacomponent.myenvironment.test.net"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "JavaComponents_List",
+  "title": "List Java Components"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_List_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_List_ServiceBind.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blueshark",
+            "type": "Microsoft.App/managedEnvironments/javaComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/blueshark",
+            "properties": {
+              "componentType": "SpringBootAdmin",
+              "configurations": [
+                {
+                  "propertyName": "spring.boot.admin.ui.enable-toasts",
+                  "value": "true"
+                },
+                {
+                  "propertyName": "spring.boot.admin.monitor.status-interval",
+                  "value": "10000ms"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "scale": {
+                "maxReplicas": 1,
+                "minReplicas": 1
+              },
+              "serviceBinds": [
+                {
+                  "name": "yellowcat",
+                  "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+                }
+              ]
+            }
+          },
+          {
+            "name": "yellowcat",
+            "type": "Microsoft.App/managedEnvironments/javaComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat",
+            "properties": {
+              "componentType": "SpringCloudEureka",
+              "configurations": [
+                {
+                  "propertyName": "spring.cloud.config.server.git.uri",
+                  "value": "<GIT-URL>"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "scale": {
+                "maxReplicas": 1,
+                "minReplicas": 1
+              },
+              "serviceBinds": [
+                {
+                  "name": "blueshark",
+                  "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/blueshark"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "JavaComponents_List",
+  "title": "List Java Components with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_Patch.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "javaComponentEnvelope": {
+      "properties": {
+        "componentType": "SpringBootAdmin",
+        "configurations": [
+          {
+            "propertyName": "spring.boot.admin.ui.enable-toasts",
+            "value": "true"
+          },
+          {
+            "propertyName": "spring.boot.admin.monitor.status-interval",
+            "value": "10000ms"
+          }
+        ],
+        "scale": {
+          "maxReplicas": 1,
+          "minReplicas": 1
+        }
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "ingress": {
+            "fqdn": "myjavacomponent.myenvironment.test.net"
+          },
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          }
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "JavaComponents_Update",
+  "title": "Patch Java Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_Patch_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/JavaComponents_Patch_ServiceBind.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "javaComponentEnvelope": {
+      "properties": {
+        "componentType": "SpringBootAdmin",
+        "configurations": [
+          {
+            "propertyName": "spring.boot.admin.ui.enable-toasts",
+            "value": "true"
+          },
+          {
+            "propertyName": "spring.boot.admin.monitor.status-interval",
+            "value": "10000ms"
+          }
+        ],
+        "scale": {
+          "maxReplicas": 1,
+          "minReplicas": 1
+        },
+        "serviceBinds": [
+          {
+            "name": "yellowcat",
+            "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          },
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "JavaComponents_Update",
+  "title": "Patch Java Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_CreateorUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_CreateorUpdate.json
@@ -1,0 +1,330 @@
+{
+  "parameters": {
+    "JobEnvelope": {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "identitySettings": [
+            {
+              "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+              "lifecycle": "All"
+            },
+            {
+              "identity": "system",
+              "lifecycle": "Init"
+            }
+          ],
+          "manualTriggerConfig": {
+            "parallelism": 4,
+            "replicaCompletionCount": 1
+          },
+          "replicaRetryLimit": 10,
+          "replicaTimeout": 10,
+          "triggerType": "Manual"
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppsJob0",
+              "image": "repo/testcontainerAppsJob0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 5,
+                  "periodSeconds": 3
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "mountPath": "/mnt/path1",
+                  "subPath": "subPath1",
+                  "volumeName": "azurefile"
+                },
+                {
+                  "mountPath": "/mnt/path2",
+                  "subPath": "subPath2",
+                  "volumeName": "nfsazurefile"
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerAppsJob0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerAppsJob0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "gpu": 1,
+                "memory": "100Mi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "gpu": 1,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "gpu": 1,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "Create or Update Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_CreateorUpdate_ConnectedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_CreateorUpdate_ConnectedEnvironment.json
@@ -1,0 +1,221 @@
+{
+  "parameters": {
+    "JobEnvelope": {
+      "extendedLocation": {
+        "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+        "type": "CustomLocation"
+      },
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "manualTriggerConfig": {
+            "parallelism": 4,
+            "replicaCompletionCount": 1
+          },
+          "replicaRetryLimit": 10,
+          "replicaTimeout": 10,
+          "triggerType": "Manual"
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppsJob0",
+              "image": "repo/testcontainerAppsJob0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 5,
+                  "periodSeconds": 3
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerAppsJob0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerAppsJob0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "Create or Update Container Apps Job On A Connected Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_CreateorUpdate_EventTrigger.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_CreateorUpdate_EventTrigger.json
@@ -1,0 +1,228 @@
+{
+  "parameters": {
+    "JobEnvelope": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "eventTriggerConfig": {
+            "parallelism": 4,
+            "replicaCompletionCount": 1,
+            "scale": {
+              "maxExecutions": 5,
+              "minExecutions": 1,
+              "pollingInterval": 40,
+              "rules": [
+                {
+                  "name": "servicebuscalingrule",
+                  "type": "azure-servicebus",
+                  "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                  "metadata": {
+                    "topicName": "my-topic"
+                  }
+                }
+              ]
+            }
+          },
+          "replicaRetryLimit": 10,
+          "replicaTimeout": 10,
+          "triggerType": "Event"
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppsJob0",
+              "image": "repo/testcontainerAppsJob0:v1"
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerAppsJob0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerAppsJob0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "eventTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1,
+              "scale": {
+                "maxExecutions": 5,
+                "minExecutions": 1,
+                "pollingInterval": 20,
+                "rules": [
+                  {
+                    "name": "servicebuscalingrule",
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "topicName": "my-topic"
+                    }
+                  }
+                ]
+              }
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Event"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "eventTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1,
+              "scale": {
+                "maxExecutions": 5,
+                "minExecutions": 1,
+                "pollingInterval": 20,
+                "rules": [
+                  {
+                    "name": "servicebuscalingrule",
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "messageCount": "50",
+                      "queueName": "my-queue"
+                    }
+                  }
+                ]
+              }
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Event"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "Create or Update Container Apps Job With Event Driven Trigger"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testWorkerContainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/jobs/testWorkerContainerAppsJob0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Jobs_Delete",
+  "title": "Delete Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Execution_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Execution_Get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobExecutionName": "jobExecution1",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jobExecution1",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0/executions/jobExecution1",
+        "properties": {
+          "endTime": "2023-02-13T20:47:30+00:00",
+          "message": "Job has reached the specified backoff limit",
+          "reason": "BackoffLimitExceeded",
+          "startTime": "2023-02-13T20:37:30+00:00",
+          "status": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerappsjob0",
+                "image": "repo/testcontainerappsjob0:v4",
+                "resources": {
+                  "cpu": 0.5,
+                  "memory": "1Gi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerappsjob0:v4",
+                "resources": {
+                  "cpu": 0.5,
+                  "memory": "1Gi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JobExecution",
+  "title": "Get a single Job Execution"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Executions_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Executions_Get.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerAppJob-27944454",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0/executions/testcontainerAppJob-27944454",
+            "properties": {
+              "detailedStatus": {
+                "replicas": [
+                  {
+                    "name": "testcontainerappsjob0-0",
+                    "containers": [
+                      {
+                        "name": "container1",
+                        "additionalInformation": "Completed",
+                        "code": 0,
+                        "status": "Succeeded"
+                      },
+                      {
+                        "name": "container2",
+                        "additionalInformation": "Completed",
+                        "code": 0,
+                        "status": "Succeeded"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "endTime": "2023-02-13T20:47:30+00:00",
+              "message": "Job has reached the specified backoff limit",
+              "reason": "BackoffLimitExceeded",
+              "startTime": "2023-02-13T20:37:30+00:00",
+              "status": "Running",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerappsjob0",
+                    "image": "repo/testcontainerappsjob0:v4",
+                    "resources": {
+                      "cpu": 0.5,
+                      "memory": "1Gi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerAppsJob0",
+                    "args": [
+                      "-c",
+                      "while true; do echo hello; sleep 10;done"
+                    ],
+                    "command": [
+                      "/bin/sh"
+                    ],
+                    "image": "repo/testcontainerappsjob0:v4",
+                    "resources": {
+                      "cpu": 0.5,
+                      "memory": "1Gi"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JobsExecutions_List",
+  "title": "Get a Container Apps Job Executions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Get.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_GetDetector.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_GetDetector.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "jobName": "mikonojob1",
+    "detectorName": "containerappjobnetworkIO",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/jobs/mikonojob1/detectors/containerappjobnetworkIO",
+        "name": "containerappjobnetworkIO",
+        "type": "Microsoft.App/jobs/detectors",
+        "properties": {
+          "metadata": {
+            "id": "containerappjobnetworkIO",
+            "name": "Container App Job Network Inbound and Outbound",
+            "description": "This detector shows the Container App Job Network Inbound and Outbound.",
+            "author": "",
+            "category": "Availability and Performance",
+            "supportTopicList": [],
+            "type": "Detector",
+            "score": 0
+          },
+          "dataset": [
+            {
+              "table": {
+                "tableName": "",
+                "columns": [
+                  {
+                    "columnName": "TimeStamp",
+                    "dataType": "DateTime"
+                  },
+                  {
+                    "columnName": "Metric",
+                    "dataType": "String"
+                  },
+                  {
+                    "columnName": "Average",
+                    "dataType": "Double"
+                  }
+                ],
+                "rows": [
+                  [
+                    "2022-03-15T21:35:00",
+                    "RxBytes",
+                    0
+                  ]
+                ]
+              },
+              "renderingProperties": {
+                "type": 8,
+                "title": "Container App Job Network Inbound ",
+                "description": "",
+                "isVisible": true
+              }
+            }
+          ],
+          "status": {
+            "statusId": 3
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Jobs_GetDetector",
+  "title": "Get diagnostic data for a Container App Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_ListDetectors.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_ListDetectors.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "jobName": "mikonojob1",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/jobs/mikonojob1/detectors/cappjobContainerAppAvailabilityMetrics",
+            "name": "cappjobContainerAppAvailabilityMetrics",
+            "type": "Microsoft.App/containerapps/detectors",
+            "properties": {
+              "metadata": {
+                "id": "cappjobContainerAppAvailabilityMetrics",
+                "name": "Availability Metrics for Container App Jobs",
+                "author": "",
+                "category": "Availability and Performance",
+                "supportTopicList": [],
+                "type": "Analysis",
+                "score": 0
+              },
+              "dataset": [],
+              "status": {
+                "statusId": 4
+              }
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  },
+  "operationId": "Jobs_ListDetectors",
+  "title": "Get the list of available diagnostic data for a Container App Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_ListSecrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_ListSecrets.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "secret1"
+          },
+          {
+            "name": "secret2"
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_ListSecrets",
+  "title": "List Container Apps Job Secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Patch.json
@@ -1,0 +1,116 @@
+{
+  "parameters": {
+    "JobEnvelope": {
+      "properties": {
+        "configuration": {
+          "manualTriggerConfig": {
+            "parallelism": 4,
+            "replicaCompletionCount": 1
+          },
+          "replicaRetryLimit": 10,
+          "replicaTimeout": 10,
+          "triggerType": "Manual"
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppsJob0",
+              "image": "repo/testcontainerAppsJob0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerAppsJob0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerAppsJob0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/locations/eastus/containerappsjobOperationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "Jobs_Update",
+  "title": "Patch Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_ProxyGet.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_ProxyGet.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "resourceGroupName": "rg",
+    "jobName": "testcontainerAppsJob0",
+    "apiName": "rootApi",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0/detectorproperties/rootApi",
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "location": "East US",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "configuration": {
+            "replicaTimeout": 10,
+            "replicaRetryLimit": 10,
+            "manualTriggerConfig": {
+              "replicaCompletionCount": 1,
+              "parallelism": 4
+            },
+            "triggerType": "Manual"
+          },
+          "template": {
+            "containers": [
+              {
+                "image": "repo/testcontainerAppsJob0:v4",
+                "name": "testcontainerAppsJob0",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "image": "repo/testcontainerAppsJob0:v4",
+                "name": "testinitcontainerAppsJob0",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Jobs_ProxyGet",
+  "title": "Get Container App Job by name"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Start.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Start.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "template": {
+      "containers": [
+        {
+          "name": "testcontainerAppsJob0",
+          "image": "repo/testcontainerAppsJob0:v4",
+          "resources": {
+            "cpu": 0.2,
+            "memory": "100Mi"
+          }
+        }
+      ],
+      "initContainers": [
+        {
+          "name": "testinitcontainerAppsJob0",
+          "args": [
+            "-c",
+            "while true; do echo hello; sleep 10;done"
+          ],
+          "command": [
+            "/bin/sh"
+          ],
+          "image": "repo/testcontainerAppsJob0:v4",
+          "resources": {
+            "cpu": 0.2,
+            "memory": "100Mi"
+          }
+        }
+      ]
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0-pjxhsye",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/{containerAppsJobName}/executions/{jobExecutionName}"
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_Start",
+  "title": "Run a Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Stop_Execution.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Stop_Execution.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobExecutionName": "jobExecution1",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_StopExecution",
+  "title": "Terminate a Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Stop_Multiple.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Job_Stop_Multiple.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobExecutionName": {
+      "value": [
+        {
+          "name": "jobExecution-27944453"
+        },
+        {
+          "name": "jobExecution-27944452"
+        },
+        {
+          "name": "jobExecution-27944451"
+        }
+      ]
+    },
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "jobExecution-27944453",
+            "properties": {
+              "endTime": "2023-02-13T20:47:30+00:00",
+              "message": "Job has reached the specified backoff limit",
+              "reason": "BackoffLimitExceeded",
+              "startTime": "2023-02-13T20:37:30+00:00",
+              "status": "Running"
+            }
+          },
+          {
+            "name": "jobExecution-27944452",
+            "properties": {
+              "endTime": "2023-02-13T21:47:30+00:00",
+              "message": "Job has reached the specified backoff limit",
+              "reason": "BackoffLimitExceeded",
+              "startTime": "2023-02-13T21:37:30+00:00",
+              "status": "Running"
+            }
+          },
+          {
+            "name": "jobExecution-27944453",
+            "properties": {
+              "endTime": "2023-02-13T22:47:30+00:00",
+              "message": "Job has reached the specified backoff limit",
+              "reason": "BackoffLimitExceeded",
+              "startTime": "2023-02-13T22:37:30+00:00",
+              "status": "Running"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_StopMultipleExecutions",
+  "title": "Terminate Multiple Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Jobs_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Jobs_ListByResourceGroup.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerAppsJob0",
+            "type": "Microsoft.App/jobs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "manualTriggerConfig": {
+                  "parallelism": 4,
+                  "replicaCompletionCount": 1
+                },
+                "replicaRetryLimit": 10,
+                "replicaTimeout": 10,
+                "triggerType": "Manual"
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerAppsJob0",
+                    "image": "repo/testcontainerAppsJob0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerAppsJob0",
+                    "image": "repo/testcontainerAppsJob0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "testcontainerAppsJob1",
+            "type": "Microsoft.App/jobs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob1",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "replicaRetryLimit": 10,
+                "replicaTimeout": 10,
+                "scheduleTriggerConfig": {
+                  "cronExpression": "* * * * 5",
+                  "parallelism": 4,
+                  "replicaCompletionCount": 1
+                },
+                "triggerType": "Scheduled"
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp0",
+                    "image": "repo/testcontainerAppsJob1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerApp0",
+                    "image": "repo/testinitcontainerAppsJob1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_ListByResourceGroup",
+  "title": "List Container Apps Jobs by resource group"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Jobs_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Jobs_ListBySubscription.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerAppsJob0",
+            "type": "Microsoft.App/jobs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "manualTriggerConfig": {
+                  "parallelism": 4,
+                  "replicaCompletionCount": 1
+                },
+                "replicaRetryLimit": 10,
+                "replicaTimeout": 10,
+                "triggerType": "Manual"
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerAppsJob0",
+                    "image": "repo/testcontainerAppsJob0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerAppsJob0",
+                    "image": "repo/testcontainerAppsJob0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "testcontainerAppsJob1",
+            "type": "Microsoft.App/jobs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob1",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "replicaRetryLimit": 10,
+                "replicaTimeout": 10,
+                "scheduleTriggerConfig": {
+                  "cronExpression": "* * * * 5",
+                  "parallelism": 5,
+                  "replicaCompletionCount": 1
+                },
+                "triggerType": "Scheduled"
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerAppsJob1",
+                    "image": "repo/testcontainerAppsJob1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerAppsJob1",
+                    "image": "repo/testcontainerAppsJob1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_ListBySubscription",
+  "title": "List Container Apps Jobs by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Jobs_Resume.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Jobs_Resume.json
@@ -1,0 +1,97 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningState": "Ready",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/jobs/testcontainerAppsJob0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview",
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/jobs/testcontainerAppsJob0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "Jobs_Resume",
+  "title": "Resume Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Jobs_Suspend.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Jobs_Suspend.json
@@ -1,0 +1,97 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningState": "Suspended",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/jobs/testcontainerAppsJob0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview",
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/jobs/testcontainerAppsJob0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "Jobs_Suspend",
+  "title": "Suspend Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LabelHistory_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LabelHistory_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testContainerApp",
+    "labelName": "dev",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ContainerAppsLabelHistory_DeleteLabelHistory",
+  "title": "Delete Container App's label history for a given label"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LabelHistory_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LabelHistory_Get.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testContainerApp",
+    "labelName": "dev",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "dev",
+        "type": "Microsoft.App/containerApps/labelHistory",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testContainerApp/labelHistory/dev",
+        "properties": {
+          "records": [
+            {
+              "revision": "testContainerApp--2",
+              "start": "2024-10-15T05:49:47+00:00",
+              "status": "Succeeded"
+            },
+            {
+              "revision": "testContainerApp--1",
+              "start": "2024-10-15T01:12:56+00:00",
+              "status": "Succeeded",
+              "stop": "2024-10-15T05:45:08+00:00"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsLabelHistory_GetLabelHistory",
+  "title": "Get Container App's single label history"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LabelHistory_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LabelHistory_List.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testContainerApp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "dev",
+            "type": "Microsoft.App/containerApps/labelHistory",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testContainerApp/labelHistory/dev",
+            "properties": {
+              "records": [
+                {
+                  "revision": "testContainerApp--2",
+                  "start": "2024-10-15T05:49:47+00:00",
+                  "status": "Starting"
+                },
+                {
+                  "revision": "testContainerApp--1",
+                  "start": "2024-10-15T01:12:56+00:00",
+                  "status": "Failed",
+                  "stop": "2024-10-15T05:45:08+00:00"
+                }
+              ]
+            }
+          },
+          {
+            "name": "prod",
+            "type": "Microsoft.App/containerApps/labelHistory",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testContainerApp/labelHistory/prod",
+            "properties": {
+              "records": [
+                {
+                  "revision": "testContainerApp--1",
+                  "start": "2024-10-15T05:45:08+00:00",
+                  "status": "Succeeded",
+                  "stop": "2024-10-15T05:49:47+00:00"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsLabelHistory_ListLabelHistory",
+  "title": "List Container App's all label history"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_Create.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_Create.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "logicAppName": "testcontainerApp0",
+    "resource": {
+      "properties": {}
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/logicApps",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0",
+        "properties": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/logicApps",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0",
+        "properties": {}
+      }
+    }
+  },
+  "operationId": "LogicApps_CreateOrUpdate",
+  "title": "Create logic app extension"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "logicAppName": "testcontainerApp0",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "LogicApps_Delete",
+  "title": "Create logic app extension"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_DeleteDeployWorkflowArtifacts.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_DeleteDeployWorkflowArtifacts.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testapp2",
+    "logicAppName": "testapp2",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workflowArtifacts": {
+      "filesToDelete": [
+        "test/workflow.json",
+        "test/"
+      ]
+    }
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "LogicApps_DeployWorkflowArtifacts",
+  "title": "Delete workflow artifacts"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_Get.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "logicAppName": "testcontainerApp0",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/logicApps",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0",
+        "properties": {}
+      }
+    }
+  },
+  "operationId": "LogicApps_Get",
+  "title": "Get logic app extension by name "
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_GetWorkflow.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_GetWorkflow.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "logicAppName": "testcontainerApp0",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9",
+    "workflowName": "stateful1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0/stateful1",
+        "type": "Microsoft.App/logicApps/workflows",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0/workflows/stateful1",
+        "kind": "Stateful",
+        "properties": {
+          "files": {
+            "connections.json": {
+              "managedApiConnections": {
+                "office365": {
+                  "api": {
+                    "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.Web/locations/brazilsouth/managedApis/office365"
+                  },
+                  "authentication": {
+                    "type": "Raw",
+                    "parameter": "@appsetting('office365-connectionKey')",
+                    "scheme": "Key"
+                  },
+                  "connection": {
+                    "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/connections/office365-1"
+                  },
+                  "connectionRuntimeUrl": "string"
+                }
+              }
+            },
+            "workflow.json": {
+              "definition": {
+                "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                "actions": {},
+                "contentVersion": "1.0.0.0",
+                "outputs": {},
+                "parameters": {},
+                "triggers": {}
+              }
+            }
+          },
+          "flowState": "Enabled",
+          "health": {
+            "state": "Healthy"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "LogicApps_GetWorkflow",
+  "title": "GET a workflow"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_ListCallbackURL.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_ListCallbackURL.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testapp2",
+    "logicAppName": "testapp2",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "x-ms-logicApps-proxy-method": "POST",
+    "x-ms-logicApps-proxy-path": "/runtime/webhooks/workflow/api/management/workflows/Stateful1/triggers/When_a_HTTP_request_is_received/listCallbackUrl"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "method": "POST",
+        "basePath": "https://testapp2.livelyriver-730e4fd9.eastasia.azurecontainerapps.io /api/test/triggers/When_a_HTTP_request_is_received/invoke",
+        "queries": {
+          "api-version": "2022-05-01",
+          "sig": "IxEQ_ygZf6WNEQCbjV0Vs6p6Y4DyNEJVAa86U5B4xhk",
+          "sp": "/triggers/When_a_HTTP_request_is_received/run",
+          "sv": "1.0"
+        },
+        "value": "https://testapp2.livelyriver-730e4fd9.eastasia.azurecontainerapps.io:443/api/test/triggers/When_a_HTTP_request_is_received/invoke?api-version=2022-05-01&sp=%2Ftriggers%2FWhen_a_HTTP_request_is_received%2Frun&sv=1.0&sig=<sig> "
+      }
+    }
+  },
+  "operationId": "LogicApps_Invoke",
+  "title": "Get workflow list call back URL"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_ListConnections.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_ListConnections.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testapp2",
+    "logicAppName": "testapp2",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testapp2/connections",
+        "type": "Microsoft.App/logicApps/workflowsconfiguration",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testapp2/providers/Microsoft.App/logicApps/testapp2/workflowconfigurations/connections",
+        "properties": {
+          "files": {
+            "connections.json": {
+              "managedApiConnections": {
+                "office365": {
+                  "api": {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/locations/centraluseuap/managedApis/arm"
+                  },
+                  "authentication": {
+                    "type": "Raw",
+                    "parameter": "@appsetting('office365-connectionKey')",
+                    "scheme": "Key"
+                  },
+                  "connection": {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.Web/connections/arm"
+                  },
+                  "connectionRuntimeUrl": "https://9d51d1ffc9f77572.00.common.logic.azure-apihub.net/apim/arm/connectionruntimeid"
+                }
+              }
+            }
+          },
+          "health": {
+            "state": "Healthy"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "LogicApps_ListWorkflowsConnections",
+  "title": "List the Workflows Configuration Connections"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_ListWorkflows.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_ListWorkflows.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "logicAppName": "testcontainerApp0",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerApp0/a1",
+            "type": "Microsoft.App/logicApps/workflows",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0/workflows/a1",
+            "kind": "Stateful",
+            "properties": {
+              "flowState": "Enabled",
+              "health": {
+                "state": "Healthy"
+              }
+            }
+          },
+          {
+            "name": "testcontainerApp0/stateful2",
+            "type": "Microsoft.App/logicApps/workflows",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0/workflows/stateful2",
+            "kind": "Stateful",
+            "properties": {
+              "flowState": "Enabled",
+              "health": {
+                "error": {
+                  "code": "InvalidWorkflowJson",
+                  "message": "Invalid character after parsing property name. Expected ':' but got: \". Path '', line 2, position 2."
+                },
+                "state": "Unhealthy"
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "LogicApps_ListWorkflows",
+  "title": "List the workflows"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_PostDeployWorkflowArtifacts.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/LogicApps_PostDeployWorkflowArtifacts.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testapp2",
+    "logicAppName": "testapp2",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workflowArtifacts": {
+      "appSettings": {
+        "eventHub_connectionString": "Endpoint=sb://example.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=EXAMPLE1a2b3c4d5e6fEXAMPLE="
+      },
+      "files": {
+        "connections.json": {
+          "managedApiConnections": {},
+          "serviceProviderConnections": {
+            "eventHub": {
+              "displayName": "example1",
+              "parameterValues": {
+                "connectionString": "@appsetting('eventHub_connectionString')"
+              },
+              "serviceProvider": {
+                "id": "/serviceProviders/eventHub"
+              }
+            }
+          }
+        },
+        "test1/workflow.json": {
+          "definition": {
+            "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+            "actions": {},
+            "contentVersion": "1.0.0.0",
+            "outputs": {},
+            "triggers": {
+              "When_events_are_available_in_Event_hub": {
+                "type": "ServiceProvider",
+                "inputs": {
+                  "parameters": {
+                    "eventHubName": "test123"
+                  },
+                  "serviceProviderConfiguration": {
+                    "operationId": "receiveEvents",
+                    "connectionName": "eventHub",
+                    "serviceProviderId": "/serviceProviders/eventHub"
+                  }
+                },
+                "splitOn": "@triggerOutputs()?['body']"
+              }
+            }
+          },
+          "kind": "Stateful"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "LogicApps_DeployWorkflowArtifacts",
+  "title": "Deploys workflow artifacts"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedCertificate_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedCertificate_CreateOrUpdate.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "managedCertificateEnvelope": {
+      "location": "East US",
+      "properties": {
+        "domainControlValidation": "CNAME",
+        "subjectName": "my-subject-name.company.country.net"
+      }
+    },
+    "managedCertificateName": "certificate-firendly-name",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "domainControlValidation": "CNAME",
+          "provisioningState": "Succeeded",
+          "subjectName": "CN=my-subject-name.company.country.net"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "domainControlValidation": "CNAME",
+          "provisioningState": "Pending",
+          "subjectName": "CN=my-subject-name.company.country.net"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/locations/eastus/managedCertificateOperationStatuses/dc27c9cd-370f-4623-95d4-827b6dc4120a?api-version=2022-06-01-preview&azureAsyncOperation=true"
+      }
+    },
+    "400": {
+      "code": "ManagedCertNoUpdate",
+      "message": "Properties of managed certificates cannot be updated. Please delete the current resource and retry or use a different resource id."
+    }
+  },
+  "operationId": "ManagedCertificates_CreateOrUpdate",
+  "title": "Create or Update Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedCertificate_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedCertificate_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "managedCertificateName": "certificate-firendly-name",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ManagedCertificates_Delete",
+  "title": "Delete Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedCertificate_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedCertificate_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "managedCertificateName": "certificate-firendly-name",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "domainControlValidation": "CNAME",
+          "provisioningState": "Succeeded",
+          "subjectName": "CN=my-subject-name.company.country.net"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedCertificates_Get",
+  "title": "Get Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedCertificates_ListByManagedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedCertificates_ListByManagedEnvironment.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name",
+            "location": "East US",
+            "properties": {
+              "domainControlValidation": "CNAME",
+              "provisioningState": "Succeeded",
+              "subjectName": "CN=my-subject-name.company.country.net"
+            }
+          },
+          {
+            "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name-root",
+            "location": "East US",
+            "properties": {
+              "domainControlValidation": "HTTP",
+              "provisioningState": "Succeeded",
+              "subjectName": "CN=company.country.net"
+            }
+          },
+          {
+            "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name-txt",
+            "location": "East US",
+            "properties": {
+              "domainControlValidation": "TXT",
+              "provisioningState": "Succeeded",
+              "subjectName": "CN=txt.company.country.net"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedCertificates_List",
+  "title": "List Managed Certificates by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedCertificates_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedCertificates_Patch.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "managedCertificateEnvelope": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "managedCertificateName": "certificate-firendly-name",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "domainControlValidation": "CNAME",
+          "provisioningState": "Succeeded",
+          "subjectName": "CN=my-subject-name.company.country.net"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedCertificates_Update",
+  "title": "Patch Managed Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentDiagnostics_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentDiagnostics_Get.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "environmentName": "mikonokubeenv",
+    "detectorName": "ManagedEnvAvailabilityMetrics",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/managedEnvironments/mikonokubeenv/detectors/ManagedEnvAvailabilityMetrics",
+        "name": "ManagedEnvAvailabilityMetrics",
+        "type": "Microsoft.App/managedEnvironments/detectors",
+        "properties": {
+          "metadata": {
+            "id": "ManagedEnvAvailabilityMetrics",
+            "name": "Managed Env Netowrk Inbound and Outbound",
+            "description": "This detector shows the Managed Environment Network Inbound and Outbound.",
+            "author": "",
+            "category": "Availability and Performance",
+            "supportTopicList": [],
+            "type": "Detector",
+            "score": 0
+          },
+          "dataset": [
+            {
+              "table": {
+                "tableName": "",
+                "columns": [
+                  {
+                    "columnName": "TimeStamp",
+                    "dataType": "DateTime"
+                  },
+                  {
+                    "columnName": "Metric",
+                    "dataType": "String"
+                  },
+                  {
+                    "columnName": "Average",
+                    "dataType": "Double"
+                  }
+                ],
+                "rows": [
+                  [
+                    "2022-03-15T21:35:00",
+                    "RxBytes",
+                    0
+                  ]
+                ]
+              },
+              "renderingProperties": {
+                "type": 8,
+                "title": "Managed Environment Network Inbound ",
+                "description": "",
+                "isVisible": true
+              }
+            }
+          ],
+          "status": {
+            "statusId": 3
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentDiagnostics_GetDetector",
+  "title": "Get diagnostic data for a managed environments"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentDiagnostics_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentDiagnostics_List.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "environmentName": "mikonokubeenv",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/managedEnvironments/mikonokubeenv/detectors/ManagedEnvAvailabilityMetrics",
+            "name": "ManagedEnvAvailabilityMetrics",
+            "type": "Microsoft.App/managedEnvironments/detectors",
+            "properties": {
+              "metadata": {
+                "id": "ManagedEnvAvailabilityMetrics",
+                "name": "Availability Metrics for Managed Environments",
+                "author": "",
+                "category": "Availability and Performance",
+                "supportTopicList": [],
+                "type": "Analysis",
+                "score": 0
+              },
+              "dataset": [],
+              "status": {
+                "statusId": 4
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentDiagnostics_ListDetectors",
+  "title": "Get the list of available diagnostic data for a managed environments"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentPrivateEndpointConnections_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentPrivateEndpointConnections_CreateOrUpdate.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "privateEndpointConnectionEnvelope": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "actionsRequired": "None",
+          "status": "Approved"
+        }
+      }
+    },
+    "privateEndpointConnectionName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateEndpointConenctions/jlaw-demo1",
+        "properties": {
+          "groupIds": [
+            "managedEnvironments"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/pltest"
+          },
+          "privateLinkServiceConnectionState": {
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateEndpointConenctions/jlaw-demo1",
+        "properties": {
+          "groupIds": [
+            "managedEnvironments"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/pltest"
+          },
+          "privateLinkServiceConnectionState": {
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Updating"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentPrivateEndpointConnections_CreateOrUpdate",
+  "title": "Update a Private Endpoint Connection by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentPrivateEndpointConnections_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentPrivateEndpointConnections_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "privateEndpointConnectionName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/operationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedEnvironmentPrivateEndpointConnections_Delete",
+  "title": "Delete a Private Endpoint Connection by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentPrivateEndpointConnections_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentPrivateEndpointConnections_Get.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "privateEndpointConnectionName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateEndpointConenctions/jlaw-demo1",
+        "properties": {
+          "groupIds": [
+            "managedEnvironments"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/pltest"
+          },
+          "privateLinkServiceConnectionState": {
+            "actionsRequired": "None",
+            "status": "Pending"
+          },
+          "provisioningState": "Waiting"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentPrivateEndpointConnections_Get",
+  "title": "Get a Private Endpoint Connection by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentPrivateEndpointConnections_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentPrivateEndpointConnections_List.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "jlaw-demo1",
+            "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateEndpointConenctions/jlaw-demo1",
+            "properties": {
+              "groupIds": [
+                "managedEnvironments"
+              ],
+              "privateEndpoint": {
+                "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/pltest"
+              },
+              "privateLinkServiceConnectionState": {
+                "actionsRequired": "None",
+                "status": "Pending"
+              },
+              "provisioningState": "Waiting"
+            }
+          },
+          {
+            "name": "jlaw-demo2",
+            "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateEndpointConenctions/jlaw-demo2",
+            "properties": {
+              "groupIds": [
+                "managedEnvironments"
+              ],
+              "privateEndpoint": {
+                "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/pltest"
+              },
+              "privateLinkServiceConnectionState": {
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentPrivateEndpointConnections_List",
+  "title": "List Private Endpoint Connections by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentPrivateLinkResources_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentPrivateLinkResources_List.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "managedEnvironments",
+            "type": "Microsoft.App/managedEnvironments/privateLinkResources",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateLinkResources/managedEnvironments",
+            "properties": {
+              "groupId": "managedEnvironments",
+              "requiredMembers": [
+                "managedEnvironments"
+              ],
+              "requiredZoneNames": [
+                "privatelink.northcentralusstage.azurecontainerapps.io"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentPrivateLinkResources_List",
+  "title": "List Private Link Resources by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentUsages_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentUsages_List.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Managed Environment Consumption Cores",
+              "value": "ManagedEnvironmentConsumptionCores"
+            },
+            "currentValue": 0.5,
+            "limit": 10,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentUsages_List",
+  "title": "List managed environment usages"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironment_MaintenanceConfigurations_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironment_MaintenanceConfigurations_CreateOrUpdate.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "configName": "default",
+    "environmentName": "managedEnv",
+    "maintenanceConfigurationEnvelope": {
+      "properties": {
+        "scheduledEntries": [
+          {
+            "durationHours": 9,
+            "startHourUtc": 12,
+            "weekDay": "Sunday"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.App/ManagedEnvironments/maintenanceConfigurations",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/rg1/providers/Microsoft.App/ManagedEnvironments/managedEnv/maintenanceConfigurations/default",
+        "properties": {
+          "scheduledEntries": [
+            {
+              "durationHours": 9,
+              "startHourUtc": 12,
+              "weekDay": "Sunday"
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.App/ManagedEnvironments/maintenanceConfigurations",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/rg1/providers/Microsoft.App/ManagedEnvironments/managedEnv/maintenanceConfigurations/default",
+        "properties": {
+          "scheduledEntries": [
+            {
+              "durationHours": 9,
+              "startHourUtc": 12,
+              "weekDay": "Sunday"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "MaintenanceConfigurations_CreateOrUpdate",
+  "title": "ManagedEnvironmentMaintenanceConfigurationsCreateOrUpdate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironment_MaintenanceConfigurations_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironment_MaintenanceConfigurations_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "configName": "default",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "MaintenanceConfigurations_Delete",
+  "title": "ManagedEnvironmentMaintenanceConfigurationsDelete"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironment_MaintenanceConfigurations_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironment_MaintenanceConfigurations_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "configName": "default",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.App/ManagedEnvironments/MaintenanceConfigurations",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/rg1/providers/Microsoft.App/managedEnvironments/managedEnv/maintenanceConfigurations/default",
+        "properties": {
+          "scheduledEntries": [
+            {
+              "durationHours": 9,
+              "startHourUtc": 12,
+              "weekDay": "Sunday"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "MaintenanceConfigurations_Get",
+  "title": "ManagedEnvironmentMaintenanceConfigurationsGet"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironment_MaintenanceConfigurations_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironment_MaintenanceConfigurations_List.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.App/ManagedEnvironments/MaintenanceConfigurations",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/rg1/providers/Microsoft.App/managedEnvironments/managedEnv/maintenanceConfigurations/default",
+            "properties": {
+              "scheduledEntries": [
+                {
+                  "durationHours": 9,
+                  "startHourUtc": 12,
+                  "weekDay": "Sunday"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MaintenanceConfigurations_List",
+  "title": "ManagedEnvironmentMaintenanceConfigurationsList"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_CreateOrUpdate.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageEnvelope": {
+      "properties": {
+        "azureFile": {
+          "accessMode": "ReadOnly",
+          "accountKey": "key",
+          "accountName": "account1",
+          "shareName": "share1"
+        }
+      }
+    },
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {}
+    },
+    "201": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo1",
+        "properties": {
+          "azureFile": {
+            "accessMode": "ReadOnly",
+            "accountKeyVaultProperties": {
+              "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+              "keyVaultUrl": "https://myvault.vault.azure.net/secrets/mysecret"
+            },
+            "accountName": "account1",
+            "shareName": "share1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_CreateOrUpdate",
+  "title": "Create or update environments storage"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_CreateOrUpdate_NfsAzureFile.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_CreateOrUpdate_NfsAzureFile.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageEnvelope": {
+      "properties": {
+        "nfsAzureFile": {
+          "accessMode": "ReadOnly",
+          "server": "server1",
+          "shareName": "share1"
+        }
+      }
+    },
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo1",
+        "properties": {
+          "nfsAzureFile": {
+            "accessMode": "ReadOnly",
+            "server": "server1",
+            "shareName": "share1"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {}
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_CreateOrUpdate",
+  "title": "Create or update environments storage for NFS Azure file"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ManagedEnvironmentsStorages_Delete",
+  "title": "List environments storages by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_Get.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo1",
+        "properties": {
+          "azureFile": {
+            "accessMode": "ReadOnly",
+            "accountKeyVaultProperties": {
+              "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+              "keyVaultUrl": "https://myvault.vault.azure.net/secrets/mysecret"
+            },
+            "accountName": "account1",
+            "shareName": "share1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_Get",
+  "title": "get a environments storage"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_Get_NfsAzureFile.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_Get_NfsAzureFile.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo1",
+        "properties": {
+          "nfsAzureFile": {
+            "accessMode": "ReadOnly",
+            "server": "server1",
+            "shareName": "share1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_Get",
+  "title": "get a environments storage for NFS Azure file"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironmentsStorages_List.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "jlaw-demo1",
+            "type": "Microsoft.App/managedEnvironments/storages",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo1",
+            "properties": {
+              "azureFile": {
+                "accessMode": "ReadOnly",
+                "accountKeyVaultProperties": {
+                  "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                  "keyVaultUrl": "https://myvault.vault.azure.net/secrets/mysecret"
+                },
+                "accountName": "account1",
+                "shareName": "share1"
+              }
+            }
+          },
+          {
+            "name": "jlaw-demo2",
+            "type": "Microsoft.App/managedEnvironments/storages",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo2",
+            "properties": {
+              "nfsAzureFile": {
+                "accessMode": "ReadOnly",
+                "server": "server1",
+                "shareName": "share1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_List",
+  "title": "List environments storages by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_CreateOrUpdate.json
@@ -1,0 +1,382 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentEnvelope": {
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "appInsightsConfiguration": {
+          "connectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+        },
+        "appLogsConfiguration": {
+          "logAnalyticsConfiguration": {
+            "customerId": "string",
+            "dynamicJsonColumns": true,
+            "sharedKey": "string"
+          }
+        },
+        "availabilityZones": [
+          "1",
+          "2",
+          "3"
+        ],
+        "customDomainConfiguration": {
+          "certificatePassword": "1234",
+          "certificateValue": "Y2VydA==",
+          "dnsSuffix": "www.my-name.com"
+        },
+        "daprAIConnectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://northcentralus-0.in.applicationinsights.azure.com/",
+        "diskEncryptionConfiguration": {
+          "keyVaultConfiguration": {
+            "auth": {
+              "identity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity"
+            },
+            "keyUrl": "https://contoso.vault.azure.net/mykey/19ff8313ca394b89b9e824bbbdc8c521"
+          }
+        },
+        "ingressConfiguration": {
+          "headerCountLimit": 30,
+          "requestIdleTimeout": 5,
+          "terminationGracePeriodSeconds": 3600,
+          "workloadProfileName": "My-CO-01"
+        },
+        "openTelemetryConfiguration": {
+          "destinationsConfiguration": {
+            "dataDogConfiguration": {
+              "key": "000000000000000000000000",
+              "site": "string"
+            },
+            "otlpConfigurations": [
+              {
+                "name": "dashboard",
+                "endpoint": "dashboard.k8s.region.azurecontainerapps.io:80",
+                "headers": [
+                  {
+                    "key": "api-key",
+                    "value": "xxxxxxxxxxx"
+                  }
+                ],
+                "insecure": true
+              }
+            ]
+          },
+          "logsConfiguration": {
+            "destinations": [
+              "appInsights"
+            ]
+          },
+          "metricsConfiguration": {
+            "destinations": [
+              "dataDog"
+            ],
+            "includeKeda": true
+          },
+          "tracesConfiguration": {
+            "destinations": [
+              "appInsights"
+            ],
+            "includeDapr": true
+          }
+        },
+        "peerAuthentication": {
+          "mtls": {
+            "enabled": true
+          }
+        },
+        "peerTrafficConfiguration": {
+          "encryption": {
+            "enabled": true
+          }
+        },
+        "vnetConfiguration": {
+          "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+        },
+        "workloadProfiles": [
+          {
+            "name": "My-GP-01",
+            "enableFips": true,
+            "maximumCount": 12,
+            "minimumCount": 3,
+            "workloadProfileType": "GeneralPurpose"
+          },
+          {
+            "name": "My-MO-01",
+            "maximumCount": 6,
+            "minimumCount": 3,
+            "workloadProfileType": "MemoryOptimized"
+          },
+          {
+            "name": "My-CO-01",
+            "maximumCount": 6,
+            "minimumCount": 3,
+            "workloadProfileType": "ComputeOptimized"
+          },
+          {
+            "name": "My-consumption-01",
+            "workloadProfileType": "Consumption"
+          }
+        ],
+        "zoneRedundant": true
+      }
+    },
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerenv",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "appInsightsConfiguration": null,
+          "appLogsConfiguration": {
+            "logAnalyticsConfiguration": {
+              "customerId": "string",
+              "dynamicJsonColumns": true
+            }
+          },
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testcontainerenv.k4apps.io",
+          "deploymentErrors": null,
+          "diskEncryptionConfiguration": {
+            "keyVaultConfiguration": {
+              "auth": {
+                "identity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity"
+              },
+              "keyUrl": "https://contoso.vault.azure.net/mykey/19ff8313ca394b89b9e824bbbdc8c521"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "capp-svc-testcontainerenv-eastus",
+          "ingressConfiguration": {
+            "headerCountLimit": 30,
+            "requestIdleTimeout": 5,
+            "terminationGracePeriodSeconds": 3600,
+            "workloadProfileName": "My-CO-01"
+          },
+          "openTelemetryConfiguration": {
+            "destinationsConfiguration": {
+              "dataDogConfiguration": {
+                "key": null,
+                "site": "datadoghq.com"
+              },
+              "otlpConfigurations": [
+                {
+                  "name": "dashboard",
+                  "endpoint": "dashboard.k8s.region.azurecontainerapps.io:80",
+                  "insecure": true
+                }
+              ]
+            },
+            "logsConfiguration": {
+              "destinations": [
+                "appInsights"
+              ]
+            },
+            "metricsConfiguration": {
+              "destinations": [
+                "dataDog"
+              ]
+            },
+            "tracesConfiguration": {
+              "destinations": [
+                "appInsights"
+              ]
+            }
+          },
+          "peerAuthentication": {
+            "mtls": {
+              "enabled": true
+            }
+          },
+          "provisioningState": "Succeeded",
+          "staticIp": "1.2.3.4",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerenv",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "appInsightsConfiguration": null,
+          "appLogsConfiguration": {
+            "logAnalyticsConfiguration": {
+              "customerId": "string"
+            }
+          },
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testcontainerenv.k4apps.io",
+          "deploymentErrors": null,
+          "diskEncryptionConfiguration": {
+            "keyVaultConfiguration": {
+              "auth": {
+                "identity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity"
+              },
+              "keyUrl": "https://contoso.vault.azure.net/mykey/19ff8313ca394b89b9e824bbbdc8c521"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "capp-svc-testcontainerenv-eastus",
+          "ingressConfiguration": {
+            "headerCountLimit": 30,
+            "requestIdleTimeout": 5,
+            "terminationGracePeriodSeconds": 3600,
+            "workloadProfileName": "My-CO-01"
+          },
+          "openTelemetryConfiguration": {
+            "destinationsConfiguration": {
+              "dataDogConfiguration": {
+                "key": null,
+                "site": "datadoghq.com"
+              },
+              "otlpConfigurations": [
+                {
+                  "name": "dashboard",
+                  "endpoint": "dashboard.k8s.region.azurecontainerapps.io:80",
+                  "insecure": true
+                }
+              ]
+            },
+            "logsConfiguration": {
+              "destinations": [
+                "appInsights"
+              ]
+            },
+            "metricsConfiguration": {
+              "destinations": [
+                "dataDog"
+              ]
+            },
+            "tracesConfiguration": {
+              "destinations": [
+                "appInsights"
+              ]
+            }
+          },
+          "peerAuthentication": {
+            "mtls": {
+              "enabled": true
+            }
+          },
+          "provisioningState": "InitializationInProgress",
+          "staticIp": "1.2.3.4",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_CreateOrUpdate",
+  "title": "Create environments"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_CustomInfrastructureResourceGroup_Create.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_CustomInfrastructureResourceGroup_Create.json
@@ -1,0 +1,188 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentEnvelope": {
+      "location": "East US",
+      "properties": {
+        "appLogsConfiguration": {
+          "logAnalyticsConfiguration": {
+            "customerId": "string",
+            "sharedKey": "string"
+          }
+        },
+        "availabilityZones": [
+          "1",
+          "2",
+          "3"
+        ],
+        "customDomainConfiguration": {
+          "certificatePassword": "1234",
+          "certificateValue": "Y2VydA==",
+          "dnsSuffix": "www.my-name.com"
+        },
+        "daprAIConnectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://northcentralus-0.in.applicationinsights.azure.com/",
+        "infrastructureResourceGroup": "myInfrastructureRgName",
+        "vnetConfiguration": {
+          "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+        },
+        "workloadProfiles": [
+          {
+            "name": "My-GP-01",
+            "enableFips": true,
+            "maximumCount": 12,
+            "minimumCount": 3,
+            "workloadProfileType": "GeneralPurpose"
+          },
+          {
+            "name": "My-MO-01",
+            "maximumCount": 6,
+            "minimumCount": 3,
+            "workloadProfileType": "MemoryOptimized"
+          },
+          {
+            "name": "My-CO-01",
+            "maximumCount": 6,
+            "minimumCount": 3,
+            "workloadProfileType": "ComputeOptimized"
+          },
+          {
+            "name": "My-consumption-01",
+            "workloadProfileType": "Consumption"
+          }
+        ],
+        "zoneRedundant": true
+      }
+    },
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerenv",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv",
+        "location": "East US",
+        "properties": {
+          "appLogsConfiguration": {
+            "logAnalyticsConfiguration": {
+              "customerId": "string"
+            }
+          },
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testcontainerenv.k4apps.io",
+          "deploymentErrors": null,
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "myInfrastructureRgName",
+          "provisioningState": "Succeeded",
+          "staticIp": "1.2.3.4",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerenv",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv",
+        "location": "East US",
+        "properties": {
+          "appLogsConfiguration": {
+            "logAnalyticsConfiguration": {
+              "customerId": "string"
+            }
+          },
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testcontainerenv.k4apps.io",
+          "deploymentErrors": null,
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "myInfrastructureRgName",
+          "provisioningState": "InitializationInProgress",
+          "staticIp": "1.2.3.4",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_CreateOrUpdate",
+  "title": "Create environment with custom infrastructureResourceGroup"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "examplekenv",
+    "location": "East US",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/operationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedEnvironments_Delete",
+  "title": "Delete environment by name"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_Get.json
@@ -1,0 +1,92 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1",
+        "location": "North Central US",
+        "properties": {
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "daprConfiguration": {
+            "version": "1.9"
+          },
+          "defaultDomain": "jlaw-demo1.k4apps.io",
+          "deploymentErrors": null,
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "capp-svc-jlaw-demo1-northcentralus",
+          "ingressConfiguration": {
+            "headerCountLimit": 30,
+            "requestIdleTimeout": 5,
+            "terminationGracePeriodSeconds": 3600,
+            "workloadProfileName": "My-CO-01"
+          },
+          "kedaConfiguration": {
+            "version": "2.8.1"
+          },
+          "peerAuthentication": {
+            "mtls": {
+              "enabled": true
+            }
+          },
+          "peerTrafficConfiguration": {
+            "encryption": {
+              "enabled": true
+            }
+          },
+          "provisioningState": "Succeeded",
+          "staticIp": "20.42.33.145",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_Get",
+  "title": "Get environments by name"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_Get1.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_Get1.json
@@ -1,0 +1,92 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1",
+        "location": "North Central US",
+        "properties": {
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "daprConfiguration": {
+            "version": "1.9"
+          },
+          "defaultDomain": "jlaw-demo1.k4apps.io",
+          "deploymentErrors": null,
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "capp-svc-jlaw-demo1-northcentralus",
+          "ingressConfiguration": {
+            "headerCountLimit": 30,
+            "requestIdleTimeout": 5,
+            "terminationGracePeriodSeconds": 3600,
+            "workloadProfileName": "My-CO-01"
+          },
+          "kedaConfiguration": {
+            "version": "2.8.1"
+          },
+          "peerAuthentication": {
+            "mtls": {
+              "enabled": true
+            }
+          },
+          "peerTrafficConfiguration": {
+            "encryption": {
+              "enabled": true
+            }
+          },
+          "provisioningState": "Succeeded",
+          "staticIp": "20.42.33.145",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsDiagnostics_GetRoot",
+  "title": "Get environments by name"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_GetAuthToken.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_GetAuthToken.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testenv",
+    "resourceGroupName": "rg",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testenv",
+        "type": "Microsoft.App/environments/accesstoken",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testenv",
+        "location": "East US",
+        "properties": {
+          "expires": "2022-07-14T19:22:50.3080223Z",
+          "token": "testToken"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedEnvironments_GetAuthToken",
+  "title": "Get Managed Environment Auth Token"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_ListByResourceGroup.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "jlaw-demo1",
+            "type": "Microsoft.App/managedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1",
+            "location": "North Central US",
+            "properties": {
+              "appLogsConfiguration": null,
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "jlaw-demo1.k4apps.io",
+              "deploymentErrors": null,
+              "eventStreamEndpoint": "testEndpoint",
+              "infrastructureResourceGroup": "capp-svc-jlaw-demo1-northcentralus",
+              "ingressConfiguration": {
+                "headerCountLimit": 50,
+                "requestIdleTimeout": null,
+                "terminationGracePeriodSeconds": 600,
+                "workloadProfileName": "My-GP-01"
+              },
+              "provisioningState": "Succeeded",
+              "staticIp": "20.42.33.145",
+              "vnetConfiguration": {
+                "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+              },
+              "workloadProfiles": [
+                {
+                  "name": "My-GP-01",
+                  "enableFips": true,
+                  "maximumCount": 12,
+                  "minimumCount": 3,
+                  "workloadProfileType": "GeneralPurpose"
+                },
+                {
+                  "name": "My-MO-01",
+                  "maximumCount": 6,
+                  "minimumCount": 3,
+                  "workloadProfileType": "MemoryOptimized"
+                },
+                {
+                  "name": "My-CO-01",
+                  "maximumCount": 6,
+                  "minimumCount": 3,
+                  "workloadProfileType": "ComputeOptimized"
+                },
+                {
+                  "name": "My-consumption-01",
+                  "workloadProfileType": "Consumption"
+                }
+              ],
+              "zoneRedundant": true
+            },
+            "tags": {}
+          },
+          {
+            "name": "demo1",
+            "type": "Microsoft.App/managedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/demo1",
+            "location": "North Central US",
+            "properties": {
+              "appLogsConfiguration": null,
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name2.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name2.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "demo1.k4apps.io",
+              "deploymentErrors": null,
+              "eventStreamEndpoint": "testEndpoint",
+              "infrastructureResourceGroup": "capp-svc-demo1-northcentralus",
+              "ingressConfiguration": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "52.142.21.61",
+              "vnetConfiguration": {
+                "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+              },
+              "zoneRedundant": true
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_ListByResourceGroup",
+  "title": "List environments by resource group"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_ListBySubscription.json
@@ -1,0 +1,173 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "jlaw-demo1",
+            "type": "Microsoft.App/managedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1",
+            "location": "North Central US",
+            "properties": {
+              "appLogsConfiguration": null,
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "jlaw-demo1.k4apps.io",
+              "deploymentErrors": null,
+              "eventStreamEndpoint": "testEndpoint",
+              "infrastructureResourceGroup": "capp-svc-jlaw-demo1-northcentralus",
+              "ingressConfiguration": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "20.42.33.145",
+              "vnetConfiguration": {
+                "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+              },
+              "workloadProfiles": [
+                {
+                  "name": "My-GP-01",
+                  "enableFips": true,
+                  "maximumCount": 12,
+                  "minimumCount": 3,
+                  "workloadProfileType": "GeneralPurpose"
+                },
+                {
+                  "name": "My-MO-01",
+                  "maximumCount": 6,
+                  "minimumCount": 3,
+                  "workloadProfileType": "MemoryOptimized"
+                },
+                {
+                  "name": "My-CO-01",
+                  "maximumCount": 6,
+                  "minimumCount": 3,
+                  "workloadProfileType": "ComputeOptimized"
+                },
+                {
+                  "name": "My-consumption-01",
+                  "workloadProfileType": "Consumption"
+                }
+              ],
+              "zoneRedundant": true
+            },
+            "tags": {}
+          },
+          {
+            "name": "demo1",
+            "type": "Microsoft.App/managedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/DemoRG/providers/Microsoft.App/managedEnvironments/demo1",
+            "location": "North Central US",
+            "properties": {
+              "appLogsConfiguration": {
+                "destination": "log-analytics",
+                "logAnalyticsConfiguration": {
+                  "customerId": "9ccccd4a-268f-4a9a-8d03-9bfe77c3fbd2",
+                  "dynamicJsonColumns": true
+                }
+              },
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name2.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name2.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "demo1.k4apps.io",
+              "deploymentErrors": null,
+              "eventStreamEndpoint": "testEndpoint",
+              "infrastructureResourceGroup": "capp-svc-demo1-northcentralus",
+              "ingressConfiguration": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "52.142.21.61",
+              "vnetConfiguration": {
+                "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+              },
+              "zoneRedundant": true
+            },
+            "tags": {}
+          },
+          {
+            "name": "pl1",
+            "type": "Microsoft.App/managedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/DemoRG/providers/Microsoft.App/managedEnvironments/pl1",
+            "location": "North Central US",
+            "properties": {
+              "appLogsConfiguration": {
+                "destination": "log-analytics",
+                "logAnalyticsConfiguration": {
+                  "customerId": "9ccccd4a-268f-4a9a-8d03-9bfe77c3fbd2",
+                  "dynamicJsonColumns": true
+                }
+              },
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name2.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name2.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "pl1.k4apps.io",
+              "deploymentErrors": null,
+              "eventStreamEndpoint": "testEndpoint",
+              "ingressConfiguration": null,
+              "privateEndpointConnections": [
+                {
+                  "name": "96101496-ed84-44f9-a28c-d4798f053023-d1908429-ca41-48a0-a026-6a4014e6e615",
+                  "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+                  "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/DemoRG/providers/Microsoft.App/managedEnvironments/pl1/privateEndpointConnections/96101496-ed84-44f9-a28c-d4798f053023-d1908429-ca41-48a0-a026-6a4014e6e615",
+                  "properties": {
+                    "groupIds": [
+                      "managedEnvironments"
+                    ],
+                    "privateEndpoint": {
+                      "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/DemoRG/providers/Microsoft.Network/privateEndpoints/96101496-ed84-44f9-a28c-d4798f053023"
+                    },
+                    "privateLinkServiceConnectionState": {
+                      "description": "please approve",
+                      "actionsRequired": "None",
+                      "status": "Approved"
+                    },
+                    "provisioningState": "Succeeded"
+                  }
+                }
+              ],
+              "privateLinkDefaultDomain": "privatelink.pl1.k4apps.io",
+              "provisioningState": "Succeeded",
+              "staticIp": "52.142.21.61",
+              "vnetConfiguration": {
+                "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+              },
+              "zoneRedundant": true
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_ListBySubscription",
+  "title": "List environments by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_ListWorkloadProfileStates.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_ListWorkloadProfileStates.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "GP1",
+            "type": "/providers/Microsoft.App/workloadProfileStates",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/workloadProfileStates/GP1",
+            "properties": {
+              "currentCount": 3,
+              "maximumCount": 10,
+              "minimumCount": 3
+            }
+          },
+          {
+            "name": "MO3",
+            "type": "/providers/Microsoft.App/workloadProfileStates",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/workloadProfileStates/MO3",
+            "properties": {
+              "currentCount": 0,
+              "maximumCount": 2,
+              "minimumCount": 0
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_ListWorkloadProfileStates",
+  "title": "List environments by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/ManagedEnvironments_Patch.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentEnvelope": {
+      "location": "East US",
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1",
+        "location": "East US",
+        "properties": {
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "jlaw-demo1.k4apps.io",
+          "deploymentErrors": null,
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "capp-svc-jlaw-demo1-northcentralus",
+          "provisioningState": "Succeeded",
+          "staticIp": "20.42.33.145",
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        },
+        "tags": {}
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_Update",
+  "title": "Patch Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Operations_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Operations_List.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.App/containerApps/Read",
+            "display": {
+              "description": "Get the properties of a Container App",
+              "operation": "Get Container App",
+              "provider": "Microsoft Apps",
+              "resource": "Container App"
+            },
+            "origin": "user,system"
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "List all operations"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Replicas_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Replicas_Get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myapp",
+    "replicaName": "myapp--0wlqy09-5d9774cff-5wnd8",
+    "resourceGroupName": "workerapps-rg-xj",
+    "revisionName": "myapp--0wlqy09",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myapp--0wlqy09-5d9774cff-5wnd8",
+        "type": "Microsoft.Web/containerapps/revisions/replicas",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/revisions/myapp--0wlqy09/replicas/myapp--0wlqy09-5d9774cff-5wnd8",
+        "properties": {
+          "containers": [
+            {
+              "name": "hello92",
+              "containerId": "containerd://6bac7bb3afed1c704b5fe563c34c0ecf59ac30c766bb73488f7fa552dc42ee54",
+              "debugEndpoint": "wss://eastasia.azurecontainerapps.dev/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/containerApps/myapp/revisions/myapp--0wlqy09/replicas/myapp--0wlqy09-5d9774cff-5wnd8/debug?targetContainer=hello92",
+              "execEndpoint": "testExecEndpoint",
+              "logStreamEndpoint": "testLogStreamEndpoint",
+              "ready": true,
+              "restartCount": 0,
+              "runningState": "Running",
+              "runningStateDetails": "testDetail",
+              "started": true
+            }
+          ],
+          "createdTime": "2022-01-25T19:42:45Z",
+          "initContainers": [],
+          "runningState": "Running",
+          "runningStateDetails": "testDetail"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsRevisionReplicas_GetReplica",
+  "title": "Get Container App's revision replica"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Replicas_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Replicas_List.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myapp",
+    "resourceGroupName": "workerapps-rg-xj",
+    "revisionName": "myapp--0wlqy09",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myapp--0wlqy09-5d9774cff-5wnd8",
+            "type": "Microsoft.Web/containerapps/revisions/replicas",
+            "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/revisions/myapp--0wlqy09/replicas/myapp--0wlqy09-5d9774cff-5wnd8",
+            "properties": {
+              "containers": [
+                {
+                  "name": "hello92",
+                  "containerId": "containerd://6bac7bb3afed1c704b5fe563c34c0ecf59ac30c766bb73488f7fa552dc42ee54",
+                  "debugEndpoint": "wss://eastasia.azurecontainerapps.dev/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/containerApps/myapp/revisions/myapp--0wlqy09/replicas/myapp--0wlqy09-5d9774cff-5wnd8/debug?targetContainer=hello92",
+                  "execEndpoint": "testExecEndpoint",
+                  "logStreamEndpoint": "testLogStreamEndpoint",
+                  "ready": true,
+                  "restartCount": 0,
+                  "runningState": "Running",
+                  "runningStateDetails": "testDetail",
+                  "started": true
+                }
+              ],
+              "createdTime": "2022-01-25T19:42:45Z",
+              "initContainers": [],
+              "runningState": "Running",
+              "runningStateDetails": "testDetail"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsRevisionReplicas_ListReplicas",
+  "title": "List Container App's replicas"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_Activate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_Activate.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "ContainerAppsRevisions_ActivateRevision",
+  "title": "Activate Container App's revision"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_Deactivate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_Deactivate.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "ContainerAppsRevisions_DeactivateRevision",
+  "title": "Deactivate Container App's revision"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_Get.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0-pjxhsye",
+        "type": "Microsoft.App/containerApps/revisions",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/revisions/testcontainerApp0-pjxhsye",
+        "properties": {
+          "active": true,
+          "createdTime": "2021-05-24T21:24:22+00:00",
+          "fqdn": "testcontainerApp0-pjxhsye.politehill-ab123456.eastus.azurecontainerapps.io",
+          "labels": [
+            "production"
+          ],
+          "lastActiveTime": "2021-05-24T21:24:22+00:00",
+          "replicas": 1,
+          "runningState": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v2",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "trafficWeight": 80
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsRevisions_GetRevision",
+  "title": "Get Container App's revision"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_Get1.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_Get1.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0-pjxhsye",
+        "type": "Microsoft.App/containerApps/revisions",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/revisions/testcontainerApp0-pjxhsye",
+        "properties": {
+          "active": true,
+          "createdTime": "2021-05-24T21:24:22+00:00",
+          "fqdn": "testcontainerApp0-pjxhsye.politehill-ab123456.eastus.azurecontainerapps.io",
+          "labels": [
+            "production"
+          ],
+          "lastActiveTime": "2021-05-24T21:24:22+00:00",
+          "replicas": 1,
+          "runningState": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v2",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "trafficWeight": 80
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsDiagnostics_GetRevision",
+  "title": "Get Container App's revision"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_List.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerApp0-pjxhsye",
+            "type": "Microsoft.App/containerApps/revisions",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/revisions/testcontainerApp0-pjxhsye",
+            "properties": {
+              "active": true,
+              "createdTime": "2021-05-24T21:24:22+00:00",
+              "fqdn": "testcontainerApp0-pjxhsye.politehill-ab123456.eastus.azurecontainerapps.io",
+              "lastActiveTime": "2021-05-24T21:24:22+00:00",
+              "replicas": 1,
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp0",
+                    "image": "repo/testcontainerApp0:v2",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "scale": {
+                  "maxReplicas": 5,
+                  "minReplicas": 1,
+                  "rules": [
+                    {
+                      "name": "httpscalingrule",
+                      "http": {
+                        "metadata": {
+                          "concurrentRequests": "50"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "trafficWeight": 80
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsRevisions_ListRevisions",
+  "title": "List Container App's revisions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_List1.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_List1.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerApp0-pjxhsye",
+            "type": "Microsoft.App/containerApps/revisions",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/revisions/testcontainerApp0-pjxhsye",
+            "properties": {
+              "active": true,
+              "createdTime": "2021-05-24T21:24:22+00:00",
+              "fqdn": "testcontainerApp0-pjxhsye.politehill-ab123456.eastus.azurecontainerapps.io",
+              "lastActiveTime": "2021-05-24T21:24:22+00:00",
+              "replicas": 1,
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp0",
+                    "image": "repo/testcontainerApp0:v2",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "scale": {
+                  "maxReplicas": 5,
+                  "minReplicas": 1,
+                  "rules": [
+                    {
+                      "name": "httpscalingrule",
+                      "http": {
+                        "metadata": {
+                          "concurrentRequests": "50"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "trafficWeight": 80
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsDiagnostics_ListRevisions",
+  "title": "List Container App's revisions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_Restart.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Revisions_Restart.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testStaticSite0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "ContainerAppsRevisions_RestartRevision",
+  "title": "Restart Container App's revision"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_Delete.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/locations/eastus/operationResults/amF3YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ContainerAppsSessionPools_Delete",
+  "title": "Delete Session Pool"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_FetchMcpServerCredentials.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_FetchMcpServerCredentials.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "apiKey": "dummyapikey"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_FetchMcpServerCredentials",
+  "title": "Fetch Session Pool MCP server credentials"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_Get.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "managedIdentitySettings": [
+            {
+              "identity": "system",
+              "lifecycle": "Main"
+            }
+          ],
+          "nodeCount": 1,
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "Succeeded",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          },
+          "templateUpdateStatus": {
+            "activeTemplate": {
+              "containers": [
+                {
+                  "name": "testinitcontainer",
+                  "args": [
+                    "-c",
+                    "while true; do echo hello; sleep 10;done"
+                  ],
+                  "command": [
+                    "/bin/sh"
+                  ],
+                  "image": "repo/testcontainer:v4",
+                  "resources": {
+                    "cpu": 0.25,
+                    "memory": "0.5Gi"
+                  }
+                }
+              ],
+              "createdTime": "2025-10-02T00:00:00.000000Z",
+              "ingress": {
+                "targetPort": 80
+              },
+              "status": {
+                "allocatedCount": 0,
+                "crashCount": 0,
+                "expectedCount": 100,
+                "imagePullFailCount": 0,
+                "pendingCount": 0,
+                "readyCount": 100
+              },
+              "details": "Running"
+            }
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_Get",
+  "title": "Get Session Pool"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_Get_InProgress.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_Get_InProgress.json
@@ -1,0 +1,145 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v5",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "managedIdentitySettings": [
+            {
+              "identity": "system",
+              "lifecycle": "Main"
+            }
+          ],
+          "nodeCount": 1,
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "InProgress",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          },
+          "templateUpdateStatus": {
+            "activeTemplate": {
+              "containers": [
+                {
+                  "name": "testinitcontainer",
+                  "args": [
+                    "-c",
+                    "while true; do echo hello; sleep 10;done"
+                  ],
+                  "command": [
+                    "/bin/sh"
+                  ],
+                  "image": "repo/testcontainer:v4",
+                  "resources": {
+                    "cpu": 0.25,
+                    "memory": "0.5Gi"
+                  }
+                }
+              ],
+              "createdTime": "2025-10-02T00:00:00.000000Z",
+              "ingress": {
+                "targetPort": 80
+              },
+              "status": {
+                "allocatedCount": 0,
+                "crashCount": 0,
+                "expectedCount": 100,
+                "imagePullFailCount": 0,
+                "pendingCount": 0,
+                "readyCount": 100
+              },
+              "details": "Running"
+            },
+            "desiredTemplate": {
+              "containers": [
+                {
+                  "name": "testinitcontainer",
+                  "args": [
+                    "-c",
+                    "while true; do echo hello; sleep 10;done"
+                  ],
+                  "command": [
+                    "/bin/sh"
+                  ],
+                  "image": "repo/testcontainer:v5",
+                  "resources": {
+                    "cpu": 0.25,
+                    "memory": "0.5Gi"
+                  }
+                }
+              ],
+              "createdTime": "2025-10-02T05:00:00.000000Z",
+              "ingress": {
+                "targetPort": 80
+              },
+              "status": {
+                "allocatedCount": 0,
+                "crashCount": 0,
+                "expectedCount": 100,
+                "imagePullFailCount": 0,
+                "pendingCount": 0,
+                "readyCount": 0
+              },
+              "details": "Updating"
+            }
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_Get",
+  "title": "Get Session Pool during update"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_LifecycleOnContainerExit_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_LifecycleOnContainerExit_CreateOrUpdate.json
@@ -1,0 +1,195 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolEnvelope": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "East US",
+      "properties": {
+        "containerType": "CustomContainer",
+        "customContainerTemplate": {
+          "containers": [
+            {
+              "name": "testinitcontainer",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainer:v4",
+              "resources": {
+                "cpu": 0.25,
+                "memory": "0.5Gi"
+              }
+            }
+          ],
+          "ingress": {
+            "targetPort": 80
+          },
+          "registryCredentials": {
+            "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+            "server": "test.azurecr.io"
+          }
+        },
+        "dynamicPoolConfiguration": {
+          "lifecycleConfiguration": {
+            "lifecycleType": "OnContainerExit",
+            "maxAlivePeriodInSeconds": 86400
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "managedIdentitySettings": [
+          {
+            "identity": "system",
+            "lifecycle": "Main"
+          }
+        ],
+        "poolManagementType": "Dynamic",
+        "scaleConfiguration": {
+          "maxConcurrentSessions": 500,
+          "readySessionInstances": 100
+        },
+        "sessionNetworkConfiguration": {
+          "status": "EgressEnabled"
+        }
+      }
+    },
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "lifecycleType": "OnContainerExit",
+              "maxAlivePeriodInSeconds": 86400
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "nodeCount": 1,
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "Succeeded",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "lifecycleType": "OnContainerExit",
+              "maxAlivePeriodInSeconds": 86400
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "managedIdentitySettings": [
+            {
+              "identity": "system",
+              "lifecycle": "Main"
+            }
+          ],
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "InProgress",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_CreateOrUpdate",
+  "title": "Create or Update Session Pool with lifecycle OnContainerExit Timed"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_LifecycleTimed_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_LifecycleTimed_CreateOrUpdate.json
@@ -1,0 +1,195 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolEnvelope": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "East US",
+      "properties": {
+        "containerType": "CustomContainer",
+        "customContainerTemplate": {
+          "containers": [
+            {
+              "name": "testinitcontainer",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainer:v4",
+              "resources": {
+                "cpu": 0.25,
+                "memory": "0.5Gi"
+              }
+            }
+          ],
+          "ingress": {
+            "targetPort": 80
+          },
+          "registryCredentials": {
+            "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+            "server": "test.azurecr.io"
+          }
+        },
+        "dynamicPoolConfiguration": {
+          "lifecycleConfiguration": {
+            "cooldownPeriodInSeconds": 600,
+            "lifecycleType": "Timed"
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "managedIdentitySettings": [
+          {
+            "identity": "system",
+            "lifecycle": "Main"
+          }
+        ],
+        "poolManagementType": "Dynamic",
+        "scaleConfiguration": {
+          "maxConcurrentSessions": 500,
+          "readySessionInstances": 100
+        },
+        "sessionNetworkConfiguration": {
+          "status": "EgressEnabled"
+        }
+      }
+    },
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "nodeCount": 1,
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "Succeeded",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "managedIdentitySettings": [
+            {
+              "identity": "system",
+              "lifecycle": "Main"
+            }
+          ],
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "InProgress",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_CreateOrUpdate",
+  "title": "Create or Update Session Pool with lifecycle type Timed"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_ListByResourceGroup.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testsessionpool",
+            "type": "Microsoft.App/sessionPools",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+            "location": "East US",
+            "properties": {
+              "containerType": "CustomContainer",
+              "customContainerTemplate": {
+                "containers": [
+                  {
+                    "name": "testinitcontainer",
+                    "args": [
+                      "-c",
+                      "while true; do echo hello; sleep 10;done"
+                    ],
+                    "command": [
+                      "/bin/sh"
+                    ],
+                    "image": "repo/testcontainer:v4",
+                    "resources": {
+                      "cpu": 0.25,
+                      "memory": "0.5Gi"
+                    }
+                  }
+                ],
+                "ingress": {
+                  "targetPort": 80
+                }
+              },
+              "dynamicPoolConfiguration": {
+                "lifecycleConfiguration": {
+                  "cooldownPeriodInSeconds": 600,
+                  "lifecycleType": "Timed"
+                }
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "nodeCount": 1,
+              "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+              "poolManagementType": "Dynamic",
+              "provisioningState": "Succeeded",
+              "scaleConfiguration": {
+                "maxConcurrentSessions": 500,
+                "readySessionInstances": 100
+              },
+              "sessionNetworkConfiguration": {
+                "status": "EgressEnabled"
+              },
+              "templateUpdateStatus": {
+                "activeTemplate": {
+                  "containers": [
+                    {
+                      "name": "testinitcontainer",
+                      "args": [
+                        "-c",
+                        "while true; do echo hello; sleep 10;done"
+                      ],
+                      "command": [
+                        "/bin/sh"
+                      ],
+                      "image": "repo/testcontainer:v4",
+                      "resources": {
+                        "cpu": 0.25,
+                        "memory": "0.5Gi"
+                      }
+                    }
+                  ],
+                  "createdTime": "2025-10-02T00:00:00.000000Z",
+                  "ingress": {
+                    "targetPort": 80
+                  },
+                  "status": {
+                    "allocatedCount": 0,
+                    "crashCount": 0,
+                    "expectedCount": 100,
+                    "imagePullFailCount": 0,
+                    "pendingCount": 0,
+                    "readyCount": 100
+                  },
+                  "details": "Running"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_ListByResourceGroup",
+  "title": "List Session Pools by resource group"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_ListBySubscription.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testsessionpool",
+            "type": "Microsoft.App/sessionPools",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+            "location": "East US",
+            "properties": {
+              "containerType": "CustomContainer",
+              "customContainerTemplate": {
+                "containers": [
+                  {
+                    "name": "testinitcontainer",
+                    "args": [
+                      "-c",
+                      "while true; do echo hello; sleep 10;done"
+                    ],
+                    "command": [
+                      "/bin/sh"
+                    ],
+                    "image": "repo/testcontainer:v4",
+                    "resources": {
+                      "cpu": 0.25,
+                      "memory": "0.5Gi"
+                    }
+                  }
+                ],
+                "ingress": {
+                  "targetPort": 80
+                }
+              },
+              "dynamicPoolConfiguration": {
+                "lifecycleConfiguration": {
+                  "cooldownPeriodInSeconds": 600,
+                  "lifecycleType": "Timed"
+                }
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "nodeCount": 1,
+              "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+              "poolManagementType": "Dynamic",
+              "provisioningState": "Succeeded",
+              "scaleConfiguration": {
+                "maxConcurrentSessions": 500,
+                "readySessionInstances": 100
+              },
+              "sessionNetworkConfiguration": {
+                "status": "EgressEnabled"
+              },
+              "templateUpdateStatus": {
+                "activeTemplate": {
+                  "containers": [
+                    {
+                      "name": "testinitcontainer",
+                      "args": [
+                        "-c",
+                        "while true; do echo hello; sleep 10;done"
+                      ],
+                      "command": [
+                        "/bin/sh"
+                      ],
+                      "image": "repo/testcontainer:v4",
+                      "resources": {
+                        "cpu": 0.25,
+                        "memory": "0.5Gi"
+                      }
+                    }
+                  ],
+                  "createdTime": "2025-10-02T00:00:00.000000Z",
+                  "ingress": {
+                    "targetPort": 80
+                  },
+                  "status": {
+                    "allocatedCount": 0,
+                    "crashCount": 0,
+                    "expectedCount": 100,
+                    "imagePullFailCount": 0,
+                    "pendingCount": 0,
+                    "readyCount": 100
+                  },
+                  "details": "Running"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_ListBySubscription",
+  "title": "List Session Pools by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_McpServer_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_McpServer_CreateOrUpdate.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolEnvelope": {
+      "location": "East US",
+      "properties": {
+        "containerType": "Shell",
+        "dynamicPoolConfiguration": {
+          "lifecycleConfiguration": {
+            "cooldownPeriodInSeconds": 600,
+            "lifecycleType": "Timed"
+          }
+        },
+        "mcpServerSettings": {
+          "isMcpServerApiKeyDisabled": false,
+          "isMcpServerEnabled": true
+        },
+        "poolManagementType": "Dynamic",
+        "scaleConfiguration": {
+          "maxConcurrentSessions": 50
+        },
+        "sessionNetworkConfiguration": {
+          "status": "EgressEnabled"
+        }
+      }
+    },
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "location": "East US",
+        "properties": {
+          "containerType": "Shell",
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "mcpServerSettings": {
+            "isMcpServerApiKeyDisabled": false,
+            "isMcpServerEnabled": true,
+            "mcpServerEndpoint": "https://eastus.dynamicsessions.io/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/sessionPools/testsessionpool/mcp"
+          },
+          "poolManagementEndpoint": "https://eastus.dynamicsessions.io/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/sessionPools/testsessionpool",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "Succeeded",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 50
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "location": "East US",
+        "properties": {
+          "containerType": "Shell",
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "mcpServerSettings": {
+            "isMcpServerApiKeyDisabled": false,
+            "isMcpServerEnabled": true,
+            "mcpServerEndpoint": "https://eastus.dynamicsessions.io/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/sessionPools/testsessionpool/mcp"
+          },
+          "poolManagementEndpoint": "https://eastus.dynamicsessions.io/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/sessionPools/testsessionpool",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "InProgress",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 50
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_CreateOrUpdate",
+  "title": "Create or Update Session Pool with MCP server"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_Patch.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolEnvelope": {
+      "properties": {
+        "customContainerTemplate": {
+          "containers": [
+            {
+              "name": "testinitcontainer",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainer:v4",
+              "resources": {
+                "cpu": 0.25,
+                "memory": "0.5Gi"
+              }
+            }
+          ],
+          "ingress": {
+            "targetPort": 80
+          }
+        },
+        "dynamicPoolConfiguration": {
+          "lifecycleConfiguration": {
+            "cooldownPeriodInSeconds": 600,
+            "lifecycleType": "Timed"
+          }
+        },
+        "scaleConfiguration": {
+          "maxConcurrentSessions": 500,
+          "readySessionInstances": 100
+        },
+        "sessionNetworkConfiguration": {
+          "status": "EgressEnabled"
+        }
+      }
+    },
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "nodeCount": 1,
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "Succeeded",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/locations/eastus/operationResults/amF3YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_Update",
+  "title": "Update Session Pool"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_RotateMcpServerCredentials.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SessionPools_RotateMcpServerCredentials.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "apiKey": "dummyapikey"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_RotateMcpServerCredentials",
+  "title": "Rotate Session Pool MCP server credentials"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_CreateOrUpdate.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "sourceControlEnvelope": {
+      "properties": {
+        "branch": "master",
+        "githubActionConfiguration": {
+          "azureCredentials": {
+            "clientId": "<clientid>",
+            "clientSecret": "<clientsecret>",
+            "kind": "feaderated",
+            "tenantId": "<tenantid>"
+          },
+          "buildEnvironmentVariables": [
+            {
+              "name": "foo1",
+              "value": "bar1"
+            },
+            {
+              "name": "foo2",
+              "value": "bar2"
+            }
+          ],
+          "contextPath": "./",
+          "dockerfilePath": "./Dockerfile",
+          "githubPersonalAccessToken": "test",
+          "image": "image/tag",
+          "registryInfo": {
+            "registryPassword": "<registrypassword>",
+            "registryUrl": "test-registry.azurecr.io",
+            "registryUserName": "test-registry"
+          }
+        },
+        "repoUrl": "https://github.com/xwang971/ghatest"
+      }
+    },
+    "sourceControlName": "current",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744",
+    "x-ms-github-auxiliary": "githubaccesstoken"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/sourcecontrols",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/sourcecontrols/current",
+        "properties": {
+          "branch": "master",
+          "githubActionConfiguration": {
+            "buildEnvironmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "contextPath": "./",
+            "image": "image/tag",
+            "registryInfo": {
+              "registryUrl": "test-registry.azurecr.io",
+              "registryUserName": "testreg"
+            }
+          },
+          "operationState": "InProgress",
+          "repoUrl": "https://github.com/xwang971/ghatest"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/sourcecontrols",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/sourcecontrols/current",
+        "properties": {
+          "branch": "master",
+          "githubActionConfiguration": {
+            "buildEnvironmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "contextPath": "./",
+            "image": "image/tag",
+            "registryInfo": {
+              "registryUrl": "test-registry.azurecr.io",
+              "registryUserName": "test-registry"
+            }
+          },
+          "operationState": "InProgress",
+          "repoUrl": "https://github.com/xwang971/ghatest"
+        }
+      },
+      "headers": {
+        "location": "https://localhost/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/sourcecontrols/currentInOperationModel/operationresults/5a7f31af-8ae5-489b-a67e-f0a2d11df796?api-version=2021-03-01"
+      }
+    }
+  },
+  "operationId": "ContainerAppsSourceControls_CreateOrUpdate",
+  "title": "Create or Update Container App SourceControl"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_Delete.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcanadacentral",
+    "deleteWorkflow": false,
+    "ignoreWorkflowDeletionFailure": false,
+    "resourceGroupName": "workerapps-rg-xj",
+    "sourceControlName": "current",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744",
+    "x-ms-github-auxiliary": "githubaccesstoken"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://localhost/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/sourcecontrols/currentInOperationModel/operationresults/14a787ee-c65f-462d-8a8b-897f69a2ab4f?api-version=2021-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ContainerAppsSourceControls_Delete",
+  "title": "Delete Container App SourceControl"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_Get.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "sourceControlName": "current",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/sourcecontrols",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/testcanadacentral/sourcecontrols/current",
+        "properties": {
+          "branch": "master",
+          "githubActionConfiguration": {
+            "buildEnvironmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "contextPath": "./",
+            "dockerfilePath": "./Dockerfile",
+            "image": "image/tag",
+            "registryInfo": {
+              "registryUrl": "xwang971reg.azurecr.io",
+              "registryUserName": "xwang971reg"
+            }
+          },
+          "repoUrl": "https://github.com/xwang971/ghatest"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSourceControls_Get",
+  "title": "Get Container App's SourceControl"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_ListByContainer.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/SourceControls_ListByContainer.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "current",
+            "type": "Microsoft.App/containerapps/sourcecontrols",
+            "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/testcanadacentral/sourcecontrols/current",
+            "properties": {
+              "branch": "master",
+              "githubActionConfiguration": {
+                "buildEnvironmentVariables": [
+                  {
+                    "name": "foo1",
+                    "value": "bar1"
+                  },
+                  {
+                    "name": "foo2",
+                    "value": "bar2"
+                  }
+                ],
+                "contextPath": "./",
+                "dockerfilePath": "./Dockerfile",
+                "image": "image/tag",
+                "registryInfo": {
+                  "registryUrl": "xwang971reg.azurecr.io",
+                  "registryUserName": "xwang971reg"
+                }
+              },
+              "repoUrl": "https://github.com/xwang971/ghatest"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSourceControls_ListByContainerApp",
+  "title": "List App's Source Controls"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Subscriptions_GetCustomDomainVerificationId.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Subscriptions_GetCustomDomainVerificationId.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "d27c3573-f76e-4b26-b871-0ccd2203d08c"
+  },
+  "responses": {
+    "200": {
+      "body": "5B406D5E790BBD224468CE0AA814C396203C7CE755F135A80E35D41865E51967",
+      "headers": {}
+    }
+  },
+  "operationId": "GetCustomDomainVerificationId",
+  "title": "List all operations"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Usages_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/examples/2026-03-02-preview/Usages_List.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "location": "westus",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "ManagedEnvironmentCount",
+              "value": "ManagedEnvironmentCount"
+            },
+            "currentValue": 5,
+            "limit": 10,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "ManagedEnvironmentCores",
+              "value": "ManagedEnvironmentCores"
+            },
+            "currentValue": 3,
+            "limit": 20,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Usages_List",
+  "title": "List usages"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/main.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/main.tsp
@@ -70,6 +70,12 @@ enum Versions {
    * The 2025-10-02-preview API version.
    */
   v2025_10_02_preview: "2025-10-02-preview",
+
+  /**
+   * The 2026-03-02-preview API version.
+   */
+  @Azure.Core.previewVersion
+  v2026_03_02_preview: "2026-03-02-preview",
 }
 
 interface Operations

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/main.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/main.tsp
@@ -59,7 +59,6 @@ using TypeSpec.Versioning;
 @armProviderNamespace
 @service(#{ title: "ContainerApps API Client" })
 @versioned(Versions)
-@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
 namespace Microsoft.App;
 
 /**
@@ -69,12 +68,14 @@ enum Versions {
   /**
    * The 2025-10-02-preview API version.
    */
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
   v2025_10_02_preview: "2025-10-02-preview",
 
   /**
    * The 2026-03-02-preview API version.
    */
   @Azure.Core.previewVersion
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v6)
   v2026_03_02_preview: "2026-03-02-preview",
 }
 

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/models.tsp
@@ -1,10 +1,12 @@
 import "@typespec/rest";
 import "@typespec/http";
+import "@typespec/versioning";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@azure-tools/typespec-azure-core";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;
+using TypeSpec.Versioning;
 using Azure.ResourceManager;
 using Azure.Core;
 using Azure.ResourceManager.Foundations;
@@ -1789,6 +1791,50 @@ model AvailableWorkloadProfileProperties {
    * The everyday name of the workload profile.
    */
   displayName?: string;
+}
+
+/**
+ * Collection of environment modes available in the location.
+ */
+@added(Versions.v2026_03_02_preview)
+model AvailableEnvironmentModesCollection
+  is Azure.Core.Page<AvailableEnvironmentMode>;
+
+/**
+ * An environment mode available to the subscription.
+ */
+#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "The service returns the standard proxy resource envelope for each available environment mode."
+@added(Versions.v2026_03_02_preview)
+model AvailableEnvironmentMode
+  extends Azure.ResourceManager.CommonTypes.ProxyResource {
+  /**
+   * The Azure region in which the environment mode is available.
+   */
+  @visibility(Lifecycle.Create, Lifecycle.Read)
+  location?: string;
+
+  /**
+   * The environment mode details.
+   */
+  properties?: AvailableEnvironmentModeProperties;
+}
+
+/**
+ * Details that describe an available environment mode.
+ */
+@added(Versions.v2026_03_02_preview)
+model AvailableEnvironmentModeProperties {
+  /**
+   * The display name of the environment mode.
+   */
+  @visibility(Lifecycle.Read)
+  displayName?: string;
+
+  /**
+   * The description of the environment mode.
+   */
+  @visibility(Lifecycle.Read)
+  description?: string;
 }
 
 /**

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AppResiliency_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AppResiliency_CreateOrUpdate.json
@@ -1,0 +1,178 @@
+{
+  "parameters": {
+    "name": "resiliency-policy-1",
+    "api-version": "2026-03-02-preview",
+    "appName": "testcontainerApp0",
+    "resiliencyEnvelope": {
+      "properties": {
+        "circuitBreakerPolicy": {
+          "consecutiveErrors": 5,
+          "intervalInSeconds": 10,
+          "maxEjectionPercent": 50
+        },
+        "httpConnectionPool": {
+          "http1MaxPendingRequests": 1024,
+          "http2MaxRequests": 1024
+        },
+        "httpRetryPolicy": {
+          "matches": {
+            "errors": [
+              "5xx",
+              "connect-failure",
+              "reset",
+              "retriable-headers",
+              "retriable-status-codes"
+            ],
+            "headers": [
+              {
+                "header": "X-Content-Type",
+                "match": {
+                  "prefixMatch": "GOATS"
+                }
+              }
+            ],
+            "httpStatusCodes": [
+              502,
+              503
+            ]
+          },
+          "maxRetries": 5,
+          "retryBackOff": {
+            "initialDelayInMilliseconds": 1000,
+            "maxIntervalInMilliseconds": 10000
+          }
+        },
+        "tcpConnectionPool": {
+          "maxConnections": 100
+        },
+        "tcpRetryPolicy": {
+          "maxConnectAttempts": 3
+        },
+        "timeoutPolicy": {
+          "connectionTimeoutInSeconds": 5,
+          "responseTimeoutInSeconds": 15
+        }
+      }
+    },
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "resiliency-policy-1",
+        "type": "Microsoft.App/containerApps/resiliencyPolicies",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/resiliencyPolicies/resiliency-policy-1",
+        "properties": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 5,
+            "intervalInSeconds": 10,
+            "maxEjectionPercent": 50
+          },
+          "httpConnectionPool": {
+            "http1MaxPendingRequests": 1024,
+            "http2MaxRequests": 1024
+          },
+          "httpRetryPolicy": {
+            "matches": {
+              "errors": [
+                "5xx",
+                "connect-failure",
+                "reset",
+                "retriable-headers",
+                "retriable-status-codes"
+              ],
+              "headers": [
+                {
+                  "header": "X-Content-Type",
+                  "match": {
+                    "prefixMatch": "GOATS"
+                  }
+                }
+              ],
+              "httpStatusCodes": [
+                502,
+                503
+              ]
+            },
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 1000,
+              "maxIntervalInMilliseconds": 10000
+            }
+          },
+          "tcpConnectionPool": {
+            "maxConnections": 100
+          },
+          "tcpRetryPolicy": {
+            "maxConnectAttempts": 3
+          },
+          "timeoutPolicy": {
+            "connectionTimeoutInSeconds": 5,
+            "responseTimeoutInSeconds": 15
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "resiliency-policy-1",
+        "type": "Microsoft.App/containerApps/resiliencyPolicies",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/resiliencyPolicies/resiliency-policy-1",
+        "properties": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 5,
+            "intervalInSeconds": 10,
+            "maxEjectionPercent": 50
+          },
+          "httpConnectionPool": {
+            "http1MaxPendingRequests": 1024,
+            "http2MaxRequests": 1024
+          },
+          "httpRetryPolicy": {
+            "matches": {
+              "errors": [
+                "5xx",
+                "connect-failure",
+                "reset",
+                "retriable-headers",
+                "retriable-status-codes"
+              ],
+              "headers": [
+                {
+                  "header": "X-Content-Type",
+                  "match": {
+                    "prefixMatch": "GOATS"
+                  }
+                }
+              ],
+              "httpStatusCodes": [
+                502,
+                503
+              ]
+            },
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 1000,
+              "maxIntervalInMilliseconds": 10000
+            }
+          },
+          "tcpConnectionPool": {
+            "maxConnections": 100
+          },
+          "tcpRetryPolicy": {
+            "maxConnectAttempts": 3
+          },
+          "timeoutPolicy": {
+            "connectionTimeoutInSeconds": 5,
+            "responseTimeoutInSeconds": 15
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AppResiliency_CreateOrUpdate",
+  "title": "Create or Update App Resiliency"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AppResiliency_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AppResiliency_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "resiliency-policy-1",
+    "api-version": "2026-03-02-preview",
+    "appName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "AppResiliency_Delete",
+  "title": "Delete App Resiliency"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AppResiliency_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AppResiliency_Get.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "name": "resiliency-policy-1",
+    "api-version": "2026-03-02-preview",
+    "appName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "resiliency-policy-1",
+        "type": "Microsoft.App/containerApps/resiliencyPolicies",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/resiliencyPolicies/resiliency-policy-1",
+        "properties": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 5,
+            "intervalInSeconds": 10,
+            "maxEjectionPercent": 50
+          },
+          "httpConnectionPool": {
+            "http1MaxPendingRequests": 1024,
+            "http2MaxRequests": 1024
+          },
+          "httpRetryPolicy": {
+            "matches": {
+              "errors": [
+                "5xx",
+                "connect-failure",
+                "reset",
+                "retriable-headers",
+                "retriable-status-codes"
+              ],
+              "headers": [
+                {
+                  "header": "X-Content-Type",
+                  "match": {
+                    "prefixMatch": "GOATS"
+                  }
+                }
+              ],
+              "httpStatusCodes": [
+                502,
+                503
+              ]
+            },
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 1000,
+              "maxIntervalInMilliseconds": 10000
+            }
+          },
+          "tcpConnectionPool": {
+            "maxConnections": 100
+          },
+          "tcpRetryPolicy": {
+            "maxConnectAttempts": 3
+          },
+          "timeoutPolicy": {
+            "connectionTimeoutInSeconds": 5,
+            "responseTimeoutInSeconds": 15
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AppResiliency_Get",
+  "title": "Get App Resiliency"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AppResiliency_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AppResiliency_List.json
@@ -1,0 +1,73 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "appName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "resiliency-policy-1",
+            "type": "Microsoft.App/containerApps/resiliencyPolicies",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/resiliencyPolicies/resiliency-policy-1",
+            "properties": {
+              "circuitBreakerPolicy": {
+                "consecutiveErrors": 5,
+                "intervalInSeconds": 10,
+                "maxEjectionPercent": 50
+              },
+              "httpConnectionPool": {
+                "http1MaxPendingRequests": 1024,
+                "http2MaxRequests": 1024
+              },
+              "httpRetryPolicy": {
+                "matches": {
+                  "errors": [
+                    "5xx",
+                    "connect-failure",
+                    "reset",
+                    "retriable-headers",
+                    "retriable-status-codes"
+                  ],
+                  "headers": [
+                    {
+                      "header": "X-Content-Type",
+                      "match": {
+                        "prefixMatch": "GOATS"
+                      }
+                    }
+                  ],
+                  "httpStatusCodes": [
+                    502,
+                    503
+                  ]
+                },
+                "maxRetries": 5,
+                "retryBackOff": {
+                  "initialDelayInMilliseconds": 1000,
+                  "maxIntervalInMilliseconds": 10000
+                }
+              },
+              "tcpConnectionPool": {
+                "maxConnections": 100
+              },
+              "tcpRetryPolicy": {
+                "maxConnectAttempts": 3
+              },
+              "timeoutPolicy": {
+                "connectionTimeoutInSeconds": 5,
+                "responseTimeoutInSeconds": 15
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AppResiliency_List",
+  "title": "List App Resiliency"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AppResiliency_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AppResiliency_Patch.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "name": "resiliency-policy-1",
+    "api-version": "2026-03-02-preview",
+    "appName": "testcontainerApp0",
+    "resiliencyEnvelope": {
+      "properties": {
+        "timeoutPolicy": {
+          "connectionTimeoutInSeconds": 40,
+          "responseTimeoutInSeconds": 30
+        }
+      }
+    },
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "resiliency-policy-1",
+        "type": "Microsoft.App/containerApps/resiliencyPolicies",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/resiliencyPolicies/resiliency-policy-1",
+        "properties": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 5,
+            "intervalInSeconds": 10,
+            "maxEjectionPercent": 50
+          },
+          "httpConnectionPool": {
+            "http1MaxPendingRequests": 1024,
+            "http2MaxRequests": 1024
+          },
+          "httpRetryPolicy": {
+            "matches": {
+              "errors": [
+                "5xx",
+                "connect-failure",
+                "reset",
+                "retriable-headers",
+                "retriable-status-codes"
+              ],
+              "headers": [
+                {
+                  "header": "X-Content-Type",
+                  "match": {
+                    "prefixMatch": "GOATS"
+                  }
+                }
+              ],
+              "httpStatusCodes": [
+                502,
+                503
+              ]
+            },
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 1000,
+              "maxIntervalInMilliseconds": 10000
+            }
+          },
+          "tcpConnectionPool": {
+            "maxConnections": 100
+          },
+          "tcpRetryPolicy": {
+            "maxConnectAttempts": 3
+          },
+          "timeoutPolicy": {
+            "connectionTimeoutInSeconds": 40,
+            "responseTimeoutInSeconds": 30
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "AppResiliency_Update",
+  "title": "Update App Resiliency"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_BlobStorageTokenStore_ClientId_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_BlobStorageTokenStore_ClientId_CreateOrUpdate.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "authConfigEnvelope": {
+      "properties": {
+        "encryptionSettings": {
+          "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+          "containerAppAuthSigningSecretName": "testSigningSecretName"
+        },
+        "globalValidation": {
+          "unauthenticatedClientAction": "AllowAnonymous"
+        },
+        "identityProviders": {
+          "facebook": {
+            "registration": {
+              "appId": "123",
+              "appSecretSettingName": "facebook-secret"
+            }
+          }
+        },
+        "login": {
+          "tokenStore": {
+            "azureBlobStorage": {
+              "blobContainerUri": "https://test.blob.core.windows.net/container1",
+              "clientId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "platform": {
+          "enabled": true
+        }
+      }
+    },
+    "authConfigName": "current",
+    "containerAppName": "myapp",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/authconfigs",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.App/containerApps/myapp/authconfigs/current",
+        "properties": {
+          "encryptionSettings": {
+            "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+            "containerAppAuthSigningSecretName": "testSigningSecretName"
+          },
+          "globalValidation": {
+            "unauthenticatedClientAction": "AllowAnonymous"
+          },
+          "identityProviders": {
+            "facebook": {
+              "registration": {
+                "appId": "123",
+                "appSecretSettingName": "facebook-secret"
+              }
+            }
+          },
+          "login": {
+            "tokenStore": {
+              "azureBlobStorage": {
+                "blobContainerUri": "https://test.blob.core.windows.net/container1",
+                "clientId": "00000000-0000-0000-0000-000000000000"
+              }
+            }
+          },
+          "platform": {
+            "enabled": true
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsAuthConfigs_CreateOrUpdate",
+  "title": "Create or Update Container App AuthConfig with msi clientID blob storage token store"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_BlobStorageTokenStore_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_BlobStorageTokenStore_CreateOrUpdate.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "authConfigEnvelope": {
+      "properties": {
+        "encryptionSettings": {
+          "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+          "containerAppAuthSigningSecretName": "testSigningSecretName"
+        },
+        "globalValidation": {
+          "unauthenticatedClientAction": "AllowAnonymous"
+        },
+        "identityProviders": {
+          "facebook": {
+            "registration": {
+              "appId": "123",
+              "appSecretSettingName": "facebook-secret"
+            }
+          }
+        },
+        "login": {
+          "tokenStore": {
+            "azureBlobStorage": {
+              "blobContainerUri": "https://test.blob.core.windows.net/container1",
+              "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            }
+          }
+        },
+        "platform": {
+          "enabled": true
+        }
+      }
+    },
+    "authConfigName": "current",
+    "containerAppName": "myapp",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/authconfigs",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.App/containerApps/myapp/authconfigs/current",
+        "properties": {
+          "encryptionSettings": {
+            "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+            "containerAppAuthSigningSecretName": "testSigningSecretName"
+          },
+          "globalValidation": {
+            "unauthenticatedClientAction": "AllowAnonymous"
+          },
+          "identityProviders": {
+            "facebook": {
+              "registration": {
+                "appId": "123",
+                "appSecretSettingName": "facebook-secret"
+              }
+            }
+          },
+          "login": {
+            "tokenStore": {
+              "azureBlobStorage": {
+                "blobContainerUri": "https://test.blob.core.windows.net/container1",
+                "managedIdentityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+              }
+            }
+          },
+          "platform": {
+            "enabled": true
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsAuthConfigs_CreateOrUpdate",
+  "title": "Create or Update Container App AuthConfig with msi managedIdentityResourceId blob storage token store"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_CreateOrUpdate.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "authConfigEnvelope": {
+      "properties": {
+        "encryptionSettings": {
+          "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+          "containerAppAuthSigningSecretName": "testSigningSecretName"
+        },
+        "globalValidation": {
+          "unauthenticatedClientAction": "AllowAnonymous"
+        },
+        "identityProviders": {
+          "facebook": {
+            "registration": {
+              "appId": "123",
+              "appSecretSettingName": "facebook-secret"
+            }
+          }
+        },
+        "platform": {
+          "enabled": true
+        }
+      }
+    },
+    "authConfigName": "current",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/authconfigs",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/authconfigs/current",
+        "properties": {
+          "encryptionSettings": {
+            "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+            "containerAppAuthSigningSecretName": "testSigningSecretName"
+          },
+          "globalValidation": {
+            "unauthenticatedClientAction": "AllowAnonymous"
+          },
+          "identityProviders": {
+            "facebook": {
+              "registration": {
+                "appId": "123",
+                "appSecretSettingName": "facebook-secret"
+              }
+            }
+          },
+          "platform": {
+            "enabled": true
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsAuthConfigs_CreateOrUpdate",
+  "title": "Create or Update Container App AuthConfig"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "authConfigName": "current",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ContainerAppsAuthConfigs_Delete",
+  "title": "Delete Container App AuthConfig"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_Get.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "authConfigName": "current",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/authconfigs",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/testcanadacentral/authconfigs/current",
+        "properties": {
+          "encryptionSettings": {
+            "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+            "containerAppAuthSigningSecretName": "testSigningSecretName"
+          },
+          "globalValidation": {
+            "unauthenticatedClientAction": "AllowAnonymous"
+          },
+          "identityProviders": {
+            "facebook": {
+              "registration": {
+                "appId": "123",
+                "appSecretSettingName": "facebook-secret"
+              }
+            }
+          },
+          "platform": {
+            "enabled": true
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsAuthConfigs_Get",
+  "title": "Get Container App's AuthConfig"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_ListByContainer.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AuthConfigs_ListByContainer.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "current",
+            "type": "Microsoft.App/containerapps/authconfigs",
+            "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/testcanadacentral/authconfigs/current",
+            "properties": {
+              "encryptionSettings": {
+                "containerAppAuthEncryptionSecretName": "testEncryptionSecretName",
+                "containerAppAuthSigningSecretName": "testSigningSecretName"
+              },
+              "globalValidation": {
+                "unauthenticatedClientAction": "AllowAnonymous"
+              },
+              "identityProviders": {
+                "facebook": {
+                  "registration": {
+                    "appId": "123",
+                    "appSecretSettingName": "facebook-secret"
+                  }
+                }
+              },
+              "platform": {
+                "enabled": true
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsAuthConfigs_ListByContainerApp",
+  "title": "List Auth Configs by Container Apps"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AvailableEnvironmentModes_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AvailableEnvironmentModes_List.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "location": "East US",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsModes/ConsumptionOnly",
+            "name": "ConsumptionOnly",
+            "type": "Microsoft.App/availableManagedEnvironmentsModes",
+            "location": "East US",
+            "properties": {
+              "displayName": "Consumption Only",
+              "description": "Serverless consumption-based environment without dedicated workload profiles."
+            }
+          },
+          {
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsModes/WorkloadProfiles",
+            "name": "WorkloadProfiles",
+            "type": "Microsoft.App/availableManagedEnvironmentsModes",
+            "location": "East US",
+            "properties": {
+              "displayName": "Workload Profiles",
+              "description": "Environment with configurable workload profiles including consumption and dedicated compute."
+            }
+          },
+          {
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsModes/Archived",
+            "name": "Archived",
+            "type": "Microsoft.App/availableManagedEnvironmentsModes",
+            "location": "East US",
+            "properties": {
+              "displayName": "Archived",
+              "description": "Deprovisioned environment in archived state."
+            }
+          },
+          {
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsModes/Express",
+            "name": "Express",
+            "type": "Microsoft.App/availableManagedEnvironmentsModes",
+            "location": "East US",
+            "properties": {
+              "displayName": "Express",
+              "description": "Multi-tenant express environment with simplified configuration."
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AvailableEnvironmentModes_List",
+  "title": "AvailableEnvironmentModes_List"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AvailableEnvironmentModes_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AvailableEnvironmentModes_List.json
@@ -53,5 +53,5 @@
     }
   },
   "operationId": "AvailableEnvironmentModes_List",
-  "title": "AvailableEnvironmentModes_List"
+  "title": "List available environment modes by location"
 }

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AvailableWorkloadProfiles_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/AvailableWorkloadProfiles_Get.json
@@ -1,0 +1,161 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "location": "East US",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Dedicated-D4",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-D4",
+            "location": "East US",
+            "properties": {
+              "applicability": "LocationDefault",
+              "category": "General purpose D-series",
+              "cores": 4,
+              "displayName": "Dedicated-D4",
+              "memoryGiB": 16
+            }
+          },
+          {
+            "name": "Dedicated-D4",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-D8",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "General purpose D-series",
+              "cores": 8,
+              "displayName": "Dedicated-D8",
+              "memoryGiB": 32
+            }
+          },
+          {
+            "name": "Dedicated-D16",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-D16",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "General purpose D-series",
+              "cores": 16,
+              "displayName": "Dedicated-D16",
+              "memoryGiB": 64
+            }
+          },
+          {
+            "name": "Dedicated-E4",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-E4",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Memory optimized E-series",
+              "cores": 4,
+              "displayName": "Dedicated-E4",
+              "memoryGiB": 32
+            }
+          },
+          {
+            "name": "Dedicated-E8",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-E8",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Memory optimized E-series",
+              "cores": 8,
+              "displayName": "Dedicated-E8",
+              "memoryGiB": 64
+            }
+          },
+          {
+            "name": "Dedicated-E16",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-E16",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Memory optimized E-series",
+              "cores": 16,
+              "displayName": "Dedicated-E16",
+              "memoryGiB": 128
+            }
+          },
+          {
+            "name": "Dedicated-F4",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-F4",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Compute optimized F-series",
+              "cores": 4,
+              "displayName": "Dedicated-F4",
+              "memoryGiB": 8
+            }
+          },
+          {
+            "name": "Dedicated-F8",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-F8",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Compute optimized F-series",
+              "cores": 8,
+              "displayName": "Dedicated-F8",
+              "memoryGiB": 16
+            }
+          },
+          {
+            "name": "Dedicated-F16",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Dedicated-F16",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Compute optimized F-series",
+              "cores": 16,
+              "displayName": "Dedicated-F16",
+              "memoryGiB": 32
+            }
+          },
+          {
+            "name": "NC48-A100",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/NC48-A100",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "GPU-NC-A100",
+              "cores": 48,
+              "displayName": "Dedicated-NC48-A100",
+              "gpus": 2,
+              "memoryGiB": 440
+            }
+          },
+          {
+            "name": "Consumption",
+            "type": "Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/availableManagedEnvironmentsWorkloadProfileTypes/Consumption",
+            "location": "East US",
+            "properties": {
+              "applicability": "Custom",
+              "category": "Consumption",
+              "cores": 3,
+              "displayName": "Consumption",
+              "memoryGiB": 3
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "AvailableWorkloadProfiles_Get",
+  "title": "BillingMeters_Get"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/BillingMeters_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/BillingMeters_Get.json
@@ -1,0 +1,83 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "location": "East US",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "GeneralPurposeDseriesCPU",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/GeneralPurposeDseriesCPU",
+            "location": "East US",
+            "properties": {
+              "category": "General purpose D-series",
+              "displayName": "General Purpose Cores per Second",
+              "meterType": "CPU"
+            }
+          },
+          {
+            "name": "GeneralPurposeDseriesMemory",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/GeneralPurposeDseriesMemory",
+            "location": "East US",
+            "properties": {
+              "category": "General purpose D-series",
+              "displayName": "General Purpose Memory GiB per Second",
+              "meterType": "Memory"
+            }
+          },
+          {
+            "name": "MemoryOptimizedEseriesCPU",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/MemoryOptimizedEseriesCPU",
+            "location": "East US",
+            "properties": {
+              "category": "Memory optimized E-series",
+              "displayName": "Memory Optimized Cores per Second",
+              "meterType": "CPU"
+            }
+          },
+          {
+            "name": "MemoryOptimizedEseriesMemory",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/MemoryOptimizedEseriesMemory",
+            "location": "East US",
+            "properties": {
+              "category": "Memory optimized E-series",
+              "displayName": "Memory Optimized Memory GiB per Second",
+              "meterType": "Memory"
+            }
+          },
+          {
+            "name": "ComputeOptimizedFseriesCPU",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/ComputeOptimizedFseriesCPU",
+            "location": "East US",
+            "properties": {
+              "category": "Compute optimized F-series",
+              "displayName": "Compute Optimized Cores per Second",
+              "meterType": "CPU"
+            }
+          },
+          {
+            "name": "GeneralComputeMemory",
+            "type": "Microsoft.App/billingMeters",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/billingMeters/GeneralComputeMemory",
+            "location": "East US",
+            "properties": {
+              "category": "Compute optimized F-series",
+              "displayName": "Compute Optimized Memory GiB per Second",
+              "meterType": "Memory"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "BillingMeters_Get",
+  "title": "BillingMeters_Get"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_CreateOrUpdate.json
@@ -1,0 +1,128 @@
+{
+  "operationId": "Builders_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "builderEnvelope": {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {}
+        }
+      },
+      "location": "eastus",
+      "properties": {
+        "containerRegistries": [
+          {
+            "containerRegistryServer": "test.azurecr.io",
+            "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+          },
+          {
+            "containerRegistryServer": "test2.azurecr.io",
+            "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+          }
+        ],
+        "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv"
+      },
+      "tags": {
+        "company": "Microsoft"
+      }
+    },
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_CreateOrUpdate_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuilder",
+        "type": "Microsoft.App/builders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "containerRegistries": [
+            {
+              "containerRegistryServer": "test.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            },
+            {
+              "containerRegistryServer": "test2.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            }
+          ],
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        },
+        "tags": {
+          "company": "Microsoft"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testBuilder",
+        "type": "Microsoft.App/builders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "containerRegistries": [
+            {
+              "containerRegistryServer": "test.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            },
+            {
+              "containerRegistryServer": "test2.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            }
+          ],
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+          "provisioningState": "Creating"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        },
+        "tags": {
+          "company": "Microsoft"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_Delete.json
@@ -1,0 +1,18 @@
+{
+  "operationId": "Builders_Delete",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_Delete_0",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_Get.json
@@ -1,0 +1,56 @@
+{
+  "operationId": "Builders_Get",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_Get_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuilder",
+        "type": "Microsoft.App/builders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "containerRegistries": [
+            {
+              "containerRegistryServer": "test.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            },
+            {
+              "containerRegistryServer": "test2.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            }
+          ],
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        },
+        "tags": {
+          "key": "value"
+        }
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_ListByResourceGroup.json
@@ -1,0 +1,102 @@
+{
+  "operationId": "Builders_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_ListByResourceGroup_0",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testBuilder1",
+            "type": "Microsoft.App/builders",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder1",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+                  "clientId": "00000000-0000-0000-0000-000000000000",
+                  "principalId": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "containerRegistries": [
+                {
+                  "containerRegistryServer": "test.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                },
+                {
+                  "containerRegistryServer": "test2.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                }
+              ],
+              "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            },
+            "tags": {
+              "key": "value"
+            }
+          },
+          {
+            "name": "testBuilder2",
+            "type": "Microsoft.App/builders",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder2",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+                  "clientId": "00000000-0000-0000-0000-000000000000",
+                  "principalId": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "containerRegistries": [
+                {
+                  "containerRegistryServer": "test.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                },
+                {
+                  "containerRegistryServer": "test2.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                }
+              ],
+              "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            },
+            "tags": {
+              "key": "value"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_ListBySubscription.json
@@ -1,0 +1,101 @@
+{
+  "operationId": "Builders_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_ListBySubscription_0",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testBuilder1",
+            "type": "Microsoft.App/builders",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg1/providers/Microsoft.App/builders/testBuilder1",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+                  "clientId": "00000000-0000-0000-0000-000000000000",
+                  "principalId": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "containerRegistries": [
+                {
+                  "containerRegistryServer": "test.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                },
+                {
+                  "containerRegistryServer": "test2.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                }
+              ],
+              "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            },
+            "tags": {
+              "key": "value"
+            }
+          },
+          {
+            "name": "testBuilder2",
+            "type": "Microsoft.App/builders",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg2/providers/Microsoft.App/builders/testBuilder2",
+            "identity": {
+              "type": "SystemAssigned,UserAssigned",
+              "principalId": "00000000-0000-0000-0000-000000000000",
+              "tenantId": "00000000-0000-0000-0000-000000000000",
+              "userAssignedIdentities": {
+                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+                  "clientId": "00000000-0000-0000-0000-000000000000",
+                  "principalId": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            },
+            "location": "eastus",
+            "properties": {
+              "containerRegistries": [
+                {
+                  "containerRegistryServer": "test.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                },
+                {
+                  "containerRegistryServer": "test2.azurecr.io",
+                  "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+                }
+              ],
+              "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            },
+            "tags": {
+              "key": "value"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_Update.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builders_Update.json
@@ -1,0 +1,66 @@
+{
+  "operationId": "Builders_Update",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "builderEnvelope": {
+      "tags": {
+        "mytag1": "myvalue1"
+      }
+    },
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builders_Update_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuilder",
+        "type": "Microsoft.App/builders",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "eastus",
+        "properties": {
+          "containerRegistries": [
+            {
+              "containerRegistryServer": "test.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            },
+            {
+              "containerRegistryServer": "test2.azurecr.io",
+              "identityResourceId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg1/providers/Microsoft.ManagedIdentity/userAssignedIdentities/identity1"
+            }
+          ],
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/managedEnvironments/testEnv",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        },
+        "tags": {
+          "mytag1": "myvalue1"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_CreateOrUpdate.json
@@ -1,0 +1,214 @@
+{
+  "operationId": "Builds_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildEnvelope": {
+      "properties": {
+        "configuration": {
+          "baseOs": "DebianBullseye",
+          "environmentVariables": [
+            {
+              "name": "foo1",
+              "value": "bar1"
+            },
+            {
+              "name": "foo2",
+              "value": "bar2"
+            }
+          ],
+          "platform": "dotnetcore",
+          "platformVersion": "7.0",
+          "preBuildSteps": [
+            {
+              "description": "First pre build step.",
+              "httpGet": {
+                "fileName": "output.txt",
+                "headers": [
+                  "foo",
+                  "bar"
+                ],
+                "url": "https://microsoft.com"
+              },
+              "scripts": [
+                "echo 'hello'",
+                "echo 'world'"
+              ]
+            },
+            {
+              "description": "Second pre build step.",
+              "httpGet": {
+                "fileName": "output.txt",
+                "headers": [
+                  "foo"
+                ],
+                "url": "https://microsoft.com"
+              },
+              "scripts": [
+                "echo 'hello'",
+                "echo 'again'"
+              ]
+            }
+          ]
+        },
+        "destinationContainerRegistry": {
+          "image": "test.azurecr.io/repo:tag",
+          "server": "test.azurecr.io"
+        }
+      }
+    },
+    "buildName": "testBuild-123456789az",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builds_CreateOrUpdate_WithConfig",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuild-123456789az",
+        "type": "Microsoft.App/builders/builds",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild-123456789az",
+        "properties": {
+          "buildStatus": "InProgress",
+          "configuration": {
+            "baseOs": "DebianBullseye",
+            "environmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "platform": "dotnetcore",
+            "platformVersion": "7.0",
+            "preBuildSteps": [
+              {
+                "description": "First pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo",
+                    "bar"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'world'"
+                ]
+              },
+              {
+                "description": "Second pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'again'"
+                ]
+              }
+            ]
+          },
+          "destinationContainerRegistry": {
+            "image": "test.azurecr.io/repo:tag",
+            "server": "test.azurecr.io"
+          },
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Succeeded",
+          "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+          "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testBuild",
+        "type": "Microsoft.App/build",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild",
+        "properties": {
+          "buildStatus": "NotStarted",
+          "configuration": {
+            "baseOs": "DebianBullseye",
+            "environmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "platform": "dotnetcore",
+            "platformVersion": "7.0",
+            "preBuildSteps": [
+              {
+                "description": "First pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo",
+                    "bar"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'world'"
+                ]
+              },
+              {
+                "description": "Second pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'again'"
+                ]
+              }
+            ]
+          },
+          "destinationContainerRegistry": {
+            "image": "test.azurecr.io/repo:tag",
+            "server": "test.azurecr.io"
+          },
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Creating",
+          "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+          "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_CreateOrUpdate_NoConfig.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_CreateOrUpdate_NoConfig.json
@@ -1,0 +1,61 @@
+{
+  "operationId": "Builds_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildEnvelope": {},
+    "buildName": "testBuild",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builds_CreateOrUpdate_NoConfig",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuild",
+        "type": "Microsoft.App/builders/builds",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild",
+        "properties": {
+          "buildStatus": "InProgress",
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Succeeded",
+          "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+          "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testBuild",
+        "type": "Microsoft.App/build",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild",
+        "properties": {
+          "buildStatus": "InProgress",
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Creating",
+          "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+          "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      },
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_Delete.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "Builds_Delete",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildName": "testBuild",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builds_Delete_0",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_Get.json
@@ -1,0 +1,85 @@
+{
+  "operationId": "Builds_Get",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildName": "testBuild",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builds_Get_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuild",
+        "type": "Microsoft.App/builders/builds",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild",
+        "properties": {
+          "buildStatus": "InProgress",
+          "configuration": {
+            "baseOs": "DebianBullseye",
+            "environmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "platform": "dotnetcore",
+            "platformVersion": "7.0",
+            "preBuildSteps": [
+              {
+                "description": "First pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo",
+                    "bar"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'world'"
+                ]
+              },
+              {
+                "description": "Second pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'again'"
+                ]
+              }
+            ]
+          },
+          "destinationContainerRegistry": {
+            "image": "test.azurecr.io/repo:tag",
+            "server": "test.azurecr.io"
+          },
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Succeeded",
+          "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+          "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_ListAuthToken.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_ListAuthToken.json
@@ -1,0 +1,20 @@
+{
+  "operationId": "BuildAuthToken_List",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildName": "testBuild",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Get Build Auth Token",
+  "responses": {
+    "200": {
+      "body": {
+        "expires": "2022-07-14T19:22:50.3080223Z",
+        "token": "foobartoken"
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_ListByBuilderResource.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Builds_ListByBuilderResource.json
@@ -1,0 +1,159 @@
+{
+  "operationId": "BuildsByBuilderResource_List",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "builderName": "testBuilder",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "Builds_ListByBuilderResource_0",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testBuild1",
+            "type": "Microsoft.App/builders/builds",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild1",
+            "properties": {
+              "buildStatus": "InProgress",
+              "configuration": {
+                "baseOs": "DebianBullseye",
+                "environmentVariables": [
+                  {
+                    "name": "foo1",
+                    "value": "bar1"
+                  },
+                  {
+                    "name": "foo2",
+                    "value": "bar2"
+                  }
+                ],
+                "platform": "dotnetcore",
+                "platformVersion": "7.0",
+                "preBuildSteps": [
+                  {
+                    "description": "First pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo",
+                        "bar"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'world'"
+                    ]
+                  },
+                  {
+                    "description": "Second pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'again'"
+                    ]
+                  }
+                ]
+              },
+              "destinationContainerRegistry": {
+                "image": "test.azurecr.io/repo:tag",
+                "server": "test.azurecr.io"
+              },
+              "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+              "provisioningState": "Succeeded",
+              "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+              "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "testBuild2",
+            "type": "Microsoft.App/builders/builds",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/builders/testBuilder/builds/testBuild2",
+            "properties": {
+              "buildStatus": "InProgress",
+              "configuration": {
+                "baseOs": "DebianBullseye",
+                "environmentVariables": [
+                  {
+                    "name": "foo1",
+                    "value": "bar1"
+                  },
+                  {
+                    "name": "foo2",
+                    "value": "bar2"
+                  }
+                ],
+                "platform": "dotnetcore",
+                "platformVersion": "7.0",
+                "preBuildSteps": [
+                  {
+                    "description": "First pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo",
+                        "bar"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'world'"
+                    ]
+                  },
+                  {
+                    "description": "Second pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'again'"
+                    ]
+                  }
+                ]
+              },
+              "destinationContainerRegistry": {
+                "image": "test.azurecr.io/repo:tag",
+                "server": "test.azurecr.io"
+              },
+              "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+              "provisioningState": "Succeeded",
+              "tokenEndpoint": "https://management.azure.com/subscriptions/{subscription-id}/resourcegroups/{rg-id}/Microsoft.App/builders/testBuilder/builds/testBuild/listAuthToken",
+              "uploadEndpoint": "https://foo.azurecontainerapps.dev/upload"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificate_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificate_CreateOrUpdate.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateEnvelope": {
+      "location": "East US",
+      "properties": {
+        "certificateType": "ImagePullTrustedCA",
+        "password": "private key password",
+        "value": "Y2VydA=="
+      }
+    },
+    "certificateName": "certificate-firendly-name",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "certificateType": "ImagePullTrustedCA",
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Certificates_CreateOrUpdate",
+  "title": "Create or Update Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificate_CreateOrUpdate_FromKeyVault.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificate_CreateOrUpdate_FromKeyVault.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateEnvelope": {
+      "location": "East US",
+      "properties": {
+        "certificateKeyVaultProperties": {
+          "identity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.managedidentity/userassignedidentities/test-user-mi",
+          "keyVaultUrl": "https://xxxxxxxx.vault.azure.net/certificates/certName"
+        },
+        "certificateType": "ServerSSLCertificate"
+      }
+    },
+    "certificateName": "certificate-firendly-name",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "certificateKeyVaultProperties": {
+            "identity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/test-rg/providers/microsoft.managedidentity/userassignedidentities/test-user-mi",
+            "keyVaultUrl": "https://xxxxxxxx.vault.azure.net/certificates/certName"
+          },
+          "certificateType": "ServerSSLCertificate",
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Certificates_CreateOrUpdate",
+  "title": "Create or Update Certificate using Managed Identity"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificate_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificate_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateName": "certificate-firendly-name",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "Certificates_Delete",
+  "title": "Delete Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificate_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificate_Get.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateName": "certificate-firendly-name",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "certificate-firendly-name",
+        "type": "Microsoft.App/ManagedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "certificateType": "ServerSSLCertificate",
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Certificates_Get",
+  "title": "Get Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificates_CheckNameAvailability.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificates_CheckNameAvailability.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "checkNameAvailabilityRequest": {
+      "name": "testcertificatename",
+      "type": "Microsoft.App/managedEnvironments/certificates"
+    },
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "Namespaces_CheckNameAvailability",
+  "title": "Certificates_CheckNameAvailability"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificates_ListByManagedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificates_ListByManagedEnvironment.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "certificate-firendly-name",
+            "type": "Microsoft.App/ManagedEnvironments/Certificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+            "location": "East US",
+            "properties": {
+              "certificateType": "ImagePullTrustedCA",
+              "expirationDate": "2022-11-06T04:00:00Z",
+              "issueDate": "2021-11-06T04:00:00Z",
+              "issuer": "Issuer Name",
+              "provisioningState": "Succeeded",
+              "subjectAlternativeNames": [
+                "CN=my-subject-name.com"
+              ],
+              "subjectName": "my-subject-name.company.country.net",
+              "thumbprint": "CERTIFICATE_THUMBPRINT",
+              "valid": true
+            }
+          },
+          {
+            "name": "certificate-firendly-name",
+            "type": "Microsoft.App/ManagedEnvironments/Certificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+            "location": "East US",
+            "properties": {
+              "certificateType": "ServerSSLCertificate",
+              "expirationDate": "2022-11-06T04:00:00Z",
+              "issueDate": "2021-11-06T04:00:00Z",
+              "issuer": "Issuer Name",
+              "provisioningState": "Succeeded",
+              "subjectAlternativeNames": [
+                "CN=my-subject-name.com"
+              ],
+              "subjectName": "my-subject-name.company.country.net",
+              "thumbprint": "CERTIFICATE_THUMBPRINT",
+              "valid": true
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Certificates_List",
+  "title": "List Certificates by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificates_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Certificates_Patch.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateEnvelope": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "certificateName": "certificate-firendly-name",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "certificateType": "ServerSSLCertificate",
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Certificates_Update",
+  "title": "Patch Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificate_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificate_CreateOrUpdate.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateEnvelope": {
+      "location": "East US",
+      "properties": {
+        "password": "private key password",
+        "value": "Y2VydA=="
+      }
+    },
+    "certificateName": "certificate-firendly-name",
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certififcates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "deploymentErrors": null,
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testenv",
+        "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certififcates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "InProgress",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsCertificates_CreateOrUpdate",
+  "title": "Create or Update Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificate_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificate_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateName": "certificate-firendly-name",
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/connectedOperationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectedEnvironmentsCertificates_Delete",
+  "title": "Delete Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificate_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificate_Get.json
@@ -1,0 +1,34 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateName": "certificate-firendly-name",
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "certificate-firendly-name",
+        "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectedEnvironmentsCertificates_Get",
+  "title": "Get Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificates_CheckNameAvailability.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificates_CheckNameAvailability.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "checkNameAvailabilityRequest": {
+      "name": "testcertificatename",
+      "type": "Microsoft.App/connectedEnvironments/certificates"
+    },
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_CheckNameAvailability",
+  "title": "Certificates_CheckNameAvailability"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificates_ListByConnectedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificates_ListByConnectedEnvironment.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "certificate-firendly-name",
+            "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+            "location": "East US",
+            "properties": {
+              "expirationDate": "2022-11-06T04:00:00Z",
+              "issueDate": "2021-11-06T04:00:00Z",
+              "issuer": "Issuer Name",
+              "provisioningState": "Succeeded",
+              "subjectAlternativeNames": [
+                "CN=my-subject-name.com"
+              ],
+              "subjectName": "my-subject-name.company.country.net",
+              "thumbprint": "CERTIFICATE_THUMBPRINT",
+              "valid": true
+            }
+          },
+          {
+            "name": "certificate-firendly-name",
+            "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+            "location": "East US",
+            "properties": {
+              "expirationDate": "2022-11-06T04:00:00Z",
+              "issueDate": "2021-11-06T04:00:00Z",
+              "issuer": "Issuer Name",
+              "provisioningState": "Succeeded",
+              "subjectAlternativeNames": [
+                "CN=my-subject-name.com"
+              ],
+              "subjectName": "my-subject-name.company.country.net",
+              "thumbprint": "CERTIFICATE_THUMBPRINT",
+              "valid": true
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectedEnvironmentsCertificates_List",
+  "title": "List Certificates by Connected Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificates_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsCertificates_Patch.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "certificateEnvelope": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "certificateName": "certificate-firendly-name",
+    "connectedEnvironmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ConnectedEnvironments/Certificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testcontainerenv/certificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "expirationDate": "2022-11-06T04:00:00Z",
+          "issueDate": "2021-11-06T04:00:00Z",
+          "issuer": "Issuer Name",
+          "provisioningState": "Succeeded",
+          "subjectAlternativeNames": [
+            "CN=my-subject-name.com"
+          ],
+          "subjectName": "my-subject-name.company.country.net",
+          "thumbprint": "CERTIFICATE_THUMBPRINT",
+          "valid": true
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/connectedOperationResults/00000"
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsCertificates_Update",
+  "title": "Patch Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsDaprComponents_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsDaprComponents_CreateOrUpdate.json
@@ -1,0 +1,162 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "connectedEnvironmentName": "myenvironment",
+    "daprComponentEnvelope": {
+      "properties": {
+        "componentType": "state.azure.cosmosdb",
+        "ignoreErrors": false,
+        "initTimeout": "50s",
+        "metadata": [
+          {
+            "name": "url",
+            "value": "<COSMOS-URL>"
+          },
+          {
+            "name": "database",
+            "value": "itemsDB"
+          },
+          {
+            "name": "collection",
+            "value": "items"
+          },
+          {
+            "name": "masterkey",
+            "secretRef": "masterkey"
+          }
+        ],
+        "scopes": [
+          "container-app-1",
+          "container-app-2"
+        ],
+        "secrets": [
+          {
+            "name": "masterkey",
+            "value": "keyvalue"
+          }
+        ],
+        "serviceComponentBind": [
+          {
+            "name": "statestore",
+            "metadata": {
+              "name": "daprcomponentBind",
+              "value": "redis-bind"
+            },
+            "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+          }
+        ],
+        "version": "v1"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/connectedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "deploymentErrors": null,
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secrets": [
+            {
+              "name": "masterkey"
+            }
+          ],
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/connectedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "provisioningState": "InProgress",
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secrets": [
+            {
+              "name": "masterkey"
+            }
+          ],
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsDaprComponents_CreateOrUpdate",
+  "title": "Create or update dapr component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsDaprComponents_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsDaprComponents_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "connectedEnvironmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/connectedOperationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectedEnvironmentsDaprComponents_Delete",
+  "title": "Delete dapr component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsDaprComponents_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsDaprComponents_Get.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "connectedEnvironmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/connectedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "deploymentErrors": null,
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secrets": [
+            {
+              "name": "masterkey"
+            }
+          ],
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsDaprComponents_Get",
+  "title": "Get Dapr Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsDaprComponents_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsDaprComponents_List.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "reddog",
+            "type": "Microsoft.App/connectedEnvironments/daprcomponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/myenvironment/daprcomponents/reddog",
+            "properties": {
+              "componentType": "state.azure.cosmosdb",
+              "deploymentErrors": null,
+              "ignoreErrors": false,
+              "initTimeout": "50s",
+              "metadata": [
+                {
+                  "name": "url",
+                  "value": "<COSMOS-URL>"
+                },
+                {
+                  "name": "database",
+                  "value": "itemsDB"
+                },
+                {
+                  "name": "collection",
+                  "value": "items"
+                },
+                {
+                  "name": "masterkey",
+                  "secretRef": "masterkey"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "scopes": [
+                "container-app-1",
+                "container-app-2"
+              ],
+              "secrets": [
+                {
+                  "name": "masterkey"
+                }
+              ],
+              "serviceComponentBind": [
+                {
+                  "name": "statestore",
+                  "metadata": {
+                    "name": "daprcomponentBind",
+                    "value": "redis-bind"
+                  },
+                  "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+                }
+              ],
+              "version": "v1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsDaprComponents_List",
+  "title": "List Dapr Components"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsDaprComponents_ListSecrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsDaprComponents_ListSecrets.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "connectedEnvironmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "secret1",
+            "value": "value1"
+          },
+          {
+            "name": "secret2",
+            "value": "value2"
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ConnectedEnvironmentsDaprComponents_ListSecrets",
+  "title": "List Container Apps Secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsStorages_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsStorages_CreateOrUpdate.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "env",
+    "resourceGroupName": "examplerg",
+    "storageEnvelope": {
+      "properties": {
+        "azureFile": {
+          "accessMode": "ReadOnly",
+          "accountKey": "key",
+          "accountName": "account1",
+          "shareName": "share1"
+        }
+      }
+    },
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/connectedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/env/storages/jlaw-demo1",
+        "properties": {
+          "azureFile": {
+            "accessMode": "ReadOnly",
+            "accountName": "account1",
+            "shareName": "share1"
+          },
+          "deploymentErrors": null,
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/connectedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/env/storages/jlaw-demo1",
+        "properties": {
+          "azureFile": {
+            "accessMode": "ReadOnly",
+            "accountName": "account1",
+            "shareName": "share1"
+          },
+          "provisioningState": "InProgress"
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsStorages_CreateOrUpdate",
+  "title": "Create or update environments storage"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsStorages_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsStorages_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "env",
+    "resourceGroupName": "examplerg",
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/connectedOperationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectedEnvironmentsStorages_Delete",
+  "title": "List environments storages by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsStorages_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsStorages_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "env",
+    "resourceGroupName": "examplerg",
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/connectedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/env/storages/jlaw-demo1",
+        "properties": {
+          "azureFile": {
+            "accessMode": "ReadOnly",
+            "accountName": "account1",
+            "shareName": "share1"
+          },
+          "deploymentErrors": null,
+          "provisioningState": "Succeeded"
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsStorages_Get",
+  "title": "get a environments storage properties by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsStorages_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironmentsStorages_List.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "jlaw-demo1",
+            "type": "Microsoft.App/connectedEnvironments/storages",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/managedEnv/storages/jlaw-demo1",
+            "properties": {
+              "azureFile": {
+                "accessMode": "ReadOnly",
+                "accountName": "account1",
+                "shareName": "share1"
+              },
+              "deploymentErrors": null,
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironmentsStorages_List",
+  "title": "List environments storages by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_CreateOrUpdate.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "testenv",
+    "environmentEnvelope": {
+      "location": "East US",
+      "properties": {
+        "customDomainConfiguration": {
+          "certificatePassword": "private key password",
+          "certificateValue": "Y2VydA==",
+          "dnsSuffix": "www.my-name.com"
+        },
+        "daprAIConnectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://northcentralus-0.in.applicationinsights.azure.com/",
+        "staticIp": "1.2.3.4"
+      }
+    },
+    "extendedLocation": {
+      "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+      "type": "CustomLocation"
+    },
+    "kind": "kubernetes",
+    "location": "East US",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testenv",
+        "type": "Microsoft.App/connectedEnvironments",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testenv",
+        "location": "East US",
+        "properties": {
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testenv.k4apps.io",
+          "deploymentErrors": null,
+          "provisioningState": "Succeeded",
+          "staticIp": "1.2.3.4"
+        },
+        "tags": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testenv",
+        "type": "Microsoft.App/connectedEnvironments",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testenv",
+        "location": "East US",
+        "properties": {
+          "defaultDomain": "testenv.k4apps.io",
+          "deploymentErrors": null,
+          "provisioningState": "Waiting",
+          "staticIp": "1.2.3.4"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_CreateOrUpdate",
+  "title": "Create kube environments"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_Delete.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "examplekenv",
+    "extendedLocation": {
+      "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+      "type": "CustomLocation"
+    },
+    "kind": "kubernetes",
+    "location": "East US",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/operationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ConnectedEnvironments_Delete",
+  "title": "Delete connected environment by connectedEnvironmentName"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_Get.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "examplekenv",
+    "extendedLocation": {
+      "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+      "type": "CustomLocation"
+    },
+    "kind": "kubernetes",
+    "location": "East US",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "examplekenv",
+        "type": "Microsoft.App/connectedEnvironments",
+        "extendedLocation": {
+          "name": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/examplekenv",
+        "location": "North Central US",
+        "properties": {
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "examplekenv.k4apps.io",
+          "deploymentErrors": null,
+          "provisioningState": "Succeeded",
+          "staticIp": "20.42.33.145"
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_Get",
+  "title": "Get connected environment by connectedEnvironmentName"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_ListByResourceGroup.json
@@ -1,0 +1,65 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sample1",
+            "type": "Microsoft.App/connectedEnvironments",
+            "extendedLocation": {
+              "name": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/sample1",
+            "location": "North Central US",
+            "properties": {
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "sample1.k4apps.io",
+              "deploymentErrors": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "20.42.33.145"
+            },
+            "tags": {}
+          },
+          {
+            "name": "sample2",
+            "type": "Microsoft.App/connectedEnvironments",
+            "extendedLocation": {
+              "name": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+              "type": "CustomLocation"
+            },
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/sample2",
+            "location": "North Central US",
+            "properties": {
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name2.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name2.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "sample2.k4apps.io",
+              "deploymentErrors": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "52.142.21.61"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_ListByResourceGroup",
+  "title": "List environments by resource group"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_ListBySubscription.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "sample1",
+            "type": "Microsoft.App/connectedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/sample1",
+            "location": "North Central US",
+            "properties": {
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "sample1.k4apps.io",
+              "deploymentErrors": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "20.42.33.145"
+            },
+            "tags": {}
+          },
+          {
+            "name": "sample2",
+            "type": "Microsoft.App/connectedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/DemoRG/providers/Microsoft.App/connectedEnvironments/sample2",
+            "location": "North Central US",
+            "properties": {
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name2.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name2.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "sample2.k4apps.io",
+              "deploymentErrors": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "52.142.21.61"
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_ListBySubscription",
+  "title": "List connected environments by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ConnectedEnvironments_Patch.json
@@ -1,0 +1,43 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "connectedEnvironmentName": "testenv",
+    "environmentEnvelope": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testenv",
+        "type": "Microsoft.App/connectedEnvironments",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/connectedEnvironments/testenv",
+        "location": "East US",
+        "properties": {
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testenv.k4apps.io",
+          "deploymentErrors": null,
+          "provisioningState": "Succeeded",
+          "staticIp": "20.42.33.145"
+        },
+        "tags": {
+          "tag1": "value1",
+          "tag2": "value2"
+        }
+      }
+    }
+  },
+  "operationId": "ConnectedEnvironments_Update",
+  "title": "Patch Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsBuilds_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsBuilds_Delete.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "ContainerAppsBuilds_Delete",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildName": "testBuild",
+    "containerAppName": "testCapp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsBuilds_Delete_0",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsBuilds_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsBuilds_Get.json
@@ -1,0 +1,83 @@
+{
+  "operationId": "ContainerAppsBuilds_Get",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "buildName": "testBuild",
+    "containerAppName": "testCapp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsBuilds_Get_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testBuild",
+        "type": "Microsoft.App/containerApps/builds",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/containerApps/testCapp/builds/testBuild",
+        "properties": {
+          "buildStatus": "InProgress",
+          "configuration": {
+            "baseOs": "DebianBullseye",
+            "environmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "platform": "dotnetcore",
+            "platformVersion": "7.0",
+            "preBuildSteps": [
+              {
+                "description": "First pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo",
+                    "bar"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'world'"
+                ]
+              },
+              {
+                "description": "Second pre build step.",
+                "httpGet": {
+                  "fileName": "output.txt",
+                  "headers": [
+                    "foo"
+                  ],
+                  "url": "https://microsoft.com"
+                },
+                "scripts": [
+                  "echo 'hello'",
+                  "echo 'again'"
+                ]
+              }
+            ]
+          },
+          "destinationContainerRegistry": {
+            "image": "test.azurecr.io/repo:tag",
+            "server": "test.azurecr.io"
+          },
+          "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdAt": "2022-10-11T11:05:51.4940669Z",
+          "createdBy": "sample@microsoft.com",
+          "createdByType": "User",
+          "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+          "lastModifiedBy": "sample@microsoft.com",
+          "lastModifiedByType": "User"
+        }
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsBuilds_ListByContainerApp.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsBuilds_ListByContainerApp.json
@@ -1,0 +1,155 @@
+{
+  "operationId": "ContainerAppsBuildsByContainerApp_List",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testCapp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsBuilds_ListByContainerApp_0",
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "testBuild1",
+            "type": "Microsoft.App/containerApps/builds",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/containerApps/testCapp/builds/testBuild1",
+            "properties": {
+              "buildStatus": "InProgress",
+              "configuration": {
+                "baseOs": "DebianBullseye",
+                "environmentVariables": [
+                  {
+                    "name": "foo1",
+                    "value": "bar1"
+                  },
+                  {
+                    "name": "foo2",
+                    "value": "bar2"
+                  }
+                ],
+                "platform": "dotnetcore",
+                "platformVersion": "7.0",
+                "preBuildSteps": [
+                  {
+                    "description": "First pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo",
+                        "bar"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'world'"
+                    ]
+                  },
+                  {
+                    "description": "Second pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'again'"
+                    ]
+                  }
+                ]
+              },
+              "destinationContainerRegistry": {
+                "image": "test.azurecr.io/repo:tag",
+                "server": "test.azurecr.io"
+              },
+              "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          },
+          {
+            "name": "testBuild2",
+            "type": "Microsoft.App/containerApps/builds",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/rg/providers/Microsoft.App/containerApps/testCapp/builds/testBuild2",
+            "properties": {
+              "buildStatus": "InProgress",
+              "configuration": {
+                "baseOs": "DebianBullseye",
+                "environmentVariables": [
+                  {
+                    "name": "foo1",
+                    "value": "bar1"
+                  },
+                  {
+                    "name": "foo2",
+                    "value": "bar2"
+                  }
+                ],
+                "platform": "dotnetcore",
+                "platformVersion": "7.0",
+                "preBuildSteps": [
+                  {
+                    "description": "First pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo",
+                        "bar"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'world'"
+                    ]
+                  },
+                  {
+                    "description": "Second pre build step.",
+                    "httpGet": {
+                      "fileName": "output.txt",
+                      "headers": [
+                        "foo"
+                      ],
+                      "url": "https://microsoft.com"
+                    },
+                    "scripts": [
+                      "echo 'hello'",
+                      "echo 'again'"
+                    ]
+                  }
+                ]
+              },
+              "destinationContainerRegistry": {
+                "image": "test.azurecr.io/repo:tag",
+                "server": "test.azurecr.io"
+              },
+              "logStreamEndpoint": "https://foo.azurecontainerapps.dev/logstream",
+              "provisioningState": "Succeeded"
+            },
+            "systemData": {
+              "createdAt": "2022-10-11T11:05:51.4940669Z",
+              "createdBy": "sample@microsoft.com",
+              "createdByType": "User",
+              "lastModifiedAt": "2022-10-11T11:05:51.4940669Z",
+              "lastModifiedBy": "sample@microsoft.com",
+              "lastModifiedByType": "User"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsDiagnostics_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsDiagnostics_Get.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "containerAppName": "mikono-capp-stage1",
+    "detectorName": "cappcontainerappnetworkIO",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/containerApps/mikono-capp-stage1/detectors/cappcontainerappnetworkIO",
+        "name": "cappcontainerappnetworkIO",
+        "type": "Microsoft.App/containerapps/detectors",
+        "properties": {
+          "metadata": {
+            "id": "cappcontainerappnetworkIO",
+            "name": "Container App Network Inbound and Outbound",
+            "description": "This detector shows the Container App Network Inbound and Outbound.",
+            "author": "",
+            "category": "Availability and Performance",
+            "supportTopicList": [],
+            "type": "Detector",
+            "score": 0
+          },
+          "dataset": [
+            {
+              "table": {
+                "tableName": "",
+                "columns": [
+                  {
+                    "columnName": "TimeStamp",
+                    "dataType": "DateTime"
+                  },
+                  {
+                    "columnName": "Metric",
+                    "dataType": "String"
+                  },
+                  {
+                    "columnName": "Average",
+                    "dataType": "Double"
+                  }
+                ],
+                "rows": [
+                  [
+                    "2022-03-15T21:35:00",
+                    "RxBytes",
+                    0
+                  ]
+                ]
+              },
+              "renderingProperties": {
+                "type": 8,
+                "title": "Container Apps Network Inbound ",
+                "description": "",
+                "isVisible": true
+              }
+            }
+          ],
+          "status": {
+            "statusId": 3
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ContainerAppsDiagnostics_GetDetector",
+  "title": "Get Container App's diagnostics info"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsDiagnostics_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsDiagnostics_List.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "containerAppName": "mikono-capp-stage1",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/containerApps/mikono-capp-stage1/detectors/cappContainerAppAvailabilityMetrics",
+            "name": "cappContainerAppAvailabilityMetrics",
+            "type": "Microsoft.App/containerapps/detectors",
+            "properties": {
+              "metadata": {
+                "id": "cappContainerAppAvailabilityMetrics",
+                "name": "Availability Metrics for Container Apps",
+                "author": "",
+                "category": "Availability and Performance",
+                "supportTopicList": [],
+                "type": "Analysis",
+                "score": 0
+              },
+              "dataset": [],
+              "status": {
+                "statusId": 4
+              }
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  },
+  "operationId": "ContainerAppsDiagnostics_ListDetectors",
+  "title": "Get the list of available diagnostics for a given Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsFunctions_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsFunctions_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myContainerApp",
+    "functionName": "HttpExample",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "12345678-1234-1234-1234-123456789abc"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myContainerApp/HttpExample",
+        "type": "Microsoft.App/containerApps/functions",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/functions/HttpExample",
+        "properties": {
+          "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/HttpExample",
+          "isDisabled": false,
+          "triggerType": "httpTrigger",
+          "language": "dotnet-isolated"
+        }
+      }
+    }
+  },
+  "operationId": "ContainerAppsFunctions_Get",
+  "title": "Get Container App's function"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsFunctions_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsFunctions_List.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myContainerApp",
+    "resourceGroupName": "myResourceGroup",
+    "subscriptionId": "12345678-1234-1234-1234-123456789abc"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "myContainerApp/HttpExample",
+            "type": "Microsoft.App/containerApps/functions",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/functions/HttpExample",
+            "properties": {
+              "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/HttpExample",
+              "isDisabled": false,
+              "triggerType": "httpTrigger",
+              "language": "dotnet-isolated"
+            }
+          },
+          {
+            "name": "myContainerApp/TimerFunction",
+            "type": "Microsoft.App/containerApps/functions",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/functions/TimerFunction",
+            "properties": {
+              "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/TimerFunction",
+              "isDisabled": false,
+              "triggerType": "timerTrigger",
+              "language": "dotnet-isolated"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ContainerAppsFunctions_List",
+  "title": "List Container App's functions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsPatches_Apply.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsPatches_Apply.json
@@ -1,0 +1,53 @@
+{
+  "operationId": "ContainerAppsPatches_Apply",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "test-app",
+    "patchName": "testPatch-25fe4b",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsPatches_Apply_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPatch-25fe4b",
+        "type": "Microsoft.App/containerApps/patches",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app/patches/testPatch-25fe4b",
+        "properties": {
+          "createdAt": "2022-10-10T12:06:20.3421+00:00",
+          "lastModifiedAt": "2022-10-10T12:06:20.3421+00:00",
+          "patchApplyStatus": "Succeeded",
+          "patchDetails": [
+            {
+              "detectionStatus": "Succeeded",
+              "lastDetectionTime": "2022-10-10T12:06:19.5241+00:00",
+              "newImageName": "testregistry.azurecr.io/test-image:latest-patched-202210101206",
+              "newLayer": {
+                "name": "mcr.microsoft.com/dotnet/aspnet:7.0.7-cbl-mariner2.0",
+                "frameworkAndVersion": "dotnet:7.0.7",
+                "osAndVersion": "cbl-mariner2.0"
+              },
+              "oldLayer": {
+                "name": "mcr.microsoft.com/dotnet/aspnet:7.0.5-cbl-mariner2.0",
+                "frameworkAndVersion": "dotnet:7.0.5",
+                "osAndVersion": "cbl-mariner2.0"
+              },
+              "patchType": "FrameworkSecurity",
+              "targetContainerName": "test-container",
+              "targetImage": "testregistry.azurecr.io/test-image:latest"
+            }
+          ],
+          "targetContainerAppId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app",
+          "targetEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/test-env",
+          "targetRevisionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/apps/test-app/revisions/test-app--jm3vvry"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsPatches_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsPatches_Delete.json
@@ -1,0 +1,19 @@
+{
+  "operationId": "ContainerAppsPatches_Delete",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "test-app",
+    "patchName": "testPatch-25fe4b",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsPatches_Delete_0",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsPatches_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsPatches_Get.json
@@ -1,0 +1,48 @@
+{
+  "operationId": "ContainerAppsPatches_Get",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "test-app",
+    "patchName": "testPatch-25fe4b",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsPatches_Get_0",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testPatch-25fe4b",
+        "type": "Microsoft.App/containerApps/patches",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app/patches/testPatch-25fe4b",
+        "properties": {
+          "createdAt": "2022-10-10T12:06:20.3421+00:00",
+          "lastModifiedAt": "2022-10-10T12:06:20.3421+00:00",
+          "patchApplyStatus": "NotStarted",
+          "patchDetails": [
+            {
+              "detectionStatus": "Succeeded",
+              "lastDetectionTime": "2022-10-10T12:06:19.5241+00:00",
+              "newImageName": "testregistry.azurecr.io/test-image:latest-patched-202210101206",
+              "newLayer": {
+                "name": "mcr.microsoft.com/dotnet/aspnet:7.0.7-cbl-mariner2.0",
+                "frameworkAndVersion": "dotnet:7.0.7",
+                "osAndVersion": "cbl-mariner2.0"
+              },
+              "oldLayer": {
+                "name": "mcr.microsoft.com/dotnet/aspnet:7.0.5-cbl-mariner2.0",
+                "frameworkAndVersion": "dotnet:7.0.5",
+                "osAndVersion": "cbl-mariner2.0"
+              },
+              "patchType": "FrameworkSecurity",
+              "targetContainerName": "test-container",
+              "targetImage": "testregistry.azurecr.io/test-image:latest"
+            }
+          ],
+          "targetContainerAppId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app",
+          "targetEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/test-env",
+          "targetRevisionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/apps/test-app/revisions/test-app--jm3vvry"
+        }
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsPatches_ListByContainerApp.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsPatches_ListByContainerApp.json
@@ -1,0 +1,103 @@
+{
+  "operationId": "ContainerAppsPatches_ListByContainerApp",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "test-app",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsPatches_ListByContainerApp_0",
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testPatch-25fe4b",
+            "type": "Microsoft.App/containerApps/patches",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app/patches/testPatch-25fe4b",
+            "properties": {
+              "createdAt": "2022-10-10T12:06:20.3421+00:00",
+              "lastModifiedAt": "2022-10-10T12:06:20.3421+00:00",
+              "patchApplyStatus": "NotStarted",
+              "patchDetails": [
+                {
+                  "detectionStatus": "Succeeded",
+                  "lastDetectionTime": "2022-10-10T12:06:19.5241+00:00",
+                  "newImageName": "testregistry.azurecr.io/test-image:release-1-patched-202210101206185241",
+                  "newLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.9-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.9",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "oldLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.7-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.7",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "patchType": "FrameworkSecurity",
+                  "targetContainerName": "test-container",
+                  "targetImage": "testregistry.azurecr.io/test-image:release-1-patched-202209101206203421"
+                }
+              ],
+              "targetContainerAppId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app",
+              "targetEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/test-env",
+              "targetRevisionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/apps/test-app/revisions/test-app--jm3vvry"
+            }
+          },
+          {
+            "name": "testPatch-27c3d5",
+            "type": "Microsoft.App/containerApps/patches",
+            "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app/patches/testPatch-27c3d5",
+            "properties": {
+              "createdAt": "2022-09-10T12:06:20.3421+00:00",
+              "lastModifiedAt": "2022-09-20T12:06:20.3421+00:00",
+              "patchApplyStatus": "Succeeded",
+              "patchDetails": [
+                {
+                  "detectionStatus": "Succeeded",
+                  "lastDetectionTime": "2022-09-21T12:06:19.5241+00:00",
+                  "newImageName": "testregistry.azurecr.io/test-image:release-1-patched-202209101206203421",
+                  "newLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.7-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.7",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "oldLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.5-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.5",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "patchType": "FrameworkSecurity",
+                  "targetContainerName": "test-container",
+                  "targetImage": "testregistry.azurecr.io/test-image:release-1"
+                },
+                {
+                  "detectionStatus": "Succeeded",
+                  "lastDetectionTime": "2022-09-21T12:06:19.5241+00:00",
+                  "newImageName": "testregistry.azurecr.io/test-image:release-2-patched-202209101206203421",
+                  "newLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.7-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.7",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "oldLayer": {
+                    "name": "mcr.microsoft.com/dotnet/aspnet:7.0.0-cbl-mariner2.0",
+                    "frameworkAndVersion": "dotnet:7.0.0",
+                    "osAndVersion": "cbl-mariner2.0"
+                  },
+                  "patchType": "FrameworkSecurity",
+                  "targetContainerName": "test-container-2",
+                  "targetImage": "testregistry.azurecr.io/test-image:release-2"
+                }
+              ],
+              "targetContainerAppId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app",
+              "targetEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/test-env",
+              "targetRevisionId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerApps/test-app2/revisions/test-app--z79h4oc"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsPatches_Skip_Configure.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsPatches_Skip_Configure.json
@@ -1,0 +1,21 @@
+{
+  "operationId": "ContainerAppsPatches_SkipConfigure",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "test-app",
+    "patchName": "testPatch-25fe4b",
+    "patchSkipConfig": {
+      "skip": true
+    },
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "title": "ContainerAppsPatches_Skip_Configure_0",
+  "responses": {
+    "202": {
+      "headers": {
+        "Location": "https://management.azure.com/subscriptions/{subscription-id}/providers/Microsoft.App/locations/{location}/operationStatuses/{operationId}"
+      }
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsRevisionFunctions_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsRevisionFunctions_Get.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myContainerApp",
+    "functionName": "HttpExample",
+    "resourceGroupName": "myResourceGroup",
+    "revisionName": "myContainerApp-abc123",
+    "subscriptionId": "12345678-1234-1234-1234-123456789abc"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myContainerApp/myContainerApp-abc123/HttpExample",
+        "type": "Microsoft.App/containerApps/revisions/functions",
+        "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/revisions/myContainerApp-abc123/functions/HttpExample",
+        "properties": {
+          "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/HttpExample",
+          "isDisabled": false,
+          "triggerType": "httpTrigger",
+          "language": "dotnet-isolated"
+        }
+      }
+    }
+  },
+  "operationId": "ContainerAppsRevisionFunctions_Get",
+  "title": "Get Container App Revision's function"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsRevisionFunctions_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerAppsRevisionFunctions_List.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myContainerApp",
+    "resourceGroupName": "myResourceGroup",
+    "revisionName": "myContainerApp-abc123",
+    "subscriptionId": "12345678-1234-1234-1234-123456789abc"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "myContainerApp/myContainerApp-abc123/HttpExample",
+            "type": "Microsoft.App/containerApps/revisions/functions",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/revisions/myContainerApp-abc123/functions/HttpExample",
+            "properties": {
+              "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/HttpExample",
+              "isDisabled": false,
+              "triggerType": "httpTrigger",
+              "language": "dotnet-isolated"
+            }
+          },
+          {
+            "name": "myContainerApp/myContainerApp-abc123/TimerFunction",
+            "type": "Microsoft.App/containerApps/revisions/functions",
+            "id": "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/myResourceGroup/providers/Microsoft.App/containerApps/myContainerApp/revisions/myContainerApp-abc123/functions/TimerFunction",
+            "properties": {
+              "invokeUrlTemplate": "https://mycontainerapp.example-region.azurecontainerapps.io/api/TimerFunction",
+              "isDisabled": false,
+              "triggerType": "timerTrigger",
+              "language": "dotnet-isolated"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ContainerAppsRevisionFunctions_List",
+  "title": "List Container App Revision's functions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_CheckNameAvailability.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_CheckNameAvailability.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "checkNameAvailabilityRequest": {
+      "name": "testcappname",
+      "type": "Microsoft.App/containerApps"
+    },
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "message": "",
+        "nameAvailable": true,
+        "reason": "None"
+      }
+    }
+  },
+  "operationId": "Namespaces_CheckNameAvailability",
+  "title": "ContainerApps_CheckNameAvailability"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_CreateOrUpdate.json
@@ -1,0 +1,692 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "dapr": {
+            "appHealth": {
+              "path": "/health",
+              "enabled": true,
+              "probeIntervalSeconds": 3,
+              "probeTimeoutMilliseconds": 1000,
+              "threshold": 3
+            },
+            "appPort": 3000,
+            "appProtocol": "http",
+            "enableApiLogging": true,
+            "enabled": true,
+            "httpMaxRequestSize": 10,
+            "httpReadBufferSize": 30,
+            "logLevel": "debug",
+            "maxConcurrency": 10
+          },
+          "identitySettings": [
+            {
+              "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+              "lifecycle": "All"
+            },
+            {
+              "identity": "system",
+              "lifecycle": "Init"
+            }
+          ],
+          "ingress": {
+            "additionalPortMappings": [
+              {
+                "external": true,
+                "targetPort": 1234
+              },
+              {
+                "exposedPort": 3456,
+                "external": false,
+                "targetPort": 2345
+              }
+            ],
+            "clientCertificateMode": "accept",
+            "corsPolicy": {
+              "allowCredentials": true,
+              "allowedHeaders": [
+                "HEADER1",
+                "HEADER2"
+              ],
+              "allowedMethods": [
+                "GET",
+                "POST"
+              ],
+              "allowedOrigins": [
+                "https://a.test.com",
+                "https://b.test.com"
+              ],
+              "exposeHeaders": [
+                "HEADER3",
+                "HEADER4"
+              ],
+              "maxAge": 1234
+            },
+            "customDomains": [
+              {
+                "name": "www.my-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+              },
+              {
+                "name": "www.my-other-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+              }
+            ],
+            "external": true,
+            "ipSecurityRestrictions": [
+              {
+                "name": "Allow work IP A subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/32"
+              },
+              {
+                "name": "Allow work IP B subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/8"
+              }
+            ],
+            "stickySessions": {
+              "affinity": "sticky"
+            },
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "label": "production",
+                "revisionName": "testcontainerApp0-ab1234",
+                "weight": 100
+              }
+            ]
+          },
+          "maxInactiveRevisions": 10,
+          "revisionTransitionThreshold": 100,
+          "runtime": {
+            "dotnet": {
+              "autoConfigureDataProtection": true
+            },
+            "java": {
+              "enableMetrics": true,
+              "javaAgent": {
+                "enabled": true,
+                "logging": {
+                  "loggerSettings": [
+                    {
+                      "level": "debug",
+                      "logger": "org.springframework.boot"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "service": {
+            "type": "redis"
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerApp0",
+              "image": "repo/testcontainerApp0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "mountPath": "/mnt/path1",
+                  "subPath": "subPath1",
+                  "volumeName": "azurefile"
+                },
+                {
+                  "mountPath": "/mnt/path2",
+                  "subPath": "subPath2",
+                  "volumeName": "nfsazurefile"
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerApp0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerApp0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "gpu": 1,
+                "memory": "100Mi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "httpscalingrule",
+                "custom": {
+                  "type": "http",
+                  "metadata": {
+                    "concurrentRequests": "50"
+                  }
+                }
+              },
+              {
+                "name": "servicebus",
+                "custom": {
+                  "type": "azure-servicebus",
+                  "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                  "metadata": {
+                    "messageCount": "5",
+                    "namespace": "mynamespace",
+                    "queueName": "myqueue"
+                  }
+                }
+              },
+              {
+                "name": "azure-queue",
+                "azureQueue": {
+                  "accountName": "account1",
+                  "identity": "system",
+                  "queueLength": 1,
+                  "queueName": "queue1"
+                }
+              }
+            ]
+          },
+          "serviceBinds": [
+            {
+              "name": "redisService",
+              "clientType": "dotnet",
+              "customizedKeys": {
+                "DesiredKey": "defaultKey"
+              },
+              "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/redisService"
+            }
+          ],
+          "volumes": [
+            {
+              "name": "azurefile",
+              "storageName": "storage",
+              "storageType": "AzureFile"
+            },
+            {
+              "name": "nfsazurefile",
+              "storageName": "nfsStorage",
+              "storageType": "NfsAzureFile"
+            }
+          ]
+        },
+        "workloadProfileName": "My-GP-01"
+      }
+    },
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30,
+              "maxConcurrency": 10
+            },
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my-other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "stickySessions": {
+                "affinity": "sticky"
+              },
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "gpu": 1,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                },
+                {
+                  "name": "servicebus",
+                  "custom": {
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "messageCount": "5",
+                      "namespace": "mynamespace",
+                      "queueName": "myqueue"
+                    }
+                  }
+                },
+                {
+                  "name": "azure-queue",
+                  "azureQueue": {
+                    "accountName": "account1",
+                    "identity": "system",
+                    "queueLength": 1,
+                    "queueName": "queue1"
+                  }
+                }
+              ]
+            },
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30,
+              "maxConcurrency": 10
+            },
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "ingress": {
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "gpu": 1,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                },
+                {
+                  "name": "servicebus",
+                  "custom": {
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "messageCount": "5",
+                      "namespace": "mynamespace",
+                      "queueName": "myqueue"
+                    }
+                  }
+                },
+                {
+                  "name": "azure-queue",
+                  "azureQueue": {
+                    "accountName": "account1",
+                    "identity": "system",
+                    "queueLength": 1,
+                    "queueName": "queue1"
+                  }
+                }
+              ]
+            },
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_CreateOrUpdate_ConnectedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_CreateOrUpdate_ConnectedEnvironment.json
@@ -1,0 +1,469 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "extendedLocation": {
+        "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+        "type": "CustomLocation"
+      },
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "dapr": {
+            "appPort": 3000,
+            "appProtocol": "http",
+            "enableApiLogging": true,
+            "enabled": true,
+            "httpMaxRequestSize": 10,
+            "httpReadBufferSize": 30,
+            "logLevel": "debug"
+          },
+          "ingress": {
+            "additionalPortMappings": [
+              {
+                "external": true,
+                "targetPort": 1234
+              },
+              {
+                "exposedPort": 3456,
+                "external": false,
+                "targetPort": 2345
+              }
+            ],
+            "clientCertificateMode": "accept",
+            "corsPolicy": {
+              "allowCredentials": true,
+              "allowedHeaders": [
+                "HEADER1",
+                "HEADER2"
+              ],
+              "allowedMethods": [
+                "GET",
+                "POST"
+              ],
+              "allowedOrigins": [
+                "https://a.test.com",
+                "https://b.test.com"
+              ],
+              "exposeHeaders": [
+                "HEADER3",
+                "HEADER4"
+              ],
+              "maxAge": 1234
+            },
+            "customDomains": [
+              {
+                "name": "www.my-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+              },
+              {
+                "name": "www.my-other-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+              }
+            ],
+            "external": true,
+            "ipSecurityRestrictions": [
+              {
+                "name": "Allow work IP A subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/32"
+              },
+              {
+                "name": "Allow work IP B subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/8"
+              }
+            ],
+            "stickySessions": {
+              "affinity": "sticky"
+            },
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "label": "production",
+                "revisionName": "testcontainerApp0-ab1234",
+                "weight": 100
+              }
+            ]
+          },
+          "maxInactiveRevisions": 10,
+          "revisionTransitionThreshold": 100,
+          "runtime": {
+            "dotnet": {
+              "autoConfigureDataProtection": true
+            },
+            "java": {
+              "enableMetrics": true,
+              "javaAgent": {
+                "enabled": true,
+                "logging": {
+                  "loggerSettings": [
+                    {
+                      "level": "debug",
+                      "logger": "org.springframework.boot"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerApp0",
+              "image": "repo/testcontainerApp0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerApp0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerApp0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "httpscalingrule",
+                "custom": {
+                  "type": "http",
+                  "metadata": {
+                    "concurrentRequests": "50"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30
+            },
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my-other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "stickySessions": {
+                "affinity": "sticky"
+              },
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30
+            },
+            "ingress": {
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update App On A Connected Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testWorkerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/containerApps/testWorkerApp0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ContainerApps_Delete",
+  "title": "Delete Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Get.json
@@ -1,0 +1,226 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enableApiLogging": true,
+              "enabled": true,
+              "httpMaxRequestSize": 10,
+              "httpReadBufferSize": 30,
+              "logLevel": "debug",
+              "maxConcurrency": 10
+            },
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my--other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "stickySessions": {
+                "affinity": "sticky"
+              },
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "maxInactiveRevisions": 10,
+            "revisionTransitionThreshold": 100,
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "service": {
+              "type": "redis"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                },
+                {
+                  "name": "servicebus",
+                  "custom": {
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "messageCount": "5",
+                      "namespace": "mynamespace",
+                      "queueName": "myqueue"
+                    }
+                  }
+                }
+              ]
+            },
+            "serviceBinds": [
+              {
+                "name": "service",
+                "clientType": "dotnet",
+                "customizedKeys": {
+                  "DesiredKey": "defaultKey"
+                },
+                "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/service"
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "404": {}
+  },
+  "operationId": "ContainerApps_Get",
+  "title": "Get Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Get1.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Get1.json
@@ -1,0 +1,226 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enableApiLogging": true,
+              "enabled": true,
+              "httpMaxRequestSize": 10,
+              "httpReadBufferSize": 30,
+              "logLevel": "debug",
+              "maxConcurrency": 10
+            },
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my--other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "stickySessions": {
+                "affinity": "sticky"
+              },
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "maxInactiveRevisions": 10,
+            "revisionTransitionThreshold": 100,
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "service": {
+              "type": "redis"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                },
+                {
+                  "name": "servicebus",
+                  "custom": {
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "messageCount": "5",
+                      "namespace": "mynamespace",
+                      "queueName": "myqueue"
+                    }
+                  }
+                }
+              ]
+            },
+            "serviceBinds": [
+              {
+                "name": "service",
+                "clientType": "dotnet",
+                "customizedKeys": {
+                  "DesiredKey": "defaultKey"
+                },
+                "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/service"
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "404": {}
+  },
+  "operationId": "ContainerAppsDiagnostics_GetRoot",
+  "title": "Get Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_GetAuthToken.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_GetAuthToken.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps/accesstoken",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "expires": "2022-07-14T19:22:50.3080223Z",
+          "token": "testToken"
+        }
+      },
+      "headers": {}
+    },
+    "404": {}
+  },
+  "operationId": "ContainerApps_GetAuthToken",
+  "title": "Get Container App Auth Token"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Kind_FunctionApp_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Kind_FunctionApp_CreateOrUpdate.json
@@ -1,0 +1,213 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "kind": "functionapp",
+      "location": "East Us",
+      "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppFunctionKind",
+      "properties": {
+        "configuration": {
+          "activeRevisionsMode": "Single",
+          "ingress": {
+            "allowInsecure": false,
+            "external": true,
+            "targetPort": 80
+          }
+        },
+        "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+        "template": {
+          "containers": [
+            {
+              "name": "function-app-container",
+              "env": [
+                {
+                  "name": "AzureWebJobsStorage",
+                  "value": "DefaultEndpointsProtocol=https;AccountName=mystorageaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
+                },
+                {
+                  "name": "FUNCTIONS_WORKER_RUNTIME",
+                  "value": "dotnet"
+                },
+                {
+                  "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+                  "value": "false"
+                }
+              ],
+              "image": "mcr.microsoft.com/azure-functions/dotnet:4",
+              "resources": {
+                "cpu": 0.5,
+                "memory": "1.0Gi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 300,
+            "maxReplicas": 10,
+            "minReplicas": 0,
+            "pollingInterval": 30
+          }
+        }
+      }
+    },
+    "containerAppName": "testcontainerAppFunctionKind",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppFunctionKind",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerapps/testcontainerAppFunctionKind",
+        "identity": {
+          "type": "None"
+        },
+        "kind": "functionapp",
+        "location": "East US",
+        "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppFunctionKind",
+        "properties": {
+          "configuration": {
+            "activeRevisionsMode": "Single",
+            "ingress": {
+              "exposedPort": 0,
+              "external": true,
+              "fqdn": "testcontainerAppFunctionKind.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+              "targetPort": 80,
+              "traffic": [
+                {
+                  "latestRevision": true,
+                  "weight": 100
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "eventStreamEndpoint": "https://azurecontainerapps-test.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/containerApps/testcontainerAppFunctionKind/eventstream",
+          "latestReadyRevisionName": "testcontainerAppFunctionKind--abc123",
+          "latestRevisionFqdn": "testcontainerAppFunctionKind--abc123.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+          "latestRevisionName": "testcontainerAppFunctionKind--abc123",
+          "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "function-app-container",
+                "env": [
+                  {
+                    "name": "AzureWebJobsStorage",
+                    "value": "DefaultEndpointsProtocol=https;AccountName=mystorageaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
+                  },
+                  {
+                    "name": "FUNCTIONS_WORKER_RUNTIME",
+                    "value": "dotnet"
+                  },
+                  {
+                    "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+                    "value": "false"
+                  }
+                ],
+                "image": "mcr.microsoft.com/azure-functions/dotnet:4",
+                "resources": {
+                  "cpu": 0.5,
+                  "ephemeralStorage": "2Gi",
+                  "memory": "1Gi"
+                }
+              }
+            ],
+            "initContainers": null,
+            "revisionSuffix": "",
+            "scale": {
+              "cooldownPeriod": 300,
+              "maxReplicas": 10,
+              "minReplicas": 0,
+              "pollingInterval": 30
+            },
+            "terminationGracePeriodSeconds": null
+          },
+          "workloadProfileName": null
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppFunctionKind",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerapps/testcontainerAppFunctionKind",
+        "identity": {
+          "type": "None"
+        },
+        "kind": "functionapp",
+        "location": "East US",
+        "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppFunctionKind",
+        "properties": {
+          "configuration": {
+            "activeRevisionsMode": "Single",
+            "ingress": {
+              "exposedPort": 0,
+              "external": true,
+              "fqdn": "testcontainerAppFunctionKind.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+              "targetPort": 80,
+              "traffic": [
+                {
+                  "latestRevision": true,
+                  "weight": 100
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "eventStreamEndpoint": "https://azurecontainerapps-test.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/containerApps/testcontainerAppFunctionKind/eventstream",
+          "latestReadyRevisionName": "testcontainerAppFunctionKind--abc123",
+          "latestRevisionFqdn": "testcontainerAppFunctionKind--abc123.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+          "latestRevisionName": "testcontainerAppFunctionKind--abc123",
+          "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "function-app-container",
+                "env": [
+                  {
+                    "name": "AzureWebJobsStorage",
+                    "value": "DefaultEndpointsProtocol=https;AccountName=mystorageaccount;AccountKey=mykey;EndpointSuffix=core.windows.net"
+                  },
+                  {
+                    "name": "FUNCTIONS_WORKER_RUNTIME",
+                    "value": "dotnet"
+                  },
+                  {
+                    "name": "WEBSITES_ENABLE_APP_SERVICE_STORAGE",
+                    "value": "false"
+                  }
+                ],
+                "image": "mcr.microsoft.com/azure-functions/dotnet:4",
+                "resources": {
+                  "cpu": 0.5,
+                  "ephemeralStorage": "2Gi",
+                  "memory": "1Gi"
+                }
+              }
+            ],
+            "revisionSuffix": "",
+            "scale": {
+              "cooldownPeriod": 300,
+              "maxReplicas": 10,
+              "minReplicas": 0,
+              "pollingInterval": 30
+            },
+            "terminationGracePeriodSeconds": null
+          },
+          "workloadProfileName": null
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update FunctionApp Kind"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Kind_WorkflowApp_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Kind_WorkflowApp_CreateOrUpdate.json
@@ -1,0 +1,171 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "kind": "workflowapp",
+      "location": "East Us",
+      "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppKind",
+      "properties": {
+        "configuration": {
+          "activeRevisionsMode": "Single",
+          "ingress": {
+            "allowInsecure": false,
+            "external": true,
+            "targetPort": 443
+          }
+        },
+        "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+        "template": {
+          "containers": [
+            {
+              "name": "logicapps-container",
+              "image": "default/logicapps-base:latest",
+              "resources": {
+                "cpu": 1,
+                "memory": "2.0Gi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 30,
+            "minReplicas": 1,
+            "pollingInterval": 35
+          }
+        }
+      }
+    },
+    "containerAppName": "testcontainerAppKind",
+    "resourceGroupName": "rg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppKind",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerapps/testcontainerAppKind",
+        "identity": {
+          "type": "None"
+        },
+        "kind": "workflowapp",
+        "location": "East US",
+        "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppKind",
+        "properties": {
+          "configuration": {
+            "activeRevisionsMode": "Single",
+            "ingress": {
+              "exposedPort": 0,
+              "external": true,
+              "fqdn": "testcontainerAppKind.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+              "targetPort": 80,
+              "traffic": [
+                {
+                  "latestRevision": true,
+                  "weight": 100
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "eventStreamEndpoint": "https://azurecontainerapps-test.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/containerApps/testcontainerAppKind/eventstream",
+          "latestReadyRevisionName": "testcontainerAppKind--2rltv14",
+          "latestRevisionFqdn": "testcontainerAppKind--2rltv14.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+          "latestRevisionName": "testcontainerAppKind--2rltv14",
+          "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "logicapps-container",
+                "image": "default/logicapps-base:latest",
+                "resources": {
+                  "cpu": 1,
+                  "ephemeralStorage": "4Gi",
+                  "memory": "2Gi"
+                }
+              }
+            ],
+            "initContainers": null,
+            "revisionSuffix": "",
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 30,
+              "minReplicas": 1,
+              "pollingInterval": 35
+            },
+            "terminationGracePeriodSeconds": null
+          },
+          "workloadProfileName": null
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppKind",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/containerapps/testcontainerAppKind",
+        "identity": {
+          "type": "None"
+        },
+        "kind": "workflowapp",
+        "location": "East US",
+        "managedBy": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.Web/sites/testcontainerAppKind",
+        "properties": {
+          "configuration": {
+            "activeRevisionsMode": "Single",
+            "ingress": {
+              "exposedPort": 0,
+              "external": true,
+              "fqdn": "testcontainerAppKind.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+              "targetPort": 80,
+              "traffic": [
+                {
+                  "latestRevision": true,
+                  "weight": 100
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "environmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "eventStreamEndpoint": "https://azurecontainerapps-test.dev/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/containerApps/testcontainerAppKind/eventstream",
+          "latestReadyRevisionName": "testcontainerAppKind--2rltv14",
+          "latestRevisionFqdn": "testcontainerAppKind--2rltv14.nicefield-53acf186.eastus.azurecontainerapps-test.io",
+          "latestRevisionName": "testcontainerAppKind--2rltv14",
+          "managedEnvironmentId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testmanagedenv3",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "logicapps-container",
+                "image": "default/logicapps-base:latest",
+                "resources": {
+                  "cpu": 1,
+                  "ephemeralStorage": "4Gi",
+                  "memory": "2Gi"
+                }
+              }
+            ],
+            "revisionSuffix": "",
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 30,
+              "minReplicas": 1,
+              "pollingInterval": 35
+            },
+            "terminationGracePeriodSeconds": null
+          },
+          "workloadProfileName": null
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update WorkflowApp Kind"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_ListByResourceGroup.json
@@ -1,0 +1,213 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerApp0",
+            "type": "Microsoft.App/containerApps",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "dapr": {
+                  "appHealth": {
+                    "path": "/health",
+                    "enabled": true,
+                    "probeIntervalSeconds": 3,
+                    "probeTimeoutMilliseconds": 1000,
+                    "threshold": 3
+                  },
+                  "appPort": 3000,
+                  "appProtocol": "http",
+                  "enableApiLogging": true,
+                  "enabled": true,
+                  "httpMaxRequestSize": 10,
+                  "httpReadBufferSize": 30,
+                  "logLevel": "debug",
+                  "maxConcurrency": 10
+                },
+                "ingress": {
+                  "customDomains": [
+                    {
+                      "name": "www.my-name.com",
+                      "bindingType": "SniEnabled",
+                      "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                    },
+                    {
+                      "name": "www.my--other-name.com",
+                      "bindingType": "SniEnabled",
+                      "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                    }
+                  ],
+                  "external": true,
+                  "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+                  "ipSecurityRestrictions": [
+                    {
+                      "name": "Allow work IP A subnet",
+                      "description": "Allowing all IP's within the subnet below to access containerapp",
+                      "action": "Allow",
+                      "ipAddressRange": "192.168.1.1/32"
+                    },
+                    {
+                      "name": "Allow work IP B subnet",
+                      "description": "Allowing all IP's within the subnet below to access containerapp",
+                      "action": "Allow",
+                      "ipAddressRange": "192.168.1.1/8"
+                    }
+                  ],
+                  "stickySessions": {
+                    "affinity": "sticky"
+                  },
+                  "targetPort": 3000,
+                  "targetPortHttpScheme": "http",
+                  "traffic": [
+                    {
+                      "revisionName": "testcontainerApp0-ab1234",
+                      "weight": 80
+                    },
+                    {
+                      "label": "staging",
+                      "revisionName": "testcontainerApp0-ab4321",
+                      "weight": 20
+                    }
+                  ],
+                  "transport": "auto"
+                },
+                "maxInactiveRevisions": 10,
+                "revisionTransitionThreshold": 100,
+                "runtime": {
+                  "dotnet": {
+                    "autoConfigureDataProtection": true
+                  },
+                  "java": {
+                    "enableMetrics": true,
+                    "javaAgent": {
+                      "enabled": true,
+                      "logging": {
+                        "loggerSettings": [
+                          {
+                            "level": "debug",
+                            "logger": "org.springframework.boot"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              "eventStreamEndpoint": "testEndpoint",
+              "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+              "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "runningStatus": "Running",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp0",
+                    "image": "repo/testcontainerApp0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerApp0",
+                    "image": "repo/testcontainerApp0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "scale": {
+                  "cooldownPeriod": 350,
+                  "maxReplicas": 5,
+                  "minReplicas": 1,
+                  "pollingInterval": 35,
+                  "rules": [
+                    {
+                      "name": "httpscalingrule",
+                      "http": {
+                        "metadata": {
+                          "concurrentRequests": "50"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "workloadProfileName": "My-GP-01"
+            }
+          },
+          {
+            "name": "testcontainerApp1",
+            "type": "Microsoft.App/containerApps",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp1",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "ingress": {
+                  "external": true,
+                  "fqdn": "testcontainerApp1.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+                  "targetPort": 3000,
+                  "targetPortHttpScheme": "http",
+                  "transport": "auto"
+                },
+                "maxInactiveRevisions": 10,
+                "revisionTransitionThreshold": 100
+              },
+              "deploymentErrors": "Code: ContainerAppImagePullProvisionError, Message: Error pulling the container image. Please check the image name or any registry credentials to access if required.",
+              "eventStreamEndpoint": "testEndpoint",
+              "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+              "latestRevisionFqdn": "testcontainerApp1-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Failed",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp1",
+                    "image": "repo/testcontainerApp1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testcontainerApp1",
+                    "image": "repo/testcontainerApp1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "scale": {
+                  "cooldownPeriod": 350,
+                  "maxReplicas": 5,
+                  "minReplicas": 1,
+                  "pollingInterval": 35
+                }
+              },
+              "workloadProfileName": "Consumption"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_ListByResourceGroup",
+  "title": "List Container Apps by resource group"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_ListBySubscription.json
@@ -1,0 +1,170 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerApp0",
+            "type": "Microsoft.App/containerApps",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "dapr": {
+                  "appHealth": {
+                    "path": "/health",
+                    "enabled": true,
+                    "probeIntervalSeconds": 3,
+                    "probeTimeoutMilliseconds": 1000,
+                    "threshold": 3
+                  },
+                  "appPort": 3000,
+                  "appProtocol": "http",
+                  "enableApiLogging": true,
+                  "enabled": true,
+                  "httpMaxRequestSize": 10,
+                  "httpReadBufferSize": 30,
+                  "logLevel": "debug"
+                },
+                "ingress": {
+                  "customDomains": [
+                    {
+                      "name": "www.my-name.com",
+                      "bindingType": "SniEnabled",
+                      "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                    },
+                    {
+                      "name": "www.my--other-name.com",
+                      "bindingType": "SniEnabled",
+                      "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                    }
+                  ],
+                  "external": true,
+                  "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+                  "ipSecurityRestrictions": [
+                    {
+                      "name": "Allow work IP A subnet",
+                      "description": "Allowing all IP's within the subnet below to access containerapp",
+                      "action": "Allow",
+                      "ipAddressRange": "192.168.1.1/32"
+                    },
+                    {
+                      "name": "Allow work IP B subnet",
+                      "description": "Allowing all IP's within the subnet below to access containerapp",
+                      "action": "Allow",
+                      "ipAddressRange": "192.168.1.1/8"
+                    }
+                  ],
+                  "stickySessions": {
+                    "affinity": "sticky"
+                  },
+                  "targetPort": 3000,
+                  "targetPortHttpScheme": "http",
+                  "traffic": [
+                    {
+                      "revisionName": "testcontainerApp0-ab1234",
+                      "weight": 80
+                    },
+                    {
+                      "label": "staging",
+                      "revisionName": "testcontainerApp0-ab4321",
+                      "weight": 20
+                    }
+                  ],
+                  "transport": "auto"
+                },
+                "maxInactiveRevisions": 10,
+                "revisionTransitionThreshold": 100,
+                "runtime": {
+                  "dotnet": {
+                    "autoConfigureDataProtection": true
+                  },
+                  "java": {
+                    "enableMetrics": true,
+                    "javaAgent": {
+                      "enabled": true,
+                      "logging": {
+                        "loggerSettings": [
+                          {
+                            "level": "debug",
+                            "logger": "org.springframework.boot"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                },
+                "service": {
+                  "type": "redis"
+                }
+              },
+              "eventStreamEndpoint": "testEndpoint",
+              "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+              "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "runningStatus": "Running",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp0",
+                    "image": "repo/testcontainerApp0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerApp0",
+                    "image": "repo/testcontainerApp0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "scale": {
+                  "cooldownPeriod": 350,
+                  "maxReplicas": 5,
+                  "minReplicas": 1,
+                  "pollingInterval": 35,
+                  "rules": [
+                    {
+                      "name": "httpscalingrule",
+                      "http": {
+                        "metadata": {
+                          "concurrentRequests": "50"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "serviceBinds": [
+                  {
+                    "name": "service",
+                    "clientType": "dotnet",
+                    "customizedKeys": {
+                      "DesiredKey": "defaultKey"
+                    },
+                    "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/service"
+                  }
+                ]
+              },
+              "workloadProfileName": "My-GP-01"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_ListBySubscription",
+  "title": "List Container Apps by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_ListCustomHostNameAnalysis.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_ListCustomHostNameAnalysis.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "customHostname": "my.name.corp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "aRecords": [
+          "aRecord1",
+          "aRecord2"
+        ],
+        "alternateCNameRecords": [
+          "cNameRecord1",
+          "cNameRecord2"
+        ],
+        "alternateTxtRecords": [
+          "txtRecord1",
+          "txtRecord2"
+        ],
+        "cNameRecords": [
+          "cNameRecord1",
+          "cNameRecord2"
+        ],
+        "conflictingContainerAppResourceId": "",
+        "customDomainVerificationFailureInfo": {},
+        "customDomainVerificationTest": "Passed",
+        "hasConflictOnManagedEnvironment": false,
+        "hostName": "my.name.corp",
+        "isHostnameAlreadyVerified": true,
+        "txtRecords": [
+          "txtRecord1",
+          "txtRecord2"
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_ListCustomHostNameAnalysis",
+  "title": "Analyze Custom Hostname"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_ListSecrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_ListSecrets.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "secret1"
+          },
+          {
+            "name": "secret2"
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_ListSecrets",
+  "title": "List Container Apps Secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_ManagedBy_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_ManagedBy_CreateOrUpdate.json
@@ -1,0 +1,214 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "location": "East US",
+      "managedBy": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.AppPlatform/Spring/springapp",
+      "properties": {
+        "configuration": {
+          "ingress": {
+            "exposedPort": 4000,
+            "external": true,
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "revisionName": "testcontainerAppManagedBy-ab1234",
+                "weight": 100
+              }
+            ],
+            "transport": "tcp"
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppManagedBy",
+              "image": "repo/testcontainerAppManagedBy:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3,
+                  "tcpSocket": {
+                    "port": 8080
+                  }
+                }
+              ]
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "tcpscalingrule",
+                "tcp": {
+                  "metadata": {
+                    "concurrentConnections": "50"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "containerAppName": "testcontainerAppManagedBy",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppManagedBy",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerAppManagedBy",
+        "location": "East US",
+        "managedBy": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.AppPlatform/Spring/springapp",
+        "properties": {
+          "configuration": {
+            "ingress": {
+              "exposedPort": 4000,
+              "external": true,
+              "fqdn": "testcontainerAppManagedBy.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "traffic": [
+                {
+                  "revisionName": "testcontainerAppManagedBy-ab1234",
+                  "weight": 80
+                },
+                {
+                  "revisionName": "testcontainerAppManagedBy-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "tcp"
+            }
+          },
+          "latestReadyRevisionName": "testcontainerAppManagedBy-pjxhsye",
+          "latestRevisionFqdn": "testcontainerAppManagedBy-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppManagedBy",
+                "image": "repo/testcontainerAppManagedBy:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3,
+                    "tcpSocket": {
+                      "port": 8080
+                    }
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "tcpscalingrule",
+                  "tcp": {
+                    "metadata": {
+                      "concurrentConnections": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppManagedBy",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerAppManagedBy",
+        "location": "East US",
+        "managedBy": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.AppPlatform/Spring/springapp",
+        "properties": {
+          "configuration": {
+            "ingress": {
+              "exposedPort": 4000,
+              "external": true,
+              "fqdn": "testcontainerAppManagedBy.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "traffic": [
+                {
+                  "revisionName": "testcontainerAppManagedBy-ab1234",
+                  "weight": 80
+                },
+                {
+                  "revisionName": "testcontainerAppManagedBy-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "tcp"
+            }
+          },
+          "latestRevisionFqdn": "testcontainerAppManagedBy-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppManagedBy",
+                "image": "repo/testcontainerAppManagedBy:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3,
+                    "tcpSocket": {
+                      "port": 8080
+                    }
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "tcpscalingrule",
+                  "tcp": {
+                    "metadata": {
+                      "concurrentConnections": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update ManagedBy App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Patch.json
@@ -1,0 +1,311 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "dapr": {
+            "appHealth": {
+              "path": "/health",
+              "enabled": true,
+              "probeIntervalSeconds": 3,
+              "probeTimeoutMilliseconds": 1000,
+              "threshold": 3
+            },
+            "appPort": 3000,
+            "appProtocol": "http",
+            "enableApiLogging": true,
+            "enabled": true,
+            "httpMaxRequestSize": 10,
+            "httpReadBufferSize": 30,
+            "logLevel": "debug",
+            "maxConcurrency": 10
+          },
+          "ingress": {
+            "customDomains": [
+              {
+                "name": "www.my-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+              },
+              {
+                "name": "www.my-other-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+              }
+            ],
+            "external": true,
+            "ipSecurityRestrictions": [
+              {
+                "name": "Allow work IP A subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/32"
+              },
+              {
+                "name": "Allow work IP B subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/8"
+              }
+            ],
+            "stickySessions": {
+              "affinity": "sticky"
+            },
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "label": "production",
+                "revisionName": "testcontainerApp0-ab1234",
+                "weight": 100
+              }
+            ]
+          },
+          "maxInactiveRevisions": 10,
+          "revisionTransitionThreshold": 100,
+          "runtime": {
+            "dotnet": {
+              "autoConfigureDataProtection": true
+            },
+            "java": {
+              "enableMetrics": true,
+              "javaAgent": {
+                "enabled": true,
+                "logging": {
+                  "loggerSettings": [
+                    {
+                      "level": "debug",
+                      "logger": "org.springframework.boot"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "service": {
+            "type": "redis"
+          }
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerApp0",
+              "image": "repo/testcontainerApp0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerApp0",
+              "image": "repo/testcontainerApp0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "httpscalingrule",
+                "custom": {
+                  "type": "http",
+                  "metadata": {
+                    "concurrentRequests": "50"
+                  }
+                }
+              }
+            ]
+          },
+          "serviceBinds": [
+            {
+              "name": "service",
+              "clientType": "dotnet",
+              "customizedKeys": {
+                "DesiredKey": "defaultKey"
+              },
+              "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/service"
+            }
+          ]
+        }
+      },
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enableApiLogging": true,
+              "enabled": true,
+              "httpMaxRequestSize": 10,
+              "httpReadBufferSize": 30,
+              "logLevel": "debug",
+              "maxConcurrency": 10
+            },
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my--other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "maxInactiveRevisions": 10,
+            "revisionTransitionThreshold": 100,
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/locations/eastus/containerappOperationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "ContainerApps_Update",
+  "title": "Patch Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_SourceToCloudApp_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_SourceToCloudApp_CreateOrUpdate.json
@@ -1,0 +1,495 @@
+{
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "dapr": {
+            "appPort": 3000,
+            "appProtocol": "http",
+            "enableApiLogging": true,
+            "enabled": true,
+            "httpMaxRequestSize": 10,
+            "httpReadBufferSize": 30,
+            "logLevel": "debug"
+          },
+          "ingress": {
+            "additionalPortMappings": [
+              {
+                "external": true,
+                "targetPort": 1234
+              },
+              {
+                "exposedPort": 3456,
+                "external": false,
+                "targetPort": 2345
+              }
+            ],
+            "clientCertificateMode": "accept",
+            "corsPolicy": {
+              "allowCredentials": true,
+              "allowedHeaders": [
+                "HEADER1",
+                "HEADER2"
+              ],
+              "allowedMethods": [
+                "GET",
+                "POST"
+              ],
+              "allowedOrigins": [
+                "https://a.test.com",
+                "https://b.test.com"
+              ],
+              "exposeHeaders": [
+                "HEADER3",
+                "HEADER4"
+              ],
+              "maxAge": 1234
+            },
+            "customDomains": [
+              {
+                "name": "www.my-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+              },
+              {
+                "name": "www.my-other-name.com",
+                "bindingType": "SniEnabled",
+                "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+              }
+            ],
+            "external": true,
+            "ipSecurityRestrictions": [
+              {
+                "name": "Allow work IP A subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/32"
+              },
+              {
+                "name": "Allow work IP B subnet",
+                "description": "Allowing all IP's within the subnet below to access containerapp",
+                "action": "Allow",
+                "ipAddressRange": "192.168.1.1/8"
+              }
+            ],
+            "stickySessions": {
+              "affinity": "sticky"
+            },
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "label": "production",
+                "revisionName": "testcontainerApp0-ab1234",
+                "weight": 100
+              }
+            ]
+          },
+          "maxInactiveRevisions": 10,
+          "revisionTransitionThreshold": 100,
+          "service": {
+            "type": "redis"
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "patchingConfiguration": {
+          "patchingMode": "Automatic"
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerApp0",
+              "image": "",
+              "imageType": "CloudBuild",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "mountPath": "/mnt/path1",
+                  "subPath": "subPath1",
+                  "volumeName": "azurefile"
+                },
+                {
+                  "mountPath": "/mnt/path2",
+                  "subPath": "subPath2",
+                  "volumeName": "nfsazurefile"
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerApp0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerApp0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "httpscalingrule",
+                "custom": {
+                  "type": "http",
+                  "metadata": {
+                    "concurrentRequests": "50"
+                  }
+                }
+              }
+            ]
+          },
+          "serviceBinds": [
+            {
+              "name": "redisService",
+              "clientType": "dotnet",
+              "customizedKeys": {
+                "DesiredKey": "defaultKey"
+              },
+              "serviceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/redisService"
+            }
+          ],
+          "volumes": [
+            {
+              "name": "azurefile",
+              "storageName": "storage",
+              "storageType": "AzureFile"
+            },
+            {
+              "name": "nfsazurefile",
+              "storageName": "nfsStorage",
+              "storageType": "NfsAzureFile"
+            }
+          ]
+        },
+        "workloadProfileName": "My-GP-01"
+      }
+    },
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "title": "Create or Update SourceToCloud App",
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30
+            },
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my-other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "stickySessions": {
+                "affinity": "sticky"
+              },
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "patchingConfiguration": {
+            "patchingMode": "Automatic"
+          },
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "mcr.microsoft.com/k8se/cloudbuild-waiting-upload:latest",
+                "imageType": "CloudBuild",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            },
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enabled": true,
+              "httpReadBufferSize": 30
+            },
+            "ingress": {
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "patchingConfiguration": {
+            "patchingMode": "Automatic"
+          },
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "mcr.microsoft.com/k8se/cloudbuild-waiting-upload:latest",
+                "imageType": "CloudBuild",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            },
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    }
+  }
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Start.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Start.json
@@ -1,0 +1,149 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testWorkerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enableApiLogging": true,
+              "enabled": true,
+              "httpMaxRequestSize": 10,
+              "httpReadBufferSize": 30,
+              "logLevel": "debug"
+            },
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my--other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "maxInactiveRevisions": 10,
+            "revisionTransitionThreshold": 100,
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/containerApps/testWorkerApp0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "ContainerApps_Start",
+  "title": "Start Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Stop.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_Stop.json
@@ -1,0 +1,155 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testWorkerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "dapr": {
+              "appHealth": {
+                "path": "/health",
+                "enabled": true,
+                "probeIntervalSeconds": 3,
+                "probeTimeoutMilliseconds": 1000,
+                "threshold": 3
+              },
+              "appPort": 3000,
+              "appProtocol": "http",
+              "enableApiLogging": true,
+              "enabled": true,
+              "httpMaxRequestSize": 10,
+              "httpReadBufferSize": 30,
+              "logLevel": "debug",
+              "maxConcurrency": 10
+            },
+            "ingress": {
+              "customDomains": [
+                {
+                  "name": "www.my-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-name-dot-com"
+                },
+                {
+                  "name": "www.my--other-name.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube/certificates/my-certificate-for-my-other-name-dot-com"
+                }
+              ],
+              "external": true,
+              "fqdn": "testcontainerApp0.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "ipSecurityRestrictions": [
+                {
+                  "name": "Allow work IP A subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/32"
+                },
+                {
+                  "name": "Allow work IP B subnet",
+                  "description": "Allowing all IP's within the subnet below to access containerapp",
+                  "action": "Allow",
+                  "ipAddressRange": "192.168.1.1/8"
+                }
+              ],
+              "targetPort": 3000,
+              "targetPortHttpScheme": "http",
+              "traffic": [
+                {
+                  "revisionName": "testcontainerApp0-ab1234",
+                  "weight": 80
+                },
+                {
+                  "label": "staging",
+                  "revisionName": "testcontainerApp0-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "auto"
+            },
+            "maxInactiveRevisions": 10,
+            "revisionTransitionThreshold": 100,
+            "runtime": {
+              "dotnet": {
+                "autoConfigureDataProtection": true
+              },
+              "java": {
+                "enableMetrics": true,
+                "javaAgent": {
+                  "enabled": true,
+                  "logging": {
+                    "loggerSettings": [
+                      {
+                        "level": "debug",
+                        "logger": "org.springframework.boot"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "latestReadyRevisionName": "testcontainerApp0-pjxhsye",
+          "latestRevisionFqdn": "testcontainerApp0-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerApp0",
+                "image": "repo/testcontainerApp0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "workloadProfileName": "My-GP-01"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/containerApps/testWorkerApp0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "ContainerApps_Stop",
+  "title": "Stop Container App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_TcpApp_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ContainerApps_TcpApp_CreateOrUpdate.json
@@ -1,0 +1,211 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppEnvelope": {
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "ingress": {
+            "exposedPort": 4000,
+            "external": true,
+            "targetPort": 3000,
+            "traffic": [
+              {
+                "revisionName": "testcontainerAppTcp-ab1234",
+                "weight": 100
+              }
+            ],
+            "transport": "tcp"
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppTcp",
+              "image": "repo/testcontainerAppTcp:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3,
+                  "tcpSocket": {
+                    "port": 8080
+                  }
+                }
+              ]
+            }
+          ],
+          "scale": {
+            "cooldownPeriod": 350,
+            "maxReplicas": 5,
+            "minReplicas": 1,
+            "pollingInterval": 35,
+            "rules": [
+              {
+                "name": "tcpscalingrule",
+                "tcp": {
+                  "metadata": {
+                    "concurrentConnections": "50"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    "containerAppName": "testcontainerAppTcp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppTcp",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerAppTcp",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "ingress": {
+              "exposedPort": 4000,
+              "external": true,
+              "fqdn": "testcontainerAppTcp.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "traffic": [
+                {
+                  "revisionName": "testcontainerAppTcp-ab1234",
+                  "weight": 80
+                },
+                {
+                  "revisionName": "testcontainerAppTcp-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "tcp"
+            }
+          },
+          "latestReadyRevisionName": "testcontainerAppTcp-pjxhsye",
+          "latestRevisionFqdn": "testcontainerAppTcp-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningStatus": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppTcp",
+                "image": "repo/testcontainerAppTcp:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3,
+                    "tcpSocket": {
+                      "port": 8080
+                    }
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "tcpscalingrule",
+                  "tcp": {
+                    "metadata": {
+                      "concurrentConnections": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppTcp",
+        "type": "Microsoft.App/containerApps",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerAppTcp",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "ingress": {
+              "exposedPort": 4000,
+              "external": true,
+              "fqdn": "testcontainerAppTcp.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+              "targetPort": 3000,
+              "traffic": [
+                {
+                  "revisionName": "testcontainerAppTcp-ab1234",
+                  "weight": 80
+                },
+                {
+                  "revisionName": "testcontainerAppTcp-ab4321",
+                  "weight": 20
+                }
+              ],
+              "transport": "tcp"
+            }
+          },
+          "latestRevisionFqdn": "testcontainerAppTcp-pjxhsye.demokube-t24clv0g.eastus.containerApps.k4apps.io",
+          "managedEnvironmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "InProgress",
+          "runningStatus": "Progressing",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppTcp",
+                "image": "repo/testcontainerAppTcp:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3,
+                    "tcpSocket": {
+                      "port": 8080
+                    }
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "cooldownPeriod": 350,
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "pollingInterval": 35,
+              "rules": [
+                {
+                  "name": "tcpscalingrule",
+                  "tcp": {
+                    "metadata": {
+                      "concurrentConnections": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerApps_CreateOrUpdate",
+  "title": "Create or Update Tcp App"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicies_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicies_Delete.json
@@ -1,0 +1,16 @@
+{
+  "parameters": {
+    "name": "myresiliencypolicy",
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DaprComponentResiliencyPolicies_Delete",
+  "title": "Delete dapr component resiliency policy"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicies_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicies_Get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "name": "myresiliencypolicy",
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "inboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 5,
+              "timeoutInSeconds": 10
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 15,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 2000,
+                "maxIntervalInMilliseconds": 5500
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 30
+            }
+          },
+          "outboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "intervalInSeconds": 60,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 100,
+                "maxIntervalInMilliseconds": 30000
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponentResiliencyPolicies_Get",
+  "title": "Get Dapr component resiliency policy"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicies_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicies_List.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "something",
+            "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+            "properties": {
+              "inboundPolicy": {
+                "circuitBreakerPolicy": {
+                  "consecutiveErrors": 5,
+                  "timeoutInSeconds": 10
+                },
+                "httpRetryPolicy": {
+                  "maxRetries": 15,
+                  "retryBackOff": {
+                    "initialDelayInMilliseconds": 2000,
+                    "maxIntervalInMilliseconds": 5500
+                  }
+                },
+                "timeoutPolicy": {
+                  "responseTimeoutInSeconds": 30
+                }
+              },
+              "outboundPolicy": {
+                "circuitBreakerPolicy": {
+                  "consecutiveErrors": 3,
+                  "intervalInSeconds": 60,
+                  "timeoutInSeconds": 20
+                },
+                "httpRetryPolicy": {
+                  "maxRetries": 5,
+                  "retryBackOff": {
+                    "initialDelayInMilliseconds": 100,
+                    "maxIntervalInMilliseconds": 30000
+                  }
+                },
+                "timeoutPolicy": {
+                  "responseTimeoutInSeconds": 12
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DaprComponentResiliencyPolicies_List",
+  "title": "List Dapr component resiliency policies"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicy_CreateOrUpdate_AllOptions.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicy_CreateOrUpdate_AllOptions.json
@@ -1,0 +1,138 @@
+{
+  "parameters": {
+    "name": "myresiliencypolicy",
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "daprComponentResiliencyPolicyEnvelope": {
+      "properties": {
+        "inboundPolicy": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 5,
+            "intervalInSeconds": 4,
+            "timeoutInSeconds": 10
+          },
+          "httpRetryPolicy": {
+            "maxRetries": 15,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 2000,
+              "maxIntervalInMilliseconds": 5500
+            }
+          },
+          "timeoutPolicy": {
+            "responseTimeoutInSeconds": 30
+          }
+        },
+        "outboundPolicy": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 3,
+            "intervalInSeconds": 60,
+            "timeoutInSeconds": 20
+          },
+          "httpRetryPolicy": {
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 100,
+              "maxIntervalInMilliseconds": 30000
+            }
+          },
+          "timeoutPolicy": {
+            "responseTimeoutInSeconds": 12
+          }
+        }
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "inboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 5,
+              "intervalInSeconds": 4,
+              "timeoutInSeconds": 10
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 15,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 2000,
+                "maxIntervalInMilliseconds": 5500
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 30
+            }
+          },
+          "outboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "intervalInSeconds": 60,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 100,
+                "maxIntervalInMilliseconds": 30000
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "inboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 5,
+              "intervalInSeconds": 4,
+              "timeoutInSeconds": 10
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 15,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 2000,
+                "maxIntervalInMilliseconds": 5500
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 30
+            }
+          },
+          "outboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "intervalInSeconds": 60,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 100,
+                "maxIntervalInMilliseconds": 30000
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponentResiliencyPolicies_CreateOrUpdate",
+  "title": "Create or update dapr component resiliency policy with all options"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicy_CreateOrUpdate_OutboundOnly.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicy_CreateOrUpdate_OutboundOnly.json
@@ -1,0 +1,87 @@
+{
+  "parameters": {
+    "name": "myresiliencypolicy",
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "daprComponentResiliencyPolicyEnvelope": {
+      "properties": {
+        "outboundPolicy": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 3,
+            "intervalInSeconds": 60,
+            "timeoutInSeconds": 20
+          },
+          "httpRetryPolicy": {
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 100,
+              "maxIntervalInMilliseconds": 30000
+            }
+          },
+          "timeoutPolicy": {
+            "responseTimeoutInSeconds": 12
+          }
+        }
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "outboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "intervalInSeconds": 60,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 100,
+                "maxIntervalInMilliseconds": 30000
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "outboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "intervalInSeconds": 60,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 100,
+                "maxIntervalInMilliseconds": 30000
+              }
+            },
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponentResiliencyPolicies_CreateOrUpdate",
+  "title": "Create or update dapr component resiliency policy with outbound policy only"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicy_CreateOrUpdate_SparseOptions.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponentResiliencyPolicy_CreateOrUpdate_SparseOptions.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "name": "myresiliencypolicy",
+    "api-version": "2026-03-02-preview",
+    "componentName": "mydaprcomponent",
+    "daprComponentResiliencyPolicyEnvelope": {
+      "properties": {
+        "inboundPolicy": {
+          "circuitBreakerPolicy": {
+            "consecutiveErrors": 3,
+            "timeoutInSeconds": 20
+          },
+          "httpRetryPolicy": {
+            "maxRetries": 5,
+            "retryBackOff": {
+              "initialDelayInMilliseconds": 2000,
+              "maxIntervalInMilliseconds": 5500
+            }
+          }
+        },
+        "outboundPolicy": {
+          "timeoutPolicy": {
+            "responseTimeoutInSeconds": 12
+          }
+        }
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "inboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 2000,
+                "maxIntervalInMilliseconds": 5500
+              }
+            }
+          },
+          "outboundPolicy": {
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "myresiliencypolicy",
+        "type": "Microsoft.App/managedEnvironments/daprComponents/resiliencyPolicies",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprComponents/mydaprcomponent/resiliencyPolicies/myresiliencypolicy",
+        "properties": {
+          "inboundPolicy": {
+            "circuitBreakerPolicy": {
+              "consecutiveErrors": 3,
+              "timeoutInSeconds": 20
+            },
+            "httpRetryPolicy": {
+              "maxRetries": 5,
+              "retryBackOff": {
+                "initialDelayInMilliseconds": 2000,
+                "maxIntervalInMilliseconds": 5500
+              }
+            }
+          },
+          "outboundPolicy": {
+            "timeoutPolicy": {
+              "responseTimeoutInSeconds": 12
+            }
+          }
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponentResiliencyPolicies_CreateOrUpdate",
+  "title": "Create or update dapr component resiliency policy with sparse options"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_CreateOrUpdate_SecretStoreComponent.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_CreateOrUpdate_SecretStoreComponent.json
@@ -1,0 +1,100 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "daprComponentEnvelope": {
+      "properties": {
+        "componentType": "state.azure.cosmosdb",
+        "ignoreErrors": false,
+        "initTimeout": "50s",
+        "metadata": [
+          {
+            "name": "url",
+            "value": "<COSMOS-URL>"
+          },
+          {
+            "name": "database",
+            "value": "itemsDB"
+          },
+          {
+            "name": "collection",
+            "value": "items"
+          },
+          {
+            "name": "masterkey",
+            "secretRef": "masterkey"
+          }
+        ],
+        "scopes": [
+          "container-app-1",
+          "container-app-2"
+        ],
+        "secretStoreComponent": "my-secret-store",
+        "serviceComponentBind": [
+          {
+            "name": "statestore",
+            "metadata": {
+              "name": "daprcomponentBind",
+              "value": "redis-bind"
+            },
+            "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+          }
+        ],
+        "version": "v1"
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/managedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secretStoreComponent": "my-secret-store",
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponents_CreateOrUpdate",
+  "title": "Create or update dapr component with secret store component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_CreateOrUpdate_Secrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_CreateOrUpdate_Secrets.json
@@ -1,0 +1,109 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "daprComponentEnvelope": {
+      "properties": {
+        "componentType": "state.azure.cosmosdb",
+        "ignoreErrors": false,
+        "initTimeout": "50s",
+        "metadata": [
+          {
+            "name": "url",
+            "value": "<COSMOS-URL>"
+          },
+          {
+            "name": "database",
+            "value": "itemsDB"
+          },
+          {
+            "name": "collection",
+            "value": "items"
+          },
+          {
+            "name": "masterkey",
+            "secretRef": "masterkey"
+          }
+        ],
+        "scopes": [
+          "container-app-1",
+          "container-app-2"
+        ],
+        "secrets": [
+          {
+            "name": "masterkey",
+            "value": "keyvalue"
+          }
+        ],
+        "serviceComponentBind": [
+          {
+            "name": "statestore",
+            "metadata": {
+              "name": "daprcomponentBind",
+              "value": "redis-bind"
+            },
+            "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+          }
+        ],
+        "version": "v1"
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/managedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secrets": [
+            {
+              "name": "masterkey"
+            }
+          ],
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponents_CreateOrUpdate",
+  "title": "Create or update dapr component with secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DaprComponents_Delete",
+  "title": "Delete dapr component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_Get_SecretStoreComponent.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_Get_SecretStoreComponent.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/managedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secretStoreComponent": "my-secret-store",
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponents_Get",
+  "title": "Get Dapr Component with secret store component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_Get_Secrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_Get_Secrets.json
@@ -1,0 +1,63 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "reddog",
+        "type": "Microsoft.App/managedEnvironments/daprcomponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1/daprcomponents/reddog",
+        "properties": {
+          "componentType": "state.azure.cosmosdb",
+          "ignoreErrors": false,
+          "initTimeout": "50s",
+          "metadata": [
+            {
+              "name": "url",
+              "value": "<COSMOS-URL>"
+            },
+            {
+              "name": "database",
+              "value": "itemsDB"
+            },
+            {
+              "name": "collection",
+              "value": "items"
+            },
+            {
+              "name": "masterkey",
+              "secretRef": "masterkey"
+            }
+          ],
+          "scopes": [
+            "container-app-1",
+            "container-app-2"
+          ],
+          "secrets": [
+            {
+              "name": "masterkey"
+            }
+          ],
+          "serviceComponentBind": [
+            {
+              "name": "statestore",
+              "metadata": {
+                "name": "daprcomponentBind",
+                "value": "redis-bind"
+              },
+              "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+            }
+          ],
+          "version": "v1"
+        }
+      }
+    }
+  },
+  "operationId": "DaprComponents_Get",
+  "title": "Get Dapr Component with secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_List.json
@@ -1,0 +1,154 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "reddog",
+            "type": "Microsoft.App/managedEnvironments/daprcomponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprcomponents/reddog",
+            "properties": {
+              "componentType": "state.azure.cosmosdb",
+              "ignoreErrors": false,
+              "initTimeout": "50s",
+              "metadata": [
+                {
+                  "name": "url",
+                  "value": "<COSMOS-URL>"
+                },
+                {
+                  "name": "database",
+                  "value": "itemsDB"
+                },
+                {
+                  "name": "collection",
+                  "value": "items"
+                },
+                {
+                  "name": "masterkey",
+                  "secretRef": "masterkey"
+                }
+              ],
+              "scopes": [
+                "container-app-1",
+                "container-app-2"
+              ],
+              "secrets": [
+                {
+                  "name": "masterkey"
+                }
+              ],
+              "serviceComponentBind": [
+                {
+                  "name": "statestore",
+                  "metadata": {
+                    "name": "daprcomponentBind",
+                    "value": "redis-bind"
+                  },
+                  "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+                }
+              ],
+              "version": "v1"
+            }
+          },
+          {
+            "name": "vaultdog",
+            "type": "Microsoft.App/managedEnvironments/daprcomponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprcomponents/vaultdog",
+            "properties": {
+              "componentType": "state.azure.cosmosdb",
+              "ignoreErrors": false,
+              "initTimeout": "50s",
+              "metadata": [
+                {
+                  "name": "url",
+                  "value": "<COSMOS-URL>"
+                },
+                {
+                  "name": "database",
+                  "value": "itemsDB"
+                },
+                {
+                  "name": "collection",
+                  "value": "items"
+                },
+                {
+                  "name": "masterkey",
+                  "secretRef": "masterkey"
+                }
+              ],
+              "scopes": [
+                "container-app-1",
+                "container-app-2"
+              ],
+              "secretStoreComponent": "my-secret-store",
+              "serviceComponentBind": [
+                {
+                  "name": "statestore",
+                  "metadata": {
+                    "name": "daprcomponentBind",
+                    "value": "redis-bind"
+                  },
+                  "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+                }
+              ],
+              "version": "v1"
+            }
+          },
+          {
+            "name": "vaultdog",
+            "type": "Microsoft.App/managedEnvironments/daprcomponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprcomponents/vaultdog",
+            "properties": {
+              "componentType": "state.azure.cosmosdb",
+              "ignoreErrors": false,
+              "initTimeout": "50s",
+              "metadata": [
+                {
+                  "name": "url",
+                  "secretRef": "cosmosdb/url"
+                },
+                {
+                  "name": "database",
+                  "value": "itemsDB"
+                },
+                {
+                  "name": "collection",
+                  "value": "items"
+                },
+                {
+                  "name": "masterkey",
+                  "secretRef": "cosmosdb/masterkey"
+                }
+              ],
+              "scopes": [
+                "container-app-1",
+                "container-app-2"
+              ],
+              "secretStoreComponent": "my-secret-store",
+              "serviceComponentBind": [
+                {
+                  "name": "statestore",
+                  "metadata": {
+                    "name": "daprcomponentBind",
+                    "value": "redis-bind"
+                  },
+                  "serviceId": "/subscriptions/9f7371f1-b593-4c3c-84e2-9167806ad358/resourceGroups/ca-syn2-group/providers/Microsoft.App/containerapps/cappredis"
+                }
+              ],
+              "version": "v1"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DaprComponents_List",
+  "title": "List Dapr Components"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_ListSecrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprComponents_ListSecrets.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "componentName": "reddog",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "secret1"
+          },
+          {
+            "name": "secret2"
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DaprComponents_ListSecrets",
+  "title": "List Container Apps Secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_CreateOrUpdate_BulkSubscribeAndScopes.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_CreateOrUpdate_BulkSubscribeAndScopes.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "name": "mysubscription",
+    "api-version": "2026-03-02-preview",
+    "daprSubscriptionEnvelope": {
+      "properties": {
+        "bulkSubscribe": {
+          "enabled": true,
+          "maxAwaitDurationMs": 500,
+          "maxMessagesCount": 123
+        },
+        "pubsubName": "mypubsubcomponent",
+        "routes": {
+          "default": "/products"
+        },
+        "scopes": [
+          "warehouseapp",
+          "customersupportapp"
+        ],
+        "topic": "inventory"
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "bulkSubscribe": {
+            "enabled": true,
+            "maxAwaitDurationMs": 500,
+            "maxMessagesCount": 123
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "scopes": [
+            "warehouseapp",
+            "customersupportapp"
+          ],
+          "topic": "inventory"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "bulkSubscribe": {
+            "enabled": true,
+            "maxAwaitDurationMs": 500,
+            "maxMessagesCount": 123
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "scopes": [
+            "warehouseapp",
+            "customersupportapp"
+          ],
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_CreateOrUpdate",
+  "title": "Create or update dapr subscription with bulk subscribe configuration and scopes"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_CreateOrUpdate_DefaultRoute.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_CreateOrUpdate_DefaultRoute.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "name": "mysubscription",
+    "api-version": "2026-03-02-preview",
+    "daprSubscriptionEnvelope": {
+      "properties": {
+        "pubsubName": "mypubsubcomponent",
+        "routes": {
+          "default": "/products"
+        },
+        "topic": "inventory"
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "topic": "inventory"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_CreateOrUpdate",
+  "title": "Create or update dapr subscription with default route only"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_CreateOrUpdate_RouteRulesAndMetadata.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_CreateOrUpdate_RouteRulesAndMetadata.json
@@ -1,0 +1,92 @@
+{
+  "parameters": {
+    "name": "mysubscription",
+    "api-version": "2026-03-02-preview",
+    "daprSubscriptionEnvelope": {
+      "properties": {
+        "metadata": {
+          "foo": "bar",
+          "hello": "world"
+        },
+        "pubsubName": "mypubsubcomponent",
+        "routes": {
+          "default": "/products",
+          "rules": [
+            {
+              "path": "/widgets",
+              "match": "event.type == 'widget'"
+            },
+            {
+              "path": "/gadgets",
+              "match": "event.type == 'gadget'"
+            }
+          ]
+        },
+        "topic": "inventory"
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "metadata": {
+            "foo": "bar",
+            "hello": "world"
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": [
+              {
+                "path": "/widgets",
+                "match": "event.type == 'widget'"
+              },
+              {
+                "path": "/gadgets",
+                "match": "event.type == 'gadget'"
+              }
+            ]
+          },
+          "topic": "inventory"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "metadata": {
+            "foo": "bar",
+            "hello": "world"
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": [
+              {
+                "path": "/widgets",
+                "match": "event.type == 'widget'"
+              },
+              {
+                "path": "/gadgets",
+                "match": "event.type == 'gadget'"
+              }
+            ]
+          },
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_CreateOrUpdate",
+  "title": "Create or update dapr subscription with route rules and metadata"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "name": "mysubscription",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "DaprSubscriptions_Delete",
+  "title": "Delete dapr subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_Get_BulkSubscribeAndScopes.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_Get_BulkSubscribeAndScopes.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "name": "mypubsubcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "bulkSubscribe": {
+            "enabled": true,
+            "maxAwaitDurationMs": 500,
+            "maxMessagesCount": 123
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "scopes": [
+            "warehouseapp",
+            "customersupportapp"
+          ],
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_Get",
+  "title": "Get Dapr subscription with default route only"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_Get_DefaultRoute.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_Get_DefaultRoute.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "name": "mypubsubcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": []
+          },
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_Get",
+  "title": "Get Dapr subscription with bulk subscribe configuration and scopes"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_Get_RouteRulesAndMetadata.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_Get_RouteRulesAndMetadata.json
@@ -1,0 +1,41 @@
+{
+  "parameters": {
+    "name": "mypubsubcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mysubscription",
+        "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mysubscription",
+        "properties": {
+          "metadata": {
+            "foo": "bar",
+            "hello": "world"
+          },
+          "pubsubName": "mypubsubcomponent",
+          "routes": {
+            "default": "/products",
+            "rules": [
+              {
+                "path": "/widgets",
+                "match": "event.type == 'widget'"
+              },
+              {
+                "path": "/gadgets",
+                "match": "event.type == 'gadget'"
+              }
+            ]
+          },
+          "topic": "inventory"
+        }
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_Get",
+  "title": "GetDapr subscription with route rules and metadata"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DaprSubscriptions_List.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "mybulksubscription",
+            "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mybulksubscription",
+            "properties": {
+              "bulkSubscribe": {
+                "enabled": true,
+                "maxAwaitDurationMs": 500,
+                "maxMessagesCount": 123
+              },
+              "pubsubName": "mypubsubcomponent",
+              "routes": {
+                "default": "/products",
+                "rules": []
+              },
+              "topic": "inventory"
+            }
+          },
+          {
+            "name": "mydefaultsubscription",
+            "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/mydefaultsubscription",
+            "properties": {
+              "pubsubName": "mypubsubcomponent",
+              "routes": {
+                "default": "/products",
+                "rules": []
+              },
+              "topic": "inventory"
+            }
+          },
+          {
+            "name": "myroutingsubscription",
+            "type": "Microsoft.App/managedEnvironments/daprSubscriptions",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/daprSubscriptions/myroutingsubscription",
+            "properties": {
+              "metadata": {
+                "foo": "bar",
+                "hello": "world"
+              },
+              "pubsubName": "mypubsubcomponent",
+              "routes": {
+                "default": "/products",
+                "rules": [
+                  {
+                    "path": "/widgets",
+                    "match": "event.type == 'widget'"
+                  },
+                  {
+                    "path": "/gadgets",
+                    "match": "event.type == 'gadget'"
+                  }
+                ]
+              },
+              "topic": "inventory"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DaprSubscriptions_List",
+  "title": "List Dapr subscriptions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_CreateOrUpdate.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "dotNetComponentEnvelope": {
+      "properties": {
+        "componentType": "AspireDashboard",
+        "configurations": [
+          {
+            "propertyName": "dashboard-theme",
+            "value": "dark"
+          }
+        ]
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "InProgress"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DotNetComponents_CreateOrUpdate",
+  "title": "Create or Update .NET Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_CreateOrUpdate_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_CreateOrUpdate_ServiceBind.json
@@ -1,0 +1,78 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "dotNetComponentEnvelope": {
+      "properties": {
+        "componentType": "AspireDashboard",
+        "configurations": [
+          {
+            "propertyName": "dashboard-theme",
+            "value": "dark"
+          }
+        ],
+        "serviceBinds": [
+          {
+            "name": "yellowcat",
+            "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+          }
+        ]
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "InProgress",
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DotNetComponents_CreateOrUpdate",
+  "title": "Create or Update .NET Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "DotNetComponents_Delete",
+  "title": "Delete .NET Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_Get.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DotNetComponents_Get",
+  "title": "Get .NET Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_Get_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_Get_ServiceBind.json
@@ -1,0 +1,37 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "DotNetComponents_Get",
+  "title": "Get .NET Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_List.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blueshark",
+            "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/blueshark",
+            "properties": {
+              "componentType": "AspireDashboard",
+              "configurations": [
+                {
+                  "propertyName": "dashboard-theme",
+                  "value": "dark"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          },
+          {
+            "name": "yellowcat",
+            "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat",
+            "properties": {
+              "componentType": "MyOtherDotNetComponentType",
+              "configurations": [
+                {
+                  "propertyName": "timeout-value",
+                  "value": "10000ms"
+                }
+              ],
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DotNetComponents_List",
+  "title": "List .NET Components"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_List_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_List_ServiceBind.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blueshark",
+            "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/blueshark",
+            "properties": {
+              "componentType": "AspireDashboard",
+              "configurations": [
+                {
+                  "propertyName": "dashboard-theme",
+                  "value": "dark"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "serviceBinds": [
+                {
+                  "name": "yellowcat",
+                  "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+                }
+              ]
+            }
+          },
+          {
+            "name": "yellowcat",
+            "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat",
+            "properties": {
+              "componentType": "MyOtherDotNetComponentType",
+              "configurations": [
+                {
+                  "propertyName": "timeout-value",
+                  "value": "10000ms"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "serviceBinds": [
+                {
+                  "name": "blueshark",
+                  "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/blueshark"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "DotNetComponents_List",
+  "title": "List .NET Components with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_Patch.json
@@ -1,0 +1,47 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "dotNetComponentEnvelope": {
+      "properties": {
+        "componentType": "AspireDashboard",
+        "configurations": [
+          {
+            "propertyName": "dashboard-theme",
+            "value": "dark"
+          }
+        ]
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded"
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "DotNetComponents_Update",
+  "title": "Patch .NET Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_Patch_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/DotNetComponents_Patch_ServiceBind.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "name": "mydotnetcomponent",
+    "api-version": "2026-03-02-preview",
+    "dotNetComponentEnvelope": {
+      "properties": {
+        "componentType": "AspireDashboard",
+        "configurations": [
+          {
+            "propertyName": "dashboard-theme",
+            "value": "dark"
+          }
+        ],
+        "serviceBinds": [
+          {
+            "name": "yellowcat",
+            "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+          }
+        ]
+      }
+    },
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "mydotnetcomponent",
+        "type": "Microsoft.App/managedEnvironments/dotNetComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/mydotnetcomponent",
+        "properties": {
+          "componentType": "AspireDashboard",
+          "configurations": [
+            {
+              "propertyName": "dashboard-theme",
+              "value": "dark"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/dotNetComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "DotNetComponents_Update",
+  "title": "Patch .NET Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/FunctionsExtension_Post.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/FunctionsExtension_Post.json
@@ -1,0 +1,17 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "functionAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": "{\"status\":\"success\"}"
+    }
+  },
+  "operationId": "FunctionsExtension_InvokeFunctionsHost",
+  "title": "Invoke Functions host using Functions Extension API"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_CreateOrUpdate.json
@@ -1,0 +1,129 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteConfigEnvelope": {
+      "properties": {
+        "customDomains": [
+          {
+            "name": "example.com",
+            "bindingType": "SniEnabled",
+            "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+          }
+        ],
+        "rules": [
+          {
+            "description": "random-description",
+            "routes": [
+              {
+                "action": {
+                  "prefixRewrite": "/v1/api"
+                },
+                "match": {
+                  "path": "/v1",
+                  "caseSensitive": true
+                }
+              }
+            ],
+            "targets": [
+              {
+                "containerApp": "capp-1",
+                "revision": "rev-1",
+                "weight": 100
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "SniEnabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "InProgress",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "path": "/v1",
+                    "caseSensitive": true
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "revision": "rev-1",
+                  "weight": 100
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "SniEnabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "Succeeded",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "path": "/v1",
+                    "caseSensitive": true
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "revision": "rev-1",
+                  "weight": 100
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_CreateOrUpdate",
+  "title": "Create or Update Http Route"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_CreateOrUpdatePrefix.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_CreateOrUpdatePrefix.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteConfigEnvelope": {
+      "properties": {
+        "customDomains": [
+          {
+            "name": "example.com",
+            "bindingType": "Disabled",
+            "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+          }
+        ],
+        "rules": [
+          {
+            "description": "random-description",
+            "routes": [
+              {
+                "action": {
+                  "prefixRewrite": "/v1/api"
+                },
+                "match": {
+                  "caseSensitive": true,
+                  "prefix": "/v1"
+                }
+              }
+            ],
+            "targets": [
+              {
+                "containerApp": "capp-1",
+                "label": "label-1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "Disabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "InProgress",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "caseSensitive": true,
+                    "prefix": "/v1"
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "label": "label-1"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "Disabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "Succeeded",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "caseSensitive": true,
+                    "prefix": "/v1"
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "label": "label-1"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_CreateOrUpdate",
+  "title": "Create or Update Http Route Prefix Rule"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_CreateOrUpdate_PathSepPrefix.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_CreateOrUpdate_PathSepPrefix.json
@@ -1,0 +1,126 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteConfigEnvelope": {
+      "properties": {
+        "customDomains": [
+          {
+            "name": "example.com",
+            "bindingType": "Disabled",
+            "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+          }
+        ],
+        "rules": [
+          {
+            "description": "random-description",
+            "routes": [
+              {
+                "action": {
+                  "prefixRewrite": "/v1/api"
+                },
+                "match": {
+                  "caseSensitive": true,
+                  "pathSeparatedPrefix": "/v1"
+                }
+              }
+            ],
+            "targets": [
+              {
+                "containerApp": "capp-1",
+                "label": "label-1"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "Disabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "InProgress",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "caseSensitive": true,
+                    "pathSeparatedPrefix": "/v1"
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "label": "label-1"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "Disabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "Succeeded",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "caseSensitive": true,
+                    "pathSeparatedPrefix": "/v1"
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "label": "label-1"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_CreateOrUpdate",
+  "title": "Create or Update Http Route Path Separated Prefix Rule"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/containerApps/testworkerapp0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2025-07-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "HttpRouteConfig_Delete",
+  "title": "Delete Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_Get.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "SniEnabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "Succeeded",
+          "rules": [
+            {
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "caseSensitive": true,
+                    "prefix": "/api"
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "revision": "rev-1",
+                  "weight": 100
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_Get",
+  "title": "Get HttpRoute"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_ListByManagedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_ListByManagedEnvironment.json
@@ -1,0 +1,96 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+            "properties": {
+              "customDomains": [
+                {
+                  "name": "example.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+                }
+              ],
+              "fqdn": "app1.example.com",
+              "provisioningState": "Succeeded",
+              "rules": [
+                {
+                  "routes": [
+                    {
+                      "action": {
+                        "prefixRewrite": "/v1/api"
+                      },
+                      "match": {
+                        "caseSensitive": true,
+                        "prefix": "/api"
+                      }
+                    }
+                  ],
+                  "targets": [
+                    {
+                      "containerApp": "containerApp1"
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-2",
+            "properties": {
+              "customDomains": [
+                {
+                  "name": "example.com",
+                  "bindingType": "SniEnabled",
+                  "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-2"
+                }
+              ],
+              "fqdn": "app2.example.com",
+              "provisioningState": "Succeeded",
+              "rules": [
+                {
+                  "routes": [
+                    {
+                      "action": {
+                        "prefixRewrite": "/v2/api"
+                      },
+                      "match": {
+                        "caseSensitive": false,
+                        "prefix": "/api"
+                      }
+                    }
+                  ],
+                  "targets": [
+                    {
+                      "containerApp": "containerApp2",
+                      "revision": "rev-2",
+                      "weight": 50
+                    },
+                    {
+                      "containerApp": "containerApp2",
+                      "revision": "rev-3",
+                      "weight": 50
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_List",
+  "title": "List Managed Http Routes by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/HttpRouteConfig_Patch.json
@@ -1,0 +1,88 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "httpRouteConfigEnvelope": {
+      "properties": {
+        "customDomains": [
+          {
+            "name": "example.com",
+            "bindingType": "SniEnabled",
+            "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+          }
+        ],
+        "rules": [
+          {
+            "description": "random-description",
+            "routes": [
+              {
+                "action": {
+                  "prefixRewrite": "/v1/api"
+                },
+                "match": {
+                  "path": "/v1",
+                  "caseSensitive": true
+                }
+              }
+            ],
+            "targets": [
+              {
+                "containerApp": "capp-1",
+                "revision": "rev-1",
+                "weight": 100
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "httpRouteName": "httproutefriendlyname",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/managedEnvironments/httpRouteConfigs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/httpRouteConfigs/route-1",
+        "properties": {
+          "customDomains": [
+            {
+              "name": "example.com",
+              "bindingType": "SniEnabled",
+              "certificateId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/certificates/certificate-1"
+            }
+          ],
+          "fqdn": "app1.example.com",
+          "provisioningState": "InProgress",
+          "rules": [
+            {
+              "description": "random-description",
+              "routes": [
+                {
+                  "action": {
+                    "prefixRewrite": "/v1/api"
+                  },
+                  "match": {
+                    "path": "/v1",
+                    "caseSensitive": true
+                  }
+                }
+              ],
+              "targets": [
+                {
+                  "containerApp": "capp-1",
+                  "revision": "rev-1",
+                  "weight": 100
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "HttpRouteConfig_Update",
+  "title": "Patch Managed Http Route"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_CreateOrUpdate.json
@@ -1,0 +1,90 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "javaComponentEnvelope": {
+      "properties": {
+        "componentType": "SpringBootAdmin",
+        "configurations": [
+          {
+            "propertyName": "spring.boot.admin.ui.enable-toasts",
+            "value": "true"
+          },
+          {
+            "propertyName": "spring.boot.admin.monitor.status-interval",
+            "value": "10000ms"
+          }
+        ],
+        "scale": {
+          "maxReplicas": 1,
+          "minReplicas": 1
+        }
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "ingress": {
+            "fqdn": "myjavacomponent.myenvironment.test.net"
+          },
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "ingress": {
+            "fqdn": "myjavacomponent.myenvironment.test.net"
+          },
+          "provisioningState": "InProgress",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JavaComponents_CreateOrUpdate",
+  "title": "Create or Update Java Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_CreateOrUpdate_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_CreateOrUpdate_ServiceBind.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "javaComponentEnvelope": {
+      "properties": {
+        "componentType": "SpringBootAdmin",
+        "configurations": [
+          {
+            "propertyName": "spring.boot.admin.ui.enable-toasts",
+            "value": "true"
+          },
+          {
+            "propertyName": "spring.boot.admin.monitor.status-interval",
+            "value": "10000ms"
+          }
+        ],
+        "scale": {
+          "maxReplicas": 1,
+          "minReplicas": 1
+        },
+        "serviceBinds": [
+          {
+            "name": "yellowcat",
+            "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          },
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "provisioningState": "InProgress",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          },
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JavaComponents_CreateOrUpdate",
+  "title": "Create or Update Java Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "JavaComponents_Delete",
+  "title": "Delete Java Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_Get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "ingress": {
+            "fqdn": "myjavacomponent.myenvironment.test.net"
+          },
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JavaComponents_Get",
+  "title": "Get Java Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_Get_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_Get_ServiceBind.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          },
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JavaComponents_Get",
+  "title": "Get Java Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_List.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blueshark",
+            "type": "Microsoft.App/managedEnvironments/javaComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/blueshark",
+            "properties": {
+              "componentType": "SpringBootAdmin",
+              "configurations": [
+                {
+                  "propertyName": "spring.boot.admin.ui.enable-toasts",
+                  "value": "true"
+                },
+                {
+                  "propertyName": "spring.boot.admin.monitor.status-interval",
+                  "value": "10000ms"
+                }
+              ],
+              "ingress": {
+                "fqdn": "myjavacomponent.myenvironment.test.net"
+              },
+              "provisioningState": "Succeeded",
+              "scale": {
+                "maxReplicas": 1,
+                "minReplicas": 1
+              }
+            }
+          },
+          {
+            "name": "yellowcat",
+            "type": "Microsoft.App/managedEnvironments/javaComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat",
+            "properties": {
+              "componentType": "SpringCloudEureka",
+              "configurations": [
+                {
+                  "propertyName": "spring.cloud.config.server.git.uri",
+                  "value": "<GIT-URL>"
+                }
+              ],
+              "ingress": {
+                "fqdn": "myjavacomponent.myenvironment.test.net"
+              },
+              "provisioningState": "Succeeded",
+              "scale": {
+                "maxReplicas": 1,
+                "minReplicas": 1
+              }
+            }
+          },
+          {
+            "name": "reddog",
+            "type": "Microsoft.App/managedEnvironments/javaComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/reddog",
+            "properties": {
+              "componentType": "SpringCloudGateway",
+              "configurations": [
+                {
+                  "propertyName": "spring.cloud.gateway.enabled",
+                  "value": "true"
+                }
+              ],
+              "ingress": {
+                "fqdn": "myjavacomponent.myenvironment.test.net"
+              },
+              "provisioningState": "Succeeded",
+              "scale": {
+                "maxReplicas": 1,
+                "minReplicas": 1
+              },
+              "springCloudGatewayRoutes": [
+                {
+                  "filters": [
+                    "SetPath=/{path}"
+                  ],
+                  "id": "route1",
+                  "predicates": [
+                    "Path=/v1/{path}",
+                    "After=2024-01-20T17:42:47.789-07:00[America/Denver]"
+                  ],
+                  "uri": "https://otherjavacomponent.myenvironment.test.net"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "JavaComponents_List",
+  "title": "List Java Components"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_List_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_List_ServiceBind.json
@@ -1,0 +1,72 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "blueshark",
+            "type": "Microsoft.App/managedEnvironments/javaComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/blueshark",
+            "properties": {
+              "componentType": "SpringBootAdmin",
+              "configurations": [
+                {
+                  "propertyName": "spring.boot.admin.ui.enable-toasts",
+                  "value": "true"
+                },
+                {
+                  "propertyName": "spring.boot.admin.monitor.status-interval",
+                  "value": "10000ms"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "scale": {
+                "maxReplicas": 1,
+                "minReplicas": 1
+              },
+              "serviceBinds": [
+                {
+                  "name": "yellowcat",
+                  "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+                }
+              ]
+            }
+          },
+          {
+            "name": "yellowcat",
+            "type": "Microsoft.App/managedEnvironments/javaComponents",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat",
+            "properties": {
+              "componentType": "SpringCloudEureka",
+              "configurations": [
+                {
+                  "propertyName": "spring.cloud.config.server.git.uri",
+                  "value": "<GIT-URL>"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "scale": {
+                "maxReplicas": 1,
+                "minReplicas": 1
+              },
+              "serviceBinds": [
+                {
+                  "name": "blueshark",
+                  "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/blueshark"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "JavaComponents_List",
+  "title": "List Java Components with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_Patch.json
@@ -1,0 +1,66 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "javaComponentEnvelope": {
+      "properties": {
+        "componentType": "SpringBootAdmin",
+        "configurations": [
+          {
+            "propertyName": "spring.boot.admin.ui.enable-toasts",
+            "value": "true"
+          },
+          {
+            "propertyName": "spring.boot.admin.monitor.status-interval",
+            "value": "10000ms"
+          }
+        ],
+        "scale": {
+          "maxReplicas": 1,
+          "minReplicas": 1
+        }
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "ingress": {
+            "fqdn": "myjavacomponent.myenvironment.test.net"
+          },
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          }
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "JavaComponents_Update",
+  "title": "Patch Java Component"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_Patch_ServiceBind.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/JavaComponents_Patch_ServiceBind.json
@@ -1,0 +1,75 @@
+{
+  "parameters": {
+    "name": "myjavacomponent",
+    "api-version": "2026-03-02-preview",
+    "environmentName": "myenvironment",
+    "javaComponentEnvelope": {
+      "properties": {
+        "componentType": "SpringBootAdmin",
+        "configurations": [
+          {
+            "propertyName": "spring.boot.admin.ui.enable-toasts",
+            "value": "true"
+          },
+          {
+            "propertyName": "spring.boot.admin.monitor.status-interval",
+            "value": "10000ms"
+          }
+        ],
+        "scale": {
+          "maxReplicas": 1,
+          "minReplicas": 1
+        },
+        "serviceBinds": [
+          {
+            "name": "yellowcat",
+            "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myjavacomponent",
+        "type": "Microsoft.App/managedEnvironments/javaComponents",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/myjavacomponent",
+        "properties": {
+          "componentType": "SpringBootAdmin",
+          "configurations": [
+            {
+              "propertyName": "spring.boot.admin.ui.enable-toasts",
+              "value": "true"
+            },
+            {
+              "propertyName": "spring.boot.admin.monitor.status-interval",
+              "value": "10000ms"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "scale": {
+            "maxReplicas": 1,
+            "minReplicas": 1
+          },
+          "serviceBinds": [
+            {
+              "name": "yellowcat",
+              "serviceId": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/myenvironment/javaComponents/yellowcat"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/providers/Microsoft.App/locations/eastus/operationResults/amF2YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "JavaComponents_Update",
+  "title": "Patch Java Component with ServiceBinds"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_CreateorUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_CreateorUpdate.json
@@ -1,0 +1,330 @@
+{
+  "parameters": {
+    "JobEnvelope": {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "identitySettings": [
+            {
+              "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+              "lifecycle": "All"
+            },
+            {
+              "identity": "system",
+              "lifecycle": "Init"
+            }
+          ],
+          "manualTriggerConfig": {
+            "parallelism": 4,
+            "replicaCompletionCount": 1
+          },
+          "replicaRetryLimit": 10,
+          "replicaTimeout": 10,
+          "triggerType": "Manual"
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppsJob0",
+              "image": "repo/testcontainerAppsJob0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 5,
+                  "periodSeconds": 3
+                }
+              ],
+              "volumeMounts": [
+                {
+                  "mountPath": "/mnt/path1",
+                  "subPath": "subPath1",
+                  "volumeName": "azurefile"
+                },
+                {
+                  "mountPath": "/mnt/path2",
+                  "subPath": "subPath2",
+                  "volumeName": "nfsazurefile"
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerAppsJob0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerAppsJob0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "gpu": 1,
+                "memory": "100Mi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "gpu": 1,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "gpu": 1,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "Create or Update Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_CreateorUpdate_ConnectedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_CreateorUpdate_ConnectedEnvironment.json
@@ -1,0 +1,221 @@
+{
+  "parameters": {
+    "JobEnvelope": {
+      "extendedLocation": {
+        "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+        "type": "CustomLocation"
+      },
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "manualTriggerConfig": {
+            "parallelism": 4,
+            "replicaCompletionCount": 1
+          },
+          "replicaRetryLimit": 10,
+          "replicaTimeout": 10,
+          "triggerType": "Manual"
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppsJob0",
+              "image": "repo/testcontainerAppsJob0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 5,
+                  "periodSeconds": 3
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerAppsJob0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerAppsJob0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "extendedLocation": {
+          "name": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.ExtendedLocation/customLocations/testcustomlocation",
+          "type": "CustomLocation"
+        },
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/connectedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "probes": [
+                  {
+                    "type": "Liveness",
+                    "httpGet": {
+                      "path": "/health",
+                      "httpHeaders": [
+                        {
+                          "name": "Custom-Header",
+                          "value": "Awesome"
+                        }
+                      ],
+                      "port": 8080
+                    },
+                    "initialDelaySeconds": 3,
+                    "periodSeconds": 3
+                  }
+                ],
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "Create or Update Container Apps Job On A Connected Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_CreateorUpdate_EventTrigger.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_CreateorUpdate_EventTrigger.json
@@ -1,0 +1,228 @@
+{
+  "parameters": {
+    "JobEnvelope": {
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "configuration": {
+          "eventTriggerConfig": {
+            "parallelism": 4,
+            "replicaCompletionCount": 1,
+            "scale": {
+              "maxExecutions": 5,
+              "minExecutions": 1,
+              "pollingInterval": 40,
+              "rules": [
+                {
+                  "name": "servicebuscalingrule",
+                  "type": "azure-servicebus",
+                  "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                  "metadata": {
+                    "topicName": "my-topic"
+                  }
+                }
+              ]
+            }
+          },
+          "replicaRetryLimit": 10,
+          "replicaTimeout": 10,
+          "triggerType": "Event"
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppsJob0",
+              "image": "repo/testcontainerAppsJob0:v1"
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerAppsJob0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerAppsJob0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "eventTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1,
+              "scale": {
+                "maxExecutions": 5,
+                "minExecutions": 1,
+                "pollingInterval": 20,
+                "rules": [
+                  {
+                    "name": "servicebuscalingrule",
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "topicName": "my-topic"
+                    }
+                  }
+                ]
+              }
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Event"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "identity": {
+          "type": "UserAssigned",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "eventTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1,
+              "scale": {
+                "maxExecutions": 5,
+                "minExecutions": 1,
+                "pollingInterval": 20,
+                "rules": [
+                  {
+                    "name": "servicebuscalingrule",
+                    "type": "azure-servicebus",
+                    "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                    "metadata": {
+                      "messageCount": "50",
+                      "queueName": "my-queue"
+                    }
+                  }
+                ]
+              }
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Event"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "eventStreamEndpoint": "testEndpoint",
+          "provisioningState": "InProgress",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_CreateOrUpdate",
+  "title": "Create or Update Container Apps Job With Event Driven Trigger"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testWorkerContainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/jobs/testWorkerContainerAppsJob0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "Jobs_Delete",
+  "title": "Delete Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Execution_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Execution_Get.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobExecutionName": "jobExecution1",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jobExecution1",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0/executions/jobExecution1",
+        "properties": {
+          "endTime": "2023-02-13T20:47:30+00:00",
+          "message": "Job has reached the specified backoff limit",
+          "reason": "BackoffLimitExceeded",
+          "startTime": "2023-02-13T20:37:30+00:00",
+          "status": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerappsjob0",
+                "image": "repo/testcontainerappsjob0:v4",
+                "resources": {
+                  "cpu": 0.5,
+                  "memory": "1Gi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainerappsjob0:v4",
+                "resources": {
+                  "cpu": 0.5,
+                  "memory": "1Gi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JobExecution",
+  "title": "Get a single Job Execution"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Executions_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Executions_Get.json
@@ -1,0 +1,81 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerAppJob-27944454",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0/executions/testcontainerAppJob-27944454",
+            "properties": {
+              "detailedStatus": {
+                "replicas": [
+                  {
+                    "name": "testcontainerappsjob0-0",
+                    "containers": [
+                      {
+                        "name": "container1",
+                        "additionalInformation": "Completed",
+                        "code": 0,
+                        "status": "Succeeded"
+                      },
+                      {
+                        "name": "container2",
+                        "additionalInformation": "Completed",
+                        "code": 0,
+                        "status": "Succeeded"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "endTime": "2023-02-13T20:47:30+00:00",
+              "message": "Job has reached the specified backoff limit",
+              "reason": "BackoffLimitExceeded",
+              "startTime": "2023-02-13T20:37:30+00:00",
+              "status": "Running",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerappsjob0",
+                    "image": "repo/testcontainerappsjob0:v4",
+                    "resources": {
+                      "cpu": 0.5,
+                      "memory": "1Gi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerAppsJob0",
+                    "args": [
+                      "-c",
+                      "while true; do echo hello; sleep 10;done"
+                    ],
+                    "command": [
+                      "/bin/sh"
+                    ],
+                    "image": "repo/testcontainerappsjob0:v4",
+                    "resources": {
+                      "cpu": 0.5,
+                      "memory": "1Gi"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "JobsExecutions_List",
+  "title": "Get a Container Apps Job Executions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Get.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "identity": {
+          "type": "SystemAssigned,UserAssigned",
+          "principalId": "24adfa4f-dedf-8dc0-ca29-b6d1a69ab319",
+          "tenantId": "23adfa4f-eedf-1dc0-ba29-a6d1a69ab3d0",
+          "userAssignedIdentities": {
+            "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity": {
+              "clientId": "14adfa4f-eedf-1dc0-ba29-a6d1a69ab3df",
+              "principalId": "74adfa4f-dedf-8dc0-ca29-b6d1a69ab312"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_Get",
+  "title": "Get Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_GetDetector.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_GetDetector.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "jobName": "mikonojob1",
+    "detectorName": "containerappjobnetworkIO",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/jobs/mikonojob1/detectors/containerappjobnetworkIO",
+        "name": "containerappjobnetworkIO",
+        "type": "Microsoft.App/jobs/detectors",
+        "properties": {
+          "metadata": {
+            "id": "containerappjobnetworkIO",
+            "name": "Container App Job Network Inbound and Outbound",
+            "description": "This detector shows the Container App Job Network Inbound and Outbound.",
+            "author": "",
+            "category": "Availability and Performance",
+            "supportTopicList": [],
+            "type": "Detector",
+            "score": 0
+          },
+          "dataset": [
+            {
+              "table": {
+                "tableName": "",
+                "columns": [
+                  {
+                    "columnName": "TimeStamp",
+                    "dataType": "DateTime"
+                  },
+                  {
+                    "columnName": "Metric",
+                    "dataType": "String"
+                  },
+                  {
+                    "columnName": "Average",
+                    "dataType": "Double"
+                  }
+                ],
+                "rows": [
+                  [
+                    "2022-03-15T21:35:00",
+                    "RxBytes",
+                    0
+                  ]
+                ]
+              },
+              "renderingProperties": {
+                "type": 8,
+                "title": "Container App Job Network Inbound ",
+                "description": "",
+                "isVisible": true
+              }
+            }
+          ],
+          "status": {
+            "statusId": 3
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Jobs_GetDetector",
+  "title": "Get diagnostic data for a Container App Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_ListDetectors.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_ListDetectors.json
@@ -1,0 +1,40 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "jobName": "mikonojob1",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/jobs/mikonojob1/detectors/cappjobContainerAppAvailabilityMetrics",
+            "name": "cappjobContainerAppAvailabilityMetrics",
+            "type": "Microsoft.App/containerapps/detectors",
+            "properties": {
+              "metadata": {
+                "id": "cappjobContainerAppAvailabilityMetrics",
+                "name": "Availability Metrics for Container App Jobs",
+                "author": "",
+                "category": "Availability and Performance",
+                "supportTopicList": [],
+                "type": "Analysis",
+                "score": 0
+              },
+              "dataset": [],
+              "status": {
+                "statusId": 4
+              }
+            }
+          }
+        ],
+        "nextLink": null
+      }
+    }
+  },
+  "operationId": "Jobs_ListDetectors",
+  "title": "Get the list of available diagnostic data for a Container App Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_ListSecrets.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_ListSecrets.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "secret1"
+          },
+          {
+            "name": "secret2"
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_ListSecrets",
+  "title": "List Container Apps Job Secrets"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Patch.json
@@ -1,0 +1,116 @@
+{
+  "parameters": {
+    "JobEnvelope": {
+      "properties": {
+        "configuration": {
+          "manualTriggerConfig": {
+            "parallelism": 4,
+            "replicaCompletionCount": 1
+          },
+          "replicaRetryLimit": 10,
+          "replicaTimeout": 10,
+          "triggerType": "Manual"
+        },
+        "template": {
+          "containers": [
+            {
+              "name": "testcontainerAppsJob0",
+              "image": "repo/testcontainerAppsJob0:v1",
+              "probes": [
+                {
+                  "type": "Liveness",
+                  "httpGet": {
+                    "path": "/health",
+                    "httpHeaders": [
+                      {
+                        "name": "Custom-Header",
+                        "value": "Awesome"
+                      }
+                    ],
+                    "port": 8080
+                  },
+                  "initialDelaySeconds": 3,
+                  "periodSeconds": 3
+                }
+              ]
+            }
+          ],
+          "initContainers": [
+            {
+              "name": "testinitcontainerAppsJob0",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainerAppsJob0:v4",
+              "resources": {
+                "cpu": 0.2,
+                "memory": "100Mi"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/locations/eastus/containerappsjobOperationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "Jobs_Update",
+  "title": "Patch Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_ProxyGet.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_ProxyGet.json
@@ -1,0 +1,57 @@
+{
+  "parameters": {
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "resourceGroupName": "rg",
+    "jobName": "testcontainerAppsJob0",
+    "apiName": "rootApi",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0/detectorproperties/rootApi",
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "location": "East US",
+        "properties": {
+          "provisioningState": "Succeeded",
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "configuration": {
+            "replicaTimeout": 10,
+            "replicaRetryLimit": 10,
+            "manualTriggerConfig": {
+              "replicaCompletionCount": 1,
+              "parallelism": 4
+            },
+            "triggerType": "Manual"
+          },
+          "template": {
+            "containers": [
+              {
+                "image": "repo/testcontainerAppsJob0:v4",
+                "name": "testcontainerAppsJob0",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "initContainers": [
+              {
+                "image": "repo/testcontainerAppsJob0:v4",
+                "name": "testinitcontainerAppsJob0",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
+  "operationId": "Jobs_ProxyGet",
+  "title": "Get Container App Job by name"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Start.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Start.json
@@ -1,0 +1,53 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "template": {
+      "containers": [
+        {
+          "name": "testcontainerAppsJob0",
+          "image": "repo/testcontainerAppsJob0:v4",
+          "resources": {
+            "cpu": 0.2,
+            "memory": "100Mi"
+          }
+        }
+      ],
+      "initContainers": [
+        {
+          "name": "testinitcontainerAppsJob0",
+          "args": [
+            "-c",
+            "while true; do echo hello; sleep 10;done"
+          ],
+          "command": [
+            "/bin/sh"
+          ],
+          "image": "repo/testcontainerAppsJob0:v4",
+          "resources": {
+            "cpu": 0.2,
+            "memory": "100Mi"
+          }
+        }
+      ]
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0-pjxhsye",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/{containerAppsJobName}/executions/{jobExecutionName}"
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_Start",
+  "title": "Run a Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Stop_Execution.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Stop_Execution.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobExecutionName": "jobExecution1",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_StopExecution",
+  "title": "Terminate a Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Stop_Multiple.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Job_Stop_Multiple.json
@@ -1,0 +1,68 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobExecutionName": {
+      "value": [
+        {
+          "name": "jobExecution-27944453"
+        },
+        {
+          "name": "jobExecution-27944452"
+        },
+        {
+          "name": "jobExecution-27944451"
+        }
+      ]
+    },
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "jobExecution-27944453",
+            "properties": {
+              "endTime": "2023-02-13T20:47:30+00:00",
+              "message": "Job has reached the specified backoff limit",
+              "reason": "BackoffLimitExceeded",
+              "startTime": "2023-02-13T20:37:30+00:00",
+              "status": "Running"
+            }
+          },
+          {
+            "name": "jobExecution-27944452",
+            "properties": {
+              "endTime": "2023-02-13T21:47:30+00:00",
+              "message": "Job has reached the specified backoff limit",
+              "reason": "BackoffLimitExceeded",
+              "startTime": "2023-02-13T21:37:30+00:00",
+              "status": "Running"
+            }
+          },
+          {
+            "name": "jobExecution-27944453",
+            "properties": {
+              "endTime": "2023-02-13T22:47:30+00:00",
+              "message": "Job has reached the specified backoff limit",
+              "reason": "BackoffLimitExceeded",
+              "startTime": "2023-02-13T22:37:30+00:00",
+              "status": "Running"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "Location": "location"
+      }
+    }
+  },
+  "operationId": "Jobs_StopMultipleExecutions",
+  "title": "Terminate Multiple Container Apps Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Jobs_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Jobs_ListByResourceGroup.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerAppsJob0",
+            "type": "Microsoft.App/jobs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "manualTriggerConfig": {
+                  "parallelism": 4,
+                  "replicaCompletionCount": 1
+                },
+                "replicaRetryLimit": 10,
+                "replicaTimeout": 10,
+                "triggerType": "Manual"
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerAppsJob0",
+                    "image": "repo/testcontainerAppsJob0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerAppsJob0",
+                    "image": "repo/testcontainerAppsJob0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "testcontainerAppsJob1",
+            "type": "Microsoft.App/jobs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob1",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "replicaRetryLimit": 10,
+                "replicaTimeout": 10,
+                "scheduleTriggerConfig": {
+                  "cronExpression": "* * * * 5",
+                  "parallelism": 4,
+                  "replicaCompletionCount": 1
+                },
+                "triggerType": "Scheduled"
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp0",
+                    "image": "repo/testcontainerAppsJob1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerApp0",
+                    "image": "repo/testinitcontainerAppsJob1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_ListByResourceGroup",
+  "title": "List Container Apps Jobs by resource group"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Jobs_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Jobs_ListBySubscription.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerAppsJob0",
+            "type": "Microsoft.App/jobs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "manualTriggerConfig": {
+                  "parallelism": 4,
+                  "replicaCompletionCount": 1
+                },
+                "replicaRetryLimit": 10,
+                "replicaTimeout": 10,
+                "triggerType": "Manual"
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerAppsJob0",
+                    "image": "repo/testcontainerAppsJob0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerAppsJob0",
+                    "image": "repo/testcontainerAppsJob0:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ]
+              }
+            }
+          },
+          {
+            "name": "testcontainerAppsJob1",
+            "type": "Microsoft.App/jobs",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob1",
+            "location": "East US",
+            "properties": {
+              "configuration": {
+                "replicaRetryLimit": 10,
+                "replicaTimeout": 10,
+                "scheduleTriggerConfig": {
+                  "cronExpression": "* * * * 5",
+                  "parallelism": 5,
+                  "replicaCompletionCount": 1
+                },
+                "triggerType": "Scheduled"
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "provisioningState": "Succeeded",
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerAppsJob1",
+                    "image": "repo/testcontainerAppsJob1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "initContainers": [
+                  {
+                    "name": "testinitcontainerAppsJob1",
+                    "image": "repo/testcontainerAppsJob1:v4",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Jobs_ListBySubscription",
+  "title": "List Container Apps Jobs by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Jobs_Resume.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Jobs_Resume.json
@@ -1,0 +1,97 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningState": "Ready",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/jobs/testcontainerAppsJob0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview",
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/jobs/testcontainerAppsJob0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "Jobs_Resume",
+  "title": "Resume Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Jobs_Suspend.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Jobs_Suspend.json
@@ -1,0 +1,97 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "jobName": "testcontainerAppsJob0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerAppsJob0",
+        "type": "Microsoft.App/jobs",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/jobs/testcontainerAppsJob0",
+        "location": "East US",
+        "properties": {
+          "configuration": {
+            "identitySettings": [
+              {
+                "identity": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourcegroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                "lifecycle": "All"
+              },
+              {
+                "identity": "system",
+                "lifecycle": "Init"
+              }
+            ],
+            "manualTriggerConfig": {
+              "parallelism": 4,
+              "replicaCompletionCount": 1
+            },
+            "replicaRetryLimit": 10,
+            "replicaTimeout": 10,
+            "triggerType": "Manual"
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "provisioningState": "Succeeded",
+          "runningState": "Suspended",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                },
+                "volumeMounts": [
+                  {
+                    "mountPath": "/mnt/path1",
+                    "subPath": "subPath1",
+                    "volumeName": "azurefile"
+                  },
+                  {
+                    "mountPath": "/mnt/path2",
+                    "subPath": "subPath2",
+                    "volumeName": "nfsazurefile"
+                  }
+                ]
+              }
+            ],
+            "initContainers": [
+              {
+                "name": "testinitcontainerAppsJob0",
+                "image": "repo/testcontainerAppsJob0:v4",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "volumes": [
+              {
+                "name": "azurefile",
+                "storageName": "storage",
+                "storageType": "AzureFile"
+              },
+              {
+                "name": "nfsazurefile",
+                "storageName": "nfsStorage",
+                "storageType": "NfsAzureFile"
+              }
+            ]
+          }
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/jobs/testcontainerAppsJob0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview",
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/jobs/testcontainerAppsJob0/operationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "Jobs_Suspend",
+  "title": "Suspend Job"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LabelHistory_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LabelHistory_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testContainerApp",
+    "labelName": "dev",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ContainerAppsLabelHistory_DeleteLabelHistory",
+  "title": "Delete Container App's label history for a given label"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LabelHistory_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LabelHistory_Get.json
@@ -1,0 +1,36 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testContainerApp",
+    "labelName": "dev",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "dev",
+        "type": "Microsoft.App/containerApps/labelHistory",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testContainerApp/labelHistory/dev",
+        "properties": {
+          "records": [
+            {
+              "revision": "testContainerApp--2",
+              "start": "2024-10-15T05:49:47+00:00",
+              "status": "Succeeded"
+            },
+            {
+              "revision": "testContainerApp--1",
+              "start": "2024-10-15T01:12:56+00:00",
+              "status": "Succeeded",
+              "stop": "2024-10-15T05:45:08+00:00"
+            }
+          ]
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsLabelHistory_GetLabelHistory",
+  "title": "Get Container App's single label history"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LabelHistory_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LabelHistory_List.json
@@ -1,0 +1,55 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testContainerApp",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "dev",
+            "type": "Microsoft.App/containerApps/labelHistory",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testContainerApp/labelHistory/dev",
+            "properties": {
+              "records": [
+                {
+                  "revision": "testContainerApp--2",
+                  "start": "2024-10-15T05:49:47+00:00",
+                  "status": "Starting"
+                },
+                {
+                  "revision": "testContainerApp--1",
+                  "start": "2024-10-15T01:12:56+00:00",
+                  "status": "Failed",
+                  "stop": "2024-10-15T05:45:08+00:00"
+                }
+              ]
+            }
+          },
+          {
+            "name": "prod",
+            "type": "Microsoft.App/containerApps/labelHistory",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testContainerApp/labelHistory/prod",
+            "properties": {
+              "records": [
+                {
+                  "revision": "testContainerApp--1",
+                  "start": "2024-10-15T05:45:08+00:00",
+                  "status": "Succeeded",
+                  "stop": "2024-10-15T05:49:47+00:00"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsLabelHistory_ListLabelHistory",
+  "title": "List Container App's all label history"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_Create.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_Create.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "logicAppName": "testcontainerApp0",
+    "resource": {
+      "properties": {}
+    },
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/logicApps",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0",
+        "properties": {}
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/logicApps",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0",
+        "properties": {}
+      }
+    }
+  },
+  "operationId": "LogicApps_CreateOrUpdate",
+  "title": "Create logic app extension"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "logicAppName": "testcontainerApp0",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "LogicApps_Delete",
+  "title": "Create logic app extension"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_DeleteDeployWorkflowArtifacts.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_DeleteDeployWorkflowArtifacts.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testapp2",
+    "logicAppName": "testapp2",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workflowArtifacts": {
+      "filesToDelete": [
+        "test/workflow.json",
+        "test/"
+      ]
+    }
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "LogicApps_DeployWorkflowArtifacts",
+  "title": "Delete workflow artifacts"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_Get.json
@@ -1,0 +1,21 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "logicAppName": "testcontainerApp0",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0",
+        "type": "Microsoft.App/logicApps",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0",
+        "properties": {}
+      }
+    }
+  },
+  "operationId": "LogicApps_Get",
+  "title": "Get logic app extension by name "
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_GetWorkflow.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_GetWorkflow.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "logicAppName": "testcontainerApp0",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9",
+    "workflowName": "stateful1"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0/stateful1",
+        "type": "Microsoft.App/logicApps/workflows",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0/workflows/stateful1",
+        "kind": "Stateful",
+        "properties": {
+          "files": {
+            "connections.json": {
+              "managedApiConnections": {
+                "office365": {
+                  "api": {
+                    "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.Web/locations/brazilsouth/managedApis/office365"
+                  },
+                  "authentication": {
+                    "type": "Raw",
+                    "parameter": "@appsetting('office365-connectionKey')",
+                    "scheme": "Key"
+                  },
+                  "connection": {
+                    "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/testrg123/providers/Microsoft.Web/connections/office365-1"
+                  },
+                  "connectionRuntimeUrl": "string"
+                }
+              }
+            },
+            "workflow.json": {
+              "definition": {
+                "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+                "actions": {},
+                "contentVersion": "1.0.0.0",
+                "outputs": {},
+                "parameters": {},
+                "triggers": {}
+              }
+            }
+          },
+          "flowState": "Enabled",
+          "health": {
+            "state": "Healthy"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "LogicApps_GetWorkflow",
+  "title": "GET a workflow"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_ListCallbackURL.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_ListCallbackURL.json
@@ -1,0 +1,28 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testapp2",
+    "logicAppName": "testapp2",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "x-ms-logicApps-proxy-method": "POST",
+    "x-ms-logicApps-proxy-path": "/runtime/webhooks/workflow/api/management/workflows/Stateful1/triggers/When_a_HTTP_request_is_received/listCallbackUrl"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "method": "POST",
+        "basePath": "https://testapp2.livelyriver-730e4fd9.eastasia.azurecontainerapps.io /api/test/triggers/When_a_HTTP_request_is_received/invoke",
+        "queries": {
+          "api-version": "2022-05-01",
+          "sig": "IxEQ_ygZf6WNEQCbjV0Vs6p6Y4DyNEJVAa86U5B4xhk",
+          "sp": "/triggers/When_a_HTTP_request_is_received/run",
+          "sv": "1.0"
+        },
+        "value": "https://testapp2.livelyriver-730e4fd9.eastasia.azurecontainerapps.io:443/api/test/triggers/When_a_HTTP_request_is_received/invoke?api-version=2022-05-01&sp=%2Ftriggers%2FWhen_a_HTTP_request_is_received%2Frun&sv=1.0&sig=<sig> "
+      }
+    }
+  },
+  "operationId": "LogicApps_Invoke",
+  "title": "Get workflow list call back URL"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_ListConnections.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_ListConnections.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testapp2",
+    "logicAppName": "testapp2",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testapp2/connections",
+        "type": "Microsoft.App/logicApps/workflowsconfiguration",
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testapp2/providers/Microsoft.App/logicApps/testapp2/workflowconfigurations/connections",
+        "properties": {
+          "files": {
+            "connections.json": {
+              "managedApiConnections": {
+                "office365": {
+                  "api": {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.Web/locations/centraluseuap/managedApis/arm"
+                  },
+                  "authentication": {
+                    "type": "Raw",
+                    "parameter": "@appsetting('office365-connectionKey')",
+                    "scheme": "Key"
+                  },
+                  "connection": {
+                    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/examplerg/providers/Microsoft.Web/connections/arm"
+                  },
+                  "connectionRuntimeUrl": "https://9d51d1ffc9f77572.00.common.logic.azure-apihub.net/apim/arm/connectionruntimeid"
+                }
+              }
+            }
+          },
+          "health": {
+            "state": "Healthy"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "LogicApps_ListWorkflowsConnections",
+  "title": "List the Workflows Configuration Connections"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_ListWorkflows.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_ListWorkflows.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "logicAppName": "testcontainerApp0",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerApp0/a1",
+            "type": "Microsoft.App/logicApps/workflows",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0/workflows/a1",
+            "kind": "Stateful",
+            "properties": {
+              "flowState": "Enabled",
+              "health": {
+                "state": "Healthy"
+              }
+            }
+          },
+          {
+            "name": "testcontainerApp0/stateful2",
+            "type": "Microsoft.App/logicApps/workflows",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/containerApps/testcontainerApp0/providers/Microsoft.App/logicApps/testcontainerApp0/workflows/stateful2",
+            "kind": "Stateful",
+            "properties": {
+              "flowState": "Enabled",
+              "health": {
+                "error": {
+                  "code": "InvalidWorkflowJson",
+                  "message": "Invalid character after parsing property name. Expected ':' but got: \". Path '', line 2, position 2."
+                },
+                "state": "Unhealthy"
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "LogicApps_ListWorkflows",
+  "title": "List the workflows"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_PostDeployWorkflowArtifacts.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/LogicApps_PostDeployWorkflowArtifacts.json
@@ -1,0 +1,60 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testapp2",
+    "logicAppName": "testapp2",
+    "resourceGroupName": "testrg123",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345",
+    "workflowArtifacts": {
+      "appSettings": {
+        "eventHub_connectionString": "Endpoint=sb://example.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=EXAMPLE1a2b3c4d5e6fEXAMPLE="
+      },
+      "files": {
+        "connections.json": {
+          "managedApiConnections": {},
+          "serviceProviderConnections": {
+            "eventHub": {
+              "displayName": "example1",
+              "parameterValues": {
+                "connectionString": "@appsetting('eventHub_connectionString')"
+              },
+              "serviceProvider": {
+                "id": "/serviceProviders/eventHub"
+              }
+            }
+          }
+        },
+        "test1/workflow.json": {
+          "definition": {
+            "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+            "actions": {},
+            "contentVersion": "1.0.0.0",
+            "outputs": {},
+            "triggers": {
+              "When_events_are_available_in_Event_hub": {
+                "type": "ServiceProvider",
+                "inputs": {
+                  "parameters": {
+                    "eventHubName": "test123"
+                  },
+                  "serviceProviderConfiguration": {
+                    "operationId": "receiveEvents",
+                    "connectionName": "eventHub",
+                    "serviceProviderId": "/serviceProviders/eventHub"
+                  }
+                },
+                "splitOn": "@triggerOutputs()?['body']"
+              }
+            }
+          },
+          "kind": "Stateful"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "LogicApps_DeployWorkflowArtifacts",
+  "title": "Deploys workflow artifacts"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedCertificate_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedCertificate_CreateOrUpdate.json
@@ -1,0 +1,52 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "managedCertificateEnvelope": {
+      "location": "East US",
+      "properties": {
+        "domainControlValidation": "CNAME",
+        "subjectName": "my-subject-name.company.country.net"
+      }
+    },
+    "managedCertificateName": "certificate-firendly-name",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "domainControlValidation": "CNAME",
+          "provisioningState": "Succeeded",
+          "subjectName": "CN=my-subject-name.company.country.net"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "domainControlValidation": "CNAME",
+          "provisioningState": "Pending",
+          "subjectName": "CN=my-subject-name.company.country.net"
+        }
+      },
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/locations/eastus/managedCertificateOperationStatuses/dc27c9cd-370f-4623-95d4-827b6dc4120a?api-version=2022-06-01-preview&azureAsyncOperation=true"
+      }
+    },
+    "400": {
+      "code": "ManagedCertNoUpdate",
+      "message": "Properties of managed certificates cannot be updated. Please delete the current resource and retry or use a different resource id."
+    }
+  },
+  "operationId": "ManagedCertificates_CreateOrUpdate",
+  "title": "Create or Update Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedCertificate_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedCertificate_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "managedCertificateName": "certificate-firendly-name",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ManagedCertificates_Delete",
+  "title": "Delete Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedCertificate_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedCertificate_Get.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "managedCertificateName": "certificate-firendly-name",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "domainControlValidation": "CNAME",
+          "provisioningState": "Succeeded",
+          "subjectName": "CN=my-subject-name.company.country.net"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedCertificates_Get",
+  "title": "Get Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedCertificates_ListByManagedEnvironment.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedCertificates_ListByManagedEnvironment.json
@@ -1,0 +1,49 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name",
+            "location": "East US",
+            "properties": {
+              "domainControlValidation": "CNAME",
+              "provisioningState": "Succeeded",
+              "subjectName": "CN=my-subject-name.company.country.net"
+            }
+          },
+          {
+            "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name-root",
+            "location": "East US",
+            "properties": {
+              "domainControlValidation": "HTTP",
+              "provisioningState": "Succeeded",
+              "subjectName": "CN=company.country.net"
+            }
+          },
+          {
+            "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name-txt",
+            "location": "East US",
+            "properties": {
+              "domainControlValidation": "TXT",
+              "provisioningState": "Succeeded",
+              "subjectName": "CN=txt.company.country.net"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedCertificates_List",
+  "title": "List Managed Certificates by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedCertificates_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedCertificates_Patch.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testcontainerenv",
+    "managedCertificateEnvelope": {
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "managedCertificateName": "certificate-firendly-name",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "type": "Microsoft.App/ManagedEnvironments/managedCertificates",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv/managedCertificates/certificate-firendly-name",
+        "location": "East US",
+        "properties": {
+          "domainControlValidation": "CNAME",
+          "provisioningState": "Succeeded",
+          "subjectName": "CN=my-subject-name.company.country.net"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedCertificates_Update",
+  "title": "Patch Managed Certificate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentDiagnostics_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentDiagnostics_Get.json
@@ -1,0 +1,70 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "environmentName": "mikonokubeenv",
+    "detectorName": "ManagedEnvAvailabilityMetrics",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/managedEnvironments/mikonokubeenv/detectors/ManagedEnvAvailabilityMetrics",
+        "name": "ManagedEnvAvailabilityMetrics",
+        "type": "Microsoft.App/managedEnvironments/detectors",
+        "properties": {
+          "metadata": {
+            "id": "ManagedEnvAvailabilityMetrics",
+            "name": "Managed Env Netowrk Inbound and Outbound",
+            "description": "This detector shows the Managed Environment Network Inbound and Outbound.",
+            "author": "",
+            "category": "Availability and Performance",
+            "supportTopicList": [],
+            "type": "Detector",
+            "score": 0
+          },
+          "dataset": [
+            {
+              "table": {
+                "tableName": "",
+                "columns": [
+                  {
+                    "columnName": "TimeStamp",
+                    "dataType": "DateTime"
+                  },
+                  {
+                    "columnName": "Metric",
+                    "dataType": "String"
+                  },
+                  {
+                    "columnName": "Average",
+                    "dataType": "Double"
+                  }
+                ],
+                "rows": [
+                  [
+                    "2022-03-15T21:35:00",
+                    "RxBytes",
+                    0
+                  ]
+                ]
+              },
+              "renderingProperties": {
+                "type": 8,
+                "title": "Managed Environment Network Inbound ",
+                "description": "",
+                "isVisible": true
+              }
+            }
+          ],
+          "status": {
+            "statusId": 3
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentDiagnostics_GetDetector",
+  "title": "Get diagnostic data for a managed environments"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentDiagnostics_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentDiagnostics_List.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "subscriptionId": "f07f3711-b45e-40fe-a941-4e6d93f851e6",
+    "resourceGroupName": "mikono-workerapp-test-rg",
+    "environmentName": "mikonokubeenv",
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "headers": {},
+      "body": {
+        "value": [
+          {
+            "id": "/subscriptions/f07f3711-b45e-40fe-a941-4e6d93f851e6/resourceGroups/mikono-workerapp-test-rg/providers/Microsoft.App/managedEnvironments/mikonokubeenv/detectors/ManagedEnvAvailabilityMetrics",
+            "name": "ManagedEnvAvailabilityMetrics",
+            "type": "Microsoft.App/managedEnvironments/detectors",
+            "properties": {
+              "metadata": {
+                "id": "ManagedEnvAvailabilityMetrics",
+                "name": "Availability Metrics for Managed Environments",
+                "author": "",
+                "category": "Availability and Performance",
+                "supportTopicList": [],
+                "type": "Analysis",
+                "score": 0
+              },
+              "dataset": [],
+              "status": {
+                "statusId": 4
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentDiagnostics_ListDetectors",
+  "title": "Get the list of available diagnostic data for a managed environments"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentPrivateEndpointConnections_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentPrivateEndpointConnections_CreateOrUpdate.json
@@ -1,0 +1,61 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "privateEndpointConnectionEnvelope": {
+      "properties": {
+        "privateLinkServiceConnectionState": {
+          "actionsRequired": "None",
+          "status": "Approved"
+        }
+      }
+    },
+    "privateEndpointConnectionName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateEndpointConenctions/jlaw-demo1",
+        "properties": {
+          "groupIds": [
+            "managedEnvironments"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/pltest"
+          },
+          "privateLinkServiceConnectionState": {
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Succeeded"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateEndpointConenctions/jlaw-demo1",
+        "properties": {
+          "groupIds": [
+            "managedEnvironments"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/pltest"
+          },
+          "privateLinkServiceConnectionState": {
+            "actionsRequired": "None",
+            "status": "Approved"
+          },
+          "provisioningState": "Updating"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentPrivateEndpointConnections_CreateOrUpdate",
+  "title": "Update a Private Endpoint Connection by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentPrivateEndpointConnections_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentPrivateEndpointConnections_Delete.json
@@ -1,0 +1,19 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "privateEndpointConnectionName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/operationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedEnvironmentPrivateEndpointConnections_Delete",
+  "title": "Delete a Private Endpoint Connection by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentPrivateEndpointConnections_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentPrivateEndpointConnections_Get.json
@@ -1,0 +1,33 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "privateEndpointConnectionName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateEndpointConenctions/jlaw-demo1",
+        "properties": {
+          "groupIds": [
+            "managedEnvironments"
+          ],
+          "privateEndpoint": {
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/pltest"
+          },
+          "privateLinkServiceConnectionState": {
+            "actionsRequired": "None",
+            "status": "Pending"
+          },
+          "provisioningState": "Waiting"
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentPrivateEndpointConnections_Get",
+  "title": "Get a Private Endpoint Connection by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentPrivateEndpointConnections_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentPrivateEndpointConnections_List.json
@@ -1,0 +1,54 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "jlaw-demo1",
+            "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateEndpointConenctions/jlaw-demo1",
+            "properties": {
+              "groupIds": [
+                "managedEnvironments"
+              ],
+              "privateEndpoint": {
+                "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/pltest"
+              },
+              "privateLinkServiceConnectionState": {
+                "actionsRequired": "None",
+                "status": "Pending"
+              },
+              "provisioningState": "Waiting"
+            }
+          },
+          {
+            "name": "jlaw-demo2",
+            "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateEndpointConenctions/jlaw-demo2",
+            "properties": {
+              "groupIds": [
+                "managedEnvironments"
+              ],
+              "privateEndpoint": {
+                "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.Network/privateEndpoints/pltest"
+              },
+              "privateLinkServiceConnectionState": {
+                "actionsRequired": "None",
+                "status": "Approved"
+              },
+              "provisioningState": "Succeeded"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentPrivateEndpointConnections_List",
+  "title": "List Private Endpoint Connections by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentPrivateLinkResources_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentPrivateLinkResources_List.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "managedEnvironments",
+            "type": "Microsoft.App/managedEnvironments/privateLinkResources",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/privateLinkResources/managedEnvironments",
+            "properties": {
+              "groupId": "managedEnvironments",
+              "requiredMembers": [
+                "managedEnvironments"
+              ],
+              "requiredZoneNames": [
+                "privatelink.northcentralusstage.azurecontainerapps.io"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentPrivateLinkResources_List",
+  "title": "List Private Link Resources by Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentUsages_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentUsages_List.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "Managed Environment Consumption Cores",
+              "value": "ManagedEnvironmentConsumptionCores"
+            },
+            "currentValue": 0.5,
+            "limit": 10,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentUsages_List",
+  "title": "List managed environment usages"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironment_MaintenanceConfigurations_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironment_MaintenanceConfigurations_CreateOrUpdate.json
@@ -1,0 +1,56 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "configName": "default",
+    "environmentName": "managedEnv",
+    "maintenanceConfigurationEnvelope": {
+      "properties": {
+        "scheduledEntries": [
+          {
+            "durationHours": 9,
+            "startHourUtc": 12,
+            "weekDay": "Sunday"
+          }
+        ]
+      }
+    },
+    "resourceGroupName": "rg1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.App/ManagedEnvironments/maintenanceConfigurations",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/rg1/providers/Microsoft.App/ManagedEnvironments/managedEnv/maintenanceConfigurations/default",
+        "properties": {
+          "scheduledEntries": [
+            {
+              "durationHours": 9,
+              "startHourUtc": 12,
+              "weekDay": "Sunday"
+            }
+          ]
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.App/ManagedEnvironments/maintenanceConfigurations",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/rg1/providers/Microsoft.App/ManagedEnvironments/managedEnv/maintenanceConfigurations/default",
+        "properties": {
+          "scheduledEntries": [
+            {
+              "durationHours": 9,
+              "startHourUtc": 12,
+              "weekDay": "Sunday"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "MaintenanceConfigurations_CreateOrUpdate",
+  "title": "ManagedEnvironmentMaintenanceConfigurationsCreateOrUpdate"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironment_MaintenanceConfigurations_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironment_MaintenanceConfigurations_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "configName": "default",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "MaintenanceConfigurations_Delete",
+  "title": "ManagedEnvironmentMaintenanceConfigurationsDelete"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironment_MaintenanceConfigurations_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironment_MaintenanceConfigurations_Get.json
@@ -1,0 +1,29 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "configName": "default",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "default",
+        "type": "Microsoft.App/ManagedEnvironments/MaintenanceConfigurations",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/rg1/providers/Microsoft.App/managedEnvironments/managedEnv/maintenanceConfigurations/default",
+        "properties": {
+          "scheduledEntries": [
+            {
+              "durationHours": 9,
+              "startHourUtc": 12,
+              "weekDay": "Sunday"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "operationId": "MaintenanceConfigurations_Get",
+  "title": "ManagedEnvironmentMaintenanceConfigurationsGet"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironment_MaintenanceConfigurations_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironment_MaintenanceConfigurations_List.json
@@ -1,0 +1,32 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "rg1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "default",
+            "type": "Microsoft.App/ManagedEnvironments/MaintenanceConfigurations",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/rg1/providers/Microsoft.App/managedEnvironments/managedEnv/maintenanceConfigurations/default",
+            "properties": {
+              "scheduledEntries": [
+                {
+                  "durationHours": 9,
+                  "startHourUtc": 12,
+                  "weekDay": "Sunday"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "MaintenanceConfigurations_List",
+  "title": "ManagedEnvironmentMaintenanceConfigurationsList"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_CreateOrUpdate.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageEnvelope": {
+      "properties": {
+        "azureFile": {
+          "accessMode": "ReadOnly",
+          "accountKey": "key",
+          "accountName": "account1",
+          "shareName": "share1"
+        }
+      }
+    },
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {}
+    },
+    "201": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo1",
+        "properties": {
+          "azureFile": {
+            "accessMode": "ReadOnly",
+            "accountKeyVaultProperties": {
+              "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+              "keyVaultUrl": "https://myvault.vault.azure.net/secrets/mysecret"
+            },
+            "accountName": "account1",
+            "shareName": "share1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_CreateOrUpdate",
+  "title": "Create or update environments storage"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_CreateOrUpdate_NfsAzureFile.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_CreateOrUpdate_NfsAzureFile.json
@@ -1,0 +1,39 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageEnvelope": {
+      "properties": {
+        "nfsAzureFile": {
+          "accessMode": "ReadOnly",
+          "server": "server1",
+          "shareName": "share1"
+        }
+      }
+    },
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo1",
+        "properties": {
+          "nfsAzureFile": {
+            "accessMode": "ReadOnly",
+            "server": "server1",
+            "shareName": "share1"
+          }
+        }
+      }
+    },
+    "201": {
+      "body": {}
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_CreateOrUpdate",
+  "title": "Create or update environments storage for NFS Azure file"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_Delete.json
@@ -1,0 +1,15 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {},
+    "204": {}
+  },
+  "operationId": "ManagedEnvironmentsStorages_Delete",
+  "title": "List environments storages by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_Get.json
@@ -1,0 +1,31 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo1",
+        "properties": {
+          "azureFile": {
+            "accessMode": "ReadOnly",
+            "accountKeyVaultProperties": {
+              "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+              "keyVaultUrl": "https://myvault.vault.azure.net/secrets/mysecret"
+            },
+            "accountName": "account1",
+            "shareName": "share1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_Get",
+  "title": "get a environments storage"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_Get_NfsAzureFile.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_Get_NfsAzureFile.json
@@ -1,0 +1,27 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "storageName": "jlaw-demo1",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments/storages",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo1",
+        "properties": {
+          "nfsAzureFile": {
+            "accessMode": "ReadOnly",
+            "server": "server1",
+            "shareName": "share1"
+          }
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_Get",
+  "title": "get a environments storage for NFS Azure file"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironmentsStorages_List.json
@@ -1,0 +1,46 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "managedEnv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "jlaw-demo1",
+            "type": "Microsoft.App/managedEnvironments/storages",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo1",
+            "properties": {
+              "azureFile": {
+                "accessMode": "ReadOnly",
+                "accountKeyVaultProperties": {
+                  "identity": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/myidentity",
+                  "keyVaultUrl": "https://myvault.vault.azure.net/secrets/mysecret"
+                },
+                "accountName": "account1",
+                "shareName": "share1"
+              }
+            }
+          },
+          {
+            "name": "jlaw-demo2",
+            "type": "Microsoft.App/managedEnvironments/storages",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/managedEnv/storages/jlaw-demo2",
+            "properties": {
+              "nfsAzureFile": {
+                "accessMode": "ReadOnly",
+                "server": "server1",
+                "shareName": "share1"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsStorages_List",
+  "title": "List environments storages by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_CreateOrUpdate.json
@@ -1,0 +1,382 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentEnvelope": {
+      "identity": {
+        "type": "SystemAssigned, UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity": {}
+        }
+      },
+      "location": "East US",
+      "properties": {
+        "appInsightsConfiguration": {
+          "connectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/"
+        },
+        "appLogsConfiguration": {
+          "logAnalyticsConfiguration": {
+            "customerId": "string",
+            "dynamicJsonColumns": true,
+            "sharedKey": "string"
+          }
+        },
+        "availabilityZones": [
+          "1",
+          "2",
+          "3"
+        ],
+        "customDomainConfiguration": {
+          "certificatePassword": "1234",
+          "certificateValue": "Y2VydA==",
+          "dnsSuffix": "www.my-name.com"
+        },
+        "daprAIConnectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://northcentralus-0.in.applicationinsights.azure.com/",
+        "diskEncryptionConfiguration": {
+          "keyVaultConfiguration": {
+            "auth": {
+              "identity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity"
+            },
+            "keyUrl": "https://contoso.vault.azure.net/mykey/19ff8313ca394b89b9e824bbbdc8c521"
+          }
+        },
+        "ingressConfiguration": {
+          "headerCountLimit": 30,
+          "requestIdleTimeout": 5,
+          "terminationGracePeriodSeconds": 3600,
+          "workloadProfileName": "My-CO-01"
+        },
+        "openTelemetryConfiguration": {
+          "destinationsConfiguration": {
+            "dataDogConfiguration": {
+              "key": "000000000000000000000000",
+              "site": "string"
+            },
+            "otlpConfigurations": [
+              {
+                "name": "dashboard",
+                "endpoint": "dashboard.k8s.region.azurecontainerapps.io:80",
+                "headers": [
+                  {
+                    "key": "api-key",
+                    "value": "xxxxxxxxxxx"
+                  }
+                ],
+                "insecure": true
+              }
+            ]
+          },
+          "logsConfiguration": {
+            "destinations": [
+              "appInsights"
+            ]
+          },
+          "metricsConfiguration": {
+            "destinations": [
+              "dataDog"
+            ],
+            "includeKeda": true
+          },
+          "tracesConfiguration": {
+            "destinations": [
+              "appInsights"
+            ],
+            "includeDapr": true
+          }
+        },
+        "peerAuthentication": {
+          "mtls": {
+            "enabled": true
+          }
+        },
+        "peerTrafficConfiguration": {
+          "encryption": {
+            "enabled": true
+          }
+        },
+        "vnetConfiguration": {
+          "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+        },
+        "workloadProfiles": [
+          {
+            "name": "My-GP-01",
+            "enableFips": true,
+            "maximumCount": 12,
+            "minimumCount": 3,
+            "workloadProfileType": "GeneralPurpose"
+          },
+          {
+            "name": "My-MO-01",
+            "maximumCount": 6,
+            "minimumCount": 3,
+            "workloadProfileType": "MemoryOptimized"
+          },
+          {
+            "name": "My-CO-01",
+            "maximumCount": 6,
+            "minimumCount": 3,
+            "workloadProfileType": "ComputeOptimized"
+          },
+          {
+            "name": "My-consumption-01",
+            "workloadProfileType": "Consumption"
+          }
+        ],
+        "zoneRedundant": true
+      }
+    },
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerenv",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "appInsightsConfiguration": null,
+          "appLogsConfiguration": {
+            "logAnalyticsConfiguration": {
+              "customerId": "string",
+              "dynamicJsonColumns": true
+            }
+          },
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testcontainerenv.k4apps.io",
+          "deploymentErrors": null,
+          "diskEncryptionConfiguration": {
+            "keyVaultConfiguration": {
+              "auth": {
+                "identity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity"
+              },
+              "keyUrl": "https://contoso.vault.azure.net/mykey/19ff8313ca394b89b9e824bbbdc8c521"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "capp-svc-testcontainerenv-eastus",
+          "ingressConfiguration": {
+            "headerCountLimit": 30,
+            "requestIdleTimeout": 5,
+            "terminationGracePeriodSeconds": 3600,
+            "workloadProfileName": "My-CO-01"
+          },
+          "openTelemetryConfiguration": {
+            "destinationsConfiguration": {
+              "dataDogConfiguration": {
+                "key": null,
+                "site": "datadoghq.com"
+              },
+              "otlpConfigurations": [
+                {
+                  "name": "dashboard",
+                  "endpoint": "dashboard.k8s.region.azurecontainerapps.io:80",
+                  "insecure": true
+                }
+              ]
+            },
+            "logsConfiguration": {
+              "destinations": [
+                "appInsights"
+              ]
+            },
+            "metricsConfiguration": {
+              "destinations": [
+                "dataDog"
+              ]
+            },
+            "tracesConfiguration": {
+              "destinations": [
+                "appInsights"
+              ]
+            }
+          },
+          "peerAuthentication": {
+            "mtls": {
+              "enabled": true
+            }
+          },
+          "provisioningState": "Succeeded",
+          "staticIp": "1.2.3.4",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerenv",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv",
+        "identity": {
+          "type": "SystemAssigned, UserAssigned",
+          "principalId": "00000000-0000-0000-0000-000000000000",
+          "tenantId": "00000000-0000-0000-0000-000000000000",
+          "userAssignedIdentities": {
+            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity": {
+              "clientId": "00000000-0000-0000-0000-000000000000",
+              "principalId": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        },
+        "location": "East US",
+        "properties": {
+          "appInsightsConfiguration": null,
+          "appLogsConfiguration": {
+            "logAnalyticsConfiguration": {
+              "customerId": "string"
+            }
+          },
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testcontainerenv.k4apps.io",
+          "deploymentErrors": null,
+          "diskEncryptionConfiguration": {
+            "keyVaultConfiguration": {
+              "auth": {
+                "identity": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/contoso-resources/providers/Microsoft.ManagedIdentity/userAssignedIdentities/contoso-identity"
+              },
+              "keyUrl": "https://contoso.vault.azure.net/mykey/19ff8313ca394b89b9e824bbbdc8c521"
+            }
+          },
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "capp-svc-testcontainerenv-eastus",
+          "ingressConfiguration": {
+            "headerCountLimit": 30,
+            "requestIdleTimeout": 5,
+            "terminationGracePeriodSeconds": 3600,
+            "workloadProfileName": "My-CO-01"
+          },
+          "openTelemetryConfiguration": {
+            "destinationsConfiguration": {
+              "dataDogConfiguration": {
+                "key": null,
+                "site": "datadoghq.com"
+              },
+              "otlpConfigurations": [
+                {
+                  "name": "dashboard",
+                  "endpoint": "dashboard.k8s.region.azurecontainerapps.io:80",
+                  "insecure": true
+                }
+              ]
+            },
+            "logsConfiguration": {
+              "destinations": [
+                "appInsights"
+              ]
+            },
+            "metricsConfiguration": {
+              "destinations": [
+                "dataDog"
+              ]
+            },
+            "tracesConfiguration": {
+              "destinations": [
+                "appInsights"
+              ]
+            }
+          },
+          "peerAuthentication": {
+            "mtls": {
+              "enabled": true
+            }
+          },
+          "provisioningState": "InitializationInProgress",
+          "staticIp": "1.2.3.4",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_CreateOrUpdate",
+  "title": "Create environments"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_CustomInfrastructureResourceGroup_Create.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_CustomInfrastructureResourceGroup_Create.json
@@ -1,0 +1,188 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentEnvelope": {
+      "location": "East US",
+      "properties": {
+        "appLogsConfiguration": {
+          "logAnalyticsConfiguration": {
+            "customerId": "string",
+            "sharedKey": "string"
+          }
+        },
+        "availabilityZones": [
+          "1",
+          "2",
+          "3"
+        ],
+        "customDomainConfiguration": {
+          "certificatePassword": "1234",
+          "certificateValue": "Y2VydA==",
+          "dnsSuffix": "www.my-name.com"
+        },
+        "daprAIConnectionString": "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://northcentralus-0.in.applicationinsights.azure.com/",
+        "infrastructureResourceGroup": "myInfrastructureRgName",
+        "vnetConfiguration": {
+          "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+        },
+        "workloadProfiles": [
+          {
+            "name": "My-GP-01",
+            "enableFips": true,
+            "maximumCount": 12,
+            "minimumCount": 3,
+            "workloadProfileType": "GeneralPurpose"
+          },
+          {
+            "name": "My-MO-01",
+            "maximumCount": 6,
+            "minimumCount": 3,
+            "workloadProfileType": "MemoryOptimized"
+          },
+          {
+            "name": "My-CO-01",
+            "maximumCount": 6,
+            "minimumCount": 3,
+            "workloadProfileType": "ComputeOptimized"
+          },
+          {
+            "name": "My-consumption-01",
+            "workloadProfileType": "Consumption"
+          }
+        ],
+        "zoneRedundant": true
+      }
+    },
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerenv",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv",
+        "location": "East US",
+        "properties": {
+          "appLogsConfiguration": {
+            "logAnalyticsConfiguration": {
+              "customerId": "string"
+            }
+          },
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testcontainerenv.k4apps.io",
+          "deploymentErrors": null,
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "myInfrastructureRgName",
+          "provisioningState": "Succeeded",
+          "staticIp": "1.2.3.4",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "name": "testcontainerenv",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/testcontainerenv",
+        "location": "East US",
+        "properties": {
+          "appLogsConfiguration": {
+            "logAnalyticsConfiguration": {
+              "customerId": "string"
+            }
+          },
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "testcontainerenv.k4apps.io",
+          "deploymentErrors": null,
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "myInfrastructureRgName",
+          "provisioningState": "InitializationInProgress",
+          "staticIp": "1.2.3.4",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        }
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_CreateOrUpdate",
+  "title": "Create environment with custom infrastructureResourceGroup"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_Delete.json
@@ -1,0 +1,20 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "examplekenv",
+    "location": "East US",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/localtions/eastus/operationResults/00000"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ManagedEnvironments_Delete",
+  "title": "Delete environment by name"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_Get.json
@@ -1,0 +1,92 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1",
+        "location": "North Central US",
+        "properties": {
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "daprConfiguration": {
+            "version": "1.9"
+          },
+          "defaultDomain": "jlaw-demo1.k4apps.io",
+          "deploymentErrors": null,
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "capp-svc-jlaw-demo1-northcentralus",
+          "ingressConfiguration": {
+            "headerCountLimit": 30,
+            "requestIdleTimeout": 5,
+            "terminationGracePeriodSeconds": 3600,
+            "workloadProfileName": "My-CO-01"
+          },
+          "kedaConfiguration": {
+            "version": "2.8.1"
+          },
+          "peerAuthentication": {
+            "mtls": {
+              "enabled": true
+            }
+          },
+          "peerTrafficConfiguration": {
+            "encryption": {
+              "enabled": true
+            }
+          },
+          "provisioningState": "Succeeded",
+          "staticIp": "20.42.33.145",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_Get",
+  "title": "Get environments by name"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_Get1.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_Get1.json
@@ -1,0 +1,92 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1",
+        "location": "North Central US",
+        "properties": {
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "daprConfiguration": {
+            "version": "1.9"
+          },
+          "defaultDomain": "jlaw-demo1.k4apps.io",
+          "deploymentErrors": null,
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "capp-svc-jlaw-demo1-northcentralus",
+          "ingressConfiguration": {
+            "headerCountLimit": 30,
+            "requestIdleTimeout": 5,
+            "terminationGracePeriodSeconds": 3600,
+            "workloadProfileName": "My-CO-01"
+          },
+          "kedaConfiguration": {
+            "version": "2.8.1"
+          },
+          "peerAuthentication": {
+            "mtls": {
+              "enabled": true
+            }
+          },
+          "peerTrafficConfiguration": {
+            "encryption": {
+              "enabled": true
+            }
+          },
+          "provisioningState": "Succeeded",
+          "staticIp": "20.42.33.145",
+          "vnetConfiguration": {
+            "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+          },
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        },
+        "tags": {}
+      }
+    }
+  },
+  "operationId": "ManagedEnvironmentsDiagnostics_GetRoot",
+  "title": "Get environments by name"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_GetAuthToken.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_GetAuthToken.json
@@ -1,0 +1,25 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "testenv",
+    "resourceGroupName": "rg",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testenv",
+        "type": "Microsoft.App/environments/accesstoken",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/testenv",
+        "location": "East US",
+        "properties": {
+          "expires": "2022-07-14T19:22:50.3080223Z",
+          "token": "testToken"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ManagedEnvironments_GetAuthToken",
+  "title": "Get Managed Environment Auth Token"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_ListByResourceGroup.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "jlaw-demo1",
+            "type": "Microsoft.App/managedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1",
+            "location": "North Central US",
+            "properties": {
+              "appLogsConfiguration": null,
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "jlaw-demo1.k4apps.io",
+              "deploymentErrors": null,
+              "eventStreamEndpoint": "testEndpoint",
+              "infrastructureResourceGroup": "capp-svc-jlaw-demo1-northcentralus",
+              "ingressConfiguration": {
+                "headerCountLimit": 50,
+                "requestIdleTimeout": null,
+                "terminationGracePeriodSeconds": 600,
+                "workloadProfileName": "My-GP-01"
+              },
+              "provisioningState": "Succeeded",
+              "staticIp": "20.42.33.145",
+              "vnetConfiguration": {
+                "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+              },
+              "workloadProfiles": [
+                {
+                  "name": "My-GP-01",
+                  "enableFips": true,
+                  "maximumCount": 12,
+                  "minimumCount": 3,
+                  "workloadProfileType": "GeneralPurpose"
+                },
+                {
+                  "name": "My-MO-01",
+                  "maximumCount": 6,
+                  "minimumCount": 3,
+                  "workloadProfileType": "MemoryOptimized"
+                },
+                {
+                  "name": "My-CO-01",
+                  "maximumCount": 6,
+                  "minimumCount": 3,
+                  "workloadProfileType": "ComputeOptimized"
+                },
+                {
+                  "name": "My-consumption-01",
+                  "workloadProfileType": "Consumption"
+                }
+              ],
+              "zoneRedundant": true
+            },
+            "tags": {}
+          },
+          {
+            "name": "demo1",
+            "type": "Microsoft.App/managedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/demo1",
+            "location": "North Central US",
+            "properties": {
+              "appLogsConfiguration": null,
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name2.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name2.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "demo1.k4apps.io",
+              "deploymentErrors": null,
+              "eventStreamEndpoint": "testEndpoint",
+              "infrastructureResourceGroup": "capp-svc-demo1-northcentralus",
+              "ingressConfiguration": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "52.142.21.61",
+              "vnetConfiguration": {
+                "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+              },
+              "zoneRedundant": true
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_ListByResourceGroup",
+  "title": "List environments by resource group"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_ListBySubscription.json
@@ -1,0 +1,173 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "jlaw-demo1",
+            "type": "Microsoft.App/managedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1",
+            "location": "North Central US",
+            "properties": {
+              "appLogsConfiguration": null,
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "jlaw-demo1.k4apps.io",
+              "deploymentErrors": null,
+              "eventStreamEndpoint": "testEndpoint",
+              "infrastructureResourceGroup": "capp-svc-jlaw-demo1-northcentralus",
+              "ingressConfiguration": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "20.42.33.145",
+              "vnetConfiguration": {
+                "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+              },
+              "workloadProfiles": [
+                {
+                  "name": "My-GP-01",
+                  "enableFips": true,
+                  "maximumCount": 12,
+                  "minimumCount": 3,
+                  "workloadProfileType": "GeneralPurpose"
+                },
+                {
+                  "name": "My-MO-01",
+                  "maximumCount": 6,
+                  "minimumCount": 3,
+                  "workloadProfileType": "MemoryOptimized"
+                },
+                {
+                  "name": "My-CO-01",
+                  "maximumCount": 6,
+                  "minimumCount": 3,
+                  "workloadProfileType": "ComputeOptimized"
+                },
+                {
+                  "name": "My-consumption-01",
+                  "workloadProfileType": "Consumption"
+                }
+              ],
+              "zoneRedundant": true
+            },
+            "tags": {}
+          },
+          {
+            "name": "demo1",
+            "type": "Microsoft.App/managedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/DemoRG/providers/Microsoft.App/managedEnvironments/demo1",
+            "location": "North Central US",
+            "properties": {
+              "appLogsConfiguration": {
+                "destination": "log-analytics",
+                "logAnalyticsConfiguration": {
+                  "customerId": "9ccccd4a-268f-4a9a-8d03-9bfe77c3fbd2",
+                  "dynamicJsonColumns": true
+                }
+              },
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name2.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name2.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "demo1.k4apps.io",
+              "deploymentErrors": null,
+              "eventStreamEndpoint": "testEndpoint",
+              "infrastructureResourceGroup": "capp-svc-demo1-northcentralus",
+              "ingressConfiguration": null,
+              "provisioningState": "Succeeded",
+              "staticIp": "52.142.21.61",
+              "vnetConfiguration": {
+                "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+              },
+              "zoneRedundant": true
+            },
+            "tags": {}
+          },
+          {
+            "name": "pl1",
+            "type": "Microsoft.App/managedEnvironments",
+            "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/DemoRG/providers/Microsoft.App/managedEnvironments/pl1",
+            "location": "North Central US",
+            "properties": {
+              "appLogsConfiguration": {
+                "destination": "log-analytics",
+                "logAnalyticsConfiguration": {
+                  "customerId": "9ccccd4a-268f-4a9a-8d03-9bfe77c3fbd2",
+                  "dynamicJsonColumns": true
+                }
+              },
+              "availabilityZones": [
+                "1",
+                "2",
+                "3"
+              ],
+              "customDomainConfiguration": {
+                "customDomainVerificationId": "custom domain verification id",
+                "dnsSuffix": "www.my-name2.com",
+                "expirationDate": "2022-11-06T04:00:00Z",
+                "subjectName": "CN=www.my-name2.com",
+                "thumbprint": "CERTIFICATE_THUMBPRINT"
+              },
+              "defaultDomain": "pl1.k4apps.io",
+              "deploymentErrors": null,
+              "eventStreamEndpoint": "testEndpoint",
+              "ingressConfiguration": null,
+              "privateEndpointConnections": [
+                {
+                  "name": "96101496-ed84-44f9-a28c-d4798f053023-d1908429-ca41-48a0-a026-6a4014e6e615",
+                  "type": "Microsoft.App/managedEnvironments/privateEndpointConnections",
+                  "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/DemoRG/providers/Microsoft.App/managedEnvironments/pl1/privateEndpointConnections/96101496-ed84-44f9-a28c-d4798f053023-d1908429-ca41-48a0-a026-6a4014e6e615",
+                  "properties": {
+                    "groupIds": [
+                      "managedEnvironments"
+                    ],
+                    "privateEndpoint": {
+                      "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/DemoRG/providers/Microsoft.Network/privateEndpoints/96101496-ed84-44f9-a28c-d4798f053023"
+                    },
+                    "privateLinkServiceConnectionState": {
+                      "description": "please approve",
+                      "actionsRequired": "None",
+                      "status": "Approved"
+                    },
+                    "provisioningState": "Succeeded"
+                  }
+                }
+              ],
+              "privateLinkDefaultDomain": "privatelink.pl1.k4apps.io",
+              "provisioningState": "Succeeded",
+              "staticIp": "52.142.21.61",
+              "vnetConfiguration": {
+                "infrastructureSubnetId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/RGName/providers/Microsoft.Network/virtualNetworks/VNetName/subnets/subnetName1"
+              },
+              "zoneRedundant": true
+            },
+            "tags": {}
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_ListBySubscription",
+  "title": "List environments by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_ListWorkloadProfileStates.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_ListWorkloadProfileStates.json
@@ -1,0 +1,38 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentName": "jlaw-demo1",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "8efdecc5-919e-44eb-b179-915dca89ebf9"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "GP1",
+            "type": "/providers/Microsoft.App/workloadProfileStates",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/workloadProfileStates/GP1",
+            "properties": {
+              "currentCount": 3,
+              "maximumCount": 10,
+              "minimumCount": 3
+            }
+          },
+          {
+            "name": "MO3",
+            "type": "/providers/Microsoft.App/workloadProfileStates",
+            "id": "/subscriptions/55f240e3-3d66-44f6-8358-4e4f3d7a2e51/providers/Microsoft.App/workloadProfileStates/MO3",
+            "properties": {
+              "currentCount": 0,
+              "maximumCount": 2,
+              "minimumCount": 0
+            }
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_ListWorkloadProfileStates",
+  "title": "List environments by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/ManagedEnvironments_Patch.json
@@ -1,0 +1,79 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "environmentEnvelope": {
+      "location": "East US",
+      "tags": {
+        "tag1": "value1",
+        "tag2": "value2"
+      }
+    },
+    "environmentName": "testcontainerenv",
+    "resourceGroupName": "examplerg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "jlaw-demo1",
+        "type": "Microsoft.App/managedEnvironments",
+        "id": "/subscriptions/8efdecc5-919e-44eb-b179-915dca89ebf9/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/jlaw-demo1",
+        "location": "East US",
+        "properties": {
+          "availabilityZones": [
+            "1",
+            "2",
+            "3"
+          ],
+          "customDomainConfiguration": {
+            "customDomainVerificationId": "custom domain verification id",
+            "dnsSuffix": "www.my-name.com",
+            "expirationDate": "2022-11-06T04:00:00Z",
+            "subjectName": "CN=www.my-name.com",
+            "thumbprint": "CERTIFICATE_THUMBPRINT"
+          },
+          "defaultDomain": "jlaw-demo1.k4apps.io",
+          "deploymentErrors": null,
+          "eventStreamEndpoint": "testEndpoint",
+          "infrastructureResourceGroup": "capp-svc-jlaw-demo1-northcentralus",
+          "provisioningState": "Succeeded",
+          "staticIp": "20.42.33.145",
+          "workloadProfiles": [
+            {
+              "name": "My-GP-01",
+              "enableFips": true,
+              "maximumCount": 12,
+              "minimumCount": 3,
+              "workloadProfileType": "GeneralPurpose"
+            },
+            {
+              "name": "My-MO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "MemoryOptimized"
+            },
+            {
+              "name": "My-CO-01",
+              "maximumCount": 6,
+              "minimumCount": 3,
+              "workloadProfileType": "ComputeOptimized"
+            },
+            {
+              "name": "My-consumption-01",
+              "workloadProfileType": "Consumption"
+            }
+          ],
+          "zoneRedundant": true
+        },
+        "tags": {}
+      }
+    },
+    "202": {
+      "headers": {
+        "azure-asyncoperation": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/locations/eastus/managedEnvironmentOperationResults/62e4d893-d233-4005-988e-a428d9f77076?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "ManagedEnvironments_Update",
+  "title": "Patch Managed Environment"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Operations_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Operations_List.json
@@ -1,0 +1,26 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.App/containerApps/Read",
+            "display": {
+              "description": "Get the properties of a Container App",
+              "operation": "Get Container App",
+              "provider": "Microsoft Apps",
+              "resource": "Container App"
+            },
+            "origin": "user,system"
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "Operations_List",
+  "title": "List all operations"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Replicas_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Replicas_Get.json
@@ -1,0 +1,42 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myapp",
+    "replicaName": "myapp--0wlqy09-5d9774cff-5wnd8",
+    "resourceGroupName": "workerapps-rg-xj",
+    "revisionName": "myapp--0wlqy09",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "myapp--0wlqy09-5d9774cff-5wnd8",
+        "type": "Microsoft.Web/containerapps/revisions/replicas",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/revisions/myapp--0wlqy09/replicas/myapp--0wlqy09-5d9774cff-5wnd8",
+        "properties": {
+          "containers": [
+            {
+              "name": "hello92",
+              "containerId": "containerd://6bac7bb3afed1c704b5fe563c34c0ecf59ac30c766bb73488f7fa552dc42ee54",
+              "debugEndpoint": "wss://eastasia.azurecontainerapps.dev/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/containerApps/myapp/revisions/myapp--0wlqy09/replicas/myapp--0wlqy09-5d9774cff-5wnd8/debug?targetContainer=hello92",
+              "execEndpoint": "testExecEndpoint",
+              "logStreamEndpoint": "testLogStreamEndpoint",
+              "ready": true,
+              "restartCount": 0,
+              "runningState": "Running",
+              "runningStateDetails": "testDetail",
+              "started": true
+            }
+          ],
+          "createdTime": "2022-01-25T19:42:45Z",
+          "initContainers": [],
+          "runningState": "Running",
+          "runningStateDetails": "testDetail"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsRevisionReplicas_GetReplica",
+  "title": "Get Container App's revision replica"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Replicas_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Replicas_List.json
@@ -1,0 +1,45 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "myapp",
+    "resourceGroupName": "workerapps-rg-xj",
+    "revisionName": "myapp--0wlqy09",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "myapp--0wlqy09-5d9774cff-5wnd8",
+            "type": "Microsoft.Web/containerapps/revisions/replicas",
+            "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/revisions/myapp--0wlqy09/replicas/myapp--0wlqy09-5d9774cff-5wnd8",
+            "properties": {
+              "containers": [
+                {
+                  "name": "hello92",
+                  "containerId": "containerd://6bac7bb3afed1c704b5fe563c34c0ecf59ac30c766bb73488f7fa552dc42ee54",
+                  "debugEndpoint": "wss://eastasia.azurecontainerapps.dev/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/containerApps/myapp/revisions/myapp--0wlqy09/replicas/myapp--0wlqy09-5d9774cff-5wnd8/debug?targetContainer=hello92",
+                  "execEndpoint": "testExecEndpoint",
+                  "logStreamEndpoint": "testLogStreamEndpoint",
+                  "ready": true,
+                  "restartCount": 0,
+                  "runningState": "Running",
+                  "runningStateDetails": "testDetail",
+                  "started": true
+                }
+              ],
+              "createdTime": "2022-01-25T19:42:45Z",
+              "initContainers": [],
+              "runningState": "Running",
+              "runningStateDetails": "testDetail"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsRevisionReplicas_ListReplicas",
+  "title": "List Container App's replicas"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_Activate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_Activate.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "ContainerAppsRevisions_ActivateRevision",
+  "title": "Activate Container App's revision"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_Deactivate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_Deactivate.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "ContainerAppsRevisions_DeactivateRevision",
+  "title": "Deactivate Container App's revision"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_Get.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0-pjxhsye",
+        "type": "Microsoft.App/containerApps/revisions",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/revisions/testcontainerApp0-pjxhsye",
+        "properties": {
+          "active": true,
+          "createdTime": "2021-05-24T21:24:22+00:00",
+          "fqdn": "testcontainerApp0-pjxhsye.politehill-ab123456.eastus.azurecontainerapps.io",
+          "labels": [
+            "production"
+          ],
+          "lastActiveTime": "2021-05-24T21:24:22+00:00",
+          "replicas": 1,
+          "runningState": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v2",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "trafficWeight": 80
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsRevisions_GetRevision",
+  "title": "Get Container App's revision"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_Get1.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_Get1.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testcontainerApp0-pjxhsye",
+        "type": "Microsoft.App/containerApps/revisions",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/revisions/testcontainerApp0-pjxhsye",
+        "properties": {
+          "active": true,
+          "createdTime": "2021-05-24T21:24:22+00:00",
+          "fqdn": "testcontainerApp0-pjxhsye.politehill-ab123456.eastus.azurecontainerapps.io",
+          "labels": [
+            "production"
+          ],
+          "lastActiveTime": "2021-05-24T21:24:22+00:00",
+          "replicas": 1,
+          "runningState": "Running",
+          "template": {
+            "containers": [
+              {
+                "name": "testcontainerApp0",
+                "image": "repo/testcontainerApp0:v2",
+                "resources": {
+                  "cpu": 0.2,
+                  "memory": "100Mi"
+                }
+              }
+            ],
+            "scale": {
+              "maxReplicas": 5,
+              "minReplicas": 1,
+              "rules": [
+                {
+                  "name": "httpscalingrule",
+                  "http": {
+                    "metadata": {
+                      "concurrentRequests": "50"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "trafficWeight": 80
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsDiagnostics_GetRevision",
+  "title": "Get Container App's revision"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_List.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerApp0-pjxhsye",
+            "type": "Microsoft.App/containerApps/revisions",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/revisions/testcontainerApp0-pjxhsye",
+            "properties": {
+              "active": true,
+              "createdTime": "2021-05-24T21:24:22+00:00",
+              "fqdn": "testcontainerApp0-pjxhsye.politehill-ab123456.eastus.azurecontainerapps.io",
+              "lastActiveTime": "2021-05-24T21:24:22+00:00",
+              "replicas": 1,
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp0",
+                    "image": "repo/testcontainerApp0:v2",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "scale": {
+                  "maxReplicas": 5,
+                  "minReplicas": 1,
+                  "rules": [
+                    {
+                      "name": "httpscalingrule",
+                      "http": {
+                        "metadata": {
+                          "concurrentRequests": "50"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "trafficWeight": 80
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsRevisions_ListRevisions",
+  "title": "List Container App's revisions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_List1.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_List1.json
@@ -1,0 +1,59 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcontainerApp0",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testcontainerApp0-pjxhsye",
+            "type": "Microsoft.App/containerApps/revisions",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/containerApps/testcontainerApp0/revisions/testcontainerApp0-pjxhsye",
+            "properties": {
+              "active": true,
+              "createdTime": "2021-05-24T21:24:22+00:00",
+              "fqdn": "testcontainerApp0-pjxhsye.politehill-ab123456.eastus.azurecontainerapps.io",
+              "lastActiveTime": "2021-05-24T21:24:22+00:00",
+              "replicas": 1,
+              "template": {
+                "containers": [
+                  {
+                    "name": "testcontainerApp0",
+                    "image": "repo/testcontainerApp0:v2",
+                    "resources": {
+                      "cpu": 0.2,
+                      "memory": "100Mi"
+                    }
+                  }
+                ],
+                "scale": {
+                  "maxReplicas": 5,
+                  "minReplicas": 1,
+                  "rules": [
+                    {
+                      "name": "httpscalingrule",
+                      "http": {
+                        "metadata": {
+                          "concurrentRequests": "50"
+                        }
+                      }
+                    }
+                  ]
+                }
+              },
+              "trafficWeight": 80
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsDiagnostics_ListRevisions",
+  "title": "List Container App's revisions"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_Restart.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Revisions_Restart.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testStaticSite0",
+    "resourceGroupName": "rg",
+    "revisionName": "testcontainerApp0-pjxhsye",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {}
+  },
+  "operationId": "ContainerAppsRevisions_RestartRevision",
+  "title": "Restart Container App's revision"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_Delete.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/locations/eastus/operationResults/amF3YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ContainerAppsSessionPools_Delete",
+  "title": "Delete Session Pool"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_FetchMcpServerCredentials.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_FetchMcpServerCredentials.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "apiKey": "dummyapikey"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_FetchMcpServerCredentials",
+  "title": "Fetch Session Pool MCP server credentials"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_Get.json
@@ -1,0 +1,113 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "managedIdentitySettings": [
+            {
+              "identity": "system",
+              "lifecycle": "Main"
+            }
+          ],
+          "nodeCount": 1,
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "Succeeded",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          },
+          "templateUpdateStatus": {
+            "activeTemplate": {
+              "containers": [
+                {
+                  "name": "testinitcontainer",
+                  "args": [
+                    "-c",
+                    "while true; do echo hello; sleep 10;done"
+                  ],
+                  "command": [
+                    "/bin/sh"
+                  ],
+                  "image": "repo/testcontainer:v4",
+                  "resources": {
+                    "cpu": 0.25,
+                    "memory": "0.5Gi"
+                  }
+                }
+              ],
+              "createdTime": "2025-10-02T00:00:00.000000Z",
+              "ingress": {
+                "targetPort": 80
+              },
+              "status": {
+                "allocatedCount": 0,
+                "crashCount": 0,
+                "expectedCount": 100,
+                "imagePullFailCount": 0,
+                "pendingCount": 0,
+                "readyCount": 100
+              },
+              "details": "Running"
+            }
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_Get",
+  "title": "Get Session Pool"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_Get_InProgress.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_Get_InProgress.json
@@ -1,0 +1,145 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v5",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "managedIdentitySettings": [
+            {
+              "identity": "system",
+              "lifecycle": "Main"
+            }
+          ],
+          "nodeCount": 1,
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "InProgress",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          },
+          "templateUpdateStatus": {
+            "activeTemplate": {
+              "containers": [
+                {
+                  "name": "testinitcontainer",
+                  "args": [
+                    "-c",
+                    "while true; do echo hello; sleep 10;done"
+                  ],
+                  "command": [
+                    "/bin/sh"
+                  ],
+                  "image": "repo/testcontainer:v4",
+                  "resources": {
+                    "cpu": 0.25,
+                    "memory": "0.5Gi"
+                  }
+                }
+              ],
+              "createdTime": "2025-10-02T00:00:00.000000Z",
+              "ingress": {
+                "targetPort": 80
+              },
+              "status": {
+                "allocatedCount": 0,
+                "crashCount": 0,
+                "expectedCount": 100,
+                "imagePullFailCount": 0,
+                "pendingCount": 0,
+                "readyCount": 100
+              },
+              "details": "Running"
+            },
+            "desiredTemplate": {
+              "containers": [
+                {
+                  "name": "testinitcontainer",
+                  "args": [
+                    "-c",
+                    "while true; do echo hello; sleep 10;done"
+                  ],
+                  "command": [
+                    "/bin/sh"
+                  ],
+                  "image": "repo/testcontainer:v5",
+                  "resources": {
+                    "cpu": 0.25,
+                    "memory": "0.5Gi"
+                  }
+                }
+              ],
+              "createdTime": "2025-10-02T05:00:00.000000Z",
+              "ingress": {
+                "targetPort": 80
+              },
+              "status": {
+                "allocatedCount": 0,
+                "crashCount": 0,
+                "expectedCount": 100,
+                "imagePullFailCount": 0,
+                "pendingCount": 0,
+                "readyCount": 0
+              },
+              "details": "Updating"
+            }
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_Get",
+  "title": "Get Session Pool during update"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_LifecycleOnContainerExit_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_LifecycleOnContainerExit_CreateOrUpdate.json
@@ -1,0 +1,195 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolEnvelope": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "East US",
+      "properties": {
+        "containerType": "CustomContainer",
+        "customContainerTemplate": {
+          "containers": [
+            {
+              "name": "testinitcontainer",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainer:v4",
+              "resources": {
+                "cpu": 0.25,
+                "memory": "0.5Gi"
+              }
+            }
+          ],
+          "ingress": {
+            "targetPort": 80
+          },
+          "registryCredentials": {
+            "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+            "server": "test.azurecr.io"
+          }
+        },
+        "dynamicPoolConfiguration": {
+          "lifecycleConfiguration": {
+            "lifecycleType": "OnContainerExit",
+            "maxAlivePeriodInSeconds": 86400
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "managedIdentitySettings": [
+          {
+            "identity": "system",
+            "lifecycle": "Main"
+          }
+        ],
+        "poolManagementType": "Dynamic",
+        "scaleConfiguration": {
+          "maxConcurrentSessions": 500,
+          "readySessionInstances": 100
+        },
+        "sessionNetworkConfiguration": {
+          "status": "EgressEnabled"
+        }
+      }
+    },
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "lifecycleType": "OnContainerExit",
+              "maxAlivePeriodInSeconds": 86400
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "nodeCount": 1,
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "Succeeded",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "lifecycleType": "OnContainerExit",
+              "maxAlivePeriodInSeconds": 86400
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "managedIdentitySettings": [
+            {
+              "identity": "system",
+              "lifecycle": "Main"
+            }
+          ],
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "InProgress",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_CreateOrUpdate",
+  "title": "Create or Update Session Pool with lifecycle OnContainerExit Timed"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_LifecycleTimed_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_LifecycleTimed_CreateOrUpdate.json
@@ -1,0 +1,195 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolEnvelope": {
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "location": "East US",
+      "properties": {
+        "containerType": "CustomContainer",
+        "customContainerTemplate": {
+          "containers": [
+            {
+              "name": "testinitcontainer",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainer:v4",
+              "resources": {
+                "cpu": 0.25,
+                "memory": "0.5Gi"
+              }
+            }
+          ],
+          "ingress": {
+            "targetPort": 80
+          },
+          "registryCredentials": {
+            "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+            "server": "test.azurecr.io"
+          }
+        },
+        "dynamicPoolConfiguration": {
+          "lifecycleConfiguration": {
+            "cooldownPeriodInSeconds": 600,
+            "lifecycleType": "Timed"
+          }
+        },
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+        "managedIdentitySettings": [
+          {
+            "identity": "system",
+            "lifecycle": "Main"
+          }
+        ],
+        "poolManagementType": "Dynamic",
+        "scaleConfiguration": {
+          "maxConcurrentSessions": 500,
+          "readySessionInstances": 100
+        },
+        "sessionNetworkConfiguration": {
+          "status": "EgressEnabled"
+        }
+      }
+    },
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "nodeCount": 1,
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "Succeeded",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "bce8c037-3d10-44a4-a970-25f799611fc6",
+          "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47"
+        },
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            },
+            "registryCredentials": {
+              "identity": "/subscriptions/7a497526-bb8d-4816-9795-db1418a1f977/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/testSP",
+              "server": "test.azurecr.io"
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "managedIdentitySettings": [
+            {
+              "identity": "system",
+              "lifecycle": "Main"
+            }
+          ],
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "InProgress",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_CreateOrUpdate",
+  "title": "Create or Update Session Pool with lifecycle type Timed"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_ListByResourceGroup.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_ListByResourceGroup.json
@@ -1,0 +1,102 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testsessionpool",
+            "type": "Microsoft.App/sessionPools",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+            "location": "East US",
+            "properties": {
+              "containerType": "CustomContainer",
+              "customContainerTemplate": {
+                "containers": [
+                  {
+                    "name": "testinitcontainer",
+                    "args": [
+                      "-c",
+                      "while true; do echo hello; sleep 10;done"
+                    ],
+                    "command": [
+                      "/bin/sh"
+                    ],
+                    "image": "repo/testcontainer:v4",
+                    "resources": {
+                      "cpu": 0.25,
+                      "memory": "0.5Gi"
+                    }
+                  }
+                ],
+                "ingress": {
+                  "targetPort": 80
+                }
+              },
+              "dynamicPoolConfiguration": {
+                "lifecycleConfiguration": {
+                  "cooldownPeriodInSeconds": 600,
+                  "lifecycleType": "Timed"
+                }
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "nodeCount": 1,
+              "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+              "poolManagementType": "Dynamic",
+              "provisioningState": "Succeeded",
+              "scaleConfiguration": {
+                "maxConcurrentSessions": 500,
+                "readySessionInstances": 100
+              },
+              "sessionNetworkConfiguration": {
+                "status": "EgressEnabled"
+              },
+              "templateUpdateStatus": {
+                "activeTemplate": {
+                  "containers": [
+                    {
+                      "name": "testinitcontainer",
+                      "args": [
+                        "-c",
+                        "while true; do echo hello; sleep 10;done"
+                      ],
+                      "command": [
+                        "/bin/sh"
+                      ],
+                      "image": "repo/testcontainer:v4",
+                      "resources": {
+                        "cpu": 0.25,
+                        "memory": "0.5Gi"
+                      }
+                    }
+                  ],
+                  "createdTime": "2025-10-02T00:00:00.000000Z",
+                  "ingress": {
+                    "targetPort": 80
+                  },
+                  "status": {
+                    "allocatedCount": 0,
+                    "crashCount": 0,
+                    "expectedCount": 100,
+                    "imagePullFailCount": 0,
+                    "pendingCount": 0,
+                    "readyCount": 100
+                  },
+                  "details": "Running"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_ListByResourceGroup",
+  "title": "List Session Pools by resource group"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_ListBySubscription.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_ListBySubscription.json
@@ -1,0 +1,101 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "testsessionpool",
+            "type": "Microsoft.App/sessionPools",
+            "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+            "location": "East US",
+            "properties": {
+              "containerType": "CustomContainer",
+              "customContainerTemplate": {
+                "containers": [
+                  {
+                    "name": "testinitcontainer",
+                    "args": [
+                      "-c",
+                      "while true; do echo hello; sleep 10;done"
+                    ],
+                    "command": [
+                      "/bin/sh"
+                    ],
+                    "image": "repo/testcontainer:v4",
+                    "resources": {
+                      "cpu": 0.25,
+                      "memory": "0.5Gi"
+                    }
+                  }
+                ],
+                "ingress": {
+                  "targetPort": 80
+                }
+              },
+              "dynamicPoolConfiguration": {
+                "lifecycleConfiguration": {
+                  "cooldownPeriodInSeconds": 600,
+                  "lifecycleType": "Timed"
+                }
+              },
+              "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+              "nodeCount": 1,
+              "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+              "poolManagementType": "Dynamic",
+              "provisioningState": "Succeeded",
+              "scaleConfiguration": {
+                "maxConcurrentSessions": 500,
+                "readySessionInstances": 100
+              },
+              "sessionNetworkConfiguration": {
+                "status": "EgressEnabled"
+              },
+              "templateUpdateStatus": {
+                "activeTemplate": {
+                  "containers": [
+                    {
+                      "name": "testinitcontainer",
+                      "args": [
+                        "-c",
+                        "while true; do echo hello; sleep 10;done"
+                      ],
+                      "command": [
+                        "/bin/sh"
+                      ],
+                      "image": "repo/testcontainer:v4",
+                      "resources": {
+                        "cpu": 0.25,
+                        "memory": "0.5Gi"
+                      }
+                    }
+                  ],
+                  "createdTime": "2025-10-02T00:00:00.000000Z",
+                  "ingress": {
+                    "targetPort": 80
+                  },
+                  "status": {
+                    "allocatedCount": 0,
+                    "crashCount": 0,
+                    "expectedCount": 100,
+                    "imagePullFailCount": 0,
+                    "pendingCount": 0,
+                    "readyCount": 100
+                  },
+                  "details": "Running"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_ListBySubscription",
+  "title": "List Session Pools by subscription"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_McpServer_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_McpServer_CreateOrUpdate.json
@@ -1,0 +1,99 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolEnvelope": {
+      "location": "East US",
+      "properties": {
+        "containerType": "Shell",
+        "dynamicPoolConfiguration": {
+          "lifecycleConfiguration": {
+            "cooldownPeriodInSeconds": 600,
+            "lifecycleType": "Timed"
+          }
+        },
+        "mcpServerSettings": {
+          "isMcpServerApiKeyDisabled": false,
+          "isMcpServerEnabled": true
+        },
+        "poolManagementType": "Dynamic",
+        "scaleConfiguration": {
+          "maxConcurrentSessions": 50
+        },
+        "sessionNetworkConfiguration": {
+          "status": "EgressEnabled"
+        }
+      }
+    },
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "location": "East US",
+        "properties": {
+          "containerType": "Shell",
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "mcpServerSettings": {
+            "isMcpServerApiKeyDisabled": false,
+            "isMcpServerEnabled": true,
+            "mcpServerEndpoint": "https://eastus.dynamicsessions.io/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/sessionPools/testsessionpool/mcp"
+          },
+          "poolManagementEndpoint": "https://eastus.dynamicsessions.io/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/sessionPools/testsessionpool",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "Succeeded",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 50
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "location": "East US",
+        "properties": {
+          "containerType": "Shell",
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "mcpServerSettings": {
+            "isMcpServerApiKeyDisabled": false,
+            "isMcpServerEnabled": true,
+            "mcpServerEndpoint": "https://eastus.dynamicsessions.io/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/sessionPools/testsessionpool/mcp"
+          },
+          "poolManagementEndpoint": "https://eastus.dynamicsessions.io/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/sessionPools/testsessionpool",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "InProgress",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 50
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_CreateOrUpdate",
+  "title": "Create or Update Session Pool with MCP server"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_Patch.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_Patch.json
@@ -1,0 +1,108 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolEnvelope": {
+      "properties": {
+        "customContainerTemplate": {
+          "containers": [
+            {
+              "name": "testinitcontainer",
+              "args": [
+                "-c",
+                "while true; do echo hello; sleep 10;done"
+              ],
+              "command": [
+                "/bin/sh"
+              ],
+              "image": "repo/testcontainer:v4",
+              "resources": {
+                "cpu": 0.25,
+                "memory": "0.5Gi"
+              }
+            }
+          ],
+          "ingress": {
+            "targetPort": 80
+          }
+        },
+        "dynamicPoolConfiguration": {
+          "lifecycleConfiguration": {
+            "cooldownPeriodInSeconds": 600,
+            "lifecycleType": "Timed"
+          }
+        },
+        "scaleConfiguration": {
+          "maxConcurrentSessions": 500,
+          "readySessionInstances": 100
+        },
+        "sessionNetworkConfiguration": {
+          "status": "EgressEnabled"
+        }
+      }
+    },
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "testsessionpool",
+        "type": "Microsoft.App/sessionPools",
+        "id": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/sessionPools/testsessionpool",
+        "location": "East US",
+        "properties": {
+          "containerType": "CustomContainer",
+          "customContainerTemplate": {
+            "containers": [
+              {
+                "name": "testinitcontainer",
+                "args": [
+                  "-c",
+                  "while true; do echo hello; sleep 10;done"
+                ],
+                "command": [
+                  "/bin/sh"
+                ],
+                "image": "repo/testcontainer:v4",
+                "resources": {
+                  "cpu": 0.25,
+                  "memory": "0.5Gi"
+                }
+              }
+            ],
+            "ingress": {
+              "targetPort": 80
+            }
+          },
+          "dynamicPoolConfiguration": {
+            "lifecycleConfiguration": {
+              "cooldownPeriodInSeconds": 600,
+              "lifecycleType": "Timed"
+            }
+          },
+          "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/rg/providers/Microsoft.App/managedEnvironments/demokube",
+          "nodeCount": 1,
+          "poolManagementEndpoint": "https://testsessionpool.agreeableriver-3d30edf1.eastus.azurecontainerapps.io",
+          "poolManagementType": "Dynamic",
+          "provisioningState": "Succeeded",
+          "scaleConfiguration": {
+            "maxConcurrentSessions": 500,
+            "readySessionInstances": 100
+          },
+          "sessionNetworkConfiguration": {
+            "status": "EgressEnabled"
+          }
+        }
+      },
+      "headers": {}
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/providers/Microsoft.App/locations/eastus/operationResults/amF3YUNvbXBvbmVudHM6OWFiZTM5OGUtY2ZjNi00NGZmLThmODQtNjRiOWJhMTUzZWYy?api-version=2026-03-02-preview"
+      }
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_Update",
+  "title": "Update Session Pool"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_RotateMcpServerCredentials.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SessionPools_RotateMcpServerCredentials.json
@@ -1,0 +1,18 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "resourceGroupName": "rg",
+    "sessionPoolName": "testsessionpool",
+    "subscriptionId": "34adfa4f-cedf-4dc0-ba29-b6d1a69ab345"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "apiKey": "dummyapikey"
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSessionPools_RotateMcpServerCredentials",
+  "title": "Rotate Session Pool MCP server credentials"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_CreateOrUpdate.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_CreateOrUpdate.json
@@ -1,0 +1,111 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "sourceControlEnvelope": {
+      "properties": {
+        "branch": "master",
+        "githubActionConfiguration": {
+          "azureCredentials": {
+            "clientId": "<clientid>",
+            "clientSecret": "<clientsecret>",
+            "kind": "feaderated",
+            "tenantId": "<tenantid>"
+          },
+          "buildEnvironmentVariables": [
+            {
+              "name": "foo1",
+              "value": "bar1"
+            },
+            {
+              "name": "foo2",
+              "value": "bar2"
+            }
+          ],
+          "contextPath": "./",
+          "dockerfilePath": "./Dockerfile",
+          "githubPersonalAccessToken": "test",
+          "image": "image/tag",
+          "registryInfo": {
+            "registryPassword": "<registrypassword>",
+            "registryUrl": "test-registry.azurecr.io",
+            "registryUserName": "test-registry"
+          }
+        },
+        "repoUrl": "https://github.com/xwang971/ghatest"
+      }
+    },
+    "sourceControlName": "current",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744",
+    "x-ms-github-auxiliary": "githubaccesstoken"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/sourcecontrols",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/sourcecontrols/current",
+        "properties": {
+          "branch": "master",
+          "githubActionConfiguration": {
+            "buildEnvironmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "contextPath": "./",
+            "image": "image/tag",
+            "registryInfo": {
+              "registryUrl": "test-registry.azurecr.io",
+              "registryUserName": "testreg"
+            }
+          },
+          "operationState": "InProgress",
+          "repoUrl": "https://github.com/xwang971/ghatest"
+        }
+      },
+      "headers": {}
+    },
+    "201": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/sourcecontrols",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/sourcecontrols/current",
+        "properties": {
+          "branch": "master",
+          "githubActionConfiguration": {
+            "buildEnvironmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "contextPath": "./",
+            "image": "image/tag",
+            "registryInfo": {
+              "registryUrl": "test-registry.azurecr.io",
+              "registryUserName": "test-registry"
+            }
+          },
+          "operationState": "InProgress",
+          "repoUrl": "https://github.com/xwang971/ghatest"
+        }
+      },
+      "headers": {
+        "location": "https://localhost/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/sourcecontrols/currentInOperationModel/operationresults/5a7f31af-8ae5-489b-a67e-f0a2d11df796?api-version=2021-03-01"
+      }
+    }
+  },
+  "operationId": "ContainerAppsSourceControls_CreateOrUpdate",
+  "title": "Create or Update Container App SourceControl"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_Delete.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_Delete.json
@@ -1,0 +1,23 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcanadacentral",
+    "deleteWorkflow": false,
+    "ignoreWorkflowDeletionFailure": false,
+    "resourceGroupName": "workerapps-rg-xj",
+    "sourceControlName": "current",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744",
+    "x-ms-github-auxiliary": "githubaccesstoken"
+  },
+  "responses": {
+    "200": {},
+    "202": {
+      "headers": {
+        "location": "https://localhost/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/myapp/sourcecontrols/currentInOperationModel/operationresults/14a787ee-c65f-462d-8a8b-897f69a2ab4f?api-version=2021-03-01"
+      }
+    },
+    "204": {}
+  },
+  "operationId": "ContainerAppsSourceControls_Delete",
+  "title": "Delete Container App SourceControl"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_Get.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_Get.json
@@ -1,0 +1,44 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "sourceControlName": "current",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "name": "current",
+        "type": "Microsoft.App/containerapps/sourcecontrols",
+        "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/testcanadacentral/sourcecontrols/current",
+        "properties": {
+          "branch": "master",
+          "githubActionConfiguration": {
+            "buildEnvironmentVariables": [
+              {
+                "name": "foo1",
+                "value": "bar1"
+              },
+              {
+                "name": "foo2",
+                "value": "bar2"
+              }
+            ],
+            "contextPath": "./",
+            "dockerfilePath": "./Dockerfile",
+            "image": "image/tag",
+            "registryInfo": {
+              "registryUrl": "xwang971reg.azurecr.io",
+              "registryUserName": "xwang971reg"
+            }
+          },
+          "repoUrl": "https://github.com/xwang971/ghatest"
+        }
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSourceControls_Get",
+  "title": "Get Container App's SourceControl"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_ListByContainer.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/SourceControls_ListByContainer.json
@@ -1,0 +1,48 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "containerAppName": "testcanadacentral",
+    "resourceGroupName": "workerapps-rg-xj",
+    "subscriptionId": "651f8027-33e8-4ec4-97b4-f6e9f3dc8744"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "nextLink": null,
+        "value": [
+          {
+            "name": "current",
+            "type": "Microsoft.App/containerapps/sourcecontrols",
+            "id": "/subscriptions/651f8027-33e8-4ec4-97b4-f6e9f3dc8744/resourceGroups/workerapps-rg-xj/providers/Microsoft.App/containerApps/testcanadacentral/sourcecontrols/current",
+            "properties": {
+              "branch": "master",
+              "githubActionConfiguration": {
+                "buildEnvironmentVariables": [
+                  {
+                    "name": "foo1",
+                    "value": "bar1"
+                  },
+                  {
+                    "name": "foo2",
+                    "value": "bar2"
+                  }
+                ],
+                "contextPath": "./",
+                "dockerfilePath": "./Dockerfile",
+                "image": "image/tag",
+                "registryInfo": {
+                  "registryUrl": "xwang971reg.azurecr.io",
+                  "registryUserName": "xwang971reg"
+                }
+              },
+              "repoUrl": "https://github.com/xwang971/ghatest"
+            }
+          }
+        ]
+      },
+      "headers": {}
+    }
+  },
+  "operationId": "ContainerAppsSourceControls_ListByContainerApp",
+  "title": "List App's Source Controls"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Subscriptions_GetCustomDomainVerificationId.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Subscriptions_GetCustomDomainVerificationId.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "subscriptionId": "d27c3573-f76e-4b26-b871-0ccd2203d08c"
+  },
+  "responses": {
+    "200": {
+      "body": "5B406D5E790BBD224468CE0AA814C396203C7CE755F135A80E35D41865E51967",
+      "headers": {}
+    }
+  },
+  "operationId": "GetCustomDomainVerificationId",
+  "title": "List all operations"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Usages_List.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/examples/Usages_List.json
@@ -1,0 +1,35 @@
+{
+  "parameters": {
+    "api-version": "2026-03-02-preview",
+    "location": "westus",
+    "subscriptionId": "00000000-0000-0000-0000-000000000000"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": {
+              "localizedValue": "ManagedEnvironmentCount",
+              "value": "ManagedEnvironmentCount"
+            },
+            "currentValue": 5,
+            "limit": 10,
+            "unit": "Count"
+          },
+          {
+            "name": {
+              "localizedValue": "ManagedEnvironmentCores",
+              "value": "ManagedEnvironmentCores"
+            },
+            "currentValue": 3,
+            "limit": 20,
+            "unit": "Count"
+          }
+        ]
+      }
+    }
+  },
+  "operationId": "Usages_List",
+  "title": "List usages"
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json
@@ -1,0 +1,22116 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "ContainerApps API Client",
+    "version": "2026-03-02-preview",
+    "description": "Functions is an extension resource to revisions and the api listed is used to proxy the call from Web RP to the function app's host process, this api is not exposed to users and only Web RP is allowed to invoke functions extension resource.",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Subscriptions"
+    },
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "ContainerAppsSessionPools"
+    },
+    {
+      "name": "ContainerAppsSourceControls"
+    },
+    {
+      "name": "ContainerApps"
+    },
+    {
+      "name": "ContainerAppsBuilds"
+    },
+    {
+      "name": "AzureFunctionsOnContainerApps"
+    },
+    {
+      "name": "ContainerAppsRevisions"
+    },
+    {
+      "name": "FunctionsExtension"
+    },
+    {
+      "name": "ContainerAppsLabelHistory"
+    },
+    {
+      "name": "ContainerAppsPatches"
+    },
+    {
+      "name": "ContainerAppsRevisionReplicas"
+    },
+    {
+      "name": "DotNetComponents"
+    },
+    {
+      "name": "JavaComponents"
+    },
+    {
+      "name": "LogicApps"
+    },
+    {
+      "name": "AppResiliency"
+    },
+    {
+      "name": "ContainerAppsAuthConfigs"
+    },
+    {
+      "name": "Builders"
+    },
+    {
+      "name": "Builds"
+    },
+    {
+      "name": "ConnectedEnvironments"
+    },
+    {
+      "name": "Certificates"
+    },
+    {
+      "name": "ManagedEnvironments"
+    },
+    {
+      "name": "PrivateLinkResources"
+    },
+    {
+      "name": "DaprComponents"
+    },
+    {
+      "name": "ConnectedEnvironmentsStorages"
+    },
+    {
+      "name": "ManagedCertificates"
+    },
+    {
+      "name": "PrivateEndpointConnections"
+    },
+    {
+      "name": "DaprComponentResiliencyPolicies"
+    },
+    {
+      "name": "DaprSubscriptions"
+    },
+    {
+      "name": "HttpRouteConfig"
+    },
+    {
+      "name": "MaintenanceConfigurations"
+    },
+    {
+      "name": "ManagedEnvironmentsStorages"
+    },
+    {
+      "name": "Jobs"
+    },
+    {
+      "name": "Diagnostics"
+    },
+    {
+      "name": "AvailableWorkloadProfiles"
+    },
+    {
+      "name": "AvailableEnvironmentModes"
+    },
+    {
+      "name": "BillingMeters"
+    },
+    {
+      "name": "Usages"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.App/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "Lists all of the available RP operations.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AvailableOperations"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all operations": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/builders": {
+      "get": {
+        "operationId": "Builders_ListBySubscription",
+        "tags": [
+          "Builders"
+        ],
+        "description": "List BuilderResource resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BuilderCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Builders_ListBySubscription_0": {
+            "$ref": "./examples/Builders_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/connectedEnvironments": {
+      "get": {
+        "operationId": "ConnectedEnvironments_ListBySubscription",
+        "tags": [
+          "ConnectedEnvironments"
+        ],
+        "summary": "Get all connectedEnvironments for a subscription.",
+        "description": "Get all connectedEnvironments for a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironmentCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List connected environments by subscription": {
+            "$ref": "./examples/ConnectedEnvironments_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/containerApps": {
+      "get": {
+        "operationId": "ContainerApps_ListBySubscription",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "Get the Container Apps in a given subscription.",
+        "description": "Get the Container Apps in a given subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container Apps by subscription": {
+            "$ref": "./examples/ContainerApps_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/getCustomDomainVerificationId": {
+      "post": {
+        "operationId": "GetCustomDomainVerificationId",
+        "tags": [
+          "Subscriptions"
+        ],
+        "description": "Get the verification id of a subscription used for verifying custom domains",
+        "produces": [
+          "text/plain",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/CustomDomainVerificationId"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List all operations": {
+            "$ref": "./examples/Subscriptions_GetCustomDomainVerificationId.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/jobs": {
+      "get": {
+        "operationId": "Jobs_ListBySubscription",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Get the Container Apps Jobs in a given subscription.",
+        "description": "Get the Container Apps Jobs in a given subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/JobsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container Apps Jobs by subscription": {
+            "$ref": "./examples/Jobs_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/locations/{location}/availableManagedEnvironmentsModes": {
+      "get": {
+        "operationId": "AvailableEnvironmentModes_List",
+        "tags": [
+          "AvailableEnvironmentModes"
+        ],
+        "summary": "Get available environment modes by location.",
+        "description": "Gets the environment modes available to a subscription in a location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AvailableEnvironmentModesCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AvailableEnvironmentModes_List": {
+            "$ref": "./examples/AvailableEnvironmentModes_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/locations/{location}/availableManagedEnvironmentsWorkloadProfileTypes": {
+      "get": {
+        "operationId": "AvailableWorkloadProfiles_Get",
+        "tags": [
+          "AvailableWorkloadProfiles"
+        ],
+        "summary": "Get available workload profiles by location.",
+        "description": "Get all available workload profiles for a location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/AvailableWorkloadProfilesCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "BillingMeters_Get": {
+            "$ref": "./examples/AvailableWorkloadProfiles_Get.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/locations/{location}/billingMeters": {
+      "get": {
+        "operationId": "BillingMeters_Get",
+        "tags": [
+          "BillingMeters"
+        ],
+        "summary": "Get billing meters by location.",
+        "description": "Get all billingMeters for a location.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/BillingMeterCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "BillingMeters_Get": {
+            "$ref": "./examples/BillingMeters_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/locations/{location}/usages": {
+      "get": {
+        "operationId": "Usages_List",
+        "tags": [
+          "Usages"
+        ],
+        "description": "Gets, for the specified location, the current resource usage information as well as the limits under the subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ListUsagesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List usages": {
+            "$ref": "./examples/Usages_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/managedEnvironments": {
+      "get": {
+        "operationId": "ManagedEnvironments_ListBySubscription",
+        "tags": [
+          "ManagedEnvironments"
+        ],
+        "summary": "Get all Environments for a subscription.",
+        "description": "Get all Managed Environments for a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironmentsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List environments by subscription": {
+            "$ref": "./examples/ManagedEnvironments_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.App/sessionPools": {
+      "get": {
+        "operationId": "ContainerAppsSessionPools_ListBySubscription",
+        "tags": [
+          "ContainerAppsSessionPools"
+        ],
+        "summary": "Get the session pools in a given subscription.",
+        "description": "Get the session pools in a given subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SessionPoolCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Session Pools by subscription": {
+            "$ref": "./examples/SessionPools_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/builders": {
+      "get": {
+        "operationId": "Builders_ListByResourceGroup",
+        "tags": [
+          "Builders"
+        ],
+        "description": "List BuilderResource resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BuilderCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Builders_ListByResourceGroup_0": {
+            "$ref": "./examples/Builders_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/builders/{builderName}": {
+      "get": {
+        "operationId": "Builders_Get",
+        "tags": [
+          "Builders"
+        ],
+        "description": "Get a BuilderResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "builderName",
+            "in": "path",
+            "description": "The name of the builder.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 32,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BuilderResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Builders_Get_0": {
+            "$ref": "./examples/Builders_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Builders_CreateOrUpdate",
+        "tags": [
+          "Builders"
+        ],
+        "description": "Create or update a BuilderResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "builderName",
+            "in": "path",
+            "description": "The name of the builder.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 32,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "builderEnvelope",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BuilderResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BuilderResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BuilderResource"
+            }
+          },
+          "201": {
+            "description": "Resource 'BuilderResource' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BuilderResource"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Builders_CreateOrUpdate_0": {
+            "$ref": "./examples/Builders_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/BuilderResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Builders_Update",
+        "tags": [
+          "Builders"
+        ],
+        "description": "Update a BuilderResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "builderName",
+            "in": "path",
+            "description": "The name of the builder.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 32,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "builderEnvelope",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BuilderResourceUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BuilderResource"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Builders_Update_0": {
+            "$ref": "./examples/Builders_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/BuilderResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Builders_Delete",
+        "tags": [
+          "Builders"
+        ],
+        "description": "Delete a BuilderResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "builderName",
+            "in": "path",
+            "description": "The name of the builder.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 32,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Builders_Delete_0": {
+            "$ref": "./examples/Builders_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/builders/{builderName}/builds": {
+      "get": {
+        "operationId": "BuildsByBuilderResource_List",
+        "tags": [
+          "Builds"
+        ],
+        "description": "List BuildResource resources by BuilderResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "builderName",
+            "in": "path",
+            "description": "The name of the builder.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 32,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BuildCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Builds_ListByBuilderResource_0": {
+            "$ref": "./examples/Builds_ListByBuilderResource.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/builders/{builderName}/builds/{buildName}": {
+      "get": {
+        "operationId": "Builds_Get",
+        "tags": [
+          "Builds"
+        ],
+        "description": "Get a BuildResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "builderName",
+            "in": "path",
+            "description": "The name of the builder.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 32,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "buildName",
+            "in": "path",
+            "description": "The name of a build.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BuildResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Builds_Get_0": {
+            "$ref": "./examples/Builds_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Builds_CreateOrUpdate",
+        "tags": [
+          "Builds"
+        ],
+        "description": "Create a BuildResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "builderName",
+            "in": "path",
+            "description": "The name of the builder.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 32,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "buildName",
+            "in": "path",
+            "description": "The name of a build.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "buildEnvelope",
+            "in": "body",
+            "description": "Resource create or update parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/BuildResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'BuildResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BuildResource"
+            }
+          },
+          "201": {
+            "description": "Resource 'BuildResource' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/BuildResource"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Builds_CreateOrUpdate_NoConfig": {
+            "$ref": "./examples/Builds_CreateOrUpdate_NoConfig.json"
+          },
+          "Builds_CreateOrUpdate_WithConfig": {
+            "$ref": "./examples/Builds_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/BuildResource"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Builds_Delete",
+        "tags": [
+          "Builds"
+        ],
+        "description": "Delete a BuildResource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "builderName",
+            "in": "path",
+            "description": "The name of the builder.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 32,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "buildName",
+            "in": "path",
+            "description": "The name of a build.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Builds_Delete_0": {
+            "$ref": "./examples/Builds_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/builders/{builderName}/builds/{buildName}/listAuthToken": {
+      "post": {
+        "operationId": "BuildAuthToken_List",
+        "tags": [
+          "Builds"
+        ],
+        "description": "Gets the token used to connect to the endpoint where source code can be uploaded for a build.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "builderName",
+            "in": "path",
+            "description": "The name of the builder.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 32,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "buildName",
+            "in": "path",
+            "description": "The name of a build.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/BuildToken"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Build Auth Token": {
+            "$ref": "./examples/Builds_ListAuthToken.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments": {
+      "get": {
+        "operationId": "ConnectedEnvironments_ListByResourceGroup",
+        "tags": [
+          "ConnectedEnvironments"
+        ],
+        "description": "Get all connectedEnvironments in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironmentCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List environments by resource group": {
+            "$ref": "./examples/ConnectedEnvironments_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}": {
+      "get": {
+        "operationId": "ConnectedEnvironments_Get",
+        "tags": [
+          "ConnectedEnvironments"
+        ],
+        "description": "Get the properties of an connectedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connectedEnvironment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get connected environment by connectedEnvironmentName": {
+            "$ref": "./examples/ConnectedEnvironments_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConnectedEnvironments_CreateOrUpdate",
+        "tags": [
+          "ConnectedEnvironments"
+        ],
+        "description": "Creates or updates an connectedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connectedEnvironment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "environmentEnvelope",
+            "in": "body",
+            "description": "Configuration details of the connectedEnvironment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectedEnvironment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironment"
+            }
+          },
+          "201": {
+            "description": "Resource 'ConnectedEnvironment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironment"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create kube environments": {
+            "$ref": "./examples/ConnectedEnvironments_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ConnectedEnvironment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ConnectedEnvironments_Update",
+        "tags": [
+          "ConnectedEnvironments"
+        ],
+        "summary": "Update connected Environment's properties.",
+        "description": "Patches a Managed Environment. Only patching of tags is supported currently",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connectedEnvironment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "environmentEnvelope",
+            "in": "body",
+            "description": "Configuration details of the connectedEnvironment.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironmentPatchResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Managed Environment": {
+            "$ref": "./examples/ConnectedEnvironments_Patch.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ConnectedEnvironments_Delete",
+        "tags": [
+          "ConnectedEnvironments"
+        ],
+        "summary": "Delete an connectedEnvironment.",
+        "description": "Delete an connectedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connectedEnvironment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete connected environment by connectedEnvironmentName": {
+            "$ref": "./examples/ConnectedEnvironments_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/certificates": {
+      "get": {
+        "operationId": "ConnectedEnvironmentsCertificates_List",
+        "tags": [
+          "Certificates",
+          "ConnectedEnvironments"
+        ],
+        "summary": "Get the Certificates in a given connected environment.",
+        "description": "Get the Certificates in a given connected environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the Connected Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CertificateCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Certificates by Connected Environment": {
+            "$ref": "./examples/ConnectedEnvironmentsCertificates_ListByConnectedEnvironment.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/certificates/{certificateName}": {
+      "get": {
+        "operationId": "ConnectedEnvironmentsCertificates_Get",
+        "tags": [
+          "Certificates",
+          "ConnectedEnvironments"
+        ],
+        "summary": "Get the specified Certificate.",
+        "description": "Get the specified Certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the Connected Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the Certificate.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Certificate": {
+            "$ref": "./examples/ConnectedEnvironmentsCertificate_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConnectedEnvironmentsCertificates_CreateOrUpdate",
+        "tags": [
+          "Certificates",
+          "ConnectedEnvironments"
+        ],
+        "summary": "Create or Update a Certificate.",
+        "description": "Create or Update a Certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the Connected Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the Certificate.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateEnvelope",
+            "in": "body",
+            "description": "Certificate to be created or updated",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Certificate' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          },
+          "201": {
+            "description": "Resource 'Certificate' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Certificate": {
+            "$ref": "./examples/ConnectedEnvironmentsCertificate_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Certificate"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ConnectedEnvironmentsCertificates_Update",
+        "tags": [
+          "Certificates",
+          "ConnectedEnvironments"
+        ],
+        "summary": "Update properties of a certificate",
+        "description": "Patches a certificate. Currently only patching of tags is supported",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the Connected Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the Certificate.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateEnvelope",
+            "in": "body",
+            "description": "Properties of a certificate that need to be updated",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CertificatePatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Certificate": {
+            "$ref": "./examples/ConnectedEnvironmentsCertificates_Patch.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Certificate"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ConnectedEnvironmentsCertificates_Delete",
+        "tags": [
+          "Certificates",
+          "ConnectedEnvironments"
+        ],
+        "summary": "Deletes the specified Certificate.",
+        "description": "Deletes the specified Certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the Connected Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the Certificate.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Certificate": {
+            "$ref": "./examples/ConnectedEnvironmentsCertificate_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/checkNameAvailability": {
+      "post": {
+        "operationId": "ConnectedEnvironments_CheckNameAvailability",
+        "tags": [
+          "ConnectedEnvironments"
+        ],
+        "summary": "Checks the resource connectedEnvironmentName availability.",
+        "description": "Checks if resource connectedEnvironmentName is available.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connectedEnvironment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "checkNameAvailabilityRequest",
+            "in": "body",
+            "description": "The check connectedEnvironmentName availability request.",
+            "required": true,
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/CheckNameAvailabilityRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/CheckNameAvailabilityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Certificates_CheckNameAvailability": {
+            "$ref": "./examples/ConnectedEnvironmentsCertificates_CheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/daprComponents": {
+      "get": {
+        "operationId": "ConnectedEnvironmentsDaprComponents_List",
+        "tags": [
+          "DaprComponents"
+        ],
+        "summary": "Get the Dapr Components for a connected environment.",
+        "description": "Get the Dapr Components for a connected environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connected environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DaprComponentsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Dapr Components": {
+            "$ref": "./examples/ConnectedEnvironmentsDaprComponents_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/daprComponents/{componentName}": {
+      "get": {
+        "operationId": "ConnectedEnvironmentsDaprComponents_Get",
+        "tags": [
+          "DaprComponents"
+        ],
+        "summary": "Get a dapr component.",
+        "description": "Get a dapr component.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connected environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DaprComponent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Dapr Component": {
+            "$ref": "./examples/ConnectedEnvironmentsDaprComponents_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConnectedEnvironmentsDaprComponents_CreateOrUpdate",
+        "tags": [
+          "DaprComponents"
+        ],
+        "summary": "Creates or updates a Dapr Component.",
+        "description": "Creates or updates a Dapr Component in a connected environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connectedEnvironment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "daprComponentEnvelope",
+            "in": "body",
+            "description": "Configuration details of the Dapr Component.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DaprComponent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DaprComponent' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DaprComponent"
+            }
+          },
+          "201": {
+            "description": "Resource 'DaprComponent' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DaprComponent"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update dapr component": {
+            "$ref": "./examples/ConnectedEnvironmentsDaprComponents_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/DaprComponent"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ConnectedEnvironmentsDaprComponents_Delete",
+        "tags": [
+          "DaprComponents"
+        ],
+        "summary": "Delete a Dapr Component.",
+        "description": "Delete a Dapr Component from a connected environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connected environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete dapr component": {
+            "$ref": "./examples/ConnectedEnvironmentsDaprComponents_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/daprComponents/{componentName}/listSecrets": {
+      "post": {
+        "operationId": "ConnectedEnvironmentsDaprComponents_ListSecrets",
+        "tags": [
+          "DaprComponents"
+        ],
+        "summary": "List secrets for a dapr component",
+        "description": "List secrets for a dapr component",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connected environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DaprSecretsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container Apps Secrets": {
+            "$ref": "./examples/ConnectedEnvironmentsDaprComponents_ListSecrets.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/storages": {
+      "get": {
+        "operationId": "ConnectedEnvironmentsStorages_List",
+        "tags": [
+          "ConnectedEnvironmentsStorages"
+        ],
+        "summary": "Get all storages for a connectedEnvironment.",
+        "description": "Get all storages for a connectedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connectedEnvironment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironmentStoragesCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List environments storages by subscription": {
+            "$ref": "./examples/ConnectedEnvironmentsStorages_List.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/connectedEnvironments/{connectedEnvironmentName}/storages/{storageName}": {
+      "get": {
+        "operationId": "ConnectedEnvironmentsStorages_Get",
+        "tags": [
+          "ConnectedEnvironmentsStorages"
+        ],
+        "summary": "Get storage for a connectedEnvironment.",
+        "description": "Get storage for a connectedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connectedEnvironment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "storageName",
+            "in": "path",
+            "description": "Name of the storage.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironmentStorage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "get a environments storage properties by subscription": {
+            "$ref": "./examples/ConnectedEnvironmentsStorages_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ConnectedEnvironmentsStorages_CreateOrUpdate",
+        "tags": [
+          "ConnectedEnvironmentsStorages"
+        ],
+        "summary": "Create or update storage for a connectedEnvironment.",
+        "description": "Create or update storage for a connectedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connectedEnvironment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "storageName",
+            "in": "path",
+            "description": "Name of the storage.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "storageEnvelope",
+            "in": "body",
+            "description": "Configuration details of storage.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironmentStorage"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ConnectedEnvironmentStorage' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironmentStorage"
+            }
+          },
+          "201": {
+            "description": "Resource 'ConnectedEnvironmentStorage' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ConnectedEnvironmentStorage"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update environments storage": {
+            "$ref": "./examples/ConnectedEnvironmentsStorages_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ConnectedEnvironmentStorage"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ConnectedEnvironmentsStorages_Delete",
+        "tags": [
+          "ConnectedEnvironmentsStorages"
+        ],
+        "summary": "Delete storage for a connectedEnvironment.",
+        "description": "Delete storage for a connectedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "connectedEnvironmentName",
+            "in": "path",
+            "description": "Name of the connectedEnvironment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "storageName",
+            "in": "path",
+            "description": "Name of the storage.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List environments storages by subscription": {
+            "$ref": "./examples/ConnectedEnvironmentsStorages_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps": {
+      "get": {
+        "operationId": "ContainerApps_ListByResourceGroup",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "Get the Container Apps in a given resource group.",
+        "description": "Get the Container Apps in a given resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container Apps by resource group": {
+            "$ref": "./examples/ContainerApps_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}": {
+      "get": {
+        "operationId": "ContainerApps_Get",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "Get the properties of a Container App.",
+        "description": "Get the properties of a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerApp"
+            }
+          },
+          "404": {
+            "description": "The server cannot find the requested resource.",
+            "x-ms-error-response": true
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App": {
+            "$ref": "./examples/ContainerApps_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ContainerApps_CreateOrUpdate",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "Create or update a Container App.",
+        "description": "Create or update a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerAppEnvelope",
+            "in": "body",
+            "description": "Properties used to create a container app",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContainerApp"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ContainerApp' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContainerApp"
+            }
+          },
+          "201": {
+            "description": "Resource 'ContainerApp' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ContainerApp"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update App On A Connected Environment": {
+            "$ref": "./examples/ContainerApps_CreateOrUpdate_ConnectedEnvironment.json"
+          },
+          "Create or Update Container App": {
+            "$ref": "./examples/ContainerApps_CreateOrUpdate.json"
+          },
+          "Create or Update FunctionApp Kind": {
+            "$ref": "./examples/ContainerApps_Kind_FunctionApp_CreateOrUpdate.json"
+          },
+          "Create or Update ManagedBy App": {
+            "$ref": "./examples/ContainerApps_ManagedBy_CreateOrUpdate.json"
+          },
+          "Create or Update SourceToCloud App": {
+            "$ref": "./examples/ContainerApps_SourceToCloudApp_CreateOrUpdate.json"
+          },
+          "Create or Update Tcp App": {
+            "$ref": "./examples/ContainerApps_TcpApp_CreateOrUpdate.json"
+          },
+          "Create or Update WorkflowApp Kind": {
+            "$ref": "./examples/ContainerApps_Kind_WorkflowApp_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ContainerApp"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ContainerApps_Update",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "Update properties of a Container App",
+        "description": "Patches a Container App using JSON Merge Patch",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "containerAppEnvelope",
+            "in": "body",
+            "description": "Properties of a Container App that need to be updated",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ContainerApp"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerApp"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Container App": {
+            "$ref": "./examples/ContainerApps_Patch.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ContainerApp"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ContainerApps_Delete",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "Delete a Container App.",
+        "description": "Delete a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Container App": {
+            "$ref": "./examples/ContainerApps_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/authConfigs": {
+      "get": {
+        "operationId": "ContainerAppsAuthConfigs_ListByContainerApp",
+        "tags": [
+          "ContainerAppsAuthConfigs"
+        ],
+        "summary": "Get the Container App AuthConfigs in a given resource group.",
+        "description": "Get the Container App AuthConfigs in a given resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthConfigCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Auth Configs by Container Apps": {
+            "$ref": "./examples/AuthConfigs_ListByContainer.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/authConfigs/{authConfigName}": {
+      "get": {
+        "operationId": "ContainerAppsAuthConfigs_Get",
+        "tags": [
+          "ContainerAppsAuthConfigs"
+        ],
+        "summary": "Get a AuthConfig of a Container App.",
+        "description": "Get a AuthConfig of a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authConfigName",
+            "in": "path",
+            "description": "Name of the Container App AuthConfig.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthConfig"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App's AuthConfig": {
+            "$ref": "./examples/AuthConfigs_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ContainerAppsAuthConfigs_CreateOrUpdate",
+        "tags": [
+          "ContainerAppsAuthConfigs"
+        ],
+        "summary": "Create or update the AuthConfig for a Container App.",
+        "description": "Create or update the AuthConfig for a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authConfigName",
+            "in": "path",
+            "description": "Name of the Container App AuthConfig.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authConfigEnvelope",
+            "in": "body",
+            "description": "Properties used to create a Container App AuthConfig",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AuthConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AuthConfig' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AuthConfig"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Container App AuthConfig": {
+            "$ref": "./examples/AuthConfigs_CreateOrUpdate.json"
+          },
+          "Create or Update Container App AuthConfig with msi clientID blob storage token store": {
+            "$ref": "./examples/AuthConfigs_BlobStorageTokenStore_ClientId_CreateOrUpdate.json"
+          },
+          "Create or Update Container App AuthConfig with msi managedIdentityResourceId blob storage token store": {
+            "$ref": "./examples/AuthConfigs_BlobStorageTokenStore_CreateOrUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ContainerAppsAuthConfigs_Delete",
+        "tags": [
+          "ContainerAppsAuthConfigs"
+        ],
+        "summary": "Delete a Container App AuthConfig.",
+        "description": "Delete a Container App AuthConfig.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "authConfigName",
+            "in": "path",
+            "description": "Name of the Container App AuthConfig.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Container App AuthConfig": {
+            "$ref": "./examples/AuthConfigs_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/builds": {
+      "get": {
+        "operationId": "ContainerAppsBuildsByContainerApp_List",
+        "tags": [
+          "ContainerAppsBuilds"
+        ],
+        "description": "List Container Apps Build resources by Container App",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppsBuildCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ContainerAppsBuilds_ListByContainerApp_0": {
+            "$ref": "./examples/ContainerAppsBuilds_ListByContainerApp.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/builds/{buildName}": {
+      "get": {
+        "operationId": "ContainerAppsBuilds_Get",
+        "tags": [
+          "ContainerAppsBuilds"
+        ],
+        "description": "Get a Container Apps Build resource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "buildName",
+            "in": "path",
+            "description": "Name of the build.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppsBuildResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ContainerAppsBuilds_Get_0": {
+            "$ref": "./examples/ContainerAppsBuilds_Get.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ContainerAppsBuilds_Delete",
+        "tags": [
+          "ContainerAppsBuilds"
+        ],
+        "description": "Delete a Container Apps Build resource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "buildName",
+            "in": "path",
+            "description": "Name of the build.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ContainerAppsBuilds_Delete_0": {
+            "$ref": "./examples/ContainerAppsBuilds_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/detectorProperties/revisionsApi/revisions/{revisionName}": {
+      "get": {
+        "operationId": "ContainerAppsDiagnostics_GetRevision",
+        "tags": [
+          "ContainerApps",
+          "Diagnostics"
+        ],
+        "summary": "Get a revision of a Container App.",
+        "description": "Get a revision of a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "revisionName",
+            "in": "path",
+            "description": "Name of the detector.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Revision"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App's revision": {
+            "$ref": "./examples/Revisions_Get1.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/detectorProperties/revisionsApi/revisions/": {
+      "get": {
+        "operationId": "ContainerAppsDiagnostics_ListRevisions",
+        "tags": [
+          "ContainerApps",
+          "Diagnostics"
+        ],
+        "summary": "Get the Revisions for a given Container App.",
+        "description": "A synchronous resource action.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RevisionCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container App's revisions": {
+            "$ref": "./examples/Revisions_List1.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/detectorProperties/rootApi/": {
+      "get": {
+        "operationId": "ContainerAppsDiagnostics_GetRoot",
+        "tags": [
+          "ContainerApps",
+          "Diagnostics"
+        ],
+        "summary": "Get the properties of a Container App.",
+        "description": "Get the properties of a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerApp"
+            }
+          },
+          "404": {
+            "description": "The server cannot find the requested resource.",
+            "x-ms-error-response": true
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App": {
+            "$ref": "./examples/ContainerApps_Get1.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/detectors": {
+      "get": {
+        "operationId": "ContainerAppsDiagnostics_ListDetectors",
+        "tags": [
+          "ContainerApps",
+          "Diagnostics"
+        ],
+        "summary": "Get the list of diagnostics for a given Container App.",
+        "description": "Get the list of diagnostics for a given Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DiagnosticsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get the list of available diagnostics for a given Container App": {
+            "$ref": "./examples/ContainerAppsDiagnostics_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/detectors/{detectorName}": {
+      "get": {
+        "operationId": "ContainerAppsDiagnostics_GetDetector",
+        "tags": [
+          "ContainerApps",
+          "Diagnostics"
+        ],
+        "summary": "Get a diagnostics result of a Container App.",
+        "description": "Get a diagnostics result of a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "detectorName",
+            "in": "path",
+            "description": "Name of the detector.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Diagnostics"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App's diagnostics info": {
+            "$ref": "./examples/ContainerAppsDiagnostics_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/functions": {
+      "get": {
+        "operationId": "ContainerAppsFunctions_List",
+        "tags": [
+          "AzureFunctionsOnContainerApps"
+        ],
+        "summary": "List the functions for a given Container App from the latest Revision.",
+        "description": "List the functions for a given Container App from the latest Revision.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppsFunctionCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container App's functions": {
+            "$ref": "./examples/ContainerAppsFunctions_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/functions/{functionName}": {
+      "get": {
+        "operationId": "ContainerAppsFunctions_Get",
+        "tags": [
+          "AzureFunctionsOnContainerApps"
+        ],
+        "summary": "Get a specific function of a Container App from the latest Revision.",
+        "description": "Get a specific function of a Container App from the latest Revision.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "functionName",
+            "in": "path",
+            "description": "Name of the Function.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppsFunction"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App's function": {
+            "$ref": "./examples/ContainerAppsFunctions_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/getAuthtoken": {
+      "post": {
+        "operationId": "ContainerApps_GetAuthToken",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "Get auth token for a container app",
+        "description": "Get auth token for a container app",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppAuthToken"
+            }
+          },
+          "404": {
+            "description": "The server cannot find the requested resource.",
+            "x-ms-error-response": true
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App Auth Token": {
+            "$ref": "./examples/ContainerApps_GetAuthToken.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/labelHistory": {
+      "get": {
+        "operationId": "ContainerAppsLabelHistory_ListLabelHistory",
+        "tags": [
+          "ContainerAppsLabelHistory"
+        ],
+        "summary": "Get the Label History for a given Container App.",
+        "description": "Get the Label History for a given Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LabelHistoryCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container App's all label history": {
+            "$ref": "./examples/LabelHistory_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/labelHistory/{labelName}": {
+      "get": {
+        "operationId": "ContainerAppsLabelHistory_GetLabelHistory",
+        "tags": [
+          "ContainerAppsLabelHistory"
+        ],
+        "summary": "Get the history of a label.",
+        "description": "Get the history of a label.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "labelName",
+            "in": "path",
+            "description": "Name of the label.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LabelHistory"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App's single label history": {
+            "$ref": "./examples/LabelHistory_Get.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ContainerAppsLabelHistory_DeleteLabelHistory",
+        "tags": [
+          "ContainerAppsLabelHistory"
+        ],
+        "summary": "Delete the history of a label.",
+        "description": "Delete the history of a label.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "labelName",
+            "in": "path",
+            "description": "Name of the label.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Container App's label history for a given label": {
+            "$ref": "./examples/LabelHistory_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/listCustomHostNameAnalysis": {
+      "post": {
+        "operationId": "ContainerApps_ListCustomHostNameAnalysis",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "Analyzes a custom hostname for a Container App",
+        "description": "Analyzes a custom hostname for a Container App",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "customHostname",
+            "in": "query",
+            "description": "Custom hostname.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CustomHostnameAnalysisResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Analyze Custom Hostname": {
+            "$ref": "./examples/ContainerApps_ListCustomHostNameAnalysis.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/listSecrets": {
+      "post": {
+        "operationId": "ContainerApps_ListSecrets",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "List secrets for a container app",
+        "description": "List secrets for a container app",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SecretsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container Apps Secrets": {
+            "$ref": "./examples/ContainerApps_ListSecrets.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/patches": {
+      "get": {
+        "operationId": "ContainerAppsPatches_ListByContainerApp",
+        "tags": [
+          "ContainerAppsPatches"
+        ],
+        "description": "List Container Apps Patch resources by ContainerApp.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation. For example, $filter=properties/patchApplyStatus eq 'Succeeded'",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PatchCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ContainerAppsPatches_ListByContainerApp_0": {
+            "$ref": "./examples/ContainerAppsPatches_ListByContainerApp.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/patches/{patchName}": {
+      "get": {
+        "operationId": "ContainerAppsPatches_Get",
+        "tags": [
+          "ContainerAppsPatches"
+        ],
+        "description": "Get details for specific Container Apps Patch by patch name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "patchName",
+            "in": "path",
+            "description": "Name of the Container Apps Patch.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppsPatchResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ContainerAppsPatches_Get_0": {
+            "$ref": "./examples/ContainerAppsPatches_Get.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ContainerAppsPatches_Delete",
+        "tags": [
+          "ContainerAppsPatches"
+        ],
+        "description": "Delete specific Container Apps Patch by patch name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "patchName",
+            "in": "path",
+            "description": "Name of the Container Apps Patch.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ContainerAppsPatches_Delete_0": {
+            "$ref": "./examples/ContainerAppsPatches_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/patches/{patchName}/apply": {
+      "post": {
+        "operationId": "ContainerAppsPatches_Apply",
+        "tags": [
+          "ContainerAppsPatches"
+        ],
+        "description": "Apply a Container Apps Patch resource with patch name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "patchName",
+            "in": "path",
+            "description": "Name of the Container Apps Patch.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppsPatchResource"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ContainerAppsPatches_Apply_0": {
+            "$ref": "./examples/ContainerAppsPatches_Apply.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ContainerAppsPatchResource"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/patches/{patchName}/skipConfig": {
+      "post": {
+        "operationId": "ContainerAppsPatches_SkipConfigure",
+        "tags": [
+          "ContainerAppsPatches"
+        ],
+        "description": "Configure the Container Apps Patch skip option by patch name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "patchName",
+            "in": "path",
+            "description": "Name of the Container Apps Patch.",
+            "required": true,
+            "type": "string",
+            "minLength": 2,
+            "maxLength": 64,
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "patchSkipConfig",
+            "in": "body",
+            "description": "Configure patcher to skip a patch or not.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PatchSkipConfig"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Updating patch skipping detail. Updating status tracked by location header.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ContainerAppsPatches_Skip_Configure_0": {
+            "$ref": "./examples/ContainerAppsPatches_Skip_Configure.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/providers/Microsoft.App/logicApps/{logicAppName}": {
+      "get": {
+        "operationId": "LogicApps_Get",
+        "tags": [
+          "LogicApps"
+        ],
+        "summary": "Gets a logic app extension resource.",
+        "description": "Gets a logic app extension resource.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "logicAppName",
+            "in": "path",
+            "description": "Name of the Logic App, the extension resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/LogicApp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get logic app extension by name ": {
+            "$ref": "./examples/LogicApps_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "LogicApps_CreateOrUpdate",
+        "tags": [
+          "LogicApps"
+        ],
+        "description": "Create or update a Logic App extension resource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "logicAppName",
+            "in": "path",
+            "description": "Name of the Logic App, the extension resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Logic app resource properties.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/LogicApp"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'LogicApp' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LogicApp"
+            }
+          },
+          "201": {
+            "description": "Resource 'LogicApp' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/LogicApp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create logic app extension": {
+            "$ref": "./examples/LogicApps_Create.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "LogicApps_Delete",
+        "tags": [
+          "LogicApps"
+        ],
+        "description": "Deletes a Logic App extension resource",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "logicAppName",
+            "in": "path",
+            "description": "Name of the Logic App, the extension resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create logic app extension": {
+            "$ref": "./examples/LogicApps_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/providers/Microsoft.App/logicApps/{logicAppName}/deployWorkflowArtifacts": {
+      "post": {
+        "operationId": "LogicApps_DeployWorkflowArtifacts",
+        "tags": [
+          "LogicApps"
+        ],
+        "description": "Creates or updates the artifacts for the logic app",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "logicAppName",
+            "in": "path",
+            "description": "Name of the Logic App, the extension resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "workflowArtifacts",
+            "in": "body",
+            "description": "Application settings and files of the workflow.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/WorkflowArtifacts"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete workflow artifacts": {
+            "$ref": "./examples/LogicApps_DeleteDeployWorkflowArtifacts.json"
+          },
+          "Deploys workflow artifacts": {
+            "$ref": "./examples/LogicApps_PostDeployWorkflowArtifacts.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/providers/Microsoft.App/logicApps/{logicAppName}/invoke": {
+      "post": {
+        "operationId": "LogicApps_Invoke",
+        "tags": [
+          "LogicApps"
+        ],
+        "summary": "Proxies a the API call to the logic app backed by the container app.",
+        "description": "Proxies a the API call to the logic app backed by the container app.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "logicAppName",
+            "in": "path",
+            "description": "Name of the Logic App, the extension resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "x-ms-logicApps-proxy-path",
+            "in": "header",
+            "description": "The proxy path for the API call",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-logicApps-proxy-method",
+            "in": "header",
+            "description": "The proxy method for the API call",
+            "required": true,
+            "type": "string",
+            "enum": [
+              "GET",
+              "POST"
+            ],
+            "x-ms-enum": {
+              "name": "LogicAppsProxyMethod",
+              "modelAsString": true,
+              "values": [
+                {
+                  "name": "GET",
+                  "value": "GET",
+                  "description": "GET"
+                },
+                {
+                  "name": "POST",
+                  "value": "POST",
+                  "description": "POST"
+                }
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Object"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get workflow list call back URL": {
+            "$ref": "./examples/LogicApps_ListCallbackURL.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/providers/Microsoft.App/logicApps/{logicAppName}/listWorkflowsConnections": {
+      "post": {
+        "operationId": "LogicApps_ListWorkflowsConnections",
+        "tags": [
+          "LogicApps"
+        ],
+        "summary": "Gets logic app's connections.",
+        "description": "Gets logic app's connections.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "logicAppName",
+            "in": "path",
+            "description": "Name of the Logic App, the extension resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowEnvelope"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List the Workflows Configuration Connections": {
+            "$ref": "./examples/LogicApps_ListConnections.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/providers/Microsoft.App/logicApps/{logicAppName}/workflows": {
+      "get": {
+        "operationId": "LogicApps_ListWorkflows",
+        "tags": [
+          "LogicApps"
+        ],
+        "summary": "List the workflows for a logic app.",
+        "description": "List the workflows for a logic app.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "logicAppName",
+            "in": "path",
+            "description": "Name of the Logic App, the extension resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowEnvelopeCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List the workflows": {
+            "$ref": "./examples/LogicApps_ListWorkflows.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/providers/Microsoft.App/logicApps/{logicAppName}/workflows/{workflowName}": {
+      "get": {
+        "operationId": "LogicApps_GetWorkflow",
+        "tags": [
+          "LogicApps"
+        ],
+        "summary": "Get workflow information by its name",
+        "description": "Get workflow information by its name",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "logicAppName",
+            "in": "path",
+            "description": "Name of the Logic App, the extension resource.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "workflowName",
+            "in": "path",
+            "description": "Workflow name.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/WorkflowEnvelope"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "GET a workflow": {
+            "$ref": "./examples/LogicApps_GetWorkflow.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{appName}/resiliencyPolicies": {
+      "get": {
+        "operationId": "AppResiliency_List",
+        "tags": [
+          "AppResiliency"
+        ],
+        "summary": "List an application's resiliency policies.",
+        "description": "List container app resiliency policies.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AppResiliencyCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List App Resiliency": {
+            "$ref": "./examples/AppResiliency_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{appName}/resiliencyPolicies/{name}": {
+      "get": {
+        "operationId": "AppResiliency_Get",
+        "tags": [
+          "AppResiliency"
+        ],
+        "summary": "Get an application's resiliency policy.",
+        "description": "Get container app resiliency policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the resiliency policy.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AppResiliency"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get App Resiliency": {
+            "$ref": "./examples/AppResiliency_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AppResiliency_CreateOrUpdate",
+        "tags": [
+          "AppResiliency"
+        ],
+        "summary": "Create or update an application's resiliency policy.",
+        "description": "Create or update container app resiliency policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the resiliency policy.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "resiliencyEnvelope",
+            "in": "body",
+            "description": "The resiliency policy to create or update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AppResiliency"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AppResiliency' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AppResiliency"
+            }
+          },
+          "201": {
+            "description": "Resource 'AppResiliency' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AppResiliency"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update App Resiliency": {
+            "$ref": "./examples/AppResiliency_CreateOrUpdate.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "AppResiliency_Update",
+        "tags": [
+          "AppResiliency"
+        ],
+        "summary": "Update an application's resiliency policy.",
+        "description": "Update container app resiliency policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the resiliency policy.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "resiliencyEnvelope",
+            "in": "body",
+            "description": "The resiliency policy to update.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AppResiliency"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AppResiliency"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update App Resiliency": {
+            "$ref": "./examples/AppResiliency_Patch.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "AppResiliency_Delete",
+        "tags": [
+          "AppResiliency"
+        ],
+        "summary": "Delete an application's resiliency policy.",
+        "description": "Delete container app resiliency policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "appName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the resiliency policy.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete App Resiliency": {
+            "$ref": "./examples/AppResiliency_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions": {
+      "get": {
+        "operationId": "ContainerAppsRevisions_ListRevisions",
+        "tags": [
+          "ContainerAppsRevisions"
+        ],
+        "summary": "Get the Revisions for a given Container App.",
+        "description": "Get the Revisions for a given Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RevisionCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container App's revisions": {
+            "$ref": "./examples/Revisions_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions/{revisionName}": {
+      "get": {
+        "operationId": "ContainerAppsRevisions_GetRevision",
+        "tags": [
+          "ContainerAppsRevisions"
+        ],
+        "summary": "Get a revision of a Container App.",
+        "description": "Get a revision of a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "revisionName",
+            "in": "path",
+            "description": "Name of the Container App Revision.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Revision"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App's revision": {
+            "$ref": "./examples/Revisions_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions/{revisionName}/activate": {
+      "post": {
+        "operationId": "ContainerAppsRevisions_ActivateRevision",
+        "tags": [
+          "ContainerAppsRevisions"
+        ],
+        "summary": "Activates a revision for a Container App",
+        "description": "Activates a revision for a Container App",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "revisionName",
+            "in": "path",
+            "description": "Name of the Container App Revision.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Activate Container App's revision": {
+            "$ref": "./examples/Revisions_Activate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions/{revisionName}/deactivate": {
+      "post": {
+        "operationId": "ContainerAppsRevisions_DeactivateRevision",
+        "tags": [
+          "ContainerAppsRevisions"
+        ],
+        "summary": "Deactivates a revision for a Container App",
+        "description": "Deactivates a revision for a Container App",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "revisionName",
+            "in": "path",
+            "description": "Name of the Container App Revision.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Deactivate Container App's revision": {
+            "$ref": "./examples/Revisions_Deactivate.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions/{revisionName}/functions": {
+      "get": {
+        "operationId": "ContainerAppsRevisionFunctions_List",
+        "tags": [
+          "AzureFunctionsOnContainerApps"
+        ],
+        "summary": "List the functions for a given Container App Revision.",
+        "description": "List the functions for a given Container App Revision.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "revisionName",
+            "in": "path",
+            "description": "Name of the Container App Revision.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppsFunctionCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container App Revision's functions": {
+            "$ref": "./examples/ContainerAppsRevisionFunctions_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions/{revisionName}/functions/{functionName}": {
+      "get": {
+        "operationId": "ContainerAppsRevisionFunctions_Get",
+        "tags": [
+          "AzureFunctionsOnContainerApps"
+        ],
+        "summary": "Get a specific function of a Container App Revision.",
+        "description": "Get a specific function of a Container App Revision.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "revisionName",
+            "in": "path",
+            "description": "Name of the Container App Revision.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "functionName",
+            "in": "path",
+            "description": "Name of the Function.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppsFunction"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App Revision's function": {
+            "$ref": "./examples/ContainerAppsRevisionFunctions_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions/{revisionName}/providers/Microsoft.App/functions/{functionAppName}/invoke": {
+      "post": {
+        "operationId": "FunctionsExtension_InvokeFunctionsHost",
+        "tags": [
+          "FunctionsExtension"
+        ],
+        "summary": "Proxies a Functions host call to the function app backed by the container app.",
+        "description": "Proxies a Functions host call to the function app backed by the container app.",
+        "produces": [
+          "text/plain",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "revisionName",
+            "in": "path",
+            "description": "Name of the Container App Revision.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "functionAppName",
+            "in": "path",
+            "description": "Name of the Function.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Invoke Functions host using Functions Extension API": {
+            "$ref": "./examples/FunctionsExtension_Post.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions/{revisionName}/replicas": {
+      "get": {
+        "operationId": "ContainerAppsRevisionReplicas_ListReplicas",
+        "tags": [
+          "ContainerAppsRevisionReplicas"
+        ],
+        "summary": "List replicas for a Container App Revision.",
+        "description": "List replicas for a Container App Revision.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "revisionName",
+            "in": "path",
+            "description": "Name of the Container App Revision.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ReplicaCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container App's replicas": {
+            "$ref": "./examples/Replicas_List.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions/{revisionName}/replicas/{replicaName}": {
+      "get": {
+        "operationId": "ContainerAppsRevisionReplicas_GetReplica",
+        "tags": [
+          "ContainerAppsRevisionReplicas"
+        ],
+        "summary": "Get a replica for a Container App Revision.",
+        "description": "Get a replica for a Container App Revision.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "revisionName",
+            "in": "path",
+            "description": "Name of the Container App Revision.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "replicaName",
+            "in": "path",
+            "description": "Name of the Container App Revision Replica.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Replica"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App's revision replica": {
+            "$ref": "./examples/Replicas_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/revisions/{revisionName}/restart": {
+      "post": {
+        "operationId": "ContainerAppsRevisions_RestartRevision",
+        "tags": [
+          "ContainerAppsRevisions"
+        ],
+        "summary": "Restarts a revision for a Container App",
+        "description": "Restarts a revision for a Container App",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "revisionName",
+            "in": "path",
+            "description": "Name of the Container App Revision.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Restart Container App's revision": {
+            "$ref": "./examples/Revisions_Restart.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/sourcecontrols": {
+      "get": {
+        "operationId": "ContainerAppsSourceControls_ListByContainerApp",
+        "tags": [
+          "ContainerAppsSourceControls"
+        ],
+        "summary": "Get the Container App SourceControls in a given resource group.",
+        "description": "Get the Container App SourceControls in a given resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SourceControlCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List App's Source Controls": {
+            "$ref": "./examples/SourceControls_ListByContainer.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/sourcecontrols/{sourceControlName}": {
+      "get": {
+        "operationId": "ContainerAppsSourceControls_Get",
+        "tags": [
+          "ContainerAppsSourceControls"
+        ],
+        "summary": "Get a SourceControl of a Container App.",
+        "description": "Get a SourceControl of a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "sourceControlName",
+            "in": "path",
+            "description": "Name of the Container App SourceControl.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SourceControl"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App's SourceControl": {
+            "$ref": "./examples/SourceControls_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ContainerAppsSourceControls_CreateOrUpdate",
+        "tags": [
+          "ContainerAppsSourceControls"
+        ],
+        "summary": "Create or update the SourceControl for a Container App.",
+        "description": "Create or update the SourceControl for a Container App.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "sourceControlName",
+            "in": "path",
+            "description": "Name of the Container App SourceControl.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-github-auxiliary",
+            "in": "header",
+            "description": "Github personal access token used for SourceControl.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "sourceControlEnvelope",
+            "in": "body",
+            "description": "Properties used to create a Container App SourceControl",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SourceControl"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SourceControl' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SourceControl"
+            }
+          },
+          "201": {
+            "description": "Resource 'SourceControl' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SourceControl"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Container App SourceControl": {
+            "$ref": "./examples/SourceControls_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/SourceControl"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ContainerAppsSourceControls_Delete",
+        "tags": [
+          "ContainerAppsSourceControls"
+        ],
+        "summary": "Delete a Container App SourceControl.",
+        "description": "Delete a Container App SourceControl.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "sourceControlName",
+            "in": "path",
+            "description": "Name of the Container App SourceControl.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "x-ms-github-auxiliary",
+            "in": "header",
+            "description": "Github personal access token used for SourceControl.",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "name": "ignoreWorkflowDeletionFailure",
+            "in": "query",
+            "description": "Ignore Workflow Deletion Failure.",
+            "required": false,
+            "type": "boolean"
+          },
+          {
+            "name": "deleteWorkflow",
+            "in": "query",
+            "description": "Delete workflow.",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Container App SourceControl": {
+            "$ref": "./examples/SourceControls_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/start": {
+      "post": {
+        "operationId": "ContainerApps_Start",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "Start a container app",
+        "description": "Start a container app",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerApp"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Start Container App": {
+            "$ref": "./examples/ContainerApps_Start.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ContainerApp"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/containerApps/{containerAppName}/stop": {
+      "post": {
+        "operationId": "ContainerApps_Stop",
+        "tags": [
+          "ContainerApps"
+        ],
+        "summary": "Stop a container app",
+        "description": "Stop a container app",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "containerAppName",
+            "in": "path",
+            "description": "Name of the Container App.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerApp"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Stop Container App": {
+            "$ref": "./examples/ContainerApps_Stop.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ContainerApp"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs": {
+      "get": {
+        "operationId": "Jobs_ListByResourceGroup",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Get the Container Apps Jobs in a given resource group.",
+        "description": "Get the Container Apps Jobs in a given resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/JobsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container Apps Jobs by resource group": {
+            "$ref": "./examples/Jobs_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}": {
+      "get": {
+        "operationId": "Jobs_Get",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Get the properties of a Container Apps Job.",
+        "description": "Get the properties of a Container Apps Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Job"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container Apps Job": {
+            "$ref": "./examples/Job_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Jobs_CreateOrUpdate",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Create or Update a Container Apps Job.",
+        "description": "Create or Update a Container Apps Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "JobEnvelope",
+            "in": "body",
+            "description": "Properties used to create a container apps job",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Job"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Job' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Job"
+            }
+          },
+          "201": {
+            "description": "Resource 'Job' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Job"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Container Apps Job": {
+            "$ref": "./examples/Job_CreateorUpdate.json"
+          },
+          "Create or Update Container Apps Job On A Connected Environment": {
+            "$ref": "./examples/Job_CreateorUpdate_ConnectedEnvironment.json"
+          },
+          "Create or Update Container Apps Job With Event Driven Trigger": {
+            "$ref": "./examples/Job_CreateorUpdate_EventTrigger.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Job"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "Jobs_Update",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Update properties of a Container Apps Job",
+        "description": "Patches a Container Apps Job using JSON Merge Patch",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "JobEnvelope",
+            "in": "body",
+            "description": "Properties used to create a container apps job",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/JobPatchProperties"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Job"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Container Apps Job": {
+            "$ref": "./examples/Job_Patch.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/Job"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Jobs_Delete",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Delete a Container Apps Job.",
+        "description": "Delete a Container Apps Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Container Apps Job": {
+            "$ref": "./examples/Job_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/detectorProperties/{apiName}": {
+      "get": {
+        "operationId": "Jobs_ProxyGet",
+        "tags": [
+          "Jobs",
+          "Diagnostics"
+        ],
+        "summary": "Get the properties for a given Container App Job.",
+        "description": "Get the properties of a Container App Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "apiName",
+            "in": "path",
+            "description": "Proxy API Name for Container App Job.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Job"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Container App Job by name": {
+            "$ref": "./examples/Job_ProxyGet.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/detectors": {
+      "get": {
+        "operationId": "Jobs_ListDetectors",
+        "tags": [
+          "Jobs",
+          "Diagnostics"
+        ],
+        "summary": "Get the list of diagnostics for a given Container App Job.",
+        "description": "Get the list of diagnostics for a Container App Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Container App Job.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DiagnosticsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get the list of available diagnostic data for a Container App Job": {
+            "$ref": "./examples/Job_ListDetectors.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/detectors/{detectorName}": {
+      "get": {
+        "operationId": "Jobs_GetDetector",
+        "tags": [
+          "Jobs",
+          "Diagnostics"
+        ],
+        "summary": "Get the diagnostics data for a given Container App Job.",
+        "description": "Get the diagnostics data for a Container App Job.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Name of the Container App Job.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "detectorName",
+            "in": "path",
+            "description": "Proxy API Name for Container App Job.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Diagnostics"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get diagnostic data for a Container App Job": {
+            "$ref": "./examples/Job_GetDetector.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/executions": {
+      "get": {
+        "operationId": "JobsExecutions_List",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Get a Container Apps Job's executions",
+        "description": "Get a Container Apps Job's executions",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "description": "The filter to apply on the operation.",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppJobExecutions"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Container Apps Job Executions": {
+            "$ref": "./examples/Job_Executions_Get.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/executions/{jobExecutionName}": {
+      "get": {
+        "operationId": "JobExecution",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Get details of a single job execution",
+        "description": "Get details of a single job execution",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "jobExecutionName",
+            "in": "path",
+            "description": "Job execution name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/JobExecution"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a single Job Execution": {
+            "$ref": "./examples/Job_Execution_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/executions/{jobExecutionName}/stop": {
+      "post": {
+        "operationId": "Jobs_StopExecution",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Terminates execution of a running container apps job",
+        "description": "Terminates execution of a running container apps job",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "jobExecutionName",
+            "in": "path",
+            "description": "Job execution name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded."
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Terminate a Container Apps Job": {
+            "$ref": "./examples/Job_Stop_Execution.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/listSecrets": {
+      "post": {
+        "operationId": "Jobs_ListSecrets",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "List secrets for a container apps job",
+        "description": "List secrets for a container apps job",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/JobSecretsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container Apps Job Secrets": {
+            "$ref": "./examples/Job_ListSecrets.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/resume": {
+      "post": {
+        "operationId": "Jobs_Resume",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Resumes a suspended job",
+        "description": "Resumes a suspended job",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Job"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Resume Job": {
+            "$ref": "./examples/Jobs_Resume.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Job"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/start": {
+      "post": {
+        "operationId": "Jobs_Start",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Start a Container Apps Job",
+        "description": "Start a Container Apps Job",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "template",
+            "in": "body",
+            "description": "Properties used to start a job execution.",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/JobExecutionTemplate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/JobExecutionBase"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Run a Container Apps Job": {
+            "$ref": "./examples/Job_Start.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/JobExecutionBase"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/stop": {
+      "post": {
+        "operationId": "Jobs_StopMultipleExecutions",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Terminates execution of a running container apps job",
+        "description": "Terminates execution of a running container apps job",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ContainerAppJobExecutions"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Terminate Multiple Container Apps Job": {
+            "$ref": "./examples/Job_Stop_Multiple.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ContainerAppJobExecutions"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/jobs/{jobName}/suspend": {
+      "post": {
+        "operationId": "Jobs_Suspend",
+        "tags": [
+          "Jobs"
+        ],
+        "summary": "Suspends a job",
+        "description": "Suspends a job",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "jobName",
+            "in": "path",
+            "description": "Job Name",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Job"
+            }
+          },
+          "202": {
+            "description": "Resource operation accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Suspend Job": {
+            "$ref": "./examples/Jobs_Suspend.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/Job"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments": {
+      "get": {
+        "operationId": "ManagedEnvironments_ListByResourceGroup",
+        "tags": [
+          "ManagedEnvironments"
+        ],
+        "summary": "Get all the Environments in a resource group.",
+        "description": "Get all the Managed Environments in a resource group.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironmentsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List environments by resource group": {
+            "$ref": "./examples/ManagedEnvironments_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}": {
+      "get": {
+        "operationId": "ManagedEnvironments_Get",
+        "tags": [
+          "ManagedEnvironments"
+        ],
+        "summary": "Get the properties of a Managed Environment.",
+        "description": "Get the properties of a Managed Environment used to host container apps.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get environments by name": {
+            "$ref": "./examples/ManagedEnvironments_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ManagedEnvironments_CreateOrUpdate",
+        "tags": [
+          "ManagedEnvironments"
+        ],
+        "summary": "Creates or updates a Managed Environment.",
+        "description": "Creates or updates a Managed Environment used to host container apps.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "environmentEnvelope",
+            "in": "body",
+            "description": "Configuration details of the Environment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ManagedEnvironment' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironment"
+            }
+          },
+          "201": {
+            "description": "Resource 'ManagedEnvironment' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironment"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create environment with custom infrastructureResourceGroup": {
+            "$ref": "./examples/ManagedEnvironments_CustomInfrastructureResourceGroup_Create.json"
+          },
+          "Create environments": {
+            "$ref": "./examples/ManagedEnvironments_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ManagedEnvironment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ManagedEnvironments_Update",
+        "tags": [
+          "ManagedEnvironments"
+        ],
+        "summary": "Update Managed Environment's properties.",
+        "description": "Patches a Managed Environment using JSON Merge Patch",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "environmentEnvelope",
+            "in": "body",
+            "description": "Configuration details of the Environment.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironment"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironment"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Managed Environment": {
+            "$ref": "./examples/ManagedEnvironments_Patch.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/ManagedEnvironment"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ManagedEnvironments_Delete",
+        "tags": [
+          "ManagedEnvironments"
+        ],
+        "summary": "Delete a Managed Environment.",
+        "description": "Delete a Managed Environment if it does not have any container apps.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete environment by name": {
+            "$ref": "./examples/ManagedEnvironments_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/certificates": {
+      "get": {
+        "operationId": "Certificates_List",
+        "tags": [
+          "Certificates",
+          "ManagedEnvironments"
+        ],
+        "summary": "Get the Certificates in a given managed environment.",
+        "description": "Get the Certificates in a given managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/CertificateCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Certificates by Managed Environment": {
+            "$ref": "./examples/Certificates_ListByManagedEnvironment.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/certificates/{certificateName}": {
+      "get": {
+        "operationId": "Certificates_Get",
+        "tags": [
+          "Certificates",
+          "ManagedEnvironments"
+        ],
+        "summary": "Get the specified Certificate.",
+        "description": "Get the specified Certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the Certificate.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Certificate": {
+            "$ref": "./examples/Certificate_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Certificates_CreateOrUpdate",
+        "tags": [
+          "Certificates",
+          "ManagedEnvironments"
+        ],
+        "summary": "Create or Update a Certificate.",
+        "description": "Create or Update a Certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the Certificate.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateEnvelope",
+            "in": "body",
+            "description": "Certificate to be created or updated",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Certificate' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Certificate": {
+            "$ref": "./examples/Certificate_CreateOrUpdate.json"
+          },
+          "Create or Update Certificate using Managed Identity": {
+            "$ref": "./examples/Certificate_CreateOrUpdate_FromKeyVault.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "Certificates_Update",
+        "tags": [
+          "Certificates",
+          "ManagedEnvironments"
+        ],
+        "summary": "Update properties of a certificate",
+        "description": "Patches a certificate. Currently only patching of tags is supported",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the Certificate.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateEnvelope",
+            "in": "body",
+            "description": "Properties of a certificate that need to be updated",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/CertificatePatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Certificate": {
+            "$ref": "./examples/Certificates_Patch.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Certificates_Delete",
+        "tags": [
+          "Certificates",
+          "ManagedEnvironments"
+        ],
+        "summary": "Deletes the specified Certificate.",
+        "description": "Deletes the specified Certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "certificateName",
+            "in": "path",
+            "description": "Name of the Certificate.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Certificate": {
+            "$ref": "./examples/Certificate_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/checkNameAvailability": {
+      "post": {
+        "operationId": "Namespaces_CheckNameAvailability",
+        "tags": [
+          "ManagedEnvironments"
+        ],
+        "summary": "Checks the resource name availability.",
+        "description": "Checks if resource name is available.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "checkNameAvailabilityRequest",
+            "in": "body",
+            "description": "The check name availability request.",
+            "required": true,
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/CheckNameAvailabilityRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/CheckNameAvailabilityResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Certificates_CheckNameAvailability": {
+            "$ref": "./examples/Certificates_CheckNameAvailability.json"
+          },
+          "ContainerApps_CheckNameAvailability": {
+            "$ref": "./examples/ContainerApps_CheckNameAvailability.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprComponents": {
+      "get": {
+        "operationId": "DaprComponents_List",
+        "tags": [
+          "DaprComponents"
+        ],
+        "summary": "Get the Dapr Components for a managed environment.",
+        "description": "Get the Dapr Components for a managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DaprComponentsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Dapr Components": {
+            "$ref": "./examples/DaprComponents_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprComponents/{componentName}": {
+      "get": {
+        "operationId": "DaprComponents_Get",
+        "tags": [
+          "DaprComponents"
+        ],
+        "summary": "Get a dapr component.",
+        "description": "Get a dapr component.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DaprComponent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Dapr Component with secret store component": {
+            "$ref": "./examples/DaprComponents_Get_SecretStoreComponent.json"
+          },
+          "Get Dapr Component with secrets": {
+            "$ref": "./examples/DaprComponents_Get_Secrets.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DaprComponents_CreateOrUpdate",
+        "tags": [
+          "DaprComponents"
+        ],
+        "summary": "Creates or updates a Dapr Component.",
+        "description": "Creates or updates a Dapr Component in a Managed Environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "daprComponentEnvelope",
+            "in": "body",
+            "description": "Configuration details of the Dapr Component.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DaprComponent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DaprComponent' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DaprComponent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update dapr component with secret store component": {
+            "$ref": "./examples/DaprComponents_CreateOrUpdate_SecretStoreComponent.json"
+          },
+          "Create or update dapr component with secrets": {
+            "$ref": "./examples/DaprComponents_CreateOrUpdate_Secrets.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DaprComponents_Delete",
+        "tags": [
+          "DaprComponents"
+        ],
+        "summary": "Delete a Dapr Component.",
+        "description": "Delete a Dapr Component from a Managed Environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete dapr component": {
+            "$ref": "./examples/DaprComponents_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprComponents/{componentName}/listSecrets": {
+      "post": {
+        "operationId": "DaprComponents_ListSecrets",
+        "tags": [
+          "DaprComponents"
+        ],
+        "summary": "List secrets for a dapr component",
+        "description": "List secrets for a dapr component",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DaprSecretsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Container Apps Secrets": {
+            "$ref": "./examples/DaprComponents_ListSecrets.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprComponents/{componentName}/resiliencyPolicies": {
+      "get": {
+        "operationId": "DaprComponentResiliencyPolicies_List",
+        "tags": [
+          "DaprComponentResiliencyPolicies"
+        ],
+        "summary": "Get the resiliency policies for a Dapr component.",
+        "description": "Get the resiliency policies for a Dapr component.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DaprComponentResiliencyPoliciesCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Dapr component resiliency policies": {
+            "$ref": "./examples/DaprComponentResiliencyPolicies_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprComponents/{componentName}/resiliencyPolicies/{name}": {
+      "get": {
+        "operationId": "DaprComponentResiliencyPolicies_Get",
+        "tags": [
+          "DaprComponentResiliencyPolicies"
+        ],
+        "summary": "Get a Dapr component resiliency policy.",
+        "description": "Get a Dapr component resiliency policy.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the Dapr Component Resiliency Policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DaprComponentResiliencyPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Dapr component resiliency policy": {
+            "$ref": "./examples/DaprComponentResiliencyPolicies_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DaprComponentResiliencyPolicies_CreateOrUpdate",
+        "tags": [
+          "DaprComponentResiliencyPolicies"
+        ],
+        "summary": "Creates or updates a Dapr component resiliency policy.",
+        "description": "Creates or updates a resiliency policy for a Dapr component.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the Dapr Component Resiliency Policy.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "daprComponentResiliencyPolicyEnvelope",
+            "in": "body",
+            "description": "Configuration details of the Dapr Component Resiliency Policy.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DaprComponentResiliencyPolicy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DaprComponentResiliencyPolicy' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DaprComponentResiliencyPolicy"
+            }
+          },
+          "201": {
+            "description": "The request has succeeded and a new resource has been created as a result.",
+            "schema": {
+              "$ref": "#/definitions/DaprComponentResiliencyPolicy"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update dapr component resiliency policy with all options": {
+            "$ref": "./examples/DaprComponentResiliencyPolicy_CreateOrUpdate_AllOptions.json"
+          },
+          "Create or update dapr component resiliency policy with outbound policy only": {
+            "$ref": "./examples/DaprComponentResiliencyPolicy_CreateOrUpdate_OutboundOnly.json"
+          },
+          "Create or update dapr component resiliency policy with sparse options": {
+            "$ref": "./examples/DaprComponentResiliencyPolicy_CreateOrUpdate_SparseOptions.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DaprComponentResiliencyPolicies_Delete",
+        "tags": [
+          "DaprComponentResiliencyPolicies"
+        ],
+        "summary": "Delete a Dapr component resiliency policy.",
+        "description": "Delete a resiliency policy for a Dapr component.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "componentName",
+            "in": "path",
+            "description": "Name of the Dapr Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the Dapr Component Resiliency Policy.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete dapr component resiliency policy": {
+            "$ref": "./examples/DaprComponentResiliencyPolicies_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprSubscriptions": {
+      "get": {
+        "operationId": "DaprSubscriptions_List",
+        "tags": [
+          "DaprSubscriptions"
+        ],
+        "summary": "Get the Dapr subscriptions for a managed environment.",
+        "description": "Get the Dapr subscriptions for a managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DaprSubscriptionsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Dapr subscriptions": {
+            "$ref": "./examples/DaprSubscriptions_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/daprSubscriptions/{name}": {
+      "get": {
+        "operationId": "DaprSubscriptions_Get",
+        "tags": [
+          "DaprSubscriptions"
+        ],
+        "summary": "Get a dapr subscription.",
+        "description": "Get a dapr subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the Dapr Subscription.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DaprSubscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Dapr subscription with bulk subscribe configuration and scopes": {
+            "$ref": "./examples/DaprSubscriptions_Get_DefaultRoute.json"
+          },
+          "Get Dapr subscription with default route only": {
+            "$ref": "./examples/DaprSubscriptions_Get_BulkSubscribeAndScopes.json"
+          },
+          "GetDapr subscription with route rules and metadata": {
+            "$ref": "./examples/DaprSubscriptions_Get_RouteRulesAndMetadata.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DaprSubscriptions_CreateOrUpdate",
+        "tags": [
+          "DaprSubscriptions"
+        ],
+        "summary": "Creates or updates a Dapr subscription.",
+        "description": "Creates or updates a Dapr subscription in a Managed Environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the Dapr Subscription.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "daprSubscriptionEnvelope",
+            "in": "body",
+            "description": "Configuration details of the Dapr subscription.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DaprSubscription"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DaprSubscription' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DaprSubscription"
+            }
+          },
+          "201": {
+            "description": "Resource 'DaprSubscription' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DaprSubscription"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update dapr subscription with bulk subscribe configuration and scopes": {
+            "$ref": "./examples/DaprSubscriptions_CreateOrUpdate_BulkSubscribeAndScopes.json"
+          },
+          "Create or update dapr subscription with default route only": {
+            "$ref": "./examples/DaprSubscriptions_CreateOrUpdate_DefaultRoute.json"
+          },
+          "Create or update dapr subscription with route rules and metadata": {
+            "$ref": "./examples/DaprSubscriptions_CreateOrUpdate_RouteRulesAndMetadata.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "DaprSubscriptions_Delete",
+        "tags": [
+          "DaprSubscriptions"
+        ],
+        "summary": "Delete a Dapr subscription.",
+        "description": "Delete a Dapr subscription from a Managed Environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the Dapr Subscription.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete dapr subscription": {
+            "$ref": "./examples/DaprSubscriptions_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/detectorProperties/rootApi/": {
+      "get": {
+        "operationId": "ManagedEnvironmentsDiagnostics_GetRoot",
+        "tags": [
+          "ManagedEnvironments",
+          "Diagnostics"
+        ],
+        "summary": "Get the properties of a Managed Environment.",
+        "description": "Get the properties of a Managed Environment used to host container apps.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironment"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get environments by name": {
+            "$ref": "./examples/ManagedEnvironments_Get1.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/detectors": {
+      "get": {
+        "operationId": "ManagedEnvironmentDiagnostics_ListDetectors",
+        "tags": [
+          "ManagedEnvironments",
+          "Diagnostics"
+        ],
+        "summary": "Get the list of diagnostics for a given Managed Environment.",
+        "description": "Get the list of diagnostics for a Managed Environment used to host container apps.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DiagnosticsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get the list of available diagnostic data for a managed environments": {
+            "$ref": "./examples/ManagedEnvironmentDiagnostics_List.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/detectors/{detectorName}": {
+      "get": {
+        "operationId": "ManagedEnvironmentDiagnostics_GetDetector",
+        "tags": [
+          "ManagedEnvironments",
+          "Diagnostics"
+        ],
+        "summary": "Get the diagnostics data for a given Managed Environment.",
+        "description": "Get the diagnostics data for a Managed Environment used to host container apps.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "detectorName",
+            "in": "path",
+            "description": "Name of the detector.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Diagnostics"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get diagnostic data for a managed environments": {
+            "$ref": "./examples/ManagedEnvironmentDiagnostics_Get.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/dotNetComponents": {
+      "get": {
+        "operationId": "DotNetComponents_List",
+        "tags": [
+          "DotNetComponents"
+        ],
+        "summary": "Get the .NET Components for a managed environment.",
+        "description": "Get the .NET Components for a managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DotNetComponentsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List .NET Components": {
+            "$ref": "./examples/DotNetComponents_List.json"
+          },
+          "List .NET Components with ServiceBinds": {
+            "$ref": "./examples/DotNetComponents_List_ServiceBind.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/dotNetComponents/{name}": {
+      "get": {
+        "operationId": "DotNetComponents_Get",
+        "tags": [
+          "DotNetComponents"
+        ],
+        "summary": "Get a .NET Component.",
+        "description": "Get a .NET Component.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the .NET Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DotNetComponent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get .NET Component": {
+            "$ref": "./examples/DotNetComponents_Get.json"
+          },
+          "Get .NET Component with ServiceBinds": {
+            "$ref": "./examples/DotNetComponents_Get_ServiceBind.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DotNetComponents_CreateOrUpdate",
+        "tags": [
+          "DotNetComponents"
+        ],
+        "summary": "Creates or updates a .NET Component.",
+        "description": "Creates or updates a .NET Component in a Managed Environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the .NET Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "dotNetComponentEnvelope",
+            "in": "body",
+            "description": "Configuration details of the .NET Component.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DotNetComponent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DotNetComponent' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DotNetComponent"
+            }
+          },
+          "201": {
+            "description": "Resource 'DotNetComponent' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DotNetComponent"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update .NET Component": {
+            "$ref": "./examples/DotNetComponents_CreateOrUpdate.json"
+          },
+          "Create or Update .NET Component with ServiceBinds": {
+            "$ref": "./examples/DotNetComponents_CreateOrUpdate_ServiceBind.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/DotNetComponent"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "DotNetComponents_Update",
+        "tags": [
+          "DotNetComponents"
+        ],
+        "summary": "Update properties of a .NET Component",
+        "description": "Patches a .NET Component using JSON Merge Patch",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the .NET Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "dotNetComponentEnvelope",
+            "in": "body",
+            "description": "Configuration details of the .NET Component.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DotNetComponent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DotNetComponent"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch .NET Component": {
+            "$ref": "./examples/DotNetComponents_Patch.json"
+          },
+          "Patch .NET Component with ServiceBinds": {
+            "$ref": "./examples/DotNetComponents_Patch_ServiceBind.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/DotNetComponent"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "DotNetComponents_Delete",
+        "tags": [
+          "DotNetComponents"
+        ],
+        "summary": "Delete a .NET Component.",
+        "description": "Delete a .NET Component.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the .NET Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete .NET Component": {
+            "$ref": "./examples/DotNetComponents_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/getAuthtoken": {
+      "post": {
+        "operationId": "ManagedEnvironments_GetAuthToken",
+        "tags": [
+          "ManagedEnvironments"
+        ],
+        "summary": "Get auth token for a managed environment",
+        "description": "Checks if resource name is available.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EnvironmentAuthToken"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Managed Environment Auth Token": {
+            "$ref": "./examples/ManagedEnvironments_GetAuthToken.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/httpRouteConfigs": {
+      "get": {
+        "operationId": "HttpRouteConfig_List",
+        "tags": [
+          "HttpRouteConfig"
+        ],
+        "summary": "Get the Managed Http Routes in a given managed environment.",
+        "description": "Get the Managed Http Routes in a given managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HttpRouteConfigCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Managed Http Routes by Managed Environment": {
+            "$ref": "./examples/HttpRouteConfig_ListByManagedEnvironment.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/httpRouteConfigs/{httpRouteName}": {
+      "get": {
+        "operationId": "HttpRouteConfig_Get",
+        "tags": [
+          "HttpRouteConfig"
+        ],
+        "summary": "Get the specified Managed Http Route Config.",
+        "description": "Get the specified Managed Http Route Config.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "httpRouteName",
+            "in": "path",
+            "description": "Name of the Http Route Config.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HttpRouteConfig"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get HttpRoute": {
+            "$ref": "./examples/HttpRouteConfig_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "HttpRouteConfig_CreateOrUpdate",
+        "tags": [
+          "HttpRouteConfig"
+        ],
+        "summary": "Create or Update a Http Route Config.",
+        "description": "Create or Update a Http Route Config.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "httpRouteName",
+            "in": "path",
+            "description": "Name of the Http Route Config.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          },
+          {
+            "name": "httpRouteConfigEnvelope",
+            "in": "body",
+            "description": "Http Route config to be created or updated",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/HttpRouteConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'HttpRouteConfig' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/HttpRouteConfig"
+            }
+          },
+          "201": {
+            "description": "Resource 'HttpRouteConfig' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/HttpRouteConfig"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Http Route": {
+            "$ref": "./examples/HttpRouteConfig_CreateOrUpdate.json"
+          },
+          "Create or Update Http Route Path Separated Prefix Rule": {
+            "$ref": "./examples/HttpRouteConfig_CreateOrUpdate_PathSepPrefix.json"
+          },
+          "Create or Update Http Route Prefix Rule": {
+            "$ref": "./examples/HttpRouteConfig_CreateOrUpdatePrefix.json"
+          }
+        }
+      },
+      "patch": {
+        "operationId": "HttpRouteConfig_Update",
+        "tags": [
+          "HttpRouteConfig"
+        ],
+        "summary": "Update tags of a manged http route object",
+        "description": "Patches an http route config resource. Only patching of tags is supported",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "httpRouteName",
+            "in": "path",
+            "description": "Name of the Http Route Config Resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          },
+          {
+            "name": "httpRouteConfigEnvelope",
+            "in": "body",
+            "description": "Properties of http route config that need to be updated",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HttpRouteConfig"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HttpRouteConfig"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Managed Http Route": {
+            "$ref": "./examples/HttpRouteConfig_Patch.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "HttpRouteConfig_Delete",
+        "tags": [
+          "HttpRouteConfig"
+        ],
+        "summary": "Deletes the specified Managed Http Route.",
+        "description": "Deletes the specified Managed Http Route.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "httpRouteName",
+            "in": "path",
+            "description": "Name of the Http Route Config Resource.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Certificate": {
+            "$ref": "./examples/HttpRouteConfig_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/javaComponents": {
+      "get": {
+        "operationId": "JavaComponents_List",
+        "tags": [
+          "JavaComponents"
+        ],
+        "summary": "Get the Java Components for a managed environment.",
+        "description": "Get the Java Components for a managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/JavaComponentsCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Java Components": {
+            "$ref": "./examples/JavaComponents_List.json"
+          },
+          "List Java Components with ServiceBinds": {
+            "$ref": "./examples/JavaComponents_List_ServiceBind.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/javaComponents/{name}": {
+      "get": {
+        "operationId": "JavaComponents_Get",
+        "tags": [
+          "JavaComponents"
+        ],
+        "summary": "Get a Java Component.",
+        "description": "Get a Java Component.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the Java Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/JavaComponent"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Java Component": {
+            "$ref": "./examples/JavaComponents_Get.json"
+          },
+          "Get Java Component with ServiceBinds": {
+            "$ref": "./examples/JavaComponents_Get_ServiceBind.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "JavaComponents_CreateOrUpdate",
+        "tags": [
+          "JavaComponents"
+        ],
+        "summary": "Creates or updates a Java Component.",
+        "description": "Creates or updates a Java Component in a Managed Environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the Java Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "javaComponentEnvelope",
+            "in": "body",
+            "description": "Configuration details of the Java Component.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/JavaComponent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'JavaComponent' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/JavaComponent"
+            }
+          },
+          "201": {
+            "description": "Resource 'JavaComponent' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/JavaComponent"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Java Component": {
+            "$ref": "./examples/JavaComponents_CreateOrUpdate.json"
+          },
+          "Create or Update Java Component with ServiceBinds": {
+            "$ref": "./examples/JavaComponents_CreateOrUpdate_ServiceBind.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/JavaComponent"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "JavaComponents_Update",
+        "tags": [
+          "JavaComponents"
+        ],
+        "summary": "Update properties of a Java Component",
+        "description": "Patches a Java Component using JSON Merge Patch",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the Java Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "javaComponentEnvelope",
+            "in": "body",
+            "description": "Configuration details of the Java Component.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/JavaComponent"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/JavaComponent"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Java Component": {
+            "$ref": "./examples/JavaComponents_Patch.json"
+          },
+          "Patch Java Component with ServiceBinds": {
+            "$ref": "./examples/JavaComponents_Patch_ServiceBind.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/JavaComponent"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "JavaComponents_Delete",
+        "tags": [
+          "JavaComponents"
+        ],
+        "summary": "Delete a Java Component.",
+        "description": "Delete a Java Component.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Name of the Java Component.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Java Component": {
+            "$ref": "./examples/JavaComponents_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/maintenanceConfigurations": {
+      "get": {
+        "operationId": "MaintenanceConfigurations_List",
+        "tags": [
+          "MaintenanceConfigurations"
+        ],
+        "description": "Gets all maintenance configurations in the specified Managed Environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceConfigurationCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ManagedEnvironmentMaintenanceConfigurationsList": {
+            "$ref": "./examples/ManagedEnvironment_MaintenanceConfigurations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/maintenanceConfigurations/{configName}": {
+      "get": {
+        "operationId": "MaintenanceConfigurations_Get",
+        "tags": [
+          "MaintenanceConfigurations"
+        ],
+        "description": "Gets the maintenance configuration of a ManagedEnvironment .",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "Name of the Maintenance Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceConfigurationResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ManagedEnvironmentMaintenanceConfigurationsGet": {
+            "$ref": "./examples/ManagedEnvironment_MaintenanceConfigurations_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "MaintenanceConfigurations_CreateOrUpdate",
+        "tags": [
+          "MaintenanceConfigurations"
+        ],
+        "description": "Create or update the maintenance configuration for Managed Environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "Name of the Maintenance Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "maintenanceConfigurationEnvelope",
+            "in": "body",
+            "description": "Parameters to set the maintenance configuration for ManagedEnvironment .",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/MaintenanceConfigurationResource"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'MaintenanceConfigurationResource' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceConfigurationResource"
+            }
+          },
+          "201": {
+            "description": "Resource 'MaintenanceConfigurationResource' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/MaintenanceConfigurationResource"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ManagedEnvironmentMaintenanceConfigurationsCreateOrUpdate": {
+            "$ref": "./examples/ManagedEnvironment_MaintenanceConfigurations_CreateOrUpdate.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "MaintenanceConfigurations_Delete",
+        "tags": [
+          "MaintenanceConfigurations"
+        ],
+        "description": "Deletes the maintenance configuration of a ManagedEnvironment .",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "configName",
+            "in": "path",
+            "description": "Name of the Maintenance Configuration.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "ManagedEnvironmentMaintenanceConfigurationsDelete": {
+            "$ref": "./examples/ManagedEnvironment_MaintenanceConfigurations_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/managedCertificates": {
+      "get": {
+        "operationId": "ManagedCertificates_List",
+        "tags": [
+          "ManagedEnvironments",
+          "ManagedCertificates"
+        ],
+        "summary": "Get the Managed Certificates in a given managed environment.",
+        "description": "Get the Managed Certificates in a given managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedCertificateCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Managed Certificates by Managed Environment": {
+            "$ref": "./examples/ManagedCertificates_ListByManagedEnvironment.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/managedCertificates/{managedCertificateName}": {
+      "get": {
+        "operationId": "ManagedCertificates_Get",
+        "tags": [
+          "ManagedEnvironments",
+          "ManagedCertificates"
+        ],
+        "summary": "Get the specified Managed Certificate.",
+        "description": "Get the specified Managed Certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "managedCertificateName",
+            "in": "path",
+            "description": "Name of the Managed Certificate.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedCertificate"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Certificate": {
+            "$ref": "./examples/ManagedCertificate_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ManagedCertificates_CreateOrUpdate",
+        "tags": [
+          "ManagedEnvironments",
+          "ManagedCertificates"
+        ],
+        "summary": "Create or Update a Managed Certificate.",
+        "description": "Create or Update a Managed Certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Managed Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "managedCertificateName",
+            "in": "path",
+            "description": "Name of the Managed Certificate.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "managedCertificateEnvelope",
+            "in": "body",
+            "description": "Managed Certificate to be created or updated",
+            "required": false,
+            "schema": {
+              "$ref": "#/definitions/ManagedCertificate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ManagedCertificate' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedCertificate"
+            }
+          },
+          "201": {
+            "description": "Resource 'ManagedCertificate' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedCertificate"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "400": {
+            "description": "The server could not understand the request due to invalid syntax.",
+            "x-ms-error-response": true
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Certificate": {
+            "$ref": "./examples/ManagedCertificate_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/ManagedCertificate"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ManagedCertificates_Update",
+        "tags": [
+          "ManagedEnvironments",
+          "ManagedCertificates"
+        ],
+        "summary": "Update tags of a managed certificate",
+        "description": "Patches a managed certificate. Oly patching of tags is supported",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "managedCertificateName",
+            "in": "path",
+            "description": "Name of the Managed Certificate.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "managedCertificateEnvelope",
+            "in": "body",
+            "description": "Properties of a managed certificate that need to be updated",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedCertificatePatch"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedCertificate"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Patch Managed Certificate": {
+            "$ref": "./examples/ManagedCertificates_Patch.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ManagedCertificates_Delete",
+        "tags": [
+          "ManagedEnvironments",
+          "ManagedCertificates"
+        ],
+        "summary": "Deletes the specified Managed Certificate.",
+        "description": "Deletes the specified Managed Certificate.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "managedCertificateName",
+            "in": "path",
+            "description": "Name of the Managed Certificate.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Certificate": {
+            "$ref": "./examples/ManagedCertificate_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/privateEndpointConnections": {
+      "get": {
+        "operationId": "ManagedEnvironmentPrivateEndpointConnections_List",
+        "tags": [
+          "ManagedEnvironments",
+          "PrivateEndpointConnections"
+        ],
+        "summary": "List private endpoint connections for a given managed environment.",
+        "description": "List private endpoint connections for a given managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Private Endpoint Connections by Managed Environment": {
+            "$ref": "./examples/ManagedEnvironmentPrivateEndpointConnections_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/privateEndpointConnections/{privateEndpointConnectionName}": {
+      "get": {
+        "operationId": "ManagedEnvironmentPrivateEndpointConnections_Get",
+        "tags": [
+          "ManagedEnvironments",
+          "PrivateEndpointConnections"
+        ],
+        "summary": "Get a private endpoint connection for a given managed environment.",
+        "description": "Get a private endpoint connection for a given managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "Name of the Private Endpoint Connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get a Private Endpoint Connection by Managed Environment": {
+            "$ref": "./examples/ManagedEnvironmentPrivateEndpointConnections_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ManagedEnvironmentPrivateEndpointConnections_CreateOrUpdate",
+        "tags": [
+          "ManagedEnvironments",
+          "PrivateEndpointConnections"
+        ],
+        "summary": "Update the state of a private endpoint connection for a given managed environment.",
+        "description": "Update the state of a private endpoint connection for a given managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "Name of the Private Endpoint Connection.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "privateEndpointConnectionEnvelope",
+            "in": "body",
+            "description": "The resource of private endpoint and its properties",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            }
+          },
+          "201": {
+            "description": "Resource 'PrivateEndpointConnection' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/PrivateEndpointConnection"
+            },
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update a Private Endpoint Connection by Managed Environment": {
+            "$ref": "./examples/ManagedEnvironmentPrivateEndpointConnections_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/definitions/PrivateEndpointConnection"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ManagedEnvironmentPrivateEndpointConnections_Delete",
+        "tags": [
+          "ManagedEnvironments",
+          "PrivateEndpointConnections"
+        ],
+        "summary": "Delete a private endpoint connection for a given managed environment.",
+        "description": "Delete a private endpoint connection for a given managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          },
+          {
+            "name": "privateEndpointConnectionName",
+            "in": "path",
+            "description": "Name of the Private Endpoint Connection.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete a Private Endpoint Connection by Managed Environment": {
+            "$ref": "./examples/ManagedEnvironmentPrivateEndpointConnections_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/privateLinkResources": {
+      "get": {
+        "operationId": "ManagedEnvironmentPrivateLinkResources_List",
+        "tags": [
+          "ManagedEnvironments",
+          "PrivateLinkResources"
+        ],
+        "summary": "List private link resources for a given managed environment.",
+        "description": "List private link resources for a given managed environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the managed environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._\\(\\)]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/PrivateLinkResourceListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Private Link Resources by Managed Environment": {
+            "$ref": "./examples/ManagedEnvironmentPrivateLinkResources_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/storages": {
+      "get": {
+        "operationId": "ManagedEnvironmentsStorages_List",
+        "tags": [
+          "ManagedEnvironmentsStorages"
+        ],
+        "summary": "Get all storages for a managedEnvironment.",
+        "description": "Get all storages for a managedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironmentStoragesCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List environments storages by subscription": {
+            "$ref": "./examples/ManagedEnvironmentsStorages_List.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/storages/{storageName}": {
+      "get": {
+        "operationId": "ManagedEnvironmentsStorages_Get",
+        "tags": [
+          "ManagedEnvironmentsStorages"
+        ],
+        "summary": "Get storage for a managedEnvironment.",
+        "description": "Get storage for a managedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "storageName",
+            "in": "path",
+            "description": "Name of the storage.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironmentStorage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "get a environments storage": {
+            "$ref": "./examples/ManagedEnvironmentsStorages_Get.json"
+          },
+          "get a environments storage for NFS Azure file": {
+            "$ref": "./examples/ManagedEnvironmentsStorages_Get_NfsAzureFile.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ManagedEnvironmentsStorages_CreateOrUpdate",
+        "tags": [
+          "ManagedEnvironmentsStorages"
+        ],
+        "summary": "Create or update storage for a managedEnvironment.",
+        "description": "Create or update storage for a managedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "storageName",
+            "in": "path",
+            "description": "Name of the storage.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "storageEnvelope",
+            "in": "body",
+            "description": "Configuration details of storage.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironmentStorage"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'ManagedEnvironmentStorage' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironmentStorage"
+            }
+          },
+          "201": {
+            "description": "Resource 'ManagedEnvironmentStorage' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/ManagedEnvironmentStorage"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or update environments storage": {
+            "$ref": "./examples/ManagedEnvironmentsStorages_CreateOrUpdate.json"
+          },
+          "Create or update environments storage for NFS Azure file": {
+            "$ref": "./examples/ManagedEnvironmentsStorages_CreateOrUpdate_NfsAzureFile.json"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "ManagedEnvironmentsStorages_Delete",
+        "tags": [
+          "ManagedEnvironmentsStorages"
+        ],
+        "summary": "Delete storage for a managedEnvironment.",
+        "description": "Delete storage for a managedEnvironment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "storageName",
+            "in": "path",
+            "description": "Name of the storage.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource deleted successfully."
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List environments storages by subscription": {
+            "$ref": "./examples/ManagedEnvironmentsStorages_Delete.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/usages": {
+      "get": {
+        "operationId": "ManagedEnvironmentUsages_List",
+        "tags": [
+          "Usages"
+        ],
+        "description": "Gets the current usage information as well as the limits for environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[-\\w\\._]+$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/ListUsagesResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/DefaultErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List managed environment usages": {
+            "$ref": "./examples/ManagedEnvironmentUsages_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{environmentName}/workloadProfileStates": {
+      "get": {
+        "operationId": "ManagedEnvironments_ListWorkloadProfileStates",
+        "tags": [
+          "ManagedEnvironments"
+        ],
+        "summary": "Get all workload Profile States for a Managed Environment..",
+        "description": "Get all workload Profile States for a Managed Environment.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "environmentName",
+            "in": "path",
+            "description": "Name of the Environment.",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/workloadProfileStatesCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List environments by subscription": {
+            "$ref": "./examples/ManagedEnvironments_ListWorkloadProfileStates.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/sessionPools": {
+      "get": {
+        "operationId": "ContainerAppsSessionPools_ListByResourceGroup",
+        "tags": [
+          "ContainerAppsSessionPools"
+        ],
+        "summary": "Get the session pools in a given resource group of a subscription.",
+        "description": "Get the session pools in a given resource group of a subscription.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SessionPoolCollection"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "List Session Pools by resource group": {
+            "$ref": "./examples/SessionPools_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/sessionPools/{sessionPoolName}": {
+      "get": {
+        "operationId": "ContainerAppsSessionPools_Get",
+        "tags": [
+          "ContainerAppsSessionPools"
+        ],
+        "summary": "Get the properties of a session pool.",
+        "description": "Get the properties of a session pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "sessionPoolName",
+            "in": "path",
+            "description": "Name of the session pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SessionPool"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Get Session Pool": {
+            "$ref": "./examples/SessionPools_Get.json"
+          },
+          "Get Session Pool during update": {
+            "$ref": "./examples/SessionPools_Get_InProgress.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "ContainerAppsSessionPools_CreateOrUpdate",
+        "tags": [
+          "ContainerAppsSessionPools"
+        ],
+        "summary": "Create or update a session pool.",
+        "description": "Create or update a session pool with the given properties.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "sessionPoolName",
+            "in": "path",
+            "description": "Name of the session pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          },
+          {
+            "name": "sessionPoolEnvelope",
+            "in": "body",
+            "description": "Properties used to create a session pool",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SessionPool"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SessionPool' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SessionPool"
+            }
+          },
+          "201": {
+            "description": "Resource 'SessionPool' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SessionPool"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Create or Update Session Pool with MCP server": {
+            "$ref": "./examples/SessionPools_McpServer_CreateOrUpdate.json"
+          },
+          "Create or Update Session Pool with lifecycle OnContainerExit Timed": {
+            "$ref": "./examples/SessionPools_LifecycleOnContainerExit_CreateOrUpdate.json"
+          },
+          "Create or Update Session Pool with lifecycle type Timed": {
+            "$ref": "./examples/SessionPools_LifecycleTimed_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/SessionPool"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "ContainerAppsSessionPools_Update",
+        "tags": [
+          "ContainerAppsSessionPools"
+        ],
+        "summary": "Update properties of a session pool",
+        "description": "Patches a session pool using JSON merge patch",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "sessionPoolName",
+            "in": "path",
+            "description": "Name of the session pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          },
+          {
+            "name": "sessionPoolEnvelope",
+            "in": "body",
+            "description": "Properties used to create a session pool",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SessionPoolUpdatableProperties"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SessionPool"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Update Session Pool": {
+            "$ref": "./examples/SessionPools_Patch.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation",
+          "final-state-schema": "#/definitions/SessionPool"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "ContainerAppsSessionPools_Delete",
+        "tags": [
+          "ContainerAppsSessionPools"
+        ],
+        "summary": "Delete a session pool.",
+        "description": "Delete the session pool with the given name.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "sessionPoolName",
+            "in": "path",
+            "description": "Name of the session pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Delete Session Pool": {
+            "$ref": "./examples/SessionPools_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/sessionPools/{sessionPoolName}/fetchMcpServerCredentials": {
+      "post": {
+        "operationId": "ContainerAppsSessionPools_FetchMcpServerCredentials",
+        "tags": [
+          "ContainerAppsSessionPools"
+        ],
+        "summary": "Fetch the MCP server credentials of a session pool.",
+        "description": "Fetch the MCP server credentials of a session pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "sessionPoolName",
+            "in": "path",
+            "description": "Name of the session pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/McpServerCredential"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Fetch Session Pool MCP server credentials": {
+            "$ref": "./examples/SessionPools_FetchMcpServerCredentials.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.App/sessionPools/{sessionPoolName}/rotateMcpServerCredentials": {
+      "post": {
+        "operationId": "ContainerAppsSessionPools_RotateMcpServerCredentials",
+        "tags": [
+          "ContainerAppsSessionPools"
+        ],
+        "summary": "Rotate and fetch the rotated MCP server credentials of a session pool.",
+        "description": "Rotate and fetch the rotated MCP server credentials of a session pool.",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "sessionPoolName",
+            "in": "path",
+            "description": "Name of the session pool.",
+            "required": true,
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 63,
+            "pattern": "^[a-z][a-z0-9]*$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/McpServerCredential"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Rotate Session Pool MCP server credentials": {
+            "$ref": "./examples/SessionPools_RotateMcpServerCredentials.json"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AccessMode": {
+      "type": "string",
+      "description": "Access mode for storage",
+      "enum": [
+        "ReadOnly",
+        "ReadWrite"
+      ],
+      "x-ms-enum": {
+        "name": "AccessMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ReadOnly",
+            "value": "ReadOnly",
+            "description": "ReadOnly"
+          },
+          {
+            "name": "ReadWrite",
+            "value": "ReadWrite",
+            "description": "ReadWrite"
+          }
+        ]
+      }
+    },
+    "Action": {
+      "type": "string",
+      "description": "Allow or Deny rules to determine for incoming IP. Note: Rules can only consist of ALL Allow or ALL Deny",
+      "enum": [
+        "Allow",
+        "Deny"
+      ],
+      "x-ms-enum": {
+        "name": "Action",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Allow",
+            "value": "Allow",
+            "description": "Allow"
+          },
+          {
+            "name": "Deny",
+            "value": "Deny",
+            "description": "Deny"
+          }
+        ]
+      }
+    },
+    "Affinity": {
+      "type": "string",
+      "description": "Sticky Session Affinity",
+      "enum": [
+        "sticky",
+        "none"
+      ],
+      "x-ms-enum": {
+        "name": "Affinity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "sticky",
+            "value": "sticky",
+            "description": "sticky"
+          },
+          {
+            "name": "none",
+            "value": "none",
+            "description": "none"
+          }
+        ]
+      }
+    },
+    "AllowedAudiencesValidation": {
+      "type": "object",
+      "description": "The configuration settings of the Allowed Audiences validation flow.",
+      "properties": {
+        "allowedAudiences": {
+          "type": "array",
+          "description": "The configuration settings of the allowed list of audiences from which to validate the JWT token.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AllowedPrincipals": {
+      "type": "object",
+      "description": "The configuration settings of the Azure Active Directory allowed principals.",
+      "properties": {
+        "groups": {
+          "type": "array",
+          "description": "The list of the allowed groups.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "identities": {
+          "type": "array",
+          "description": "The list of the allowed identities.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AppInsightsConfiguration": {
+      "type": "object",
+      "description": "Configuration of Application Insights",
+      "properties": {
+        "connectionString": {
+          "type": "string",
+          "format": "password",
+          "description": "Application Insights connection string",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "AppLogsConfiguration": {
+      "type": "object",
+      "description": "Configuration of application logs",
+      "properties": {
+        "destination": {
+          "type": "string",
+          "description": "Logs destination, can be 'log-analytics', 'azure-monitor' or 'none'"
+        },
+        "logAnalyticsConfiguration": {
+          "$ref": "#/definitions/LogAnalyticsConfiguration",
+          "description": "Log Analytics configuration, must only be provided when destination is configured as 'log-analytics'"
+        }
+      }
+    },
+    "AppRegistration": {
+      "type": "object",
+      "description": "The configuration settings of the app registration for providers that have app ids and app secrets",
+      "properties": {
+        "appId": {
+          "type": "string",
+          "description": "The App ID of the app used for login."
+        },
+        "appSecretSettingName": {
+          "type": "string",
+          "description": "The app setting name that contains the app secret."
+        }
+      }
+    },
+    "AppResiliency": {
+      "type": "object",
+      "description": "Configuration to setup App Resiliency",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AppResiliencyProperties",
+          "description": "App Resiliency resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AppResiliencyCollection": {
+      "type": "object",
+      "description": "Collection of AppResiliency policies",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AppResiliency items on this page",
+          "items": {
+            "$ref": "#/definitions/AppResiliency"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AppResiliencyProperties": {
+      "type": "object",
+      "description": "App Resiliency resource specific properties",
+      "properties": {
+        "timeoutPolicy": {
+          "$ref": "#/definitions/TimeoutPolicy",
+          "description": "Policy to set request timeouts"
+        },
+        "httpRetryPolicy": {
+          "$ref": "#/definitions/HttpRetryPolicy",
+          "description": "Policy that defines http request retry conditions"
+        },
+        "tcpRetryPolicy": {
+          "$ref": "#/definitions/TcpRetryPolicy",
+          "description": "Policy that defines tcp request retry conditions"
+        },
+        "circuitBreakerPolicy": {
+          "$ref": "#/definitions/CircuitBreakerPolicy",
+          "description": "Policy that defines circuit breaker conditions"
+        },
+        "httpConnectionPool": {
+          "$ref": "#/definitions/HttpConnectionPool",
+          "description": "Defines parameters for http connection pooling"
+        },
+        "tcpConnectionPool": {
+          "$ref": "#/definitions/TcpConnectionPool",
+          "description": "Defines parameters for tcp connection pooling"
+        }
+      }
+    },
+    "Apple": {
+      "type": "object",
+      "description": "The configuration settings of the Apple provider.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "<code>false</code> if the Apple provider should not be enabled despite the set registration; otherwise, <code>true</code>."
+        },
+        "registration": {
+          "$ref": "#/definitions/AppleRegistration",
+          "description": "The configuration settings of the Apple registration."
+        },
+        "login": {
+          "$ref": "#/definitions/LoginScopes",
+          "description": "The configuration settings of the login flow."
+        }
+      }
+    },
+    "AppleRegistration": {
+      "type": "object",
+      "description": "The configuration settings of the registration for the Apple provider",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The Client ID of the app used for login."
+        },
+        "clientSecretSettingName": {
+          "type": "string",
+          "description": "The app setting name that contains the client secret."
+        }
+      }
+    },
+    "Applicability": {
+      "type": "string",
+      "description": "indicates whether the profile is default for the location.",
+      "enum": [
+        "LocationDefault",
+        "Custom"
+      ],
+      "x-ms-enum": {
+        "name": "Applicability",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "LocationDefault",
+            "value": "LocationDefault",
+            "description": "LocationDefault"
+          },
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "Custom"
+          }
+        ]
+      }
+    },
+    "AuthConfig": {
+      "type": "object",
+      "description": "Configuration settings for the Azure ContainerApp Service Authentication / Authorization feature.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AuthConfigProperties",
+          "description": "AuthConfig resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AuthConfigCollection": {
+      "type": "object",
+      "description": "AuthConfig collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AuthConfig items on this page",
+          "items": {
+            "$ref": "#/definitions/AuthConfig"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AuthConfigProperties": {
+      "type": "object",
+      "description": "AuthConfig resource specific properties",
+      "properties": {
+        "platform": {
+          "$ref": "#/definitions/AuthPlatform",
+          "description": "The configuration settings of the platform of ContainerApp Service Authentication/Authorization."
+        },
+        "globalValidation": {
+          "$ref": "#/definitions/GlobalValidation",
+          "description": "The configuration settings that determines the validation flow of users using  Service Authentication/Authorization."
+        },
+        "identityProviders": {
+          "$ref": "#/definitions/IdentityProviders",
+          "description": "The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization."
+        },
+        "login": {
+          "$ref": "#/definitions/Login",
+          "description": "The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization."
+        },
+        "httpSettings": {
+          "$ref": "#/definitions/HttpSettings",
+          "description": "The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization."
+        },
+        "encryptionSettings": {
+          "$ref": "#/definitions/EncryptionSettings",
+          "description": "The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization."
+        }
+      }
+    },
+    "AuthPlatform": {
+      "type": "object",
+      "description": "The configuration settings of the platform of ContainerApp Service Authentication/Authorization.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "<code>true</code> if the Authentication / Authorization feature is enabled for the current app; otherwise, <code>false</code>."
+        },
+        "runtimeVersion": {
+          "type": "string",
+          "description": "The RuntimeVersion of the Authentication / Authorization feature in use for the current app.\nThe setting in this value can control the behavior of certain features in the Authentication / Authorization module."
+        }
+      }
+    },
+    "AvailableEnvironmentMode": {
+      "type": "object",
+      "description": "An environment mode available to the subscription.",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "The Azure region in which the environment mode is available.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/AvailableEnvironmentModeProperties",
+          "description": "The environment mode details."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AvailableEnvironmentModeProperties": {
+      "type": "object",
+      "description": "Details that describe an available environment mode.",
+      "properties": {
+        "displayName": {
+          "type": "string",
+          "description": "The display name of the environment mode.",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the environment mode.",
+          "readOnly": true
+        }
+      }
+    },
+    "AvailableEnvironmentModesCollection": {
+      "type": "object",
+      "description": "Collection of environment modes available in the location.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AvailableEnvironmentMode items on this page",
+          "items": {
+            "$ref": "#/definitions/AvailableEnvironmentMode"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AvailableOperations": {
+      "type": "object",
+      "description": "Available operations of the service",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The OperationDetail items on this page",
+          "items": {
+            "$ref": "#/definitions/OperationDetail"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AvailableWorkloadProfile": {
+      "type": "object",
+      "description": "A workload profile with specific hardware configure to run container apps.",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Region of the workload profile."
+        },
+        "properties": {
+          "$ref": "#/definitions/AvailableWorkloadProfileProperties",
+          "description": "Revision resource specific properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AvailableWorkloadProfileProperties": {
+      "type": "object",
+      "description": "Revision resource specific properties",
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "Used to categorize workload profiles."
+        },
+        "applicability": {
+          "$ref": "#/definitions/Applicability",
+          "description": "indicates whether the profile is default for the location."
+        },
+        "cores": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of cores in CPU."
+        },
+        "memoryGiB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Memory in GiB."
+        },
+        "gpus": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of GPUs."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The everyday name of the workload profile."
+        }
+      }
+    },
+    "AvailableWorkloadProfilesCollection": {
+      "type": "object",
+      "description": "Collection of available workload profiles in the location.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AvailableWorkloadProfile items on this page",
+          "items": {
+            "$ref": "#/definitions/AvailableWorkloadProfile"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AzureActiveDirectory": {
+      "type": "object",
+      "description": "The configuration settings of the Azure Active directory provider.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "<code>false</code> if the Azure Active Directory provider should not be enabled despite the set registration; otherwise, <code>true</code>."
+        },
+        "registration": {
+          "$ref": "#/definitions/AzureActiveDirectoryRegistration",
+          "description": "The configuration settings of the Azure Active Directory app registration."
+        },
+        "login": {
+          "$ref": "#/definitions/AzureActiveDirectoryLogin",
+          "description": "The configuration settings of the Azure Active Directory login flow."
+        },
+        "validation": {
+          "$ref": "#/definitions/AzureActiveDirectoryValidation",
+          "description": "The configuration settings of the Azure Active Directory token validation flow."
+        },
+        "isAutoProvisioned": {
+          "type": "boolean",
+          "description": "Gets a value indicating whether the Azure AD configuration was auto-provisioned using 1st party tooling.\nThis is an internal flag primarily intended to support the Azure Management Portal. Users should not\nread or write to this property."
+        }
+      }
+    },
+    "AzureActiveDirectoryLogin": {
+      "type": "object",
+      "description": "The configuration settings of the Azure Active Directory login flow.",
+      "properties": {
+        "loginParameters": {
+          "type": "array",
+          "description": "Login parameters to send to the OpenID Connect authorization endpoint when\na user logs in. Each parameter must be in the form \"key=value\".",
+          "items": {
+            "type": "string"
+          }
+        },
+        "disableWWWAuthenticate": {
+          "type": "boolean",
+          "description": "<code>true</code> if the www-authenticate provider should be omitted from the request; otherwise, <code>false</code>."
+        }
+      }
+    },
+    "AzureActiveDirectoryRegistration": {
+      "type": "object",
+      "description": "The configuration settings of the Azure Active Directory app registration.",
+      "properties": {
+        "openIdIssuer": {
+          "type": "string",
+          "description": "The OpenID Connect Issuer URI that represents the entity which issues access tokens for this application.\nWhen using Azure Active Directory, this value is the URI of the directory tenant, e.g. https://login.microsoftonline.com/v2.0/{tenant-guid}/.\nThis URI is a case-sensitive identifier for the token issuer.\nMore information on OpenID Connect Discovery: http://openid.net/specs/openid-connect-discovery-1_0.html"
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The Client ID of this relying party application, known as the client_id.\nThis setting is required for enabling OpenID Connection authentication with Azure Active Directory or\nother 3rd party OpenID Connect providers.\nMore information on OpenID Connect: http://openid.net/specs/openid-connect-core-1_0.html"
+        },
+        "clientSecretSettingName": {
+          "type": "string",
+          "description": "The app setting name that contains the client secret of the relying party application."
+        },
+        "clientSecretCertificateThumbprint": {
+          "type": "string",
+          "description": "An alternative to the client secret, that is the thumbprint of a certificate used for signing purposes. This property acts as\na replacement for the Client Secret. It is also optional."
+        },
+        "clientSecretCertificateSubjectAlternativeName": {
+          "type": "string",
+          "description": "An alternative to the client secret thumbprint, that is the subject alternative name of a certificate used for signing purposes. This property acts as\na replacement for the Client Secret Certificate Thumbprint. It is also optional."
+        },
+        "clientSecretCertificateIssuer": {
+          "type": "string",
+          "description": "An alternative to the client secret thumbprint, that is the issuer of a certificate used for signing purposes. This property acts as\na replacement for the Client Secret Certificate Thumbprint. It is also optional."
+        }
+      }
+    },
+    "AzureActiveDirectoryValidation": {
+      "type": "object",
+      "description": "The configuration settings of the Azure Active Directory token validation flow.",
+      "properties": {
+        "jwtClaimChecks": {
+          "$ref": "#/definitions/JwtClaimChecks",
+          "description": "The configuration settings of the checks that should be made while validating the JWT Claims."
+        },
+        "allowedAudiences": {
+          "type": "array",
+          "description": "The list of audiences that can make successful authentication/authorization requests.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "defaultAuthorizationPolicy": {
+          "$ref": "#/definitions/DefaultAuthorizationPolicy",
+          "description": "The configuration settings of the default authorization policy."
+        }
+      }
+    },
+    "AzureCredentials": {
+      "type": "object",
+      "description": "Container App credentials.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "format": "password",
+          "description": "Client Id.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "clientSecret": {
+          "type": "string",
+          "format": "password",
+          "description": "Client Secret.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "tenantId": {
+          "type": "string",
+          "format": "password",
+          "description": "Tenant Id.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind of auth github does for deploying the template",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        },
+        "subscriptionId": {
+          "type": "string",
+          "description": "Subscription Id."
+        }
+      }
+    },
+    "AzureFileProperties": {
+      "type": "object",
+      "description": "Azure File Properties.",
+      "properties": {
+        "accountName": {
+          "type": "string",
+          "description": "Storage account name for azure file."
+        },
+        "accountKey": {
+          "type": "string",
+          "format": "password",
+          "description": "Storage account key for azure file.",
+          "x-ms-secret": true
+        },
+        "accountKeyVaultProperties": {
+          "$ref": "#/definitions/SecretKeyVaultProperties",
+          "description": "Storage account key stored as an Azure Key Vault secret."
+        },
+        "accessMode": {
+          "$ref": "#/definitions/AccessMode",
+          "description": "Access mode for storage"
+        },
+        "shareName": {
+          "type": "string",
+          "description": "Azure file share name."
+        }
+      }
+    },
+    "AzureStaticWebApps": {
+      "type": "object",
+      "description": "The configuration settings of the Azure Static Web Apps provider.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "<code>false</code> if the Azure Static Web Apps provider should not be enabled despite the set registration; otherwise, <code>true</code>."
+        },
+        "registration": {
+          "$ref": "#/definitions/AzureStaticWebAppsRegistration",
+          "description": "The configuration settings of the Azure Static Web Apps registration."
+        }
+      }
+    },
+    "AzureStaticWebAppsRegistration": {
+      "type": "object",
+      "description": "The configuration settings of the registration for the Azure Static Web Apps provider",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The Client ID of the app used for login."
+        }
+      }
+    },
+    "BaseContainer": {
+      "type": "object",
+      "description": "Container App base container definition.",
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Container image tag."
+        },
+        "imageType": {
+          "$ref": "#/definitions/ImageType",
+          "description": "The type of the image. Set to CloudBuild to let the system manages the image, where user will not be able to update image through image field. Set to ContainerImage for user provided image."
+        },
+        "name": {
+          "type": "string",
+          "description": "Custom container name."
+        },
+        "command": {
+          "type": "array",
+          "description": "Container start command.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "type": "array",
+          "description": "Container start command arguments.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "array",
+          "description": "Container environment variables.",
+          "items": {
+            "$ref": "#/definitions/EnvironmentVar"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "resources": {
+          "$ref": "#/definitions/ContainerResources",
+          "description": "Container resource requirements."
+        },
+        "volumeMounts": {
+          "type": "array",
+          "description": "Container volume mounts.",
+          "items": {
+            "$ref": "#/definitions/VolumeMount"
+          },
+          "x-ms-identifiers": [
+            "volumeName"
+          ]
+        }
+      }
+    },
+    "BillingMeter": {
+      "type": "object",
+      "description": "Billing meter.",
+      "properties": {
+        "location": {
+          "type": "string",
+          "description": "Region for the billing meter."
+        },
+        "properties": {
+          "$ref": "#/definitions/BillingMeterProperties",
+          "description": "Revision resource specific properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "BillingMeterCollection": {
+      "type": "object",
+      "description": "Collection of billing meters.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Collection of billing meters.",
+          "items": {
+            "$ref": "#/definitions/BillingMeter"
+          }
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BillingMeterProperties": {
+      "type": "object",
+      "description": "Revision resource specific properties",
+      "properties": {
+        "category": {
+          "type": "string",
+          "description": "Used to categorize billing meters."
+        },
+        "meterType": {
+          "type": "string",
+          "description": "Billing meter type."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "The everyday name of the billing meter."
+        }
+      }
+    },
+    "BindingType": {
+      "type": "string",
+      "description": "Custom Domain binding type.",
+      "enum": [
+        "Disabled",
+        "SniEnabled",
+        "Auto"
+      ],
+      "x-ms-enum": {
+        "name": "BindingType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "SniEnabled",
+            "value": "SniEnabled",
+            "description": "SniEnabled"
+          },
+          {
+            "name": "Auto",
+            "value": "Auto",
+            "description": "Auto"
+          }
+        ]
+      }
+    },
+    "BlobStorageTokenStore": {
+      "type": "object",
+      "description": "The configuration settings of the storage of the tokens if blob storage is used.",
+      "properties": {
+        "sasUrlSettingName": {
+          "type": "string",
+          "description": "The name of the app secrets containing the SAS URL of the blob storage containing the tokens. Should not be used along with blobContainerUri."
+        },
+        "blobContainerUri": {
+          "type": "string",
+          "description": "The URI of the blob storage containing the tokens. Should not be used along with sasUrlSettingName."
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The Client ID of a User-Assigned Managed Identity. Should not be used along with managedIdentityResourceId."
+        },
+        "managedIdentityResourceId": {
+          "type": "string",
+          "description": "The Resource ID of a User-Assigned Managed Identity. Should not be used along with clientId."
+        }
+      }
+    },
+    "BuildCollection": {
+      "type": "object",
+      "description": "The response of a BuildResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BuildResource items on this page",
+          "items": {
+            "$ref": "#/definitions/BuildResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BuildConfiguration": {
+      "type": "object",
+      "description": "Configuration of the build.",
+      "properties": {
+        "baseOs": {
+          "type": "string",
+          "description": "Base OS used to build and run the app."
+        },
+        "platform": {
+          "type": "string",
+          "description": "Platform to be used to build and run the app."
+        },
+        "platformVersion": {
+          "type": "string",
+          "description": "Platform version to be used to build and run the app."
+        },
+        "environmentVariables": {
+          "type": "array",
+          "description": "List of environment variables to be passed to the build, secrets should not be used in environment variable.",
+          "items": {
+            "$ref": "#/definitions/EnvironmentVariable"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "preBuildSteps": {
+          "type": "array",
+          "description": "List of steps to perform before the build.",
+          "items": {
+            "$ref": "#/definitions/PreBuildStep"
+          },
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "BuildProperties": {
+      "type": "object",
+      "description": "The build properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/BuildProvisioningState",
+          "description": "Build provisioning state.",
+          "readOnly": true
+        },
+        "buildStatus": {
+          "$ref": "#/definitions/BuildStatus",
+          "description": "Status of the build once it has been provisioned.",
+          "readOnly": true
+        },
+        "destinationContainerRegistry": {
+          "$ref": "#/definitions/ContainerRegistryWithCustomImage",
+          "description": "Container registry that the final image will be uploaded to."
+        },
+        "configuration": {
+          "$ref": "#/definitions/BuildConfiguration",
+          "description": "Configuration of the build."
+        },
+        "uploadEndpoint": {
+          "type": "string",
+          "description": "Endpoint to which the source code should be uploaded.",
+          "readOnly": true
+        },
+        "logStreamEndpoint": {
+          "type": "string",
+          "description": "Endpoint from which the build logs can be streamed.",
+          "readOnly": true
+        },
+        "tokenEndpoint": {
+          "type": "string",
+          "description": "Endpoint to use to retrieve an authentication token for log streaming and uploading source code.",
+          "readOnly": true
+        }
+      }
+    },
+    "BuildProvisioningState": {
+      "type": "string",
+      "description": "Resource instance provisioning state.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "BuildProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "BuildResource": {
+      "type": "object",
+      "description": "Information pertaining to an individual build.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BuildProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "BuildStatus": {
+      "type": "string",
+      "description": "Status of the build once it has been provisioned.",
+      "enum": [
+        "NotStarted",
+        "InProgress",
+        "Succeeded",
+        "Canceled",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "BuildStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "NotStarted"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "InProgress"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "BuildToken": {
+      "type": "object",
+      "description": "Build Auth Token.",
+      "properties": {
+        "token": {
+          "type": "string",
+          "format": "password",
+          "description": "Authentication token.",
+          "readOnly": true,
+          "x-ms-secret": true
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Token expiration date.",
+          "readOnly": true
+        }
+      }
+    },
+    "BuilderCollection": {
+      "type": "object",
+      "description": "The response of a BuilderResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The BuilderResource items on this page",
+          "items": {
+            "$ref": "#/definitions/BuilderResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "BuilderProperties": {
+      "type": "object",
+      "description": "The builder properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/BuilderProvisioningState",
+          "description": "Provisioning state of a builder resource.",
+          "readOnly": true
+        },
+        "environmentId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the container apps environment that the builder is associated with."
+        },
+        "containerRegistries": {
+          "type": "array",
+          "description": "List of mappings of container registries and the managed identity used to connect to it.",
+          "items": {
+            "$ref": "#/definitions/ContainerRegistry"
+          },
+          "x-ms-identifiers": [
+            "containerRegistryServer"
+          ]
+        }
+      },
+      "required": [
+        "environmentId"
+      ]
+    },
+    "BuilderProvisioningState": {
+      "type": "string",
+      "description": "Resource instance provisioning state.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Updating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "BuilderProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Creating",
+            "value": "Creating",
+            "description": "Creating"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "BuilderResource": {
+      "type": "object",
+      "description": "Information about the SourceToCloud builder resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/BuilderProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "BuilderResourceUpdate": {
+      "type": "object",
+      "description": "The type used for update operations of the BuilderResource.",
+      "properties": {
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "properties": {
+          "$ref": "#/definitions/BuilderResourceUpdateProperties",
+          "description": "The updatable properties of the BuilderResource.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "BuilderResourceUpdateProperties": {
+      "type": "object",
+      "description": "The updatable properties of the BuilderResource.",
+      "properties": {
+        "environmentId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the container apps environment that the builder is associated with."
+        }
+      }
+    },
+    "Certificate": {
+      "type": "object",
+      "description": "Certificate used for Custom Domain bindings of Container Apps in a Managed Environment",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/CertificateProperties",
+          "description": "Certificate resource specific properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "CertificateCollection": {
+      "type": "object",
+      "description": "Collection of Certificates.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Certificate items on this page",
+          "items": {
+            "$ref": "#/definitions/Certificate"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "CertificateKeyVaultProperties": {
+      "type": "object",
+      "description": "Properties for a certificate stored in a Key Vault.",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "description": "Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a system-assigned identity."
+        },
+        "keyVaultUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL pointing to the Azure Key Vault secret that holds the certificate."
+        }
+      }
+    },
+    "CertificatePatch": {
+      "type": "object",
+      "description": "A certificate to update",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Application-specific metadata in the form of key-value pairs.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CertificateProperties": {
+      "type": "object",
+      "description": "Certificate resource specific properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/CertificateProvisioningState",
+          "description": "Provisioning state of the certificate.",
+          "readOnly": true
+        },
+        "deploymentErrors": {
+          "type": "string",
+          "description": "Any errors that occurred during deployment or deployment validation",
+          "readOnly": true
+        },
+        "certificateKeyVaultProperties": {
+          "$ref": "#/definitions/CertificateKeyVaultProperties",
+          "description": "Properties for a certificate stored in a Key Vault."
+        },
+        "password": {
+          "type": "string",
+          "format": "password",
+          "description": "Certificate password.",
+          "x-ms-mutability": [
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "subjectName": {
+          "type": "string",
+          "description": "Subject name of the certificate.",
+          "readOnly": true
+        },
+        "subjectAlternativeNames": {
+          "type": "array",
+          "description": "Subject alternative names the certificate applies to.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "format": "password",
+          "description": "PFX or PEM blob",
+          "x-ms-mutability": [
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "issuer": {
+          "type": "string",
+          "description": "Certificate issuer.",
+          "readOnly": true
+        },
+        "issueDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Certificate issue Date.",
+          "readOnly": true
+        },
+        "expirationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Certificate expiration date.",
+          "readOnly": true
+        },
+        "thumbprint": {
+          "type": "string",
+          "description": "Certificate thumbprint.",
+          "readOnly": true
+        },
+        "valid": {
+          "type": "boolean",
+          "description": "Is the certificate valid?.",
+          "readOnly": true
+        },
+        "publicKeyHash": {
+          "type": "string",
+          "description": "Public key hash.",
+          "readOnly": true
+        },
+        "certificateType": {
+          "$ref": "#/definitions/CertificateType",
+          "description": "The type of the certificate. Allowed values are `ServerSSLCertificate` and `ImagePullTrustedCA`"
+        }
+      }
+    },
+    "CertificateProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the certificate.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "DeleteFailed",
+        "Pending",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "CertificateProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "DeleteFailed",
+            "value": "DeleteFailed",
+            "description": "DeleteFailed"
+          },
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Pending"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "CertificateType": {
+      "type": "string",
+      "description": "The type of the certificate. Allowed values are `ServerSSLCertificate` and `ImagePullTrustedCA`",
+      "enum": [
+        "ServerSSLCertificate",
+        "ImagePullTrustedCA"
+      ],
+      "x-ms-enum": {
+        "name": "CertificateType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ServerSSLCertificate",
+            "value": "ServerSSLCertificate",
+            "description": "ServerSSLCertificate"
+          },
+          {
+            "name": "ImagePullTrustedCA",
+            "value": "ImagePullTrustedCA",
+            "description": "ImagePullTrustedCA"
+          }
+        ]
+      }
+    },
+    "CircuitBreakerPolicy": {
+      "type": "object",
+      "description": "Policy that defines circuit breaker conditions",
+      "properties": {
+        "consecutiveErrors": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of consecutive errors before the circuit breaker opens"
+        },
+        "intervalInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The time interval, in seconds, between endpoint checks. This can result in opening the circuit breaker if the check fails as well as closing the circuit breaker if the check succeeds. Defaults to 10s."
+        },
+        "maxEjectionPercent": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum percentage of hosts that will be ejected after failure threshold has been met"
+        }
+      }
+    },
+    "ClientRegistration": {
+      "type": "object",
+      "description": "The configuration settings of the app registration for providers that have client ids and client secrets",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The Client ID of the app used for login."
+        },
+        "clientSecretSettingName": {
+          "type": "string",
+          "description": "The app setting name that contains the client secret."
+        }
+      }
+    },
+    "Configuration": {
+      "type": "object",
+      "description": "Non versioned Container App configuration properties that define the mutable settings of a Container app",
+      "properties": {
+        "secrets": {
+          "type": "array",
+          "description": "Collection of secrets used by a Container app",
+          "items": {
+            "$ref": "#/definitions/Secret"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "activeRevisionsMode": {
+          "type": "string",
+          "description": "ActiveRevisionsMode controls how active revisions are handled for the Container app:\n<list><item>Single: Only one revision can be active at a time. Traffic weights cannot be used. This is the default.</item><item>Multiple: Multiple revisions can be active, including optional traffic weights and labels.</item><item>Labels: Only revisions with labels are active. Traffic weights can be applied to labels.</item></list>",
+          "default": "Single",
+          "enum": [
+            "Multiple",
+            "Single",
+            "Labels"
+          ],
+          "x-ms-enum": {
+            "name": "ActiveRevisionsMode",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Multiple",
+                "value": "Multiple",
+                "description": "Multiple"
+              },
+              {
+                "name": "Single",
+                "value": "Single",
+                "description": "Single"
+              },
+              {
+                "name": "Labels",
+                "value": "Labels",
+                "description": "Labels"
+              }
+            ]
+          }
+        },
+        "targetLabel": {
+          "type": "string",
+          "description": "Required in labels revisions mode. Label to apply to newly created revision."
+        },
+        "ingress": {
+          "$ref": "#/definitions/Ingress",
+          "description": "Ingress configurations."
+        },
+        "registries": {
+          "type": "array",
+          "description": "Collection of private container registry credentials for containers used by the Container app",
+          "items": {
+            "$ref": "#/definitions/RegistryCredentials"
+          },
+          "x-ms-identifiers": [
+            "server"
+          ]
+        },
+        "dapr": {
+          "$ref": "#/definitions/Dapr",
+          "description": "Dapr configuration for the Container App."
+        },
+        "runtime": {
+          "$ref": "#/definitions/Runtime",
+          "description": "App runtime configuration for the Container App."
+        },
+        "maxInactiveRevisions": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. Max inactive revisions a Container App can have."
+        },
+        "revisionTransitionThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. The percent of the total number of replicas that must be brought up before revision transition occurs. Defaults to 100 when none is given. Value must be greater than 0 and less than or equal to 100.",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "service": {
+          "$ref": "#/definitions/Service",
+          "description": "Container App to be a dev Container App Service"
+        },
+        "identitySettings": {
+          "type": "array",
+          "description": "Optional settings for Managed Identities that are assigned to the Container App. If a Managed Identity is not specified here, default settings will be used.",
+          "items": {
+            "$ref": "#/definitions/IdentitySettings"
+          },
+          "x-ms-identifiers": [
+            "identity"
+          ]
+        }
+      }
+    },
+    "ConnectedEnvironment": {
+      "type": "object",
+      "description": "An environment for Kubernetes cluster specialized for web workloads by Azure App Service",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectedEnvironmentProperties",
+          "description": "ConnectedEnvironment resource specific properties",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The complex type of the extended location."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ConnectedEnvironmentCollection": {
+      "type": "object",
+      "description": "Collection of connectedEnvironments",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ConnectedEnvironment items on this page",
+          "items": {
+            "$ref": "#/definitions/ConnectedEnvironment"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ConnectedEnvironmentPatchResource": {
+      "type": "object",
+      "description": "Connected environment patch properties",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ResourceTags"
+        }
+      ]
+    },
+    "ConnectedEnvironmentProperties": {
+      "type": "object",
+      "description": "ConnectedEnvironment resource specific properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ConnectedEnvironmentProvisioningState",
+          "description": "Provisioning state of the Kubernetes Environment.",
+          "readOnly": true
+        },
+        "deploymentErrors": {
+          "type": "string",
+          "description": "Any errors that occurred during deployment or deployment validation",
+          "readOnly": true
+        },
+        "defaultDomain": {
+          "type": "string",
+          "description": "Default Domain Name for the cluster",
+          "readOnly": true
+        },
+        "staticIp": {
+          "type": "string",
+          "description": "Static IP of the connectedEnvironment"
+        },
+        "daprAIConnectionString": {
+          "type": "string",
+          "format": "password",
+          "description": "Application Insights connection string used by Dapr to export Service to Service communication telemetry",
+          "x-ms-secret": true
+        },
+        "customDomainConfiguration": {
+          "$ref": "#/definitions/CustomDomainConfiguration",
+          "description": "Custom domain configuration for the environment"
+        }
+      }
+    },
+    "ConnectedEnvironmentProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Kubernetes Environment.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Waiting",
+        "InitializationInProgress",
+        "InfrastructureSetupInProgress",
+        "InfrastructureSetupComplete",
+        "ScheduledForDelete"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectedEnvironmentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Waiting",
+            "value": "Waiting",
+            "description": "Waiting"
+          },
+          {
+            "name": "InitializationInProgress",
+            "value": "InitializationInProgress",
+            "description": "InitializationInProgress"
+          },
+          {
+            "name": "InfrastructureSetupInProgress",
+            "value": "InfrastructureSetupInProgress",
+            "description": "InfrastructureSetupInProgress"
+          },
+          {
+            "name": "InfrastructureSetupComplete",
+            "value": "InfrastructureSetupComplete",
+            "description": "InfrastructureSetupComplete"
+          },
+          {
+            "name": "ScheduledForDelete",
+            "value": "ScheduledForDelete",
+            "description": "ScheduledForDelete"
+          }
+        ]
+      }
+    },
+    "ConnectedEnvironmentStorage": {
+      "type": "object",
+      "description": "Storage resource for connectedEnvironment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ConnectedEnvironmentStorageProperties",
+          "description": "Storage properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ConnectedEnvironmentStorageProperties": {
+      "type": "object",
+      "description": "Storage properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ConnectedEnvironmentStorageProvisioningState",
+          "description": "Provisioning state of the storage.",
+          "readOnly": true
+        },
+        "deploymentErrors": {
+          "type": "string",
+          "description": "Any errors that occurred during deployment or deployment validation",
+          "readOnly": true
+        },
+        "azureFile": {
+          "$ref": "#/definitions/AzureFileProperties",
+          "description": "Azure file properties"
+        },
+        "smb": {
+          "$ref": "#/definitions/SmbStorage",
+          "description": "SMB storage properties"
+        }
+      }
+    },
+    "ConnectedEnvironmentStorageProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the storage.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "InProgress",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "ConnectedEnvironmentStorageProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "InProgress"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "ConnectedEnvironmentStoragesCollection": {
+      "type": "object",
+      "description": "Collection of Storage for Environments",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Collection of storage resources.",
+          "items": {
+            "$ref": "#/definitions/ConnectedEnvironmentStorage"
+          }
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Container": {
+      "type": "object",
+      "description": "Container App container definition",
+      "properties": {
+        "probes": {
+          "type": "array",
+          "description": "List of probes for the container.",
+          "items": {
+            "$ref": "#/definitions/ContainerAppProbe"
+          },
+          "x-ms-identifiers": [
+            "type"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseContainer"
+        }
+      ]
+    },
+    "ContainerApp": {
+      "type": "object",
+      "description": "Container App.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContainerAppProperties",
+          "description": "ContainerApp resource specific properties",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The complex type of the extended location."
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "managed identities for the Container App to interact with other Azure services without maintaining any secrets or credentials in code."
+        },
+        "managedBy": {
+          "type": "string",
+          "description": "The fully qualified resource ID of the resource that manages this resource. Indicates if this resource is managed by another Azure resource. If this is present, complete mode deployment will not delete the resource if it is removed from the template since it is managed by another resource.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "kind": {
+          "$ref": "#/definitions/Kind",
+          "description": "Metadata to represent the container app kind, representing if a container app is workflowapp or functionapp.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ContainerAppAuthToken": {
+      "type": "object",
+      "description": "Container App Auth Token.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContainerAppAuthTokenProperties",
+          "description": "Container App auth token resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ContainerAppAuthTokenProperties": {
+      "type": "object",
+      "description": "Container App auth token resource specific properties",
+      "properties": {
+        "token": {
+          "type": "string",
+          "format": "password",
+          "description": "Auth token value.",
+          "readOnly": true,
+          "x-ms-secret": true
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Token expiration date.",
+          "readOnly": true
+        }
+      }
+    },
+    "ContainerAppCollection": {
+      "type": "object",
+      "description": "Container App collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContainerApp items on this page",
+          "items": {
+            "$ref": "#/definitions/ContainerApp"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContainerAppContainerRunningState": {
+      "type": "string",
+      "description": "Current running state of the container",
+      "enum": [
+        "Running",
+        "Terminated",
+        "Waiting"
+      ],
+      "x-ms-enum": {
+        "name": "ContainerAppContainerRunningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Running"
+          },
+          {
+            "name": "Terminated",
+            "value": "Terminated",
+            "description": "Terminated"
+          },
+          {
+            "name": "Waiting",
+            "value": "Waiting",
+            "description": "Waiting"
+          }
+        ]
+      }
+    },
+    "ContainerAppJobExecutions": {
+      "type": "object",
+      "description": "Container App executions collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The JobExecution items on this page",
+          "items": {
+            "$ref": "#/definitions/JobExecution"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContainerAppProbe": {
+      "type": "object",
+      "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+      "properties": {
+        "failureThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1. Maximum value is 10."
+        },
+        "httpGet": {
+          "$ref": "#/definitions/ContainerAppProbeHttpGet",
+          "description": "HTTPGet specifies the http request to perform."
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of seconds after the container has started before liveness probes are initiated. Minimum value is 1. Maximum value is 60."
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1. Maximum value is 240."
+        },
+        "successThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1. Maximum value is 10."
+        },
+        "tcpSocket": {
+          "$ref": "#/definitions/ContainerAppProbeTcpSocket",
+          "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported."
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate. Maximum value is 3600 seconds (1 hour)"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 240."
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The type of probe."
+        }
+      }
+    },
+    "ContainerAppProbeHttpGet": {
+      "type": "object",
+      "description": "HTTPGet specifies the http request to perform.",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead."
+        },
+        "httpHeaders": {
+          "type": "array",
+          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+          "items": {
+            "$ref": "#/definitions/ContainerAppProbeHttpGetHttpHeadersItem"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to access on the HTTP server."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+        },
+        "scheme": {
+          "$ref": "#/definitions/Scheme",
+          "description": "Scheme to use for connecting to the host. Defaults to HTTP."
+        }
+      },
+      "required": [
+        "port"
+      ]
+    },
+    "ContainerAppProbeHttpGetHttpHeadersItem": {
+      "type": "object",
+      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The header field name"
+        },
+        "value": {
+          "type": "string",
+          "description": "The header field value"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    },
+    "ContainerAppProbeTcpSocket": {
+      "type": "object",
+      "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported.",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Optional: Host name to connect to, defaults to the pod IP."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+        }
+      },
+      "required": [
+        "port"
+      ]
+    },
+    "ContainerAppProperties": {
+      "type": "object",
+      "description": "ContainerApp resource specific properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/ContainerAppProvisioningState",
+          "description": "Provisioning state of the Container App.",
+          "readOnly": true
+        },
+        "runningStatus": {
+          "$ref": "#/definitions/ContainerAppRunningStatus",
+          "description": "Running status of the Container App.",
+          "readOnly": true
+        },
+        "deploymentErrors": {
+          "type": "string",
+          "description": "Any errors that occurred during deployment",
+          "readOnly": true
+        },
+        "managedEnvironmentId": {
+          "type": "string",
+          "description": "Deprecated. Resource ID of the Container App's environment.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "environmentId": {
+          "type": "string",
+          "description": "Resource ID of environment.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "workloadProfileName": {
+          "type": "string",
+          "description": "Workload profile name to pin for container app execution."
+        },
+        "patchingConfiguration": {
+          "$ref": "#/definitions/ContainerAppPropertiesPatchingConfiguration",
+          "description": "Container App auto patch configuration."
+        },
+        "latestRevisionName": {
+          "type": "string",
+          "description": "Name of the latest revision of the Container App.",
+          "readOnly": true
+        },
+        "latestReadyRevisionName": {
+          "type": "string",
+          "description": "Name of the latest ready revision of the Container App.",
+          "readOnly": true
+        },
+        "latestRevisionFqdn": {
+          "type": "string",
+          "description": "Fully Qualified Domain Name of the latest revision of the Container App.",
+          "readOnly": true
+        },
+        "customDomainVerificationId": {
+          "type": "string",
+          "description": "Id used to verify domain name ownership",
+          "readOnly": true
+        },
+        "configuration": {
+          "$ref": "#/definitions/Configuration",
+          "description": "Non versioned Container App configuration properties."
+        },
+        "template": {
+          "$ref": "#/definitions/Template",
+          "description": "Container App versioned application definition."
+        },
+        "outboundIpAddresses": {
+          "type": "array",
+          "description": "Outbound IP Addresses for container app.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "eventStreamEndpoint": {
+          "type": "string",
+          "description": "The endpoint of the eventstream of the container app.",
+          "readOnly": true
+        }
+      }
+    },
+    "ContainerAppPropertiesPatchingConfiguration": {
+      "type": "object",
+      "description": "Container App auto patch configuration.",
+      "properties": {
+        "patchingMode": {
+          "$ref": "#/definitions/PatchingMode",
+          "description": "Patching mode for the container app. Null or default in this field will be interpreted as Automatic by RP. Automatic mode will automatically apply available patches. Manual mode will require the user to manually apply patches. Disabled mode will stop patch detection and auto patching."
+        }
+      }
+    },
+    "ContainerAppProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Container App.",
+      "enum": [
+        "InProgress",
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "ContainerAppProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "InProgress"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "ContainerAppReplicaRunningState": {
+      "type": "string",
+      "description": "Current running state of the replica",
+      "enum": [
+        "Running",
+        "NotRunning",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "ContainerAppReplicaRunningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Running"
+          },
+          {
+            "name": "NotRunning",
+            "value": "NotRunning",
+            "description": "NotRunning"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          }
+        ]
+      }
+    },
+    "ContainerAppRunningStatus": {
+      "type": "string",
+      "description": "Running status of the Container App.",
+      "enum": [
+        "Progressing",
+        "Running",
+        "Stopped",
+        "Suspended",
+        "Ready"
+      ],
+      "x-ms-enum": {
+        "name": "ContainerAppRunningStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Progressing",
+            "value": "Progressing",
+            "description": "Container App is transitioning between Stopped and Running states."
+          },
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Container App is in Running state."
+          },
+          {
+            "name": "Stopped",
+            "value": "Stopped",
+            "description": "Container App is in Stopped state."
+          },
+          {
+            "name": "Suspended",
+            "value": "Suspended",
+            "description": "Container App Job is in Suspended state."
+          },
+          {
+            "name": "Ready",
+            "value": "Ready",
+            "description": "Container App Job is in Ready state."
+          }
+        ]
+      }
+    },
+    "ContainerAppSecret": {
+      "type": "object",
+      "description": "Container App Secret.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Secret Name.",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "format": "password",
+          "description": "Secret Value.",
+          "readOnly": true,
+          "x-ms-secret": true
+        },
+        "identity": {
+          "type": "string",
+          "description": "Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a system-assigned identity.",
+          "readOnly": true
+        },
+        "keyVaultUrl": {
+          "type": "string",
+          "description": "Azure Key Vault URL pointing to the secret referenced by the container app.",
+          "readOnly": true
+        }
+      }
+    },
+    "ContainerAppsBuildCollection": {
+      "type": "object",
+      "description": "The response of a Container Apps Build Resource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContainerAppsBuildResource items on this page",
+          "items": {
+            "$ref": "#/definitions/ContainerAppsBuildResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContainerAppsBuildConfiguration": {
+      "type": "object",
+      "description": "Configuration of the build.",
+      "properties": {
+        "baseOs": {
+          "type": "string",
+          "description": "Base OS used to build and run the app.",
+          "readOnly": true
+        },
+        "platform": {
+          "type": "string",
+          "description": "Platform to be used to build and run the app.",
+          "readOnly": true
+        },
+        "platformVersion": {
+          "type": "string",
+          "description": "Platform version to be used to build and run the app.",
+          "readOnly": true
+        },
+        "environmentVariables": {
+          "type": "array",
+          "description": "List of environment variables to be passed to the build, secrets should not be used in environment variable.",
+          "items": {
+            "$ref": "#/definitions/EnvironmentVariable"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "preBuildSteps": {
+          "type": "array",
+          "description": "List of steps to perform before the build.",
+          "items": {
+            "$ref": "#/definitions/PreBuildStep"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "ContainerAppsBuildProperties": {
+      "type": "object",
+      "description": "The ContainerAppBuild properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/BuildProvisioningState",
+          "description": "Build provisioning state.",
+          "readOnly": true
+        },
+        "buildStatus": {
+          "$ref": "#/definitions/BuildStatus",
+          "description": "Status of the build once it has been provisioned.",
+          "readOnly": true
+        },
+        "destinationContainerRegistry": {
+          "$ref": "#/definitions/ContainerRegistryWithCustomImage",
+          "description": "Container registry that the final image will be uploaded to.",
+          "readOnly": true
+        },
+        "configuration": {
+          "$ref": "#/definitions/ContainerAppsBuildConfiguration",
+          "description": "Configuration of the build.",
+          "readOnly": true
+        },
+        "logStreamEndpoint": {
+          "type": "string",
+          "description": "Endpoint from which the build logs can be streamed.",
+          "readOnly": true
+        }
+      }
+    },
+    "ContainerAppsBuildResource": {
+      "type": "object",
+      "description": "Information pertaining to an individual build.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContainerAppsBuildProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ContainerAppsFunction": {
+      "type": "object",
+      "description": "Container App Function.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ContainerAppsFunctionProperties",
+          "description": "Function resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ContainerAppsFunctionCollection": {
+      "type": "object",
+      "description": "Container App Functions collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContainerAppsFunction items on this page",
+          "items": {
+            "$ref": "#/definitions/ContainerAppsFunction"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ContainerAppsFunctionProperties": {
+      "type": "object",
+      "description": "Function resource specific properties",
+      "properties": {
+        "invokeUrlTemplate": {
+          "type": "string",
+          "format": "uri",
+          "description": "Invoke URL for the function.",
+          "readOnly": true
+        },
+        "triggerType": {
+          "type": "string",
+          "description": "Trigger type of the function.",
+          "readOnly": true
+        },
+        "language": {
+          "type": "string",
+          "description": "Programming language of the function.",
+          "readOnly": true
+        },
+        "isDisabled": {
+          "type": "boolean",
+          "description": "Indicates whether the function is disabled.",
+          "readOnly": true
+        }
+      }
+    },
+    "ContainerAppsPatchResource": {
+      "type": "object",
+      "description": "Container App Patch",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PatchProperties",
+          "description": "Properties that describes current states of the patch resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ContainerExecutionStatus": {
+      "type": "object",
+      "description": "Container Apps Job execution container status. Contains status code and reason",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Container Name."
+        },
+        "code": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Exit code"
+        },
+        "additionalInformation": {
+          "type": "string",
+          "description": "Additional information for the container status"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status of the container"
+        }
+      }
+    },
+    "ContainerRegistry": {
+      "type": "object",
+      "description": "Model representing a mapping from a container registry to the identity used to connect to it.",
+      "properties": {
+        "containerRegistryServer": {
+          "type": "string",
+          "description": "Login server of the container registry."
+        },
+        "identityResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the managed identity."
+        }
+      },
+      "required": [
+        "containerRegistryServer",
+        "identityResourceId"
+      ]
+    },
+    "ContainerRegistryWithCustomImage": {
+      "type": "object",
+      "description": "Container registry that the final image will be uploaded to.",
+      "properties": {
+        "server": {
+          "type": "string",
+          "description": "Login server of the container registry that the final image should be uploaded to. Builder resource needs to have this container registry defined along with an identity to use to access it."
+        },
+        "image": {
+          "type": "string",
+          "description": "Full name that the final image should be uploaded as, including both image name and tag."
+        }
+      },
+      "required": [
+        "server"
+      ]
+    },
+    "ContainerResources": {
+      "type": "object",
+      "description": "Container App container resource requirements.",
+      "properties": {
+        "cpu": {
+          "type": "number",
+          "format": "double",
+          "description": "Required CPU in cores, e.g. 0.5"
+        },
+        "memory": {
+          "type": "string",
+          "description": "Required memory, e.g. \"250Mb\""
+        },
+        "ephemeralStorage": {
+          "type": "string",
+          "description": "Ephemeral Storage, e.g. \"1Gi\"",
+          "readOnly": true
+        },
+        "gpu": {
+          "type": "number",
+          "format": "double",
+          "description": "Required GPU in cores for GPU based app, e.g. 1.0"
+        }
+      }
+    },
+    "ContainerType": {
+      "type": "string",
+      "description": "The container type of the sessions. You can use your own container to build the session pool, or you can use a predefined container to run workload with specific language.",
+      "enum": [
+        "CustomContainer",
+        "PythonLTS",
+        "Shell",
+        "NodeLTS"
+      ],
+      "x-ms-enum": {
+        "name": "ContainerType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "CustomContainer",
+            "value": "CustomContainer",
+            "description": "CustomContainer"
+          },
+          {
+            "name": "PythonLTS",
+            "value": "PythonLTS",
+            "description": "PythonLTS"
+          },
+          {
+            "name": "Shell",
+            "value": "Shell",
+            "description": "Shell"
+          },
+          {
+            "name": "NodeLTS",
+            "value": "NodeLTS",
+            "description": "NodeLTS"
+          }
+        ]
+      }
+    },
+    "CookieExpiration": {
+      "type": "object",
+      "description": "The configuration settings of the session cookie's expiration.",
+      "properties": {
+        "convention": {
+          "$ref": "#/definitions/CookieExpirationConvention",
+          "description": "The convention used when determining the session cookie's expiration."
+        },
+        "timeToExpiration": {
+          "type": "string",
+          "description": "The time after the request is made when the session cookie should expire."
+        }
+      }
+    },
+    "CookieExpirationConvention": {
+      "type": "string",
+      "description": "The convention used when determining the session cookie's expiration.",
+      "enum": [
+        "FixedTime",
+        "IdentityProviderDerived"
+      ],
+      "x-ms-enum": {
+        "name": "CookieExpirationConvention",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "FixedTime",
+            "value": "FixedTime",
+            "description": "FixedTime"
+          },
+          {
+            "name": "IdentityProviderDerived",
+            "value": "IdentityProviderDerived",
+            "description": "IdentityProviderDerived"
+          }
+        ]
+      }
+    },
+    "CorsPolicy": {
+      "type": "object",
+      "description": "Cross-Origin-Resource-Sharing policy",
+      "properties": {
+        "allowedOrigins": {
+          "type": "array",
+          "description": "Specifies the content for the access-control-allow-origins header",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowedMethods": {
+          "type": "array",
+          "description": "Specifies the content for the access-control-allow-methods header",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowedHeaders": {
+          "type": "array",
+          "description": "Specifies the content for the access-control-allow-headers header",
+          "items": {
+            "type": "string"
+          }
+        },
+        "exposeHeaders": {
+          "type": "array",
+          "description": "Specifies the content for the access-control-expose-headers header",
+          "items": {
+            "type": "string"
+          }
+        },
+        "maxAge": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the content for the access-control-max-age header"
+        },
+        "allowCredentials": {
+          "type": "boolean",
+          "description": "Specifies whether the resource allows credentials"
+        }
+      },
+      "required": [
+        "allowedOrigins"
+      ]
+    },
+    "CustomContainerTemplate": {
+      "type": "object",
+      "description": "Custom container configuration.",
+      "properties": {
+        "registryCredentials": {
+          "$ref": "#/definitions/SessionRegistryCredentials",
+          "description": "Private container registry credentials for containers used by the sessions of the session pool."
+        },
+        "containers": {
+          "type": "array",
+          "description": "List of container definitions for the sessions of the session pool.",
+          "items": {
+            "$ref": "#/definitions/SessionContainer"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "ingress": {
+          "$ref": "#/definitions/SessionIngress",
+          "description": "Session pool ingress configuration."
+        }
+      }
+    },
+    "CustomDomain": {
+      "type": "object",
+      "description": "Custom Domain of a Container App",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Hostname."
+        },
+        "bindingType": {
+          "$ref": "#/definitions/BindingType",
+          "description": "Custom Domain binding type."
+        },
+        "certificateId": {
+          "type": "string",
+          "description": "Resource Id of the Certificate to be bound to this hostname. Must exist in the Managed Environment."
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
+    "CustomDomainConfiguration": {
+      "type": "object",
+      "description": "Configuration properties for apps environment custom domain",
+      "properties": {
+        "customDomainVerificationId": {
+          "type": "string",
+          "description": "Id used to verify domain name ownership",
+          "readOnly": true
+        },
+        "dnsSuffix": {
+          "type": "string",
+          "description": "Dns suffix for the environment domain",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "certificateKeyVaultProperties": {
+          "$ref": "#/definitions/CertificateKeyVaultProperties",
+          "description": "Certificate stored in Azure Key Vault."
+        },
+        "certificateValue": {
+          "type": "string",
+          "format": "password",
+          "description": "PFX or PEM blob",
+          "x-ms-secret": true
+        },
+        "certificatePassword": {
+          "type": "string",
+          "format": "password",
+          "description": "Certificate password",
+          "x-ms-secret": true
+        },
+        "expirationDate": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Certificate expiration date.",
+          "readOnly": true
+        },
+        "thumbprint": {
+          "type": "string",
+          "description": "Certificate thumbprint.",
+          "readOnly": true
+        },
+        "subjectName": {
+          "type": "string",
+          "description": "Subject name of the certificate.",
+          "readOnly": true
+        }
+      }
+    },
+    "CustomDomainVerificationId": {
+      "type": "string",
+      "description": "Custom domain verification Id of a subscription"
+    },
+    "CustomHostnameAnalysisResult": {
+      "type": "object",
+      "description": "Custom domain analysis.",
+      "properties": {
+        "hostName": {
+          "type": "string",
+          "description": "Host name that was analyzed",
+          "readOnly": true
+        },
+        "isHostnameAlreadyVerified": {
+          "type": "boolean",
+          "description": "<code>true</code> if hostname is already verified; otherwise, <code>false</code>.",
+          "readOnly": true
+        },
+        "customDomainVerificationTest": {
+          "$ref": "#/definitions/DnsVerificationTestResult",
+          "description": "DNS verification test result.",
+          "readOnly": true
+        },
+        "customDomainVerificationFailureInfo": {
+          "$ref": "#/definitions/CustomHostnameAnalysisResultCustomDomainVerificationFailureInfo",
+          "description": "Raw failure information if DNS verification fails.",
+          "readOnly": true
+        },
+        "hasConflictOnManagedEnvironment": {
+          "type": "boolean",
+          "description": "<code>true</code> if there is a conflict on the Container App's managed environment; otherwise, <code>false</code>.",
+          "readOnly": true
+        },
+        "conflictWithEnvironmentCustomDomain": {
+          "type": "boolean",
+          "description": "<code>true</code> if there is a conflict on the Container App's managed environment level custom domain; otherwise, <code>false</code>.",
+          "readOnly": true
+        },
+        "conflictingContainerAppResourceId": {
+          "type": "string",
+          "description": "Name of the conflicting Container App on the Managed Environment if it's within the same subscription.",
+          "readOnly": true
+        },
+        "cNameRecords": {
+          "type": "array",
+          "description": "CName records visible for this hostname.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "txtRecords": {
+          "type": "array",
+          "description": "TXT records visible for this hostname.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "aRecords": {
+          "type": "array",
+          "description": "A records visible for this hostname.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "alternateCNameRecords": {
+          "type": "array",
+          "description": "Alternate CName records visible for this hostname.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "alternateTxtRecords": {
+          "type": "array",
+          "description": "Alternate TXT records visible for this hostname.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CustomHostnameAnalysisResultCustomDomainVerificationFailureInfo": {
+      "type": "object",
+      "description": "Raw failure information if DNS verification fails.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Standardized string to programmatically identify the error.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Detailed error description and debugging information.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "Detailed error description and debugging information.",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "description": "Details or the error",
+          "items": {
+            "$ref": "#/definitions/CustomHostnameAnalysisResultCustomDomainVerificationFailureInfoDetailsItem"
+          },
+          "x-ms-identifiers": [
+            "code"
+          ]
+        }
+      }
+    },
+    "CustomHostnameAnalysisResultCustomDomainVerificationFailureInfoDetailsItem": {
+      "type": "object",
+      "description": "Detailed errors.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Standardized string to programmatically identify the error.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Detailed error description and debugging information.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "Detailed error description and debugging information.",
+          "readOnly": true
+        }
+      }
+    },
+    "CustomOpenIdConnectProvider": {
+      "type": "object",
+      "description": "The configuration settings of the custom Open ID Connect provider.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "<code>false</code> if the custom Open ID provider provider should not be enabled; otherwise, <code>true</code>."
+        },
+        "registration": {
+          "$ref": "#/definitions/OpenIdConnectRegistration",
+          "description": "The configuration settings of the app registration for the custom Open ID Connect provider."
+        },
+        "login": {
+          "$ref": "#/definitions/OpenIdConnectLogin",
+          "description": "The configuration settings of the login flow of the custom Open ID Connect provider."
+        }
+      }
+    },
+    "CustomScaleRule": {
+      "type": "object",
+      "description": "Container App container Custom scaling rule.",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of the custom scale rule\neg: azure-servicebus, redis etc."
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Metadata properties to describe custom scale rule.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "auth": {
+          "type": "array",
+          "description": "Authentication secrets for the custom scale rule.",
+          "items": {
+            "$ref": "#/definitions/ScaleRuleAuth"
+          },
+          "x-ms-identifiers": [
+            "triggerParameter"
+          ]
+        },
+        "identity": {
+          "type": "string",
+          "description": "The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for system-assigned identity."
+        }
+      }
+    },
+    "Dapr": {
+      "type": "object",
+      "description": "Container App Dapr configuration.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Boolean indicating if the Dapr side car is enabled",
+          "default": false
+        },
+        "appId": {
+          "type": "string",
+          "description": "Dapr application identifier"
+        },
+        "appProtocol": {
+          "type": "string",
+          "description": "Tells Dapr which protocol your application is using. Valid options are http and grpc. Default is http",
+          "default": "http",
+          "enum": [
+            "http",
+            "grpc"
+          ],
+          "x-ms-enum": {
+            "name": "AppProtocol",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "http",
+                "value": "http",
+                "description": "http"
+              },
+              {
+                "name": "grpc",
+                "value": "grpc",
+                "description": "grpc"
+              }
+            ]
+          }
+        },
+        "appPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Tells Dapr which port your application is listening on"
+        },
+        "httpReadBufferSize": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Dapr max size of http header read buffer in KB to handle when sending multi-KB headers. Default is 65KB."
+        },
+        "httpMaxRequestSize": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Increasing max size of request body http and grpc servers parameter in MB to handle uploading of big files. Default is 4 MB."
+        },
+        "logLevel": {
+          "$ref": "#/definitions/LogLevel",
+          "description": "Sets the log level for the Dapr sidecar. Allowed values are debug, info, warn, error. Default is info."
+        },
+        "enableApiLogging": {
+          "type": "boolean",
+          "description": "Enables API logging for the Dapr sidecar"
+        },
+        "appHealth": {
+          "$ref": "#/definitions/DaprAppHealth",
+          "description": "Dapr application health check configuration"
+        },
+        "maxConcurrency": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of concurrent requests, events handled by the Dapr sidecar"
+        }
+      }
+    },
+    "DaprAppHealth": {
+      "type": "object",
+      "description": "Dapr application health check configuration",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Boolean indicating if the health probe is enabled"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path for the health probe"
+        },
+        "probeIntervalSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Interval for the health probe in seconds",
+          "minimum": 1
+        },
+        "probeTimeoutMilliseconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Timeout for the health probe in milliseconds",
+          "minimum": 1
+        },
+        "threshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Threshold for the health probe",
+          "minimum": 1
+        }
+      }
+    },
+    "DaprComponent": {
+      "type": "object",
+      "description": "Dapr Component.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DaprComponentProperties",
+          "description": "Dapr Component resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DaprComponentProperties": {
+      "type": "object",
+      "description": "Dapr Component resource specific properties",
+      "properties": {
+        "componentType": {
+          "type": "string",
+          "description": "Component type"
+        },
+        "version": {
+          "type": "string",
+          "description": "Component version"
+        },
+        "ignoreErrors": {
+          "type": "boolean",
+          "description": "Boolean describing if the component errors are ignores",
+          "default": false
+        },
+        "initTimeout": {
+          "type": "string",
+          "description": "Initialization timeout"
+        },
+        "secrets": {
+          "type": "array",
+          "description": "Collection of secrets used by a Dapr component",
+          "items": {
+            "$ref": "#/definitions/Secret"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "secretStoreComponent": {
+          "type": "string",
+          "description": "Name of a Dapr component to retrieve component secrets from"
+        },
+        "metadata": {
+          "type": "array",
+          "description": "Component metadata",
+          "items": {
+            "$ref": "#/definitions/DaprMetadata"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "scopes": {
+          "type": "array",
+          "description": "Names of container apps that can use this Dapr component",
+          "items": {
+            "type": "string"
+          }
+        },
+        "serviceComponentBind": {
+          "type": "array",
+          "description": "List of container app services that are bound to the Dapr component",
+          "items": {
+            "$ref": "#/definitions/DaprComponentServiceBinding"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/DaprComponentProvisioningState",
+          "description": "Provisioning state of the Connected Environment Dapr Component.",
+          "readOnly": true
+        },
+        "deploymentErrors": {
+          "type": "string",
+          "description": "Any errors that occurred during deployment or deployment validation",
+          "readOnly": true
+        }
+      }
+    },
+    "DaprComponentProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Connected Environment Dapr Component.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "InProgress",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "DaprComponentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "InProgress"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "DaprComponentResiliencyPoliciesCollection": {
+      "type": "object",
+      "description": "Dapr Component Resiliency Policies ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DaprComponentResiliencyPolicy items on this page",
+          "items": {
+            "$ref": "#/definitions/DaprComponentResiliencyPolicy"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DaprComponentResiliencyPolicy": {
+      "type": "object",
+      "description": "Dapr Component Resiliency Policy.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DaprComponentResiliencyPolicyProperties",
+          "description": "Dapr Component Resiliency Policy resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DaprComponentResiliencyPolicyCircuitBreakerPolicyConfiguration": {
+      "type": "object",
+      "description": "Dapr Component Resiliency Policy Circuit Breaker Policy Configuration.",
+      "properties": {
+        "consecutiveErrors": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of consecutive errors before the circuit is opened."
+        },
+        "timeoutInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The interval in seconds until a retry attempt is made after the circuit is opened."
+        },
+        "intervalInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The optional interval in seconds after which the error count resets to 0. An interval of 0 will never reset. If not specified, the timeoutInSeconds value will be used."
+        }
+      }
+    },
+    "DaprComponentResiliencyPolicyConfiguration": {
+      "type": "object",
+      "description": "Dapr Component Resiliency Policy Configuration.",
+      "properties": {
+        "httpRetryPolicy": {
+          "$ref": "#/definitions/DaprComponentResiliencyPolicyHttpRetryPolicyConfiguration",
+          "description": "The optional HTTP retry policy configuration"
+        },
+        "timeoutPolicy": {
+          "$ref": "#/definitions/DaprComponentResiliencyPolicyTimeoutPolicyConfiguration",
+          "description": "The optional timeout policy configuration"
+        },
+        "circuitBreakerPolicy": {
+          "$ref": "#/definitions/DaprComponentResiliencyPolicyCircuitBreakerPolicyConfiguration",
+          "description": "The optional circuit breaker policy configuration"
+        }
+      }
+    },
+    "DaprComponentResiliencyPolicyHttpRetryBackOffConfiguration": {
+      "type": "object",
+      "description": "Dapr Component Resiliency Policy HTTP Retry Backoff Configuration.",
+      "properties": {
+        "initialDelayInMilliseconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The optional initial delay in milliseconds before an operation is retried"
+        },
+        "maxIntervalInMilliseconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The optional maximum time interval in milliseconds between retry attempts"
+        }
+      }
+    },
+    "DaprComponentResiliencyPolicyHttpRetryPolicyConfiguration": {
+      "type": "object",
+      "description": "Dapr Component Resiliency Policy HTTP Retry Policy Configuration.",
+      "properties": {
+        "maxRetries": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The optional maximum number of retries"
+        },
+        "retryBackOff": {
+          "$ref": "#/definitions/DaprComponentResiliencyPolicyHttpRetryBackOffConfiguration",
+          "description": "The optional retry backoff configuration"
+        }
+      }
+    },
+    "DaprComponentResiliencyPolicyProperties": {
+      "type": "object",
+      "description": "Dapr Component Resiliency Policy resource specific properties",
+      "properties": {
+        "inboundPolicy": {
+          "$ref": "#/definitions/DaprComponentResiliencyPolicyConfiguration",
+          "description": "The optional inbound component resiliency policy configuration"
+        },
+        "outboundPolicy": {
+          "$ref": "#/definitions/DaprComponentResiliencyPolicyConfiguration",
+          "description": "The optional outbound component resiliency policy configuration"
+        }
+      }
+    },
+    "DaprComponentResiliencyPolicyTimeoutPolicyConfiguration": {
+      "type": "object",
+      "description": "Dapr Component Resiliency Policy Timeout Policy Configuration.",
+      "properties": {
+        "responseTimeoutInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The optional response timeout in seconds"
+        }
+      }
+    },
+    "DaprComponentServiceBinding": {
+      "type": "object",
+      "description": "Configuration to bind a Dapr Component to a dev ContainerApp Service",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the service bind"
+        },
+        "serviceId": {
+          "type": "string",
+          "description": "Resource id of the target service"
+        },
+        "metadata": {
+          "$ref": "#/definitions/DaprServiceBindMetadata",
+          "description": "Service bind metadata"
+        }
+      }
+    },
+    "DaprComponentsCollection": {
+      "type": "object",
+      "description": "Dapr Components ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DaprComponent items on this page",
+          "items": {
+            "$ref": "#/definitions/DaprComponent"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DaprConfiguration": {
+      "type": "object",
+      "description": "Configuration properties Dapr component",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The version of Dapr",
+          "readOnly": true
+        }
+      }
+    },
+    "DaprMetadata": {
+      "type": "object",
+      "description": "Dapr component metadata.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Metadata property name."
+        },
+        "value": {
+          "type": "string",
+          "description": "Metadata property value."
+        },
+        "secretRef": {
+          "type": "string",
+          "description": "Name of the Dapr Component secret from which to pull the metadata property value."
+        }
+      }
+    },
+    "DaprSecret": {
+      "type": "object",
+      "description": "Dapr component Secret for ListSecrets Action",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Secret Name.",
+          "readOnly": true
+        },
+        "value": {
+          "type": "string",
+          "format": "password",
+          "description": "Secret Value.",
+          "readOnly": true,
+          "x-ms-secret": true
+        }
+      }
+    },
+    "DaprSecretsCollection": {
+      "type": "object",
+      "description": "Dapr component Secrets Collection for ListSecrets Action.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Collection of secrets used by a Dapr component",
+          "items": {
+            "$ref": "#/definitions/DaprSecret"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DaprServiceBindMetadata": {
+      "type": "object",
+      "description": "Dapr component metadata.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Service bind metadata property name."
+        },
+        "value": {
+          "type": "string",
+          "description": "Service bind metadata property value."
+        }
+      }
+    },
+    "DaprSubscription": {
+      "type": "object",
+      "description": "Dapr PubSub Event Subscription.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DaprSubscriptionProperties",
+          "description": "Dapr PubSub Event Subscription resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DaprSubscriptionBulkSubscribeOptions": {
+      "type": "object",
+      "description": "Dapr PubSub Bulk Subscription Options.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable bulk subscription",
+          "default": false
+        },
+        "maxMessagesCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of messages to deliver in a bulk message."
+        },
+        "maxAwaitDurationMs": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum duration in milliseconds to wait before a bulk message is sent to the app."
+        }
+      }
+    },
+    "DaprSubscriptionProperties": {
+      "type": "object",
+      "description": "Dapr PubSub Event Subscription resource specific properties",
+      "properties": {
+        "pubsubName": {
+          "type": "string",
+          "description": "Dapr PubSub component name"
+        },
+        "topic": {
+          "type": "string",
+          "description": "Topic name"
+        },
+        "deadLetterTopic": {
+          "type": "string",
+          "description": "Deadletter topic name"
+        },
+        "routes": {
+          "$ref": "#/definitions/DaprSubscriptionRoutes",
+          "description": "Subscription routes"
+        },
+        "scopes": {
+          "type": "array",
+          "description": "Application scopes to restrict the subscription to specific apps.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "metadata": {
+          "type": "object",
+          "description": "Subscription metadata",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "bulkSubscribe": {
+          "$ref": "#/definitions/DaprSubscriptionBulkSubscribeOptions",
+          "description": "Bulk subscription options"
+        }
+      }
+    },
+    "DaprSubscriptionRouteRule": {
+      "type": "object",
+      "description": "Dapr Pubsub Event Subscription Route Rule is used to specify the condition for sending a message to a specific path.",
+      "properties": {
+        "match": {
+          "type": "string",
+          "description": "The optional CEL expression used to match the event. If the match is not specified, then the route is considered the default. The rules are tested in the order specified, so they should be define from most-to-least specific. The default route should appear last in the list."
+        },
+        "path": {
+          "type": "string",
+          "description": "The path for events that match this rule"
+        }
+      }
+    },
+    "DaprSubscriptionRoutes": {
+      "type": "object",
+      "description": "Dapr PubSub Event Subscription Routes configuration.",
+      "properties": {
+        "rules": {
+          "type": "array",
+          "description": "The list of Dapr PubSub Event Subscription Route Rules.",
+          "items": {
+            "$ref": "#/definitions/DaprSubscriptionRouteRule"
+          },
+          "x-ms-identifiers": []
+        },
+        "default": {
+          "type": "string",
+          "description": "The default path to deliver events that do not match any of the rules."
+        }
+      }
+    },
+    "DaprSubscriptionsCollection": {
+      "type": "object",
+      "description": "Dapr Subscriptions ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DaprSubscription items on this page",
+          "items": {
+            "$ref": "#/definitions/DaprSubscription"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DataDogConfiguration": {
+      "type": "object",
+      "description": "Configuration of datadog",
+      "properties": {
+        "site": {
+          "type": "string",
+          "description": "The data dog site"
+        },
+        "key": {
+          "type": "string",
+          "format": "password",
+          "description": "The data dog api key",
+          "x-ms-secret": true
+        }
+      }
+    },
+    "DefaultAuthorizationPolicy": {
+      "type": "object",
+      "description": "The configuration settings of the Azure Active Directory default authorization policy.",
+      "properties": {
+        "allowedPrincipals": {
+          "$ref": "#/definitions/AllowedPrincipals",
+          "description": "The configuration settings of the Azure Active Directory allowed principals."
+        },
+        "allowedApplications": {
+          "type": "array",
+          "description": "The configuration settings of the Azure Active Directory allowed applications.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DefaultErrorResponse": {
+      "type": "object",
+      "description": "App Service error response.",
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/DefaultErrorResponseError",
+          "description": "Error model.",
+          "readOnly": true
+        }
+      }
+    },
+    "DefaultErrorResponseError": {
+      "type": "object",
+      "description": "Error model.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Standardized string to programmatically identify the error.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Detailed error description and debugging information.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "Detailed error description and debugging information.",
+          "readOnly": true
+        },
+        "details": {
+          "type": "array",
+          "description": "Details or the error",
+          "items": {
+            "$ref": "#/definitions/DefaultErrorResponseErrorDetailsItem"
+          },
+          "x-ms-identifiers": [
+            "code"
+          ]
+        },
+        "innererror": {
+          "type": "string",
+          "description": "More information to debug error.",
+          "readOnly": true
+        }
+      }
+    },
+    "DefaultErrorResponseErrorDetailsItem": {
+      "type": "object",
+      "description": "Detailed errors.",
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "Standardized string to programmatically identify the error.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Detailed error description and debugging information.",
+          "readOnly": true
+        },
+        "target": {
+          "type": "string",
+          "description": "Detailed error description and debugging information.",
+          "readOnly": true
+        }
+      }
+    },
+    "DestinationsConfiguration": {
+      "type": "object",
+      "description": "Configuration of Open Telemetry destinations",
+      "properties": {
+        "dataDogConfiguration": {
+          "$ref": "#/definitions/DataDogConfiguration",
+          "description": "Open telemetry datadog destination configuration"
+        },
+        "otlpConfigurations": {
+          "type": "array",
+          "description": "Open telemetry otlp configurations",
+          "items": {
+            "$ref": "#/definitions/OtlpConfiguration"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "DetectionStatus": {
+      "type": "string",
+      "description": "The status of the patch detection.",
+      "enum": [
+        "Succeeded",
+        "RegistryLoginFailed",
+        "Failed"
+      ],
+      "x-ms-enum": {
+        "name": "DetectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "RegistryLoginFailed",
+            "value": "RegistryLoginFailed",
+            "description": "RegistryLoginFailed"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          }
+        ]
+      }
+    },
+    "DiagnosticDataProviderMetadata": {
+      "type": "object",
+      "description": "Details of a diagnostics data provider",
+      "properties": {
+        "providerName": {
+          "type": "string",
+          "description": "Name of data provider"
+        },
+        "propertyBag": {
+          "type": "array",
+          "description": "Collection of properties",
+          "items": {
+            "$ref": "#/definitions/DiagnosticDataProviderMetadataPropertyBagItem"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "DiagnosticDataProviderMetadataPropertyBagItem": {
+      "type": "object",
+      "description": "Property details",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Property name"
+        },
+        "value": {
+          "type": "string",
+          "description": "Property value"
+        }
+      }
+    },
+    "DiagnosticDataTableResponseColumn": {
+      "type": "object",
+      "description": "Diagnostics data column",
+      "properties": {
+        "columnName": {
+          "type": "string",
+          "description": "Column name"
+        },
+        "dataType": {
+          "type": "string",
+          "description": "Data type of the column"
+        },
+        "columnType": {
+          "type": "string",
+          "description": "Column type"
+        }
+      }
+    },
+    "DiagnosticDataTableResponseObject": {
+      "type": "object",
+      "description": "Diagnostics data table",
+      "properties": {
+        "tableName": {
+          "type": "string",
+          "description": "Table name"
+        },
+        "columns": {
+          "type": "array",
+          "description": "Columns in the table",
+          "items": {
+            "$ref": "#/definitions/DiagnosticDataTableResponseColumn"
+          },
+          "x-ms-identifiers": [
+            "columnName"
+          ]
+        },
+        "rows": {
+          "type": "array",
+          "description": "Rows in the table",
+          "items": {}
+        }
+      }
+    },
+    "DiagnosticRendering": {
+      "type": "object",
+      "description": "Rendering details of a diagnostics table",
+      "properties": {
+        "type": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Rendering type"
+        },
+        "title": {
+          "type": "string",
+          "description": "Title of the table"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of the table"
+        },
+        "isVisible": {
+          "type": "boolean",
+          "description": "Flag if the table should be rendered"
+        }
+      }
+    },
+    "DiagnosticSupportTopic": {
+      "type": "object",
+      "description": "Support topic information",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique topic identifier",
+          "readOnly": true
+        },
+        "pesId": {
+          "type": "string",
+          "description": "PES identifier",
+          "readOnly": true
+        }
+      }
+    },
+    "Diagnostics": {
+      "type": "object",
+      "description": "Diagnostics data for a resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DiagnosticsProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DiagnosticsCollection": {
+      "type": "object",
+      "description": "Diagnostics data collection for a resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Diagnostics items on this page",
+          "items": {
+            "$ref": "#/definitions/Diagnostics"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DiagnosticsDataApiResponse": {
+      "type": "object",
+      "description": "Diagnostics data returned from a detector",
+      "properties": {
+        "table": {
+          "$ref": "#/definitions/DiagnosticDataTableResponseObject",
+          "description": "Table response"
+        },
+        "renderingProperties": {
+          "$ref": "#/definitions/DiagnosticRendering",
+          "description": "Details of the table response"
+        }
+      }
+    },
+    "DiagnosticsDefinition": {
+      "type": "object",
+      "description": "Metadata of the diagnostics response",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique detector name",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Display Name of the detector",
+          "readOnly": true
+        },
+        "description": {
+          "type": "string",
+          "description": "Details of the diagnostics info",
+          "readOnly": true
+        },
+        "author": {
+          "type": "string",
+          "description": "Authors' names of the detector",
+          "readOnly": true
+        },
+        "category": {
+          "type": "string",
+          "description": "Category of the detector",
+          "readOnly": true
+        },
+        "supportTopicList": {
+          "type": "array",
+          "description": "List of support topics",
+          "items": {
+            "$ref": "#/definitions/DiagnosticSupportTopic"
+          }
+        },
+        "analysisTypes": {
+          "type": "array",
+          "description": "List of analysis types",
+          "items": {
+            "type": "string"
+          }
+        },
+        "type": {
+          "type": "string",
+          "description": "Authors' names of the detector",
+          "readOnly": true
+        },
+        "score": {
+          "type": "number",
+          "format": "float",
+          "description": "Authors' names of the detector",
+          "readOnly": true
+        }
+      }
+    },
+    "DiagnosticsProperties": {
+      "type": "object",
+      "description": "Diagnostics resource specific properties",
+      "properties": {
+        "metadata": {
+          "$ref": "#/definitions/DiagnosticsDefinition",
+          "description": "Metadata of the diagnostics response."
+        },
+        "dataset": {
+          "type": "array",
+          "description": "Set of data collections associated with the response.",
+          "items": {
+            "$ref": "#/definitions/DiagnosticsDataApiResponse"
+          },
+          "x-ms-identifiers": []
+        },
+        "status": {
+          "$ref": "#/definitions/DiagnosticsStatus",
+          "description": "Status of the diagnostics response."
+        },
+        "dataProviderMetadata": {
+          "$ref": "#/definitions/DiagnosticDataProviderMetadata",
+          "description": "List of data providers' metadata."
+        }
+      }
+    },
+    "DiagnosticsStatus": {
+      "type": "object",
+      "description": "Rendering details of a diagnostics table",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Diagnostic message"
+        },
+        "statusId": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Status"
+        }
+      }
+    },
+    "DiskEncryptionConfiguration": {
+      "type": "object",
+      "description": "Configuration properties for disk encryption",
+      "properties": {
+        "keyVaultConfiguration": {
+          "$ref": "#/definitions/DiskEncryptionConfigurationKeyVaultConfiguration",
+          "description": "The Key Vault that contains your key to use for disk encryption. The Key Vault must be in the same region as the Managed Environment."
+        }
+      }
+    },
+    "DiskEncryptionConfigurationKeyVaultConfiguration": {
+      "type": "object",
+      "description": "The Key Vault that contains your key to use for disk encryption. The Key Vault must be in the same region as the Managed Environment.",
+      "properties": {
+        "keyUrl": {
+          "type": "string",
+          "format": "uri",
+          "description": "Key URL pointing to a key in KeyVault. Version segment of the Url is required."
+        },
+        "auth": {
+          "$ref": "#/definitions/DiskEncryptionConfigurationKeyVaultConfigurationAuth",
+          "description": "Configuration properties for the authentication to the Key Vault"
+        }
+      }
+    },
+    "DiskEncryptionConfigurationKeyVaultConfigurationAuth": {
+      "type": "object",
+      "description": "Configuration properties for the authentication to the Key Vault",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of a user-assigned managed identity to authenticate to the Key Vault. The identity must be assigned to the managed environment, in the same tenant as the Key Vault, and it must have the following key permissions on the Key Vault: wrapkey, unwrapkey, get."
+        }
+      }
+    },
+    "DnsVerificationTestResult": {
+      "type": "string",
+      "description": "DNS verification test result.",
+      "enum": [
+        "Passed",
+        "Failed",
+        "Skipped"
+      ],
+      "x-ms-enum": {
+        "name": "DnsVerificationTestResult",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Passed",
+            "value": "Passed",
+            "description": "Passed"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Skipped",
+            "value": "Skipped",
+            "description": "Skipped"
+          }
+        ]
+      }
+    },
+    "DotNetComponent": {
+      "type": "object",
+      "description": ".NET Component.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DotNetComponentProperties",
+          "description": ".NET Component resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DotNetComponentConfigurationProperty": {
+      "type": "object",
+      "description": "Configuration properties for a .NET Component",
+      "properties": {
+        "propertyName": {
+          "type": "string",
+          "description": "The name of the property"
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the property"
+        }
+      }
+    },
+    "DotNetComponentProperties": {
+      "type": "object",
+      "description": ".NET Component resource specific properties",
+      "properties": {
+        "componentType": {
+          "$ref": "#/definitions/DotNetComponentType",
+          "description": "Type of the .NET Component."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/DotNetComponentProvisioningState",
+          "description": "Provisioning state of the .NET Component.",
+          "readOnly": true
+        },
+        "configurations": {
+          "type": "array",
+          "description": "List of .NET Components configuration properties",
+          "items": {
+            "$ref": "#/definitions/DotNetComponentConfigurationProperty"
+          },
+          "x-ms-identifiers": [
+            "propertyName"
+          ]
+        },
+        "serviceBinds": {
+          "type": "array",
+          "description": "List of .NET Components that are bound to the .NET component",
+          "items": {
+            "$ref": "#/definitions/DotNetComponentServiceBind"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "DotNetComponentProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the .NET Component.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Deleting",
+        "InProgress"
+      ],
+      "x-ms-enum": {
+        "name": "DotNetComponentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "InProgress"
+          }
+        ]
+      }
+    },
+    "DotNetComponentServiceBind": {
+      "type": "object",
+      "description": "Configuration to bind a .NET Component to another .NET Component",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the service bind"
+        },
+        "serviceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource id of the target service"
+        }
+      }
+    },
+    "DotNetComponentType": {
+      "type": "string",
+      "description": "Type of the .NET Component.",
+      "enum": [
+        "AspireDashboard"
+      ],
+      "x-ms-enum": {
+        "name": "DotNetComponentType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AspireDashboard",
+            "value": "AspireDashboard",
+            "description": "AspireDashboard"
+          }
+        ]
+      }
+    },
+    "DotNetComponentsCollection": {
+      "type": "object",
+      "description": ".NET Components ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DotNetComponent items on this page",
+          "items": {
+            "$ref": "#/definitions/DotNetComponent"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DynamicPoolConfiguration": {
+      "type": "object",
+      "description": "Dynamic pool configuration.",
+      "properties": {
+        "lifecycleConfiguration": {
+          "$ref": "#/definitions/LifecycleConfiguration",
+          "description": "The lifecycle configuration of a session in the dynamic session pool"
+        }
+      }
+    },
+    "EncryptionSettings": {
+      "type": "object",
+      "description": "The configuration settings of the secrets references of encryption key and signing key for ContainerApp Service Authentication/Authorization.",
+      "properties": {
+        "containerAppAuthEncryptionSecretName": {
+          "type": "string",
+          "description": "The secret name which is referenced for EncryptionKey."
+        },
+        "containerAppAuthSigningSecretName": {
+          "type": "string",
+          "description": "The secret name which is referenced for SigningKey."
+        }
+      }
+    },
+    "EnvironmentAuthToken": {
+      "type": "object",
+      "description": "Environment Auth Token.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EnvironmentAuthTokenProperties",
+          "description": "Environment auth token resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "EnvironmentAuthTokenProperties": {
+      "type": "object",
+      "description": "Environment auth token resource specific properties",
+      "properties": {
+        "token": {
+          "type": "string",
+          "format": "password",
+          "description": "Auth token value.",
+          "readOnly": true,
+          "x-ms-secret": true
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Token expiration date.",
+          "readOnly": true
+        }
+      }
+    },
+    "EnvironmentProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Environment.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Waiting",
+        "InitializationInProgress",
+        "InfrastructureSetupInProgress",
+        "InfrastructureSetupComplete",
+        "ScheduledForDelete",
+        "UpgradeRequested",
+        "UpgradeFailed"
+      ],
+      "x-ms-enum": {
+        "name": "EnvironmentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Waiting",
+            "value": "Waiting",
+            "description": "Waiting"
+          },
+          {
+            "name": "InitializationInProgress",
+            "value": "InitializationInProgress",
+            "description": "InitializationInProgress"
+          },
+          {
+            "name": "InfrastructureSetupInProgress",
+            "value": "InfrastructureSetupInProgress",
+            "description": "InfrastructureSetupInProgress"
+          },
+          {
+            "name": "InfrastructureSetupComplete",
+            "value": "InfrastructureSetupComplete",
+            "description": "InfrastructureSetupComplete"
+          },
+          {
+            "name": "ScheduledForDelete",
+            "value": "ScheduledForDelete",
+            "description": "ScheduledForDelete"
+          },
+          {
+            "name": "UpgradeRequested",
+            "value": "UpgradeRequested",
+            "description": "UpgradeRequested"
+          },
+          {
+            "name": "UpgradeFailed",
+            "value": "UpgradeFailed",
+            "description": "UpgradeFailed"
+          }
+        ]
+      }
+    },
+    "EnvironmentVar": {
+      "type": "object",
+      "description": "Container App container environment variable.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Environment variable name."
+        },
+        "value": {
+          "type": "string",
+          "description": "Non-secret environment variable value."
+        },
+        "secretRef": {
+          "type": "string",
+          "description": "Name of the Container App secret from which to pull the environment variable value."
+        }
+      }
+    },
+    "EnvironmentVariable": {
+      "type": "object",
+      "description": "Model representing an environment variable.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Environment variable name."
+        },
+        "value": {
+          "type": "string",
+          "description": "Environment variable value."
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    },
+    "ErrorEntity": {
+      "type": "object",
+      "description": "Body of the error response returned from the API.",
+      "properties": {
+        "extendedCode": {
+          "type": "string",
+          "description": "Type of error."
+        },
+        "messageTemplate": {
+          "type": "string",
+          "description": "Message template."
+        },
+        "parameters": {
+          "type": "array",
+          "description": "Parameters for the template.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "innerErrors": {
+          "type": "array",
+          "description": "Inner errors.",
+          "items": {
+            "$ref": "#/definitions/ErrorEntity"
+          },
+          "x-ms-identifiers": []
+        },
+        "details": {
+          "type": "array",
+          "description": "Error Details.",
+          "items": {
+            "$ref": "#/definitions/ErrorEntity"
+          },
+          "x-ms-identifiers": []
+        },
+        "target": {
+          "type": "string",
+          "description": "The error target."
+        },
+        "code": {
+          "type": "string",
+          "description": "Basic error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "Any details of the error."
+        }
+      }
+    },
+    "ExecutionStatus": {
+      "type": "object",
+      "description": "Container Apps Job execution status.",
+      "properties": {
+        "replicas": {
+          "type": "array",
+          "description": "Replicas in the execution.",
+          "items": {
+            "$ref": "#/definitions/ReplicaExecutionStatus"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "ExtendedLocation": {
+      "type": "object",
+      "description": "The complex type of the extended location.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the extended location."
+        },
+        "type": {
+          "$ref": "#/definitions/ExtendedLocationTypes",
+          "description": "The type of the extended location."
+        }
+      }
+    },
+    "ExtendedLocationTypes": {
+      "type": "string",
+      "description": "The type of extendedLocation.",
+      "enum": [
+        "CustomLocation"
+      ],
+      "x-ms-enum": {
+        "name": "ExtendedLocationTypes",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "CustomLocation",
+            "value": "CustomLocation",
+            "description": "CustomLocation"
+          }
+        ]
+      }
+    },
+    "Facebook": {
+      "type": "object",
+      "description": "The configuration settings of the Facebook provider.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "<code>false</code> if the Facebook provider should not be enabled despite the set registration; otherwise, <code>true</code>."
+        },
+        "registration": {
+          "$ref": "#/definitions/AppRegistration",
+          "description": "The configuration settings of the app registration for the Facebook provider."
+        },
+        "graphApiVersion": {
+          "type": "string",
+          "description": "The version of the Facebook api to be used while logging in."
+        },
+        "login": {
+          "$ref": "#/definitions/LoginScopes",
+          "description": "The configuration settings of the login flow."
+        }
+      }
+    },
+    "ForwardProxy": {
+      "type": "object",
+      "description": "The configuration settings of a forward proxy used to make the requests.",
+      "properties": {
+        "convention": {
+          "$ref": "#/definitions/ForwardProxyConvention",
+          "description": "The convention used to determine the url of the request made."
+        },
+        "customHostHeaderName": {
+          "type": "string",
+          "description": "The name of the header containing the host of the request."
+        },
+        "customProtoHeaderName": {
+          "type": "string",
+          "description": "The name of the header containing the scheme of the request."
+        }
+      }
+    },
+    "ForwardProxyConvention": {
+      "type": "string",
+      "description": "The convention used to determine the url of the request made.",
+      "enum": [
+        "NoProxy",
+        "Standard",
+        "Custom"
+      ],
+      "x-ms-enum": {
+        "name": "ForwardProxyConvention",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "NoProxy",
+            "value": "NoProxy",
+            "description": "NoProxy"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard",
+            "description": "Standard"
+          },
+          {
+            "name": "Custom",
+            "value": "Custom",
+            "description": "Custom"
+          }
+        ]
+      }
+    },
+    "GitHub": {
+      "type": "object",
+      "description": "The configuration settings of the GitHub provider.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "<code>false</code> if the GitHub provider should not be enabled despite the set registration; otherwise, <code>true</code>."
+        },
+        "registration": {
+          "$ref": "#/definitions/ClientRegistration",
+          "description": "The configuration settings of the app registration for the GitHub provider."
+        },
+        "login": {
+          "$ref": "#/definitions/LoginScopes",
+          "description": "The configuration settings of the login flow."
+        }
+      }
+    },
+    "GithubActionConfiguration": {
+      "type": "object",
+      "description": "Configuration properties that define the mutable settings of a Container App SourceControl",
+      "properties": {
+        "registryInfo": {
+          "$ref": "#/definitions/RegistryInfo",
+          "description": "Registry configurations."
+        },
+        "azureCredentials": {
+          "$ref": "#/definitions/AzureCredentials",
+          "description": "AzureCredentials configurations."
+        },
+        "contextPath": {
+          "type": "string",
+          "description": "Context path"
+        },
+        "dockerfilePath": {
+          "type": "string",
+          "description": "Dockerfile path"
+        },
+        "githubPersonalAccessToken": {
+          "type": "string",
+          "format": "password",
+          "description": "One time Github PAT to configure github environment",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "image": {
+          "type": "string",
+          "description": "Image name"
+        },
+        "publishType": {
+          "type": "string",
+          "description": "Code or Image"
+        },
+        "os": {
+          "type": "string",
+          "description": "Operation system"
+        },
+        "runtimeStack": {
+          "type": "string",
+          "description": "Runtime stack"
+        },
+        "runtimeVersion": {
+          "type": "string",
+          "description": "Runtime version"
+        },
+        "buildEnvironmentVariables": {
+          "type": "array",
+          "description": "List of environment variables to be passed to the build.",
+          "items": {
+            "$ref": "#/definitions/EnvironmentVariable"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "GlobalValidation": {
+      "type": "object",
+      "description": "The configuration settings that determines the validation flow of users using ContainerApp Service Authentication/Authorization.",
+      "properties": {
+        "unauthenticatedClientAction": {
+          "$ref": "#/definitions/UnauthenticatedClientActionV2",
+          "description": "The action to take when an unauthenticated client attempts to access the app."
+        },
+        "redirectToProvider": {
+          "type": "string",
+          "description": "The default authentication provider to use when multiple providers are configured.\nThis setting is only needed if multiple providers are configured and the unauthenticated client\naction is set to \"RedirectToLoginPage\"."
+        },
+        "excludedPaths": {
+          "type": "array",
+          "description": "The paths for which unauthenticated flow would not be redirected to the login page.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Google": {
+      "type": "object",
+      "description": "The configuration settings of the Google provider.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "<code>false</code> if the Google provider should not be enabled despite the set registration; otherwise, <code>true</code>."
+        },
+        "registration": {
+          "$ref": "#/definitions/ClientRegistration",
+          "description": "The configuration settings of the app registration for the Google provider."
+        },
+        "login": {
+          "$ref": "#/definitions/LoginScopes",
+          "description": "The configuration settings of the login flow."
+        },
+        "validation": {
+          "$ref": "#/definitions/AllowedAudiencesValidation",
+          "description": "The configuration settings of the Azure Active Directory token validation flow."
+        }
+      }
+    },
+    "Header": {
+      "type": "object",
+      "description": "Header of otlp configuration",
+      "properties": {
+        "key": {
+          "type": "string",
+          "description": "The key of otlp configuration header"
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of otlp configuration header"
+        }
+      }
+    },
+    "HeaderMatch": {
+      "type": "object",
+      "description": "Conditions required to match a header",
+      "properties": {
+        "header": {
+          "type": "string",
+          "description": "Name of the header"
+        },
+        "match": {
+          "$ref": "#/definitions/HeaderMatchMatch",
+          "description": "Type of match to perform",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "HeaderMatchMatch": {
+      "type": "object",
+      "description": "Type of match to perform",
+      "properties": {
+        "exactMatch": {
+          "type": "string",
+          "description": "Exact value of the header"
+        },
+        "prefixMatch": {
+          "type": "string",
+          "description": "Prefix value of the header"
+        },
+        "suffixMatch": {
+          "type": "string",
+          "description": "Suffix value of the header"
+        },
+        "regexMatch": {
+          "type": "string",
+          "description": "Regex value of the header"
+        }
+      }
+    },
+    "HttpConnectionPool": {
+      "type": "object",
+      "description": "Defines parameters for http connection pooling",
+      "properties": {
+        "http1MaxPendingRequests": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of pending http1 requests allowed"
+        },
+        "http2MaxRequests": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of http2 requests allowed"
+        }
+      }
+    },
+    "HttpGet": {
+      "type": "object",
+      "description": "Model representing a http get request.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL to make HTTP GET request against."
+        },
+        "fileName": {
+          "type": "string",
+          "description": "Name of the file that the request should be saved to."
+        },
+        "headers": {
+          "type": "array",
+          "description": "List of headers to send with the request.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "HttpRetryPolicy": {
+      "type": "object",
+      "description": "Policy that defines http request retry conditions",
+      "properties": {
+        "maxRetries": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of times a request will retry"
+        },
+        "retryBackOff": {
+          "$ref": "#/definitions/HttpRetryPolicyRetryBackOff",
+          "description": "Settings for retry backoff characteristics",
+          "x-ms-client-flatten": true
+        },
+        "matches": {
+          "$ref": "#/definitions/HttpRetryPolicyMatches",
+          "description": "Conditions that must be met for a request to be retried",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "HttpRetryPolicyMatches": {
+      "type": "object",
+      "description": "Conditions that must be met for a request to be retried",
+      "properties": {
+        "headers": {
+          "type": "array",
+          "description": "Headers that must be present for a request to be retried",
+          "items": {
+            "$ref": "#/definitions/HeaderMatch"
+          },
+          "x-ms-identifiers": [
+            "header"
+          ]
+        },
+        "httpStatusCodes": {
+          "type": "array",
+          "description": "Additional http status codes that can trigger a retry",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "errors": {
+          "type": "array",
+          "description": "Errors that can trigger a retry",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "HttpRetryPolicyRetryBackOff": {
+      "type": "object",
+      "description": "Settings for retry backoff characteristics",
+      "properties": {
+        "initialDelayInMilliseconds": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Initial delay, in milliseconds, before retrying a request"
+        },
+        "maxIntervalInMilliseconds": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Maximum interval, in milliseconds, between retries"
+        }
+      }
+    },
+    "HttpRoute": {
+      "type": "object",
+      "description": "Http Routes configuration, including paths to match on and whether or not rewrites are to be done.",
+      "properties": {
+        "match": {
+          "$ref": "#/definitions/HttpRouteMatch",
+          "description": "Conditions route will match on"
+        },
+        "action": {
+          "$ref": "#/definitions/HttpRouteAction",
+          "description": "Once route is matched, what is the desired action"
+        }
+      }
+    },
+    "HttpRouteAction": {
+      "type": "object",
+      "description": "Action to perform once matching of routes is done",
+      "properties": {
+        "prefixRewrite": {
+          "type": "string",
+          "description": "Rewrite prefix, default is no rewrites"
+        }
+      }
+    },
+    "HttpRouteConfig": {
+      "type": "object",
+      "description": "Advanced Ingress routing for path/header based routing for a Container App Environment",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/HttpRouteConfigProperties",
+          "description": "Http Route Config properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "HttpRouteConfigCollection": {
+      "type": "object",
+      "description": "Collection of Advanced Ingress Routing Config resources.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The HttpRouteConfig items on this page",
+          "items": {
+            "$ref": "#/definitions/HttpRouteConfig"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "HttpRouteConfigProperties": {
+      "type": "object",
+      "description": "Http Route Config properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/HttpRouteProvisioningState",
+          "description": "The provisioning state of the Http Route Config in cluster",
+          "readOnly": true
+        },
+        "provisioningErrors": {
+          "type": "array",
+          "description": "List of errors when trying to reconcile http routes",
+          "items": {
+            "$ref": "#/definitions/HttpRouteProvisioningErrors"
+          },
+          "readOnly": true
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "FQDN of the route resource.",
+          "readOnly": true
+        },
+        "customDomains": {
+          "type": "array",
+          "description": "Custom domain bindings for http Routes' hostnames.",
+          "items": {
+            "$ref": "#/definitions/CustomDomain"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "rules": {
+          "type": "array",
+          "description": "Routing Rules for http route resource.",
+          "items": {
+            "$ref": "#/definitions/HttpRouteRule"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "HttpRouteMatch": {
+      "type": "object",
+      "description": "Criteria to match on",
+      "properties": {
+        "prefix": {
+          "type": "string",
+          "description": "match on all prefix's. Not exact"
+        },
+        "path": {
+          "type": "string",
+          "description": "match on exact path"
+        },
+        "pathSeparatedPrefix": {
+          "type": "string",
+          "description": "match on all prefix's. Not exact"
+        },
+        "caseSensitive": {
+          "type": "boolean",
+          "description": "path case sensitive, default is true"
+        }
+      }
+    },
+    "HttpRouteProvisioningErrors": {
+      "type": "object",
+      "description": "List of provisioning errors for a http route config object",
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp error occured at",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Description or error message",
+          "readOnly": true
+        }
+      }
+    },
+    "HttpRouteProvisioningState": {
+      "type": "string",
+      "description": "The current provisioning state.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Waiting",
+        "Updating",
+        "Deleting",
+        "Pending"
+      ],
+      "x-ms-enum": {
+        "name": "HttpRouteProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Waiting",
+            "value": "Waiting",
+            "description": "Waiting"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Pending"
+          }
+        ]
+      }
+    },
+    "HttpRouteRule": {
+      "type": "object",
+      "description": "Http Route rule.",
+      "properties": {
+        "targets": {
+          "type": "array",
+          "description": "Targets- container apps, revisions, labels",
+          "items": {
+            "$ref": "#/definitions/HttpRouteTarget"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "routes": {
+          "type": "array",
+          "description": "Routing configuration that will allow matches on specific paths/headers.",
+          "items": {
+            "$ref": "#/definitions/HttpRoute"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of rule. Optional."
+        }
+      }
+    },
+    "HttpRouteTarget": {
+      "type": "object",
+      "description": "Targets - Container App Names, Revision Names, Labels.",
+      "properties": {
+        "containerApp": {
+          "type": "string",
+          "description": "Container App Name to route requests to"
+        },
+        "revision": {
+          "type": "string",
+          "description": "Revision to route requests to"
+        },
+        "label": {
+          "type": "string",
+          "description": "Label/Revision to route requests to"
+        },
+        "weight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Weighted routing",
+          "minimum": 0,
+          "maximum": 100
+        }
+      },
+      "required": [
+        "containerApp"
+      ]
+    },
+    "HttpScaleRule": {
+      "type": "object",
+      "description": "Container App container Http scaling rule.",
+      "properties": {
+        "metadata": {
+          "type": "object",
+          "description": "Metadata properties to describe http scale rule.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "auth": {
+          "type": "array",
+          "description": "Authentication secrets for the custom scale rule.",
+          "items": {
+            "$ref": "#/definitions/ScaleRuleAuth"
+          },
+          "x-ms-identifiers": [
+            "triggerParameter"
+          ]
+        },
+        "identity": {
+          "type": "string",
+          "description": "The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for system-assigned identity."
+        }
+      }
+    },
+    "HttpSettings": {
+      "type": "object",
+      "description": "The configuration settings of the HTTP requests for authentication and authorization requests made against ContainerApp Service Authentication/Authorization.",
+      "properties": {
+        "requireHttps": {
+          "type": "boolean",
+          "description": "<code>false</code> if the authentication/authorization responses not having the HTTPS scheme are permissible; otherwise, <code>true</code>."
+        },
+        "routes": {
+          "$ref": "#/definitions/HttpSettingsRoutes",
+          "description": "The configuration settings of the paths HTTP requests."
+        },
+        "forwardProxy": {
+          "$ref": "#/definitions/ForwardProxy",
+          "description": "The configuration settings of a forward proxy used to make the requests."
+        }
+      }
+    },
+    "HttpSettingsRoutes": {
+      "type": "object",
+      "description": "The configuration settings of the paths HTTP requests.",
+      "properties": {
+        "apiPrefix": {
+          "type": "string",
+          "description": "The prefix that should precede all the authentication/authorization paths."
+        }
+      }
+    },
+    "IdentityProviders": {
+      "type": "object",
+      "description": "The configuration settings of each of the identity providers used to configure ContainerApp Service Authentication/Authorization.",
+      "properties": {
+        "azureActiveDirectory": {
+          "$ref": "#/definitions/AzureActiveDirectory",
+          "description": "The configuration settings of the Azure Active directory provider."
+        },
+        "facebook": {
+          "$ref": "#/definitions/Facebook",
+          "description": "The configuration settings of the Facebook provider."
+        },
+        "gitHub": {
+          "$ref": "#/definitions/GitHub",
+          "description": "The configuration settings of the GitHub provider."
+        },
+        "google": {
+          "$ref": "#/definitions/Google",
+          "description": "The configuration settings of the Google provider."
+        },
+        "twitter": {
+          "$ref": "#/definitions/Twitter",
+          "description": "The configuration settings of the Twitter provider."
+        },
+        "apple": {
+          "$ref": "#/definitions/Apple",
+          "description": "The configuration settings of the Apple provider."
+        },
+        "azureStaticWebApps": {
+          "$ref": "#/definitions/AzureStaticWebApps",
+          "description": "The configuration settings of the Azure Static Web Apps provider."
+        },
+        "customOpenIdConnectProviders": {
+          "type": "object",
+          "description": "The map of the name of the alias of each custom Open ID Connect provider to the\nconfiguration settings of the custom Open ID Connect provider.",
+          "additionalProperties": {
+            "$ref": "#/definitions/CustomOpenIdConnectProvider"
+          }
+        }
+      }
+    },
+    "IdentitySettings": {
+      "type": "object",
+      "description": "Optional settings for a Managed Identity that is assigned to the Container App.",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "description": "The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for system-assigned identity."
+        },
+        "lifecycle": {
+          "type": "string",
+          "description": "Use to select the lifecycle stages of a Container App during which the Managed Identity should be available.",
+          "default": "All",
+          "enum": [
+            "None",
+            "Main",
+            "Init",
+            "All"
+          ],
+          "x-ms-enum": {
+            "name": "IdentitySettingsLifeCycle",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "None",
+                "value": "None",
+                "description": "None"
+              },
+              {
+                "name": "Main",
+                "value": "Main",
+                "description": "Main"
+              },
+              {
+                "name": "Init",
+                "value": "Init",
+                "description": "Init"
+              },
+              {
+                "name": "All",
+                "value": "All",
+                "description": "All"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "identity"
+      ]
+    },
+    "ImageType": {
+      "type": "string",
+      "description": "The type of the image. Set to CloudBuild to let the system manages the image, where user will not be able to update image through image field. Set to ContainerImage for user provided image.",
+      "enum": [
+        "CloudBuild",
+        "ContainerImage"
+      ],
+      "x-ms-enum": {
+        "name": "ImageType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "CloudBuild",
+            "value": "CloudBuild",
+            "description": "CloudBuild"
+          },
+          {
+            "name": "ContainerImage",
+            "value": "ContainerImage",
+            "description": "ContainerImage"
+          }
+        ]
+      }
+    },
+    "Ingress": {
+      "type": "object",
+      "description": "Container App Ingress configuration.",
+      "properties": {
+        "fqdn": {
+          "type": "string",
+          "description": "Hostname.",
+          "readOnly": true
+        },
+        "external": {
+          "type": "boolean",
+          "description": "Bool indicating if app exposes an external http endpoint",
+          "default": false
+        },
+        "targetPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Target Port in containers for traffic from ingress"
+        },
+        "exposedPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Exposed Port in containers for TCP traffic from ingress"
+        },
+        "transport": {
+          "type": "string",
+          "description": "Ingress transport protocol",
+          "default": "auto",
+          "enum": [
+            "auto",
+            "http",
+            "http2",
+            "tcp"
+          ],
+          "x-ms-enum": {
+            "name": "IngressTransportMethod",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "auto",
+                "value": "auto",
+                "description": "auto"
+              },
+              {
+                "name": "http",
+                "value": "http",
+                "description": "http"
+              },
+              {
+                "name": "http2",
+                "value": "http2",
+                "description": "http2"
+              },
+              {
+                "name": "tcp",
+                "value": "tcp",
+                "description": "tcp"
+              }
+            ]
+          }
+        },
+        "traffic": {
+          "type": "array",
+          "description": "Traffic weights for app's revisions",
+          "items": {
+            "$ref": "#/definitions/TrafficWeight"
+          },
+          "x-ms-identifiers": [
+            "revisionName"
+          ]
+        },
+        "customDomains": {
+          "type": "array",
+          "description": "custom domain bindings for Container Apps' hostnames.",
+          "items": {
+            "$ref": "#/definitions/CustomDomain"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "allowInsecure": {
+          "type": "boolean",
+          "description": "Bool indicating if HTTP connections to is allowed. If set to false HTTP connections are automatically redirected to HTTPS connections",
+          "default": false
+        },
+        "ipSecurityRestrictions": {
+          "type": "array",
+          "description": "Rules to restrict incoming IP address.",
+          "items": {
+            "$ref": "#/definitions/IpSecurityRestrictionRule"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "stickySessions": {
+          "$ref": "#/definitions/IngressStickySessions",
+          "description": "Sticky Sessions for Single Revision Mode"
+        },
+        "clientCertificateMode": {
+          "$ref": "#/definitions/IngressClientCertificateMode",
+          "description": "Client certificate mode for mTLS authentication. Ignore indicates server drops client certificate on forwarding. Accept indicates server forwards client certificate but does not require a client certificate. Require indicates server requires a client certificate."
+        },
+        "corsPolicy": {
+          "$ref": "#/definitions/CorsPolicy",
+          "description": "CORS policy for container app"
+        },
+        "additionalPortMappings": {
+          "type": "array",
+          "description": "Settings to expose additional ports on container app",
+          "items": {
+            "$ref": "#/definitions/IngressPortMapping"
+          },
+          "x-ms-identifiers": [
+            "targetPort"
+          ]
+        },
+        "targetPortHttpScheme": {
+          "$ref": "#/definitions/IngressTargetPortHttpScheme",
+          "description": "Whether an http app listens on http or https"
+        }
+      }
+    },
+    "IngressClientCertificateMode": {
+      "type": "string",
+      "description": "Client certificate mode for mTLS authentication. Ignore indicates server drops client certificate on forwarding. Accept indicates server forwards client certificate but does not require a client certificate. Require indicates server requires a client certificate.",
+      "enum": [
+        "ignore",
+        "accept",
+        "require"
+      ],
+      "x-ms-enum": {
+        "name": "IngressClientCertificateMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ignore",
+            "value": "ignore",
+            "description": "ignore"
+          },
+          {
+            "name": "accept",
+            "value": "accept",
+            "description": "accept"
+          },
+          {
+            "name": "require",
+            "value": "require",
+            "description": "require"
+          }
+        ]
+      }
+    },
+    "IngressConfiguration": {
+      "type": "object",
+      "description": "Settings for the ingress component, including workload profile, scaling, and connection handling.",
+      "properties": {
+        "workloadProfileName": {
+          "type": "string",
+          "description": "Name of the workload profile used by the ingress component. Required."
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Time (in seconds) to allow active connections to complete on termination. Must be between 0 and 3600. Defaults to 480 seconds."
+        },
+        "headerCountLimit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of headers per request allowed by the ingress. Must be at least 1. Defaults to 100."
+        },
+        "requestIdleTimeout": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Duration (in minutes) before idle requests are timed out. Must be between 4 and 30 inclusive. Defaults to 4 minutes."
+        }
+      }
+    },
+    "IngressPortMapping": {
+      "type": "object",
+      "description": "Port mappings of container app ingress",
+      "properties": {
+        "external": {
+          "type": "boolean",
+          "description": "Specifies whether the app port is accessible outside of the environment"
+        },
+        "targetPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the port user's container listens on"
+        },
+        "exposedPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the exposed port for the target port. If not specified, it defaults to target port"
+        }
+      },
+      "required": [
+        "external",
+        "targetPort"
+      ]
+    },
+    "IngressStickySessions": {
+      "type": "object",
+      "description": "Sticky Sessions for Single Revision Mode",
+      "properties": {
+        "affinity": {
+          "$ref": "#/definitions/Affinity",
+          "description": "Sticky Session Affinity"
+        }
+      }
+    },
+    "IngressTargetPortHttpScheme": {
+      "type": "string",
+      "description": "Whether an http app listens on http or https",
+      "enum": [
+        "http",
+        "https"
+      ],
+      "x-ms-enum": {
+        "name": "IngressTargetPortHttpScheme",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "http",
+            "value": "http",
+            "description": "http"
+          },
+          {
+            "name": "https",
+            "value": "https",
+            "description": "https"
+          }
+        ]
+      }
+    },
+    "InitContainer": {
+      "type": "object",
+      "description": "Container App init container definition",
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseContainer"
+        }
+      ]
+    },
+    "IpSecurityRestrictionRule": {
+      "type": "object",
+      "description": "Rule to restrict incoming IP address.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name for the IP restriction rule."
+        },
+        "description": {
+          "type": "string",
+          "description": "Describe the IP restriction rule that is being sent to the container-app. This is an optional field."
+        },
+        "ipAddressRange": {
+          "type": "string",
+          "description": "CIDR notation to match incoming IP address"
+        },
+        "action": {
+          "$ref": "#/definitions/Action",
+          "description": "Allow or Deny rules to determine for incoming IP. Note: Rules can only consist of ALL Allow or ALL Deny"
+        }
+      },
+      "required": [
+        "name",
+        "ipAddressRange",
+        "action"
+      ]
+    },
+    "JavaComponent": {
+      "type": "object",
+      "description": "Java Component.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/JavaComponentProperties",
+          "description": "Java Component resource specific properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "JavaComponentConfigurationProperty": {
+      "type": "object",
+      "description": "Configuration properties for a Java Component",
+      "properties": {
+        "propertyName": {
+          "type": "string",
+          "description": "The name of the property"
+        },
+        "value": {
+          "type": "string",
+          "description": "The value of the property"
+        }
+      }
+    },
+    "JavaComponentIngress": {
+      "type": "object",
+      "description": "Container App Ingress configuration.",
+      "properties": {
+        "fqdn": {
+          "type": "string",
+          "description": "Hostname of the Java Component endpoint",
+          "readOnly": true
+        }
+      }
+    },
+    "JavaComponentProperties": {
+      "type": "object",
+      "description": "Java Component common properties.",
+      "properties": {
+        "componentType": {
+          "$ref": "#/definitions/JavaComponentType",
+          "description": "Type of the Java Component."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/JavaComponentProvisioningState",
+          "description": "Provisioning state of the Java Component.",
+          "readOnly": true
+        },
+        "configurations": {
+          "type": "array",
+          "description": "List of Java Components configuration properties",
+          "items": {
+            "$ref": "#/definitions/JavaComponentConfigurationProperty"
+          },
+          "x-ms-identifiers": [
+            "propertyName"
+          ]
+        },
+        "scale": {
+          "$ref": "#/definitions/JavaComponentPropertiesScale",
+          "description": "Java component scaling configurations"
+        },
+        "serviceBinds": {
+          "type": "array",
+          "description": "List of Java Components that are bound to the Java component",
+          "items": {
+            "$ref": "#/definitions/JavaComponentServiceBind"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "discriminator": "componentType",
+      "required": [
+        "componentType"
+      ]
+    },
+    "JavaComponentPropertiesScale": {
+      "type": "object",
+      "description": "Java component scaling configurations",
+      "properties": {
+        "minReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. Minimum number of Java component replicas. Defaults to 1 if not set"
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. Maximum number of Java component replicas"
+        }
+      }
+    },
+    "JavaComponentProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Java Component.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Deleting",
+        "InProgress"
+      ],
+      "x-ms-enum": {
+        "name": "JavaComponentProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "InProgress"
+          }
+        ]
+      }
+    },
+    "JavaComponentServiceBind": {
+      "type": "object",
+      "description": "Configuration to bind a Java Component to another Java Component",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the service bind"
+        },
+        "serviceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource id of the target service"
+        }
+      }
+    },
+    "JavaComponentType": {
+      "type": "string",
+      "description": "Type of the Java Component.",
+      "enum": [
+        "SpringBootAdmin",
+        "SpringCloudEureka",
+        "SpringCloudConfig",
+        "SpringCloudGateway",
+        "Nacos"
+      ],
+      "x-ms-enum": {
+        "name": "JavaComponentType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SpringBootAdmin",
+            "value": "SpringBootAdmin",
+            "description": "SpringBootAdmin"
+          },
+          {
+            "name": "SpringCloudEureka",
+            "value": "SpringCloudEureka",
+            "description": "SpringCloudEureka"
+          },
+          {
+            "name": "SpringCloudConfig",
+            "value": "SpringCloudConfig",
+            "description": "SpringCloudConfig"
+          },
+          {
+            "name": "SpringCloudGateway",
+            "value": "SpringCloudGateway",
+            "description": "SpringCloudGateway"
+          },
+          {
+            "name": "Nacos",
+            "value": "Nacos",
+            "description": "Nacos"
+          }
+        ]
+      }
+    },
+    "JavaComponentsCollection": {
+      "type": "object",
+      "description": "Java Components ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The JavaComponent items on this page",
+          "items": {
+            "$ref": "#/definitions/JavaComponent"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Job": {
+      "type": "object",
+      "description": "Container App Job",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/JobProperties",
+          "description": "Container Apps Job resource specific properties.",
+          "x-ms-client-flatten": true
+        },
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The complex type of the extended location."
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "JobConfiguration": {
+      "type": "object",
+      "description": "Non versioned Container Apps Job configuration properties",
+      "properties": {
+        "secrets": {
+          "type": "array",
+          "description": "Collection of secrets used by a Container Apps Job",
+          "items": {
+            "$ref": "#/definitions/Secret"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "triggerType": {
+          "type": "string",
+          "description": "Trigger type of the job",
+          "default": "Manual",
+          "enum": [
+            "Schedule",
+            "Event",
+            "Manual"
+          ],
+          "x-ms-enum": {
+            "name": "TriggerType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Schedule",
+                "value": "Schedule",
+                "description": "Schedule"
+              },
+              {
+                "name": "Event",
+                "value": "Event",
+                "description": "Event"
+              },
+              {
+                "name": "Manual",
+                "value": "Manual",
+                "description": "Manual"
+              }
+            ]
+          }
+        },
+        "replicaTimeout": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of seconds a replica is allowed to run."
+        },
+        "replicaRetryLimit": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of retries before failing the job."
+        },
+        "manualTriggerConfig": {
+          "$ref": "#/definitions/JobConfigurationManualTriggerConfig",
+          "description": "Manual trigger configuration for a single execution job. Properties replicaCompletionCount and parallelism would be set to 1 by default"
+        },
+        "scheduleTriggerConfig": {
+          "$ref": "#/definitions/JobConfigurationScheduleTriggerConfig",
+          "description": "Cron formatted repeating trigger schedule (\"* * * * *\") for cronjobs. Properties completions and parallelism would be set to 1 by default"
+        },
+        "eventTriggerConfig": {
+          "$ref": "#/definitions/JobConfigurationEventTriggerConfig",
+          "description": "Trigger configuration of an event driven job."
+        },
+        "registries": {
+          "type": "array",
+          "description": "Collection of private container registry credentials used by a Container apps job",
+          "items": {
+            "$ref": "#/definitions/RegistryCredentials"
+          },
+          "x-ms-identifiers": [
+            "server"
+          ]
+        },
+        "identitySettings": {
+          "type": "array",
+          "description": "Optional settings for Managed Identities that are assigned to the Container App Job. If a Managed Identity is not specified here, default settings will be used.",
+          "items": {
+            "$ref": "#/definitions/IdentitySettings"
+          },
+          "x-ms-identifiers": [
+            "identity"
+          ]
+        }
+      },
+      "required": [
+        "triggerType",
+        "replicaTimeout"
+      ]
+    },
+    "JobConfigurationEventTriggerConfig": {
+      "type": "object",
+      "description": "Trigger configuration of an event driven job.",
+      "properties": {
+        "replicaCompletionCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of successful replica completions before overall job completion."
+        },
+        "parallelism": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of parallel replicas of a job that can run at a given time."
+        },
+        "scale": {
+          "$ref": "#/definitions/JobScale",
+          "description": "Scaling configurations for event driven jobs."
+        }
+      }
+    },
+    "JobConfigurationManualTriggerConfig": {
+      "type": "object",
+      "description": "Manual trigger configuration for a single execution job. Properties replicaCompletionCount and parallelism would be set to 1 by default",
+      "properties": {
+        "replicaCompletionCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of successful replica completions before overall job completion."
+        },
+        "parallelism": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of parallel replicas of a job that can run at a given time."
+        }
+      }
+    },
+    "JobConfigurationScheduleTriggerConfig": {
+      "type": "object",
+      "description": "Cron formatted repeating trigger schedule (\"* * * * *\") for cronjobs. Properties completions and parallelism would be set to 1 by default",
+      "properties": {
+        "replicaCompletionCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of successful replica completions before overall job completion."
+        },
+        "cronExpression": {
+          "type": "string",
+          "description": "Cron formatted repeating schedule (\"* * * * *\") of a Cron Job."
+        },
+        "parallelism": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of parallel replicas of a job that can run at a given time."
+        }
+      },
+      "required": [
+        "cronExpression"
+      ]
+    },
+    "JobExecution": {
+      "type": "object",
+      "description": "Container Apps Job execution.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/JobExecutionProperties",
+          "description": "Container Apps Job execution specific properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "JobExecutionBase": {
+      "type": "object",
+      "description": "Container App's Job execution name.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Job execution name."
+        },
+        "id": {
+          "type": "string",
+          "description": "Job execution Id."
+        }
+      }
+    },
+    "JobExecutionContainer": {
+      "type": "object",
+      "description": "Container Apps Jobs execution container definition.",
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Container image tag."
+        },
+        "name": {
+          "type": "string",
+          "description": "Custom container name."
+        },
+        "command": {
+          "type": "array",
+          "description": "Container start command.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "type": "array",
+          "description": "Container start command arguments.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "array",
+          "description": "Container environment variables.",
+          "items": {
+            "$ref": "#/definitions/EnvironmentVar"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "resources": {
+          "$ref": "#/definitions/ContainerResources",
+          "description": "Container resource requirements."
+        }
+      }
+    },
+    "JobExecutionProperties": {
+      "type": "object",
+      "description": "Container Apps Job execution specific properties.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/JobExecutionRunningState",
+          "description": "Current running State of the job",
+          "readOnly": true
+        },
+        "startTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Job execution start time."
+        },
+        "endTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Job execution end time."
+        },
+        "template": {
+          "$ref": "#/definitions/JobExecutionTemplate",
+          "description": "Job's execution container."
+        },
+        "detailedStatus": {
+          "$ref": "#/definitions/ExecutionStatus",
+          "description": "Detailed status of the job execution."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Reason for the current condition of job execution.",
+          "readOnly": true
+        },
+        "message": {
+          "type": "string",
+          "description": "Human readable message indicating details about the current condition of the job execution.",
+          "readOnly": true
+        }
+      }
+    },
+    "JobExecutionRunningState": {
+      "type": "string",
+      "description": "Current running State of the job",
+      "enum": [
+        "Running",
+        "Processing",
+        "Stopped",
+        "Degraded",
+        "Failed",
+        "Unknown",
+        "Succeeded"
+      ],
+      "x-ms-enum": {
+        "name": "JobExecutionRunningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Running"
+          },
+          {
+            "name": "Processing",
+            "value": "Processing",
+            "description": "Processing"
+          },
+          {
+            "name": "Stopped",
+            "value": "Stopped",
+            "description": "Stopped"
+          },
+          {
+            "name": "Degraded",
+            "value": "Degraded",
+            "description": "Degraded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          }
+        ]
+      }
+    },
+    "JobExecutionTemplate": {
+      "type": "object",
+      "description": "Job's execution template, containing container configuration for a job's execution",
+      "properties": {
+        "containers": {
+          "type": "array",
+          "description": "List of container definitions for the Container Apps Job.",
+          "items": {
+            "$ref": "#/definitions/JobExecutionContainer"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "initContainers": {
+          "type": "array",
+          "description": "List of specialized containers that run before job containers.",
+          "items": {
+            "$ref": "#/definitions/JobExecutionContainer"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "JobPatchProperties": {
+      "type": "object",
+      "description": "Container Apps Job resource specific properties.",
+      "properties": {
+        "extendedLocation": {
+          "$ref": "#/definitions/ExtendedLocation",
+          "description": "The complex type of the extended location."
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "Managed identities needed by a container app job to interact with other Azure services to not maintain any secrets or credentials in code."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "properties": {
+          "$ref": "#/definitions/JobPatchPropertiesProperties"
+        }
+      }
+    },
+    "JobPatchPropertiesProperties": {
+      "type": "object",
+      "properties": {
+        "environmentId": {
+          "type": "string",
+          "description": "Resource ID of environment.",
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "configuration": {
+          "$ref": "#/definitions/JobConfiguration",
+          "description": "Container Apps Job configuration properties."
+        },
+        "template": {
+          "$ref": "#/definitions/JobTemplate",
+          "description": "Container Apps job definition."
+        },
+        "outboundIpAddresses": {
+          "type": "array",
+          "description": "Outbound IP Addresses of a container apps job.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "eventStreamEndpoint": {
+          "type": "string",
+          "description": "The endpoint of the eventstream of the container apps job."
+        }
+      }
+    },
+    "JobProperties": {
+      "type": "object",
+      "description": "Container Apps Job resource specific properties.",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/JobProvisioningState",
+          "description": "Provisioning state of the Container Apps Job.",
+          "readOnly": true
+        },
+        "runningState": {
+          "$ref": "#/definitions/JobRunningState",
+          "description": "Current running state of the job",
+          "readOnly": true
+        },
+        "environmentId": {
+          "type": "string",
+          "description": "Resource ID of environment.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "workloadProfileName": {
+          "type": "string",
+          "description": "Workload profile name to pin for container apps job execution."
+        },
+        "configuration": {
+          "$ref": "#/definitions/JobConfiguration",
+          "description": "Container Apps Job configuration properties."
+        },
+        "template": {
+          "$ref": "#/definitions/JobTemplate",
+          "description": "Container Apps job definition."
+        },
+        "outboundIpAddresses": {
+          "type": "array",
+          "description": "Outbound IP Addresses of a container apps job.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "eventStreamEndpoint": {
+          "type": "string",
+          "description": "The endpoint of the eventstream of the container apps job.",
+          "readOnly": true
+        }
+      }
+    },
+    "JobProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the Container Apps Job.",
+      "enum": [
+        "InProgress",
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "JobProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "InProgress"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "JobRunningState": {
+      "type": "string",
+      "description": "Current running state of the job",
+      "enum": [
+        "Ready",
+        "Progressing",
+        "Suspended"
+      ],
+      "x-ms-enum": {
+        "name": "JobRunningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Ready",
+            "value": "Ready",
+            "description": "Ready"
+          },
+          {
+            "name": "Progressing",
+            "value": "Progressing",
+            "description": "Progressing"
+          },
+          {
+            "name": "Suspended",
+            "value": "Suspended",
+            "description": "Suspended"
+          }
+        ]
+      }
+    },
+    "JobScale": {
+      "type": "object",
+      "description": "Scaling configurations for event driven jobs.",
+      "properties": {
+        "pollingInterval": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Interval to check each event source in seconds. Defaults to 30s"
+        },
+        "minExecutions": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of job executions that are created for a trigger, default 0",
+          "default": 0
+        },
+        "maxExecutions": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of job executions that are created for a trigger, default 100.",
+          "default": 100
+        },
+        "rules": {
+          "type": "array",
+          "description": "Scaling rules.",
+          "items": {
+            "$ref": "#/definitions/JobScaleRule"
+          }
+        }
+      }
+    },
+    "JobScaleRule": {
+      "type": "object",
+      "description": "Scaling rule.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Scale Rule Name"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of the scale rule\neg: azure-servicebus, redis etc."
+        },
+        "metadata": {
+          "description": "Metadata properties to describe the scale rule."
+        },
+        "auth": {
+          "type": "array",
+          "description": "Authentication secrets for the scale rule.",
+          "items": {
+            "$ref": "#/definitions/ScaleRuleAuth"
+          }
+        },
+        "identity": {
+          "type": "string",
+          "description": "The resource ID of a user-assigned managed identity that is assigned to the job, or 'system' for system-assigned identity."
+        }
+      }
+    },
+    "JobSecretsCollection": {
+      "type": "object",
+      "description": "Container Apps Job Secrets Collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Collection of resources.",
+          "items": {
+            "$ref": "#/definitions/Secret"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "JobTemplate": {
+      "type": "object",
+      "description": "Container Apps Job versioned application definition. Defines the desired state of an immutable revision. Any changes to this section Will result in a new revision being created",
+      "properties": {
+        "initContainers": {
+          "type": "array",
+          "description": "List of specialized containers that run before app containers.",
+          "items": {
+            "$ref": "#/definitions/InitContainer"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "containers": {
+          "type": "array",
+          "description": "List of container definitions for the Container App.",
+          "items": {
+            "$ref": "#/definitions/Container"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "volumes": {
+          "type": "array",
+          "description": "List of volume definitions for the Container App.",
+          "items": {
+            "$ref": "#/definitions/Volume"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "JobsCollection": {
+      "type": "object",
+      "description": "Container Apps Jobs collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Job items on this page",
+          "items": {
+            "$ref": "#/definitions/Job"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "JwtClaimChecks": {
+      "type": "object",
+      "description": "The configuration settings of the checks that should be made while validating the JWT Claims.",
+      "properties": {
+        "allowedGroups": {
+          "type": "array",
+          "description": "The list of the allowed groups.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowedClientApplications": {
+          "type": "array",
+          "description": "The list of the allowed client applications.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "KedaConfiguration": {
+      "type": "object",
+      "description": "Configuration properties Keda component",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "The version of Keda",
+          "readOnly": true
+        }
+      }
+    },
+    "Kind": {
+      "type": "string",
+      "description": "Metadata to represent the container app kind, representing if a container app is workflowapp or functionapp.",
+      "enum": [
+        "workflowapp",
+        "functionapp"
+      ],
+      "x-ms-enum": {
+        "name": "Kind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "workflowapp",
+            "value": "workflowapp",
+            "description": "workflowapp"
+          },
+          {
+            "name": "functionapp",
+            "value": "functionapp",
+            "description": "functionapp"
+          }
+        ]
+      }
+    },
+    "LabelHistory": {
+      "type": "object",
+      "description": "Container App Label History.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/LabelHistoryProperties",
+          "description": "Container App Label History resource specific properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "LabelHistoryCollection": {
+      "type": "object",
+      "description": "Container App Label History collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The LabelHistory items on this page",
+          "items": {
+            "$ref": "#/definitions/LabelHistory"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LabelHistoryProperties": {
+      "type": "object",
+      "description": "Container App Label History resource specific properties",
+      "properties": {
+        "records": {
+          "type": "array",
+          "description": "List of label history records.",
+          "items": {
+            "$ref": "#/definitions/LabelHistoryRecordItem"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "label"
+          ]
+        }
+      }
+    },
+    "LabelHistoryRecordItem": {
+      "type": "object",
+      "description": "Container App Label History Item resource specific properties",
+      "properties": {
+        "revision": {
+          "type": "string",
+          "description": "Container App revision name that label was applied to.",
+          "readOnly": true
+        },
+        "start": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp describing when the label was applied to the revision.",
+          "readOnly": true
+        },
+        "stop": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp describing when the label was removed from the revision. Only meaningful when the label is currently applied to the revision.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/Status",
+          "description": "Status of the label history record.",
+          "readOnly": true
+        }
+      }
+    },
+    "Level": {
+      "type": "string",
+      "description": "The specified logger's log level.",
+      "enum": [
+        "off",
+        "error",
+        "info",
+        "debug",
+        "trace",
+        "warn"
+      ],
+      "x-ms-enum": {
+        "name": "Level",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "off",
+            "value": "off",
+            "description": "off"
+          },
+          {
+            "name": "error",
+            "value": "error",
+            "description": "error"
+          },
+          {
+            "name": "info",
+            "value": "info",
+            "description": "info"
+          },
+          {
+            "name": "debug",
+            "value": "debug",
+            "description": "debug"
+          },
+          {
+            "name": "trace",
+            "value": "trace",
+            "description": "trace"
+          },
+          {
+            "name": "warn",
+            "value": "warn",
+            "description": "warn"
+          }
+        ]
+      }
+    },
+    "LifecycleConfiguration": {
+      "type": "object",
+      "description": "The lifecycle configuration properties of a session in the dynamic session pool",
+      "properties": {
+        "lifecycleType": {
+          "$ref": "#/definitions/LifecycleType",
+          "description": "The lifecycle type of the session pool."
+        },
+        "cooldownPeriodInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The cooldown period of a session in seconds when the lifecycle type is 'Timed'."
+        },
+        "maxAlivePeriodInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum alive period of a session in seconds when the lifecycle type is 'OnContainerExit'."
+        }
+      }
+    },
+    "LifecycleType": {
+      "type": "string",
+      "description": "The lifecycle type of the session pool.",
+      "enum": [
+        "Timed",
+        "OnContainerExit"
+      ],
+      "x-ms-enum": {
+        "name": "LifecycleType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Timed",
+            "value": "Timed",
+            "description": "Timed"
+          },
+          {
+            "name": "OnContainerExit",
+            "value": "OnContainerExit",
+            "description": "OnContainerExit"
+          }
+        ]
+      }
+    },
+    "ListUsagesResult": {
+      "type": "object",
+      "description": "Paged collection of Usage items",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Usage items on this page",
+          "items": {
+            "$ref": "#/definitions/Usage"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "LogAnalyticsConfiguration": {
+      "type": "object",
+      "description": "Log Analytics configuration, must only be provided when destination is configured as 'log-analytics'",
+      "properties": {
+        "customerId": {
+          "type": "string",
+          "description": "Log analytics customer id"
+        },
+        "sharedKey": {
+          "type": "string",
+          "format": "password",
+          "description": "Log analytics customer key",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "dynamicJsonColumns": {
+          "type": "boolean",
+          "description": "Boolean indicating whether to parse json string log into dynamic json columns"
+        }
+      }
+    },
+    "LogLevel": {
+      "type": "string",
+      "description": "Sets the log level for the Dapr sidecar. Allowed values are debug, info, warn, error. Default is info.",
+      "enum": [
+        "info",
+        "debug",
+        "warn",
+        "error"
+      ],
+      "x-ms-enum": {
+        "name": "LogLevel",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "info",
+            "value": "info",
+            "description": "info"
+          },
+          {
+            "name": "debug",
+            "value": "debug",
+            "description": "debug"
+          },
+          {
+            "name": "warn",
+            "value": "warn",
+            "description": "warn"
+          },
+          {
+            "name": "error",
+            "value": "error",
+            "description": "error"
+          }
+        ]
+      }
+    },
+    "LoggerSetting": {
+      "type": "object",
+      "description": "Logger settings for java workloads.",
+      "properties": {
+        "logger": {
+          "type": "string",
+          "description": "Logger name."
+        },
+        "level": {
+          "$ref": "#/definitions/Level",
+          "description": "The specified logger's log level."
+        }
+      },
+      "required": [
+        "logger",
+        "level"
+      ]
+    },
+    "LogicApp": {
+      "type": "object",
+      "description": "A logic app extension resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/LogicAppProperties",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "LogicAppProperties": {
+      "type": "object",
+      "description": "The properties of logic apps extension."
+    },
+    "Login": {
+      "type": "object",
+      "description": "The configuration settings of the login flow of users using ContainerApp Service Authentication/Authorization.",
+      "properties": {
+        "routes": {
+          "$ref": "#/definitions/LoginRoutes",
+          "description": "The routes that specify the endpoints used for login and logout requests."
+        },
+        "tokenStore": {
+          "$ref": "#/definitions/TokenStore",
+          "description": "The configuration settings of the token store."
+        },
+        "preserveUrlFragmentsForLogins": {
+          "type": "boolean",
+          "description": "<code>true</code> if the fragments from the request are preserved after the login request is made; otherwise, <code>false</code>."
+        },
+        "allowedExternalRedirectUrls": {
+          "type": "array",
+          "description": "External URLs that can be redirected to as part of logging in or logging out of the app. Note that the query string part of the URL is ignored.\nThis is an advanced setting typically only needed by Windows Store application backends.\nNote that URLs within the current domain are always implicitly allowed.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "cookieExpiration": {
+          "$ref": "#/definitions/CookieExpiration",
+          "description": "The configuration settings of the session cookie's expiration."
+        },
+        "nonce": {
+          "$ref": "#/definitions/Nonce",
+          "description": "The configuration settings of the nonce used in the login flow."
+        }
+      }
+    },
+    "LoginRoutes": {
+      "type": "object",
+      "description": "The routes that specify the endpoints used for login and logout requests.",
+      "properties": {
+        "logoutEndpoint": {
+          "type": "string",
+          "description": "The endpoint at which a logout request should be made."
+        }
+      }
+    },
+    "LoginScopes": {
+      "type": "object",
+      "description": "The configuration settings of the login flow, including the scopes that should be requested.",
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "description": "A list of the scopes that should be requested while authenticating.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "LogsConfiguration": {
+      "type": "object",
+      "description": "Configuration of Open Telemetry logs",
+      "properties": {
+        "destinations": {
+          "type": "array",
+          "description": "Open telemetry logs destinations",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MaintenanceConfigurationCollection": {
+      "type": "object",
+      "description": "The response of list maintenance configuration resources.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The MaintenanceConfigurationResource items on this page",
+          "items": {
+            "$ref": "#/definitions/MaintenanceConfigurationResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "MaintenanceConfigurationResource": {
+      "type": "object",
+      "description": "Information about the Maintenance Configuration resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ScheduledEntries",
+          "description": "The resource-specific properties for this resource.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ManagedCertificate": {
+      "type": "object",
+      "description": "Managed certificates used for Custom Domain bindings of Container Apps in a Managed Environment",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedCertificateProperties",
+          "description": "Certificate resource specific properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ManagedCertificateCollection": {
+      "type": "object",
+      "description": "Collection of Managed Certificates.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ManagedCertificate items on this page",
+          "items": {
+            "$ref": "#/definitions/ManagedCertificate"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ManagedCertificateDomainControlValidation": {
+      "type": "string",
+      "description": "Selected type of domain control validation for managed certificates.",
+      "enum": [
+        "CNAME",
+        "HTTP",
+        "TXT"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedCertificateDomainControlValidation",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "CNAME",
+            "value": "CNAME",
+            "description": "CNAME"
+          },
+          {
+            "name": "HTTP",
+            "value": "HTTP",
+            "description": "HTTP"
+          },
+          {
+            "name": "TXT",
+            "value": "TXT",
+            "description": "TXT"
+          }
+        ]
+      }
+    },
+    "ManagedCertificatePatch": {
+      "type": "object",
+      "description": "A managed certificate to update",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Application-specific metadata in the form of key-value pairs.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ManagedCertificateProperties": {
+      "type": "object",
+      "description": "Certificate resource specific properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/CertificateProvisioningState",
+          "description": "Provisioning state of the certificate.",
+          "readOnly": true
+        },
+        "subjectName": {
+          "type": "string",
+          "description": "Subject name of the certificate."
+        },
+        "error": {
+          "type": "string",
+          "description": "Any error occurred during the certificate provision.",
+          "readOnly": true
+        },
+        "domainControlValidation": {
+          "$ref": "#/definitions/ManagedCertificateDomainControlValidation",
+          "description": "Selected type of domain control validation for managed certificates."
+        },
+        "validationToken": {
+          "type": "string",
+          "description": "A TXT token used for DNS TXT domain control validation when issuing this type of managed certificates.",
+          "readOnly": true
+        }
+      }
+    },
+    "ManagedEnvironment": {
+      "type": "object",
+      "description": "An environment for hosting container apps",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedEnvironmentProperties",
+          "description": "Managed environment resource specific properties",
+          "x-ms-client-flatten": true
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind of the Environment."
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "ManagedEnvironmentProperties": {
+      "type": "object",
+      "description": "Managed environment resource specific properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/EnvironmentProvisioningState",
+          "description": "Provisioning state of the Environment.",
+          "readOnly": true
+        },
+        "daprAIInstrumentationKey": {
+          "type": "string",
+          "format": "password",
+          "description": "Azure Monitor instrumentation key used by Dapr to export Service to Service communication telemetry",
+          "x-ms-secret": true
+        },
+        "daprAIConnectionString": {
+          "type": "string",
+          "format": "password",
+          "description": "Application Insights connection string used by Dapr to export Service to Service communication telemetry",
+          "x-ms-secret": true
+        },
+        "vnetConfiguration": {
+          "$ref": "#/definitions/VnetConfiguration",
+          "description": "Vnet configuration for the environment"
+        },
+        "deploymentErrors": {
+          "type": "string",
+          "description": "Any errors that occurred during deployment or deployment validation",
+          "readOnly": true
+        },
+        "defaultDomain": {
+          "type": "string",
+          "description": "Default Domain Name for the cluster",
+          "readOnly": true
+        },
+        "privateLinkDefaultDomain": {
+          "type": "string",
+          "description": "Private Link Default Domain Name for the environment",
+          "readOnly": true
+        },
+        "staticIp": {
+          "type": "string",
+          "description": "Static IP of the Environment",
+          "readOnly": true
+        },
+        "appLogsConfiguration": {
+          "$ref": "#/definitions/AppLogsConfiguration",
+          "description": "Cluster configuration which enables the log daemon to export app logs to configured destination"
+        },
+        "appInsightsConfiguration": {
+          "$ref": "#/definitions/AppInsightsConfiguration",
+          "description": "Environment level Application Insights configuration"
+        },
+        "openTelemetryConfiguration": {
+          "$ref": "#/definitions/OpenTelemetryConfiguration",
+          "description": "Environment Open Telemetry configuration"
+        },
+        "zoneRedundant": {
+          "type": "boolean",
+          "description": "Whether or not this Managed Environment is zone-redundant.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "availabilityZones": {
+          "type": "array",
+          "description": "The list of availability zones to use for managed environment",
+          "items": {
+            "type": "string"
+          }
+        },
+        "customDomainConfiguration": {
+          "$ref": "#/definitions/CustomDomainConfiguration",
+          "description": "Custom domain configuration for the environment"
+        },
+        "eventStreamEndpoint": {
+          "type": "string",
+          "description": "The endpoint of the eventstream of the Environment.",
+          "readOnly": true
+        },
+        "workloadProfiles": {
+          "type": "array",
+          "description": "Workload profiles configured for the Managed Environment.",
+          "items": {
+            "$ref": "#/definitions/WorkloadProfile"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "kedaConfiguration": {
+          "$ref": "#/definitions/KedaConfiguration",
+          "description": "The configuration of Keda component."
+        },
+        "daprConfiguration": {
+          "$ref": "#/definitions/DaprConfiguration",
+          "description": "The configuration of Dapr component."
+        },
+        "infrastructureResourceGroup": {
+          "type": "string",
+          "description": "Name of the platform-managed resource group created for the Managed Environment to host infrastructure resources. If a subnet ID is provided, this resource group will be created in the same subscription as the subnet.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "peerAuthentication": {
+          "$ref": "#/definitions/ManagedEnvironmentPropertiesPeerAuthentication",
+          "description": "Peer authentication settings for the Managed Environment"
+        },
+        "peerTrafficConfiguration": {
+          "$ref": "#/definitions/ManagedEnvironmentPropertiesPeerTrafficConfiguration",
+          "description": "Peer traffic settings for the Managed Environment"
+        },
+        "ingressConfiguration": {
+          "$ref": "#/definitions/IngressConfiguration",
+          "description": "Ingress configuration for the Managed Environment."
+        },
+        "privateEndpointConnections": {
+          "type": "array",
+          "description": "Private endpoint connections to the resource.",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          },
+          "readOnly": true
+        },
+        "publicNetworkAccess": {
+          "$ref": "#/definitions/PublicNetworkAccess",
+          "description": "Property to allow or block all public traffic. Allowed Values: 'Enabled', 'Disabled'."
+        },
+        "diskEncryptionConfiguration": {
+          "$ref": "#/definitions/DiskEncryptionConfiguration",
+          "description": "Disk encryption configuration for the Managed Environment."
+        }
+      }
+    },
+    "ManagedEnvironmentPropertiesPeerAuthentication": {
+      "type": "object",
+      "description": "Peer authentication settings for the Managed Environment",
+      "properties": {
+        "mtls": {
+          "$ref": "#/definitions/Mtls",
+          "description": "Mutual TLS authentication settings for the Managed Environment"
+        }
+      }
+    },
+    "ManagedEnvironmentPropertiesPeerTrafficConfiguration": {
+      "type": "object",
+      "description": "Peer traffic settings for the Managed Environment",
+      "properties": {
+        "encryption": {
+          "$ref": "#/definitions/ManagedEnvironmentPropertiesPeerTrafficConfigurationEncryption",
+          "description": "Peer traffic encryption settings for the Managed Environment"
+        }
+      }
+    },
+    "ManagedEnvironmentPropertiesPeerTrafficConfigurationEncryption": {
+      "type": "object",
+      "description": "Peer traffic encryption settings for the Managed Environment",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Boolean indicating whether the peer traffic encryption is enabled"
+        }
+      }
+    },
+    "ManagedEnvironmentStorage": {
+      "type": "object",
+      "description": "Storage resource for managedEnvironment.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ManagedEnvironmentStorageProperties",
+          "description": "Storage properties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ManagedEnvironmentStorageProperties": {
+      "type": "object",
+      "description": "Storage properties",
+      "properties": {
+        "azureFile": {
+          "$ref": "#/definitions/AzureFileProperties",
+          "description": "Azure file properties"
+        },
+        "nfsAzureFile": {
+          "$ref": "#/definitions/NfsAzureFileProperties",
+          "description": "NFS Azure file properties"
+        }
+      }
+    },
+    "ManagedEnvironmentStoragesCollection": {
+      "type": "object",
+      "description": "Collection of Storage for Environments",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Collection of storage resources.",
+          "items": {
+            "$ref": "#/definitions/ManagedEnvironmentStorage"
+          }
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ManagedEnvironmentsCollection": {
+      "type": "object",
+      "description": "Collection of Environments",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ManagedEnvironment items on this page",
+          "items": {
+            "$ref": "#/definitions/ManagedEnvironment"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ManagedIdentitySetting": {
+      "type": "object",
+      "description": "Optional settings for a Managed Identity that is assigned to the Session pool.",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "description": "The resource ID of a user-assigned managed identity that is assigned to the Session Pool, or 'system' for system-assigned identity."
+        },
+        "lifecycle": {
+          "type": "string",
+          "description": "Use to select the lifecycle stages of a Session Pool during which the Managed Identity should be available.",
+          "default": "None",
+          "enum": [
+            "None",
+            "Main",
+            "Init",
+            "All"
+          ],
+          "x-ms-enum": {
+            "name": "IdentitySettingsLifeCycle",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "None",
+                "value": "None",
+                "description": "None"
+              },
+              {
+                "name": "Main",
+                "value": "Main",
+                "description": "Main"
+              },
+              {
+                "name": "Init",
+                "value": "Init",
+                "description": "Init"
+              },
+              {
+                "name": "All",
+                "value": "All",
+                "description": "All"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "identity"
+      ]
+    },
+    "McpServerCredential": {
+      "type": "object",
+      "description": "The credentials used for the MCP server endpoint authentication.",
+      "properties": {
+        "apiKey": {
+          "type": "string",
+          "format": "password",
+          "description": "The API key for the MCP server.",
+          "readOnly": true,
+          "x-ms-secret": true
+        }
+      }
+    },
+    "McpServerSettings": {
+      "type": "object",
+      "description": "The settings of the MCP (Model Context Protocol) server for this session pool.",
+      "properties": {
+        "isMcpServerEnabled": {
+          "type": "boolean",
+          "description": "Indicates whether the MCP server is enabled.",
+          "default": false
+        },
+        "isMcpServerApiKeyDisabled": {
+          "type": "boolean",
+          "description": "Indicates whether the MCP server API key is disabled.",
+          "default": false
+        },
+        "mcpServerEndpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "The endpoint of the MCP server.",
+          "readOnly": true
+        }
+      }
+    },
+    "MetricsConfiguration": {
+      "type": "object",
+      "description": "Configuration of Open Telemetry metrics",
+      "properties": {
+        "includeKeda": {
+          "type": "boolean",
+          "description": "Boolean indicating if including keda metrics"
+        },
+        "destinations": {
+          "type": "array",
+          "description": "Open telemetry metrics destinations",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Mtls": {
+      "type": "object",
+      "description": "Configuration properties for mutual TLS authentication",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Boolean indicating whether the mutual TLS authentication is enabled"
+        }
+      }
+    },
+    "NacosComponent": {
+      "type": "object",
+      "description": "Nacos properties.",
+      "properties": {
+        "ingress": {
+          "$ref": "#/definitions/JavaComponentIngress",
+          "description": "Java Component Ingress configurations."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/JavaComponentProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Nacos"
+    },
+    "NfsAzureFileProperties": {
+      "type": "object",
+      "description": "NFS Azure File Properties.",
+      "properties": {
+        "server": {
+          "type": "string",
+          "description": "Server for NFS azure file."
+        },
+        "accessMode": {
+          "$ref": "#/definitions/AccessMode",
+          "description": "Access mode for storage"
+        },
+        "shareName": {
+          "type": "string",
+          "description": "NFS Azure file share name."
+        }
+      }
+    },
+    "Nonce": {
+      "type": "object",
+      "description": "The configuration settings of the nonce used in the login flow.",
+      "properties": {
+        "validateNonce": {
+          "type": "boolean",
+          "description": "<code>false</code> if the nonce should not be validated while completing the login flow; otherwise, <code>true</code>."
+        },
+        "nonceExpirationInterval": {
+          "type": "string",
+          "description": "The time after the request is made when the nonce should expire."
+        }
+      }
+    },
+    "Object": {
+      "type": "object",
+      "description": "Logic App call response object.",
+      "additionalProperties": {}
+    },
+    "OpenIdConnectClientCredential": {
+      "type": "object",
+      "description": "The authentication client credentials of the custom Open ID Connect provider.",
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "The method that should be used to authenticate the user.",
+          "enum": [
+            "ClientSecretPost"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "clientSecretSettingName": {
+          "type": "string",
+          "description": "The app setting that contains the client secret for the custom Open ID Connect provider."
+        }
+      }
+    },
+    "OpenIdConnectConfig": {
+      "type": "object",
+      "description": "The configuration settings of the endpoints used for the custom Open ID Connect provider.",
+      "properties": {
+        "authorizationEndpoint": {
+          "type": "string",
+          "description": "The endpoint to be used to make an authorization request."
+        },
+        "tokenEndpoint": {
+          "type": "string",
+          "description": "The endpoint to be used to request a token."
+        },
+        "issuer": {
+          "type": "string",
+          "description": "The endpoint that issues the token."
+        },
+        "certificationUri": {
+          "type": "string",
+          "description": "The endpoint that provides the keys necessary to validate the token."
+        },
+        "wellKnownOpenIdConfiguration": {
+          "type": "string",
+          "description": "The endpoint that contains all the configuration endpoints for the provider."
+        }
+      }
+    },
+    "OpenIdConnectLogin": {
+      "type": "object",
+      "description": "The configuration settings of the login flow of the custom Open ID Connect provider.",
+      "properties": {
+        "nameClaimType": {
+          "type": "string",
+          "description": "The name of the claim that contains the users name."
+        },
+        "scopes": {
+          "type": "array",
+          "description": "A list of the scopes that should be requested while authenticating.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "OpenIdConnectRegistration": {
+      "type": "object",
+      "description": "The configuration settings of the app registration for the custom Open ID Connect provider.",
+      "properties": {
+        "clientId": {
+          "type": "string",
+          "description": "The client id of the custom Open ID Connect provider."
+        },
+        "clientCredential": {
+          "$ref": "#/definitions/OpenIdConnectClientCredential",
+          "description": "The authentication credentials of the custom Open ID Connect provider."
+        },
+        "openIdConnectConfiguration": {
+          "$ref": "#/definitions/OpenIdConnectConfig",
+          "description": "The configuration settings of the endpoints used for the custom Open ID Connect provider."
+        }
+      }
+    },
+    "OpenTelemetryConfiguration": {
+      "type": "object",
+      "description": "Configuration of Open Telemetry",
+      "properties": {
+        "destinationsConfiguration": {
+          "$ref": "#/definitions/DestinationsConfiguration",
+          "description": "Open telemetry destinations configuration"
+        },
+        "tracesConfiguration": {
+          "$ref": "#/definitions/TracesConfiguration",
+          "description": "Open telemetry trace configuration"
+        },
+        "logsConfiguration": {
+          "$ref": "#/definitions/LogsConfiguration",
+          "description": "Open telemetry logs configuration"
+        },
+        "metricsConfiguration": {
+          "$ref": "#/definitions/MetricsConfiguration",
+          "description": "Open telemetry metrics configuration"
+        }
+      }
+    },
+    "OperationDetail": {
+      "type": "object",
+      "description": "Operation detail payload",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the operation"
+        },
+        "isDataAction": {
+          "type": "boolean",
+          "description": "Indicates whether the operation is a data action"
+        },
+        "display": {
+          "$ref": "#/definitions/OperationDisplay",
+          "description": "Display of the operation"
+        },
+        "origin": {
+          "type": "string",
+          "description": "Origin of the operation"
+        }
+      }
+    },
+    "OperationDisplay": {
+      "type": "object",
+      "description": "Operation display payload",
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "Resource provider of the operation"
+        },
+        "resource": {
+          "type": "string",
+          "description": "Resource of the operation"
+        },
+        "operation": {
+          "type": "string",
+          "description": "Localized friendly name for the operation"
+        },
+        "description": {
+          "type": "string",
+          "description": "Localized friendly description for the operation"
+        }
+      }
+    },
+    "OtlpConfiguration": {
+      "type": "object",
+      "description": "Configuration of otlp",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of otlp configuration"
+        },
+        "endpoint": {
+          "type": "string",
+          "description": "The endpoint of otlp configuration"
+        },
+        "insecure": {
+          "type": "boolean",
+          "description": "Boolean indicating if otlp configuration is insecure"
+        },
+        "headers": {
+          "type": "array",
+          "description": "Headers of otlp configurations",
+          "items": {
+            "$ref": "#/definitions/Header"
+          },
+          "x-ms-identifiers": [
+            "key"
+          ]
+        }
+      }
+    },
+    "PatchApplyStatus": {
+      "type": "string",
+      "description": "The status of the patch once it has been provisioned",
+      "enum": [
+        "NotStarted",
+        "RebaseInProgress",
+        "CreatingRevision",
+        "Succeeded",
+        "Canceled",
+        "RebaseFailed",
+        "RevisionCreationFailed",
+        "ImagePushPullFailed",
+        "ManuallySkipped"
+      ],
+      "x-ms-enum": {
+        "name": "PatchApplyStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotStarted",
+            "value": "NotStarted",
+            "description": "NotStarted"
+          },
+          {
+            "name": "RebaseInProgress",
+            "value": "RebaseInProgress",
+            "description": "RebaseInProgress"
+          },
+          {
+            "name": "CreatingRevision",
+            "value": "CreatingRevision",
+            "description": "CreatingRevision"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "RebaseFailed",
+            "value": "RebaseFailed",
+            "description": "RebaseFailed"
+          },
+          {
+            "name": "RevisionCreationFailed",
+            "value": "RevisionCreationFailed",
+            "description": "RevisionCreationFailed"
+          },
+          {
+            "name": "ImagePushPullFailed",
+            "value": "ImagePushPullFailed",
+            "description": "ImagePushPullFailed"
+          },
+          {
+            "name": "ManuallySkipped",
+            "value": "ManuallySkipped",
+            "description": "ManuallySkipped"
+          }
+        ]
+      }
+    },
+    "PatchCollection": {
+      "type": "object",
+      "description": "Container App patch collection",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The ContainerAppsPatchResource items on this page",
+          "items": {
+            "$ref": "#/definitions/ContainerAppsPatchResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PatchDetails": {
+      "type": "object",
+      "description": "The detailed info of patch operation performing when applying a patch.",
+      "properties": {
+        "targetContainerName": {
+          "type": "string",
+          "description": "The name of the target container for the patch.",
+          "readOnly": true
+        },
+        "targetImage": {
+          "type": "string",
+          "description": "The name of the target image for the patch.",
+          "readOnly": true
+        },
+        "lastDetectionTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The UTC timestamp that describes the latest detection was done.",
+          "readOnly": true
+        },
+        "detectionStatus": {
+          "$ref": "#/definitions/DetectionStatus",
+          "description": "The status of the patch detection.",
+          "readOnly": true
+        },
+        "newImageName": {
+          "type": "string",
+          "description": "The name of the new image created by the patch.",
+          "readOnly": true
+        },
+        "newLayer": {
+          "$ref": "#/definitions/PatchDetailsNewLayer",
+          "description": "New layer update details in the target image.",
+          "readOnly": true
+        },
+        "oldLayer": {
+          "$ref": "#/definitions/PatchDetailsOldLayer",
+          "description": "The old layer details in the target image.",
+          "readOnly": true
+        },
+        "patchType": {
+          "$ref": "#/definitions/PatchType",
+          "description": "The type for the patch.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "targetContainerName",
+        "targetImage",
+        "lastDetectionTime",
+        "detectionStatus"
+      ]
+    },
+    "PatchDetailsNewLayer": {
+      "type": "object",
+      "description": "New layer update details in the target image.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The details of the new layer for the target image."
+        },
+        "frameworkAndVersion": {
+          "type": "string",
+          "description": "The framework and its version in the new run image for the target image."
+        },
+        "osAndVersion": {
+          "type": "string",
+          "description": "The OS name and its version in the new run image for the target image."
+        }
+      }
+    },
+    "PatchDetailsOldLayer": {
+      "type": "object",
+      "description": "The old layer details in the target image.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The details of the old layer for the target image."
+        },
+        "frameworkAndVersion": {
+          "type": "string",
+          "description": "The framework and its version in the old run image for the target image."
+        },
+        "osAndVersion": {
+          "type": "string",
+          "description": "The OS name and its version in the old run image for the target image."
+        }
+      }
+    },
+    "PatchProperties": {
+      "type": "object",
+      "description": "Top level properties that describes current states of the patch resource",
+      "properties": {
+        "targetEnvironmentId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure resource id of the target environment for the patch."
+        },
+        "targetContainerAppId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure resource id of the target container app for the patch."
+        },
+        "targetRevisionId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The Azure resource id of the target revision for the patch."
+        },
+        "patchApplyStatus": {
+          "$ref": "#/definitions/PatchApplyStatus",
+          "description": "The status of the patch operation.",
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The UTC timestamp that describes when the patch object was created.",
+          "readOnly": true
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The UTC timestamp that describes when the patch object was last updated.",
+          "readOnly": true
+        },
+        "patchDetails": {
+          "type": "array",
+          "description": "Detailed info describes the patch operation for the target container app.",
+          "items": {
+            "$ref": "#/definitions/PatchDetails"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": []
+        }
+      }
+    },
+    "PatchSkipConfig": {
+      "type": "object",
+      "description": "The configuration for patcher to skip a patch or not.",
+      "properties": {
+        "skip": {
+          "type": "boolean",
+          "description": "The flag to indicate whether to skip the patch or not."
+        }
+      }
+    },
+    "PatchType": {
+      "type": "string",
+      "description": "The type for the patch.",
+      "enum": [
+        "FrameworkSecurity",
+        "OSSecurity",
+        "FrameworkAndOSSecurity",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "PatchType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "FrameworkSecurity",
+            "value": "FrameworkSecurity",
+            "description": "FrameworkSecurity"
+          },
+          {
+            "name": "OSSecurity",
+            "value": "OSSecurity",
+            "description": "OSSecurity"
+          },
+          {
+            "name": "FrameworkAndOSSecurity",
+            "value": "FrameworkAndOSSecurity",
+            "description": "FrameworkAndOSSecurity"
+          },
+          {
+            "name": "Other",
+            "value": "Other",
+            "description": "Other"
+          }
+        ]
+      }
+    },
+    "PatchingMode": {
+      "type": "string",
+      "description": "Patching mode for the container app. Null or default in this field will be interpreted as Automatic by RP. Automatic mode will automatically apply available patches. Manual mode will require the user to manually apply patches. Disabled mode will stop patch detection and auto patching.",
+      "enum": [
+        "Automatic",
+        "Manual",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "PatchingMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Automatic",
+            "value": "Automatic",
+            "description": "Automatic"
+          },
+          {
+            "name": "Manual",
+            "value": "Manual",
+            "description": "Manual"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "PoolManagementType": {
+      "type": "string",
+      "description": "The pool management type of the session pool.",
+      "enum": [
+        "Manual",
+        "Dynamic"
+      ],
+      "x-ms-enum": {
+        "name": "PoolManagementType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Manual",
+            "value": "Manual",
+            "description": "Manual"
+          },
+          {
+            "name": "Dynamic",
+            "value": "Dynamic",
+            "description": "Dynamic"
+          }
+        ]
+      }
+    },
+    "PreBuildStep": {
+      "type": "object",
+      "description": "Model representing a pre-build step.",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description of the pre-build step."
+        },
+        "scripts": {
+          "type": "array",
+          "description": "List of custom commands to run.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "httpGet": {
+          "$ref": "#/definitions/HttpGet",
+          "description": "Http get request to send before the build."
+        }
+      }
+    },
+    "PrivateEndpoint": {
+      "type": "object",
+      "description": "The Private Endpoint resource.",
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The ARM identifier for Private Endpoint",
+          "readOnly": true
+        }
+      }
+    },
+    "PrivateEndpointConnection": {
+      "type": "object",
+      "description": "The Private Endpoint Connection resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "description": "Resource properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "PrivateEndpointConnectionListResult": {
+      "type": "object",
+      "description": "The response of a PrivateEndpointConnection list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateEndpointConnection items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateEndpointConnection"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateEndpointConnectionProperties": {
+      "type": "object",
+      "description": "Properties of the private endpoint connection.",
+      "properties": {
+        "groupIds": {
+          "type": "array",
+          "description": "The group ids for the private endpoint resource.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "privateEndpoint": {
+          "$ref": "#/definitions/PrivateEndpoint",
+          "description": "The resource of private end point."
+        },
+        "privateLinkServiceConnectionState": {
+          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
+          "description": "A collection of information about the state of the connection between service consumer and provider."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/PrivateEndpointConnectionProvisioningState",
+          "description": "The provisioning state of the private endpoint connection resource.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "privateLinkServiceConnectionState"
+      ]
+    },
+    "PrivateEndpointConnectionProvisioningState": {
+      "type": "string",
+      "description": "The current provisioning state.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Waiting",
+        "Updating",
+        "Deleting",
+        "Pending"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointConnectionProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Waiting",
+            "value": "Waiting",
+            "description": "Waiting"
+          },
+          {
+            "name": "Updating",
+            "value": "Updating",
+            "description": "Updating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          },
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Pending"
+          }
+        ]
+      }
+    },
+    "PrivateEndpointServiceConnectionStatus": {
+      "type": "string",
+      "description": "The private endpoint connection status.",
+      "enum": [
+        "Pending",
+        "Approved",
+        "Rejected",
+        "Disconnected"
+      ],
+      "x-ms-enum": {
+        "name": "PrivateEndpointServiceConnectionStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Pending",
+            "value": "Pending",
+            "description": "Pending"
+          },
+          {
+            "name": "Approved",
+            "value": "Approved",
+            "description": "Approved"
+          },
+          {
+            "name": "Rejected",
+            "value": "Rejected",
+            "description": "Rejected"
+          },
+          {
+            "name": "Disconnected",
+            "value": "Disconnected",
+            "description": "Disconnected"
+          }
+        ]
+      }
+    },
+    "PrivateLinkResource": {
+      "type": "object",
+      "description": "A private link resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "description": "Resource properties.",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
+        }
+      ]
+    },
+    "PrivateLinkResourceListResult": {
+      "type": "object",
+      "description": "The response of a PrivateLinkResource list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The PrivateLinkResource items on this page",
+          "items": {
+            "$ref": "#/definitions/PrivateLinkResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "PrivateLinkResourceProperties": {
+      "type": "object",
+      "description": "Properties of a private link resource.",
+      "properties": {
+        "groupId": {
+          "type": "string",
+          "description": "The private link resource group id.",
+          "readOnly": true
+        },
+        "requiredMembers": {
+          "type": "array",
+          "description": "The private link resource required member names.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "requiredZoneNames": {
+          "type": "array",
+          "description": "The private link resource private link DNS zone name.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PrivateLinkServiceConnectionState": {
+      "type": "object",
+      "description": "A collection of information about the state of the connection between service consumer and provider.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/PrivateEndpointServiceConnectionStatus",
+          "description": "Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service."
+        },
+        "description": {
+          "type": "string",
+          "description": "The reason for approval/rejection of the connection."
+        },
+        "actionsRequired": {
+          "type": "string",
+          "description": "A message indicating if changes on the service provider require any updates on the consumer."
+        }
+      }
+    },
+    "PublicNetworkAccess": {
+      "type": "string",
+      "description": "Property to allow or block all public traffic. Allowed Values: 'Enabled', 'Disabled'.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "PublicNetworkAccess",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          }
+        ]
+      }
+    },
+    "QueueScaleRule": {
+      "type": "object",
+      "description": "Container App container Azure Queue based scaling rule.",
+      "properties": {
+        "accountName": {
+          "type": "string",
+          "description": "Storage account name. required if using managed identity to authenticate"
+        },
+        "queueName": {
+          "type": "string",
+          "description": "Queue name."
+        },
+        "queueLength": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Queue length."
+        },
+        "auth": {
+          "type": "array",
+          "description": "Authentication secrets for the queue scale rule.",
+          "items": {
+            "$ref": "#/definitions/ScaleRuleAuth"
+          },
+          "x-ms-identifiers": [
+            "triggerParameter"
+          ]
+        },
+        "identity": {
+          "type": "string",
+          "description": "The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for system-assigned identity."
+        }
+      }
+    },
+    "RegistryCredentials": {
+      "type": "object",
+      "description": "Container App Private Registry",
+      "properties": {
+        "server": {
+          "type": "string",
+          "description": "Container Registry Server"
+        },
+        "username": {
+          "type": "string",
+          "description": "Container Registry Username"
+        },
+        "passwordSecretRef": {
+          "type": "string",
+          "description": "The name of the Secret that contains the registry login password"
+        },
+        "identity": {
+          "type": "string",
+          "description": "A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned identities, use the full user-assigned identity Resource ID. For system-assigned identities, use 'system'"
+        }
+      }
+    },
+    "RegistryInfo": {
+      "type": "object",
+      "description": "Container App registry information.",
+      "properties": {
+        "registryUrl": {
+          "type": "string",
+          "description": "registry server Url."
+        },
+        "registryUserName": {
+          "type": "string",
+          "description": "registry username."
+        },
+        "registryPassword": {
+          "type": "string",
+          "description": "registry secret.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
+    "Replica": {
+      "type": "object",
+      "description": "Container App Revision Replica.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ReplicaProperties",
+          "description": "Replica resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ReplicaCollection": {
+      "type": "object",
+      "description": "Container App Revision Replicas collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Collection of resources.",
+          "items": {
+            "$ref": "#/definitions/Replica"
+          }
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "ReplicaContainer": {
+      "type": "object",
+      "description": "Container object under Container App Revision Replica.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The Name of the Container"
+        },
+        "containerId": {
+          "type": "string",
+          "description": "The Id of the Container"
+        },
+        "ready": {
+          "type": "boolean",
+          "description": "The container ready status"
+        },
+        "started": {
+          "type": "boolean",
+          "description": "The container start status"
+        },
+        "restartCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The container restart count"
+        },
+        "runningState": {
+          "$ref": "#/definitions/ContainerAppContainerRunningState",
+          "description": "Current running state of the container",
+          "readOnly": true
+        },
+        "runningStateDetails": {
+          "type": "string",
+          "description": "The details of container current running state",
+          "readOnly": true
+        },
+        "logStreamEndpoint": {
+          "type": "string",
+          "description": "Log Stream endpoint",
+          "readOnly": true
+        },
+        "execEndpoint": {
+          "type": "string",
+          "description": "Container exec endpoint",
+          "readOnly": true
+        },
+        "debugEndpoint": {
+          "type": "string",
+          "description": "Container debug endpoint",
+          "readOnly": true
+        }
+      }
+    },
+    "ReplicaExecutionStatus": {
+      "type": "object",
+      "description": "Container Apps Job execution replica status.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Replica Name."
+        },
+        "containers": {
+          "type": "array",
+          "description": "Containers in the execution replica",
+          "items": {
+            "$ref": "#/definitions/ContainerExecutionStatus"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "ReplicaProperties": {
+      "type": "object",
+      "description": "Replica resource specific properties",
+      "properties": {
+        "createdTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp describing when the pod was created by controller",
+          "readOnly": true
+        },
+        "runningState": {
+          "$ref": "#/definitions/ContainerAppReplicaRunningState",
+          "description": "Current running state of the replica",
+          "readOnly": true
+        },
+        "runningStateDetails": {
+          "type": "string",
+          "description": "The details of replica current running state",
+          "readOnly": true
+        },
+        "containers": {
+          "type": "array",
+          "description": "The containers collection under a replica.",
+          "items": {
+            "$ref": "#/definitions/ReplicaContainer"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "initContainers": {
+          "type": "array",
+          "description": "The init containers collection under a replica.",
+          "items": {
+            "$ref": "#/definitions/ReplicaContainer"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "ResourceTags": {
+      "type": "object",
+      "description": "List of key value pairs that describe the resource. This will overwrite the existing tags.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        }
+      }
+    },
+    "Revision": {
+      "type": "object",
+      "description": "Container App Revision.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RevisionProperties",
+          "description": "Revision resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RevisionCollection": {
+      "type": "object",
+      "description": "Container App Revisions collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Revision items on this page",
+          "items": {
+            "$ref": "#/definitions/Revision"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RevisionHealthState": {
+      "type": "string",
+      "description": "Current health State of the revision",
+      "enum": [
+        "Healthy",
+        "Unhealthy",
+        "None"
+      ],
+      "x-ms-enum": {
+        "name": "RevisionHealthState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Healthy",
+            "value": "Healthy",
+            "description": "Healthy"
+          },
+          {
+            "name": "Unhealthy",
+            "value": "Unhealthy",
+            "description": "Unhealthy"
+          },
+          {
+            "name": "None",
+            "value": "None",
+            "description": "None"
+          }
+        ]
+      }
+    },
+    "RevisionProperties": {
+      "type": "object",
+      "description": "Revision resource specific properties",
+      "properties": {
+        "createdTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp describing when the revision was created\nby controller",
+          "readOnly": true
+        },
+        "lastActiveTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp describing when the revision was last active. Only meaningful when revision is inactive",
+          "readOnly": true
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "Fully qualified domain name of the revision",
+          "readOnly": true
+        },
+        "template": {
+          "$ref": "#/definitions/Template",
+          "description": "Container App Revision Template with all possible settings and the\ndefaults if user did not provide them. The defaults are populated\nas they were at the creation time",
+          "readOnly": true
+        },
+        "active": {
+          "type": "boolean",
+          "description": "Boolean describing if the Revision is Active",
+          "readOnly": true
+        },
+        "replicas": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of pods currently running for this revision",
+          "readOnly": true
+        },
+        "trafficWeight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Traffic weight assigned to this revision",
+          "readOnly": true
+        },
+        "labels": {
+          "type": "array",
+          "description": "List of labels assigned to this revision.",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        },
+        "provisioningError": {
+          "type": "string",
+          "description": "Optional Field - Platform Error Message",
+          "readOnly": true
+        },
+        "healthState": {
+          "$ref": "#/definitions/RevisionHealthState",
+          "description": "Current health State of the revision",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/RevisionProvisioningState",
+          "description": "Current provisioning State of the revision",
+          "readOnly": true
+        },
+        "runningState": {
+          "$ref": "#/definitions/RevisionRunningState",
+          "description": "Current running state of the revision",
+          "readOnly": true
+        }
+      }
+    },
+    "RevisionProvisioningState": {
+      "type": "string",
+      "description": "Current provisioning State of the revision",
+      "enum": [
+        "Provisioning",
+        "Provisioned",
+        "Failed",
+        "Deprovisioning",
+        "Deprovisioned"
+      ],
+      "x-ms-enum": {
+        "name": "RevisionProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Provisioning",
+            "value": "Provisioning",
+            "description": "Provisioning"
+          },
+          {
+            "name": "Provisioned",
+            "value": "Provisioned",
+            "description": "Provisioned"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Deprovisioning",
+            "value": "Deprovisioning",
+            "description": "Deprovisioning"
+          },
+          {
+            "name": "Deprovisioned",
+            "value": "Deprovisioned",
+            "description": "Deprovisioned"
+          }
+        ]
+      }
+    },
+    "RevisionRunningState": {
+      "type": "string",
+      "description": "Current running state of the revision",
+      "enum": [
+        "Running",
+        "Processing",
+        "Stopped",
+        "Degraded",
+        "Failed",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "RevisionRunningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Running",
+            "value": "Running",
+            "description": "Running"
+          },
+          {
+            "name": "Processing",
+            "value": "Processing",
+            "description": "Processing"
+          },
+          {
+            "name": "Stopped",
+            "value": "Stopped",
+            "description": "Stopped"
+          },
+          {
+            "name": "Degraded",
+            "value": "Degraded",
+            "description": "Degraded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          }
+        ]
+      }
+    },
+    "Runtime": {
+      "type": "object",
+      "description": "Container App Runtime configuration.",
+      "properties": {
+        "java": {
+          "$ref": "#/definitions/RuntimeJava",
+          "description": "Java app configuration"
+        },
+        "dotnet": {
+          "$ref": "#/definitions/RuntimeDotnet",
+          "description": ".NET app configuration"
+        }
+      }
+    },
+    "RuntimeDotnet": {
+      "type": "object",
+      "description": ".NET app configuration",
+      "properties": {
+        "autoConfigureDataProtection": {
+          "type": "boolean",
+          "description": "Auto configure the ASP.NET Core Data Protection feature"
+        }
+      }
+    },
+    "RuntimeJava": {
+      "type": "object",
+      "description": "Java app configuration",
+      "properties": {
+        "enableMetrics": {
+          "type": "boolean",
+          "description": "Enable jmx core metrics for the java app"
+        },
+        "javaAgent": {
+          "$ref": "#/definitions/RuntimeJavaJavaAgent",
+          "description": "Diagnostic capabilities achieved by java agent"
+        }
+      }
+    },
+    "RuntimeJavaJavaAgent": {
+      "type": "object",
+      "description": "Diagnostic capabilities achieved by java agent",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable java agent injection for the java app."
+        },
+        "logging": {
+          "$ref": "#/definitions/RuntimeJavaJavaAgentLogging",
+          "description": "Capabilities on the java logging scenario."
+        }
+      }
+    },
+    "RuntimeJavaJavaAgentLogging": {
+      "type": "object",
+      "description": "Capabilities on the java logging scenario.",
+      "properties": {
+        "loggerSettings": {
+          "type": "array",
+          "description": "Settings of the logger for the java app.",
+          "items": {
+            "$ref": "#/definitions/LoggerSetting"
+          },
+          "x-ms-identifiers": [
+            "logger",
+            "level"
+          ]
+        }
+      }
+    },
+    "Scale": {
+      "type": "object",
+      "description": "Container App scaling configurations.",
+      "properties": {
+        "minReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. Minimum number of container replicas."
+        },
+        "maxReplicas": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. Maximum number of container replicas. Defaults to 10 if not set.",
+          "default": 10
+        },
+        "cooldownPeriod": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. KEDA Cooldown Period. Defaults to 300 seconds if not set."
+        },
+        "pollingInterval": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Optional. KEDA Polling Interval. Defaults to 30 seconds if not set."
+        },
+        "rules": {
+          "type": "array",
+          "description": "Scaling rules.",
+          "items": {
+            "$ref": "#/definitions/ScaleRule"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "ScaleConfiguration": {
+      "type": "object",
+      "description": "Scale configuration.",
+      "properties": {
+        "maxConcurrentSessions": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum count of sessions at the same time."
+        },
+        "readySessionInstances": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum count of ready session instances."
+        }
+      }
+    },
+    "ScaleRule": {
+      "type": "object",
+      "description": "Container App container scaling rule.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Scale Rule Name"
+        },
+        "azureQueue": {
+          "$ref": "#/definitions/QueueScaleRule",
+          "description": "Azure Queue based scaling."
+        },
+        "custom": {
+          "$ref": "#/definitions/CustomScaleRule",
+          "description": "Custom scale rule."
+        },
+        "http": {
+          "$ref": "#/definitions/HttpScaleRule",
+          "description": "HTTP requests based scaling."
+        },
+        "tcp": {
+          "$ref": "#/definitions/TcpScaleRule",
+          "description": "Tcp requests based scaling."
+        }
+      }
+    },
+    "ScaleRuleAuth": {
+      "type": "object",
+      "description": "Auth Secrets for Scale Rule",
+      "properties": {
+        "secretRef": {
+          "type": "string",
+          "description": "Name of the secret from which to pull the auth params."
+        },
+        "triggerParameter": {
+          "type": "string",
+          "description": "Trigger Parameter that uses the secret"
+        }
+      }
+    },
+    "ScgRoute": {
+      "type": "object",
+      "description": "Spring Cloud Gateway route definition",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Id of the route"
+        },
+        "uri": {
+          "type": "string",
+          "description": "Uri of the route"
+        },
+        "predicates": {
+          "type": "array",
+          "description": "Predicates of the route",
+          "items": {
+            "type": "string"
+          }
+        },
+        "filters": {
+          "type": "array",
+          "description": "Filters of the route",
+          "items": {
+            "type": "string"
+          }
+        },
+        "order": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Order of the route"
+        }
+      },
+      "required": [
+        "id",
+        "uri"
+      ]
+    },
+    "ScheduledEntries": {
+      "type": "object",
+      "description": "List of maintenance schedules for a managed environment.",
+      "properties": {
+        "scheduledEntries": {
+          "type": "array",
+          "description": "List of maintenance schedules for a managed environment.",
+          "items": {
+            "$ref": "#/definitions/ScheduledEntry"
+          },
+          "x-ms-client-name": "ScheduledEntries",
+          "x-ms-identifiers": []
+        }
+      },
+      "required": [
+        "scheduledEntries"
+      ]
+    },
+    "ScheduledEntry": {
+      "type": "object",
+      "description": "Maintenance schedule entry for a managed environment.",
+      "properties": {
+        "weekDay": {
+          "$ref": "#/definitions/WeekDay",
+          "description": "Day of the week when a managed environment can be patched."
+        },
+        "startHourUtc": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Start hour after which managed environment maintenance can start from 0 to 23 hour."
+        },
+        "durationHours": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Length of maintenance window range from 8 to 24 hours."
+        }
+      },
+      "required": [
+        "weekDay",
+        "startHourUtc",
+        "durationHours"
+      ]
+    },
+    "Scheme": {
+      "type": "string",
+      "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
+      "enum": [
+        "HTTP",
+        "HTTPS"
+      ],
+      "x-ms-enum": {
+        "name": "Scheme",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "HTTP",
+            "value": "HTTP",
+            "description": "HTTP"
+          },
+          {
+            "name": "HTTPS",
+            "value": "HTTPS",
+            "description": "HTTPS"
+          }
+        ]
+      }
+    },
+    "Secret": {
+      "type": "object",
+      "description": "Secret definition.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Secret Name."
+        },
+        "value": {
+          "type": "string",
+          "format": "password",
+          "description": "Secret Value.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
+        },
+        "identity": {
+          "type": "string",
+          "description": "Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a system-assigned identity."
+        },
+        "keyVaultUrl": {
+          "type": "string",
+          "description": "Azure Key Vault URL pointing to the secret referenced by the container app."
+        }
+      }
+    },
+    "SecretKeyVaultProperties": {
+      "type": "object",
+      "description": "Properties for a secret stored in a Key Vault.",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "description": "Resource ID of a managed identity to authenticate with Azure Key Vault, or System to use a system-assigned identity."
+        },
+        "keyVaultUrl": {
+          "type": "string",
+          "description": "URL pointing to the Azure Key Vault secret."
+        }
+      }
+    },
+    "SecretVolumeItem": {
+      "type": "object",
+      "description": "Secret to be added to volume.",
+      "properties": {
+        "secretRef": {
+          "type": "string",
+          "description": "Name of the Container App secret from which to pull the secret value."
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to project secret to. If no path is provided, path defaults to name of secret listed in secretRef."
+        }
+      }
+    },
+    "SecretsCollection": {
+      "type": "object",
+      "description": "Container App Secrets Collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "Collection of resources.",
+          "items": {
+            "$ref": "#/definitions/ContainerAppSecret"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "Service": {
+      "type": "object",
+      "description": "Container App to be a dev service",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Dev ContainerApp service type"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "ServiceBind": {
+      "type": "object",
+      "description": "Configuration to bind a ContainerApp to a dev ContainerApp Service",
+      "properties": {
+        "serviceId": {
+          "type": "string",
+          "description": "Resource id of the target service"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the service bind"
+        },
+        "clientType": {
+          "type": "string",
+          "description": "Type of the client to be used to connect to the service"
+        },
+        "customizedKeys": {
+          "type": "object",
+          "description": "Customized keys for customizing injected values to the app",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SessionContainer": {
+      "type": "object",
+      "description": "Container definitions for the sessions of the session pool.",
+      "properties": {
+        "image": {
+          "type": "string",
+          "description": "Container image tag."
+        },
+        "name": {
+          "type": "string",
+          "description": "Custom container name."
+        },
+        "command": {
+          "type": "array",
+          "description": "Container start command.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "args": {
+          "type": "array",
+          "description": "Container start command arguments.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "array",
+          "description": "Container environment variables.",
+          "items": {
+            "$ref": "#/definitions/EnvironmentVar"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "resources": {
+          "$ref": "#/definitions/SessionContainerResources",
+          "description": "Container resource requirements."
+        },
+        "probes": {
+          "type": "array",
+          "description": "List of probes for the container.",
+          "items": {
+            "$ref": "#/definitions/SessionProbe"
+          },
+          "x-ms-identifiers": [
+            "type"
+          ]
+        }
+      }
+    },
+    "SessionContainerResources": {
+      "type": "object",
+      "description": "Container resource requirements for sessions of the session pool.",
+      "properties": {
+        "cpu": {
+          "type": "number",
+          "format": "double",
+          "description": "Required CPU in cores, e.g. 0.5"
+        },
+        "memory": {
+          "type": "string",
+          "description": "Required memory, e.g. \"250Mb\""
+        }
+      }
+    },
+    "SessionIngress": {
+      "type": "object",
+      "description": "Session pool ingress configuration.",
+      "properties": {
+        "targetPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Target port in containers for traffic from ingress"
+        }
+      }
+    },
+    "SessionNetworkConfiguration": {
+      "type": "object",
+      "description": "Session network configuration.",
+      "properties": {
+        "status": {
+          "$ref": "#/definitions/SessionNetworkStatus",
+          "description": "Network status for the sessions."
+        }
+      }
+    },
+    "SessionNetworkStatus": {
+      "type": "string",
+      "description": "Network status for the sessions.",
+      "enum": [
+        "EgressEnabled",
+        "EgressDisabled"
+      ],
+      "x-ms-enum": {
+        "name": "SessionNetworkStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "EgressEnabled",
+            "value": "EgressEnabled",
+            "description": "EgressEnabled"
+          },
+          {
+            "name": "EgressDisabled",
+            "value": "EgressDisabled",
+            "description": "EgressDisabled"
+          }
+        ]
+      }
+    },
+    "SessionPool": {
+      "type": "object",
+      "description": "Container App session pool.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SessionPoolProperties",
+          "description": "Container App session pool resource specific properties",
+          "x-ms-client-flatten": true
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "SessionPoolCollection": {
+      "type": "object",
+      "description": "Session pool collection Azure resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SessionPool items on this page",
+          "items": {
+            "$ref": "#/definitions/SessionPool"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SessionPoolProperties": {
+      "type": "object",
+      "description": "Container App session pool resource specific properties",
+      "properties": {
+        "environmentId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Resource ID of the session pool's environment.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ],
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.App/managedEnvironments"
+              }
+            ]
+          }
+        },
+        "containerType": {
+          "$ref": "#/definitions/ContainerType",
+          "description": "The container type of the sessions. You can use your own container to build the session pool, or you can use a predefined container to run workload with specific language."
+        },
+        "poolManagementType": {
+          "$ref": "#/definitions/PoolManagementType",
+          "description": "The pool management type of the session pool."
+        },
+        "nodeCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of nodes the session pool is using.",
+          "readOnly": true
+        },
+        "scaleConfiguration": {
+          "$ref": "#/definitions/ScaleConfiguration",
+          "description": "The scale configuration of the session pool."
+        },
+        "secrets": {
+          "type": "array",
+          "description": "The secrets of the session pool.",
+          "items": {
+            "$ref": "#/definitions/SessionPoolSecret"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "dynamicPoolConfiguration": {
+          "$ref": "#/definitions/DynamicPoolConfiguration",
+          "description": "The pool configuration if the poolManagementType is dynamic."
+        },
+        "customContainerTemplate": {
+          "$ref": "#/definitions/CustomContainerTemplate",
+          "description": "The custom container configuration if the containerType is CustomContainer."
+        },
+        "sessionNetworkConfiguration": {
+          "$ref": "#/definitions/SessionNetworkConfiguration",
+          "description": "The network configuration of the sessions in the session pool."
+        },
+        "templateUpdateStatus": {
+          "$ref": "#/definitions/TemplateUpdateStatus",
+          "description": "The template status of the session pool, showing active template, or desired template during session pool update. This is only available if the containerType is CustomContainer.",
+          "readOnly": true
+        },
+        "poolManagementEndpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "The endpoint to manage the pool.",
+          "readOnly": true
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/SessionPoolProvisioningState",
+          "description": "Provisioning state of the session pool.",
+          "readOnly": true
+        },
+        "managedIdentitySettings": {
+          "type": "array",
+          "description": "Optional settings for a Managed Identity that is assigned to the Session pool.",
+          "items": {
+            "$ref": "#/definitions/ManagedIdentitySetting"
+          },
+          "x-ms-identifiers": [
+            "identity"
+          ]
+        },
+        "mcpServerSettings": {
+          "$ref": "#/definitions/McpServerSettings",
+          "description": "The MCP (Model Context Protocol) server settings of the session pool."
+        }
+      }
+    },
+    "SessionPoolProvisioningState": {
+      "type": "string",
+      "description": "Provisioning state of the session pool.",
+      "enum": [
+        "InProgress",
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "SessionPoolProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "InProgress"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting",
+            "description": "Deleting"
+          }
+        ]
+      }
+    },
+    "SessionPoolSecret": {
+      "type": "object",
+      "description": "Secret definition.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Secret Name."
+        },
+        "value": {
+          "type": "string",
+          "format": "password",
+          "description": "Secret Value.",
+          "x-ms-mutability": [
+            "update",
+            "create"
+          ],
+          "x-ms-secret": true
+        }
+      }
+    },
+    "SessionPoolUpdatableProperties": {
+      "type": "object",
+      "description": "Container App session pool updatable properties.",
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-ms-mutability": [
+            "read",
+            "update",
+            "create"
+          ]
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "Managed identities needed by a session pool to interact with other Azure services to not maintain any secrets or credentials in code."
+        },
+        "properties": {
+          "$ref": "#/definitions/SessionPoolUpdatablePropertiesProperties",
+          "description": "Session pool resource specific updatable properties.",
+          "x-ms-client-flatten": true
+        }
+      }
+    },
+    "SessionPoolUpdatablePropertiesProperties": {
+      "type": "object",
+      "description": "Session pool resource specific updatable properties.",
+      "properties": {
+        "scaleConfiguration": {
+          "$ref": "#/definitions/ScaleConfiguration",
+          "description": "The scale configuration of the session pool."
+        },
+        "secrets": {
+          "type": "array",
+          "description": "The secrets of the session pool.",
+          "items": {
+            "$ref": "#/definitions/SessionPoolSecret"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "dynamicPoolConfiguration": {
+          "$ref": "#/definitions/DynamicPoolConfiguration",
+          "description": "The pool configuration if the poolManagementType is dynamic."
+        },
+        "customContainerTemplate": {
+          "$ref": "#/definitions/CustomContainerTemplate",
+          "description": "The custom container configuration if the containerType is CustomContainer."
+        },
+        "sessionNetworkConfiguration": {
+          "$ref": "#/definitions/SessionNetworkConfiguration",
+          "description": "The network configuration of the sessions in the session pool."
+        }
+      }
+    },
+    "SessionProbe": {
+      "type": "object",
+      "description": "Session probe configuration.",
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/SessionProbeType",
+          "description": "Denotes the type of probe. Can be Liveness or Startup, Readiness probe is not supported in sessions. Type must be unique for each probe within the context of a list of probes (SessionProbes)."
+        },
+        "httpGet": {
+          "$ref": "#/definitions/SessionProbeHttpGet",
+          "description": "HTTPGet specifies the http request to perform."
+        },
+        "tcpSocket": {
+          "$ref": "#/definitions/SessionProbeTcpSocket",
+          "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported."
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1. Maximum value is 10."
+        },
+        "initialDelaySeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of seconds after the container has started before liveness probes are initiated. Minimum value is 1. Maximum value is 60."
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1. Maximum value is 240."
+        },
+        "successThreshold": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1. Maximum value is 10."
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is an alpha field and requires enabling ProbeTerminationGracePeriod feature gate. Maximum value is 3600 seconds (1 hour)"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. Maximum value is 240."
+        }
+      }
+    },
+    "SessionProbeHttpGet": {
+      "type": "object",
+      "description": "HTTPGet specifies the http request to perform.",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Host name to connect to, defaults to the pod IP. You probably want to set \"Host\" in httpHeaders instead."
+        },
+        "httpHeaders": {
+          "type": "array",
+          "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+          "items": {
+            "$ref": "#/definitions/SessionProbeHttpGetHttpHeadersItem"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "path": {
+          "type": "string",
+          "description": "Path to access on the HTTP server."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+        },
+        "scheme": {
+          "$ref": "#/definitions/Scheme",
+          "description": "Scheme to use for connecting to the host. Defaults to HTTP."
+        }
+      },
+      "required": [
+        "port"
+      ]
+    },
+    "SessionProbeHttpGetHttpHeadersItem": {
+      "type": "object",
+      "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The header field name"
+        },
+        "value": {
+          "type": "string",
+          "description": "The header field value"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ]
+    },
+    "SessionProbeTcpSocket": {
+      "type": "object",
+      "description": "TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported.",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "Optional: Host name to connect to, defaults to the pod IP."
+        },
+        "port": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME."
+        }
+      },
+      "required": [
+        "port"
+      ]
+    },
+    "SessionProbeType": {
+      "type": "string",
+      "description": "Denotes the type of probe. Can be Liveness or Startup, Readiness probe is not supported in sessions. Type must be unique for each probe within the context of a list of probes (SessionProbes).",
+      "enum": [
+        "Liveness",
+        "Startup"
+      ],
+      "x-ms-enum": {
+        "name": "SessionProbeType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Liveness",
+            "value": "Liveness",
+            "description": "Liveness"
+          },
+          {
+            "name": "Startup",
+            "value": "Startup",
+            "description": "Startup"
+          }
+        ]
+      }
+    },
+    "SessionRegistryCredentials": {
+      "type": "object",
+      "description": "Session pool private registry credentials.",
+      "properties": {
+        "server": {
+          "type": "string",
+          "description": "Container registry server."
+        },
+        "username": {
+          "type": "string",
+          "description": "Container registry username."
+        },
+        "passwordSecretRef": {
+          "type": "string",
+          "description": "The name of the secret that contains the registry login password"
+        },
+        "identity": {
+          "type": "string",
+          "description": "A Managed Identity to use to authenticate with Azure Container Registry. For user-assigned identities, use the full user-assigned identity Resource ID. For system-assigned identities, use 'system'"
+        }
+      }
+    },
+    "SmbStorage": {
+      "type": "object",
+      "description": "SMB storage properties",
+      "properties": {
+        "host": {
+          "type": "string",
+          "description": "The host name or IP address of the SMB server."
+        },
+        "shareName": {
+          "type": "string",
+          "description": "The path to the SMB shared folder."
+        },
+        "username": {
+          "type": "string",
+          "description": "The user to log on to the SMB server."
+        },
+        "domain": {
+          "type": "string",
+          "description": "The domain name for the user."
+        },
+        "password": {
+          "type": "string",
+          "format": "password",
+          "description": "The password for the user.",
+          "x-ms-secret": true
+        },
+        "accessMode": {
+          "$ref": "#/definitions/AccessMode",
+          "description": "Access mode for storage"
+        }
+      }
+    },
+    "SourceControl": {
+      "type": "object",
+      "description": "Container App SourceControl.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SourceControlProperties",
+          "description": "SourceControl resource specific properties",
+          "x-ms-client-flatten": true
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "SourceControlCollection": {
+      "type": "object",
+      "description": "SourceControl collection ARM resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SourceControl items on this page",
+          "items": {
+            "$ref": "#/definitions/SourceControl"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SourceControlOperationState": {
+      "type": "string",
+      "description": "Current provisioning State of the operation",
+      "enum": [
+        "InProgress",
+        "Succeeded",
+        "Failed",
+        "Canceled"
+      ],
+      "x-ms-enum": {
+        "name": "SourceControlOperationState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "InProgress",
+            "value": "InProgress",
+            "description": "InProgress"
+          },
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Canceled"
+          }
+        ]
+      }
+    },
+    "SourceControlProperties": {
+      "type": "object",
+      "description": "SourceControl resource specific properties",
+      "properties": {
+        "operationState": {
+          "$ref": "#/definitions/SourceControlOperationState",
+          "description": "Current provisioning State of the operation",
+          "readOnly": true
+        },
+        "repoUrl": {
+          "type": "string",
+          "description": "The repo url which will be integrated to ContainerApp."
+        },
+        "branch": {
+          "type": "string",
+          "description": "The branch which will trigger the auto deployment"
+        },
+        "githubActionConfiguration": {
+          "$ref": "#/definitions/GithubActionConfiguration",
+          "description": "Container App Revision Template with all possible settings and the\ndefaults if user did not provide them. The defaults are populated\nas they were at the creation time"
+        }
+      }
+    },
+    "SpringBootAdminComponent": {
+      "type": "object",
+      "description": "Spring Boot Admin properties.",
+      "properties": {
+        "ingress": {
+          "$ref": "#/definitions/JavaComponentIngress",
+          "description": "Java Component Ingress configurations."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/JavaComponentProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "SpringBootAdmin"
+    },
+    "SpringCloudConfigComponent": {
+      "type": "object",
+      "description": "Spring Cloud Config properties.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/JavaComponentProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "SpringCloudConfig"
+    },
+    "SpringCloudEurekaComponent": {
+      "type": "object",
+      "description": "Spring Cloud Eureka properties.",
+      "properties": {
+        "ingress": {
+          "$ref": "#/definitions/JavaComponentIngress",
+          "description": "Java Component Ingress configurations."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/JavaComponentProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "SpringCloudEureka"
+    },
+    "SpringCloudGatewayComponent": {
+      "type": "object",
+      "description": "Spring Cloud Gateway properties.",
+      "properties": {
+        "ingress": {
+          "$ref": "#/definitions/JavaComponentIngress",
+          "description": "Java Component Ingress configurations."
+        },
+        "springCloudGatewayRoutes": {
+          "type": "array",
+          "description": "Gateway route definition",
+          "items": {
+            "$ref": "#/definitions/ScgRoute"
+          },
+          "x-ms-identifiers": [
+            "id"
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/JavaComponentProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "SpringCloudGateway"
+    },
+    "Status": {
+      "type": "string",
+      "description": "Status of the label history record.",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Starting"
+      ],
+      "x-ms-enum": {
+        "name": "Status",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Succeeded"
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Failed"
+          },
+          {
+            "name": "Starting",
+            "value": "Starting",
+            "description": "Starting"
+          }
+        ]
+      }
+    },
+    "StorageType": {
+      "type": "string",
+      "description": "Storage type for the volume. If not provided, use EmptyDir.",
+      "enum": [
+        "AzureFile",
+        "EmptyDir",
+        "Secret",
+        "NfsAzureFile",
+        "Smb"
+      ],
+      "x-ms-enum": {
+        "name": "StorageType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzureFile",
+            "value": "AzureFile",
+            "description": "AzureFile"
+          },
+          {
+            "name": "EmptyDir",
+            "value": "EmptyDir",
+            "description": "EmptyDir"
+          },
+          {
+            "name": "Secret",
+            "value": "Secret",
+            "description": "Secret"
+          },
+          {
+            "name": "NfsAzureFile",
+            "value": "NfsAzureFile",
+            "description": "NfsAzureFile"
+          },
+          {
+            "name": "Smb",
+            "value": "Smb",
+            "description": "Smb"
+          }
+        ]
+      }
+    },
+    "TcpConnectionPool": {
+      "type": "object",
+      "description": "Defines parameters for tcp connection pooling",
+      "properties": {
+        "maxConnections": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of tcp connections allowed"
+        }
+      }
+    },
+    "TcpRetryPolicy": {
+      "type": "object",
+      "description": "Policy that defines tcp request retry conditions",
+      "properties": {
+        "maxConnectAttempts": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of attempts to connect to the tcp service"
+        }
+      }
+    },
+    "TcpScaleRule": {
+      "type": "object",
+      "description": "Container App container Tcp scaling rule.",
+      "properties": {
+        "metadata": {
+          "type": "object",
+          "description": "Metadata properties to describe tcp scale rule.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "auth": {
+          "type": "array",
+          "description": "Authentication secrets for the tcp scale rule.",
+          "items": {
+            "$ref": "#/definitions/ScaleRuleAuth"
+          },
+          "x-ms-identifiers": [
+            "triggerParameter"
+          ]
+        },
+        "identity": {
+          "type": "string",
+          "description": "The resource ID of a user-assigned managed identity that is assigned to the Container App, or 'system' for system-assigned identity."
+        }
+      }
+    },
+    "Template": {
+      "type": "object",
+      "description": "Container App versioned application definition.\nDefines the desired state of an immutable revision.\nAny changes to this section Will result in a new revision being created",
+      "properties": {
+        "revisionSuffix": {
+          "type": "string",
+          "description": "User friendly suffix that is appended to the revision name"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Optional duration in seconds the Container App Instance needs to terminate gracefully. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). If this value is nil, the default grace period will be used instead. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds."
+        },
+        "initContainers": {
+          "type": "array",
+          "description": "List of specialized containers that run before app containers.",
+          "items": {
+            "$ref": "#/definitions/InitContainer"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "containers": {
+          "type": "array",
+          "description": "List of container definitions for the Container App.",
+          "items": {
+            "$ref": "#/definitions/Container"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "scale": {
+          "$ref": "#/definitions/Scale",
+          "description": "Scaling properties for the Container App."
+        },
+        "volumes": {
+          "type": "array",
+          "description": "List of volume definitions for the Container App.",
+          "items": {
+            "$ref": "#/definitions/Volume"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "serviceBinds": {
+          "type": "array",
+          "description": "List of container app services bound to the app",
+          "items": {
+            "$ref": "#/definitions/ServiceBind"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "TemplatePoolStatus": {
+      "type": "object",
+      "description": "The status of pods in the pool of this template.",
+      "properties": {
+        "expectedCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The expected count of pods in this pool"
+        },
+        "readyCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The ready count of pods in this pool"
+        },
+        "pendingCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The pending count of pods in this pool"
+        },
+        "imagePullFailCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The image pull fail count of pods in this pool"
+        },
+        "crashCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The crash count of pods in this pool"
+        },
+        "allocatedCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The allocated count of pods in this pool"
+        }
+      }
+    },
+    "TemplateStatus": {
+      "type": "object",
+      "description": "The status of the session pool template.",
+      "properties": {
+        "details": {
+          "type": "string",
+          "description": "The detailed status of this template."
+        },
+        "createdTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The creation time of this template."
+        },
+        "status": {
+          "$ref": "#/definitions/TemplatePoolStatus",
+          "description": "The status of this template."
+        },
+        "containers": {
+          "type": "array",
+          "description": "List of container definitions for the sessions of this template.",
+          "items": {
+            "$ref": "#/definitions/SessionContainer"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "ingress": {
+          "$ref": "#/definitions/SessionIngress",
+          "description": "Session pool ingress configuration of this template."
+        }
+      }
+    },
+    "TemplateUpdateStatus": {
+      "type": "object",
+      "properties": {
+        "activeTemplate": {
+          "$ref": "#/definitions/TemplateStatus",
+          "description": "The status of the current active template."
+        },
+        "desiredTemplate": {
+          "$ref": "#/definitions/TemplateStatus",
+          "description": "The status of the desired template during session pool update."
+        }
+      }
+    },
+    "TimeoutPolicy": {
+      "type": "object",
+      "description": "Policy to set request timeouts",
+      "properties": {
+        "responseTimeoutInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Timeout, in seconds, for a request to respond"
+        },
+        "connectionTimeoutInSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Timeout, in seconds, for a request to initiate a connection"
+        }
+      }
+    },
+    "TokenStore": {
+      "type": "object",
+      "description": "The configuration settings of the token store.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "<code>true</code> to durably store platform-specific security tokens that are obtained during login flows; otherwise, <code>false</code>.\nThe default is <code>false</code>."
+        },
+        "tokenRefreshExtensionHours": {
+          "type": "number",
+          "format": "double",
+          "description": "The number of hours after session token expiration that a session token can be used to\ncall the token refresh API. The default is 72 hours."
+        },
+        "azureBlobStorage": {
+          "$ref": "#/definitions/BlobStorageTokenStore",
+          "description": "The configuration settings of the storage of the tokens if blob storage is used."
+        }
+      }
+    },
+    "TracesConfiguration": {
+      "type": "object",
+      "description": "Configuration of Open Telemetry traces",
+      "properties": {
+        "includeDapr": {
+          "type": "boolean",
+          "description": "Boolean indicating if including dapr traces"
+        },
+        "destinations": {
+          "type": "array",
+          "description": "Open telemetry traces destinations",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TrafficWeight": {
+      "type": "object",
+      "description": "Traffic weight assigned to a revision",
+      "properties": {
+        "revisionName": {
+          "type": "string",
+          "description": "Name of a revision"
+        },
+        "weight": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Traffic weight assigned to a revision"
+        },
+        "latestRevision": {
+          "type": "boolean",
+          "description": "Indicates that the traffic weight belongs to a latest stable revision",
+          "default": false
+        },
+        "label": {
+          "type": "string",
+          "description": "Associates a traffic label with a revision"
+        }
+      }
+    },
+    "Twitter": {
+      "type": "object",
+      "description": "The configuration settings of the Twitter provider.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "<code>false</code> if the Twitter provider should not be enabled despite the set registration; otherwise, <code>true</code>."
+        },
+        "registration": {
+          "$ref": "#/definitions/TwitterRegistration",
+          "description": "The configuration settings of the app registration for the Twitter provider."
+        }
+      }
+    },
+    "TwitterRegistration": {
+      "type": "object",
+      "description": "The configuration settings of the app registration for the Twitter provider.",
+      "properties": {
+        "consumerKey": {
+          "type": "string",
+          "description": "The OAuth 1.0a consumer key of the Twitter application used for sign-in.\nThis setting is required for enabling Twitter Sign-In.\nTwitter Sign-In documentation: https://dev.twitter.com/web/sign-in"
+        },
+        "consumerSecretSettingName": {
+          "type": "string",
+          "description": "The app setting name that contains the OAuth 1.0a consumer secret of the Twitter\napplication used for sign-in."
+        }
+      }
+    },
+    "Type": {
+      "type": "string",
+      "description": "The type of probe.",
+      "enum": [
+        "Liveness",
+        "Readiness",
+        "Startup"
+      ],
+      "x-ms-enum": {
+        "name": "Type",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Liveness",
+            "value": "Liveness",
+            "description": "Liveness"
+          },
+          {
+            "name": "Readiness",
+            "value": "Readiness",
+            "description": "Readiness"
+          },
+          {
+            "name": "Startup",
+            "value": "Startup",
+            "description": "Startup"
+          }
+        ]
+      }
+    },
+    "UnauthenticatedClientActionV2": {
+      "type": "string",
+      "description": "The action to take when an unauthenticated client attempts to access the app.",
+      "enum": [
+        "RedirectToLoginPage",
+        "AllowAnonymous",
+        "Return401",
+        "Return403"
+      ],
+      "x-ms-enum": {
+        "name": "UnauthenticatedClientActionV2",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "RedirectToLoginPage",
+            "value": "RedirectToLoginPage",
+            "description": "RedirectToLoginPage"
+          },
+          {
+            "name": "AllowAnonymous",
+            "value": "AllowAnonymous",
+            "description": "AllowAnonymous"
+          },
+          {
+            "name": "Return401",
+            "value": "Return401",
+            "description": "Return401"
+          },
+          {
+            "name": "Return403",
+            "value": "Return403",
+            "description": "Return403"
+          }
+        ]
+      }
+    },
+    "Usage": {
+      "type": "object",
+      "description": "Describes Compute Resource Usage.",
+      "properties": {
+        "unit": {
+          "type": "string",
+          "description": "An enum describing the unit of usage measurement.",
+          "enum": [
+            "Count"
+          ],
+          "x-ms-enum": {
+            "modelAsString": false
+          }
+        },
+        "currentValue": {
+          "type": "number",
+          "format": "float",
+          "description": "The current usage of the resource."
+        },
+        "limit": {
+          "type": "number",
+          "format": "float",
+          "description": "The maximum permitted usage of the resource."
+        },
+        "name": {
+          "$ref": "#/definitions/UsageName",
+          "description": "The name of the type of usage."
+        }
+      },
+      "required": [
+        "unit",
+        "currentValue",
+        "limit",
+        "name"
+      ]
+    },
+    "UsageName": {
+      "type": "object",
+      "description": "The Usage Names.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The name of the resource."
+        },
+        "localizedValue": {
+          "type": "string",
+          "description": "The localized name of the resource."
+        }
+      }
+    },
+    "VnetConfiguration": {
+      "type": "object",
+      "description": "Configuration properties for apps environment to join a Virtual Network",
+      "properties": {
+        "internal": {
+          "type": "boolean",
+          "description": "Boolean indicating the environment only has an internal load balancer. These environments do not have a public static IP resource. They must provide infrastructureSubnetId if enabling this property",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "infrastructureSubnetId": {
+          "type": "string",
+          "description": "Resource ID of a subnet for infrastructure components. Must not overlap with any other provided IP ranges.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "dockerBridgeCidr": {
+          "type": "string",
+          "description": "CIDR notation IP range assigned to the Docker bridge, network. Must not overlap with any other provided IP ranges.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "platformReservedCidr": {
+          "type": "string",
+          "description": "IP range in CIDR notation that can be reserved for environment infrastructure IP addresses. Must not overlap with any other provided IP ranges.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "platformReservedDnsIP": {
+          "type": "string",
+          "description": "An IP address from the IP range defined by platformReservedCidr that will be reserved for the internal DNS server.",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        }
+      }
+    },
+    "Volume": {
+      "type": "object",
+      "description": "Volume definitions for the Container App.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Volume name."
+        },
+        "storageType": {
+          "$ref": "#/definitions/StorageType",
+          "description": "Storage type for the volume. If not provided, use EmptyDir."
+        },
+        "storageName": {
+          "type": "string",
+          "description": "Name of storage resource. No need to provide for EmptyDir and Secret."
+        },
+        "secrets": {
+          "type": "array",
+          "description": "List of secrets to be added in volume. If no secrets are provided, all secrets in collection will be added to volume.",
+          "items": {
+            "$ref": "#/definitions/SecretVolumeItem"
+          },
+          "x-ms-identifiers": [
+            "secretRef"
+          ]
+        },
+        "mountOptions": {
+          "type": "string",
+          "description": "Mount options used while mounting the Azure file share or NFS Azure file share. Must be a comma-separated string."
+        }
+      }
+    },
+    "VolumeMount": {
+      "type": "object",
+      "description": "Volume mount for the Container App.",
+      "properties": {
+        "volumeName": {
+          "type": "string",
+          "description": "This must match the Name of a Volume."
+        },
+        "mountPath": {
+          "type": "string",
+          "description": "Path within the container at which the volume should be mounted.Must not contain ':'."
+        },
+        "subPath": {
+          "type": "string",
+          "description": "Path within the volume from which the container's volume should be mounted. Defaults to \"\" (volume's root)."
+        }
+      }
+    },
+    "WeekDay": {
+      "type": "string",
+      "description": "Day of the week when a managed environment can be patched.",
+      "enum": [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+      ],
+      "x-ms-enum": {
+        "name": "WeekDay",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "Monday",
+            "value": "Monday",
+            "description": "Monday"
+          },
+          {
+            "name": "Tuesday",
+            "value": "Tuesday",
+            "description": "Tuesday"
+          },
+          {
+            "name": "Wednesday",
+            "value": "Wednesday",
+            "description": "Wednesday"
+          },
+          {
+            "name": "Thursday",
+            "value": "Thursday",
+            "description": "Thursday"
+          },
+          {
+            "name": "Friday",
+            "value": "Friday",
+            "description": "Friday"
+          },
+          {
+            "name": "Saturday",
+            "value": "Saturday",
+            "description": "Saturday"
+          },
+          {
+            "name": "Sunday",
+            "value": "Sunday",
+            "description": "Sunday"
+          }
+        ]
+      }
+    },
+    "WorkflowArtifacts": {
+      "type": "object",
+      "description": "The workflow filter.",
+      "properties": {
+        "appSettings": {
+          "description": "Application settings of the workflow."
+        },
+        "files": {
+          "description": "Files of the app."
+        },
+        "filesToDelete": {
+          "type": "array",
+          "description": "Files of the app to delete.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "x-ms-secret": true
+    },
+    "WorkflowEnvelope": {
+      "type": "object",
+      "description": "Schema for the workflow object.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WorkflowEnvelopeProperties",
+          "description": "Additional workflow properties."
+        },
+        "kind": {
+          "$ref": "#/definitions/WorkflowKind",
+          "description": "Gets the logic app hybrid workflow kind."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "WorkflowEnvelopeCollection": {
+      "type": "object",
+      "description": "Collection of workflow information elements.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The WorkflowEnvelope items on this page",
+          "items": {
+            "$ref": "#/definitions/WorkflowEnvelope"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "WorkflowEnvelopeProperties": {
+      "type": "object",
+      "description": "Additional workflow properties.",
+      "properties": {
+        "files": {
+          "description": "Gets or sets the files."
+        },
+        "flowState": {
+          "$ref": "#/definitions/WorkflowState",
+          "description": "Gets or sets the state of the workflow."
+        },
+        "health": {
+          "$ref": "#/definitions/WorkflowHealth",
+          "description": "Gets or sets workflow health."
+        }
+      }
+    },
+    "WorkflowHealth": {
+      "type": "object",
+      "description": "Represents the workflow health.",
+      "properties": {
+        "state": {
+          "$ref": "#/definitions/WorkflowHealthState",
+          "description": "Gets or sets the workflow health state."
+        },
+        "error": {
+          "$ref": "#/definitions/ErrorEntity",
+          "description": "Gets or sets the workflow error."
+        }
+      },
+      "required": [
+        "state"
+      ]
+    },
+    "WorkflowHealthState": {
+      "type": "string",
+      "description": "Gets or sets the workflow health state.",
+      "enum": [
+        "NotSpecified",
+        "Healthy",
+        "Unhealthy",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "WorkflowHealthState",
+        "modelAsString": false,
+        "values": [
+          {
+            "name": "NotSpecified",
+            "value": "NotSpecified",
+            "description": "NotSpecified"
+          },
+          {
+            "name": "Healthy",
+            "value": "Healthy",
+            "description": "Healthy"
+          },
+          {
+            "name": "Unhealthy",
+            "value": "Unhealthy",
+            "description": "Unhealthy"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown"
+          }
+        ]
+      }
+    },
+    "WorkflowKind": {
+      "type": "string",
+      "description": "Gets the logic app hybrid workflow kind.",
+      "enum": [
+        "Stateful",
+        "Stateless",
+        "Agentic"
+      ],
+      "x-ms-enum": {
+        "name": "WorkflowKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Stateful",
+            "value": "Stateful",
+            "description": "Stateful"
+          },
+          {
+            "name": "Stateless",
+            "value": "Stateless",
+            "description": "Stateless"
+          },
+          {
+            "name": "Agentic",
+            "value": "Agentic",
+            "description": "Agentic"
+          }
+        ]
+      }
+    },
+    "WorkflowState": {
+      "type": "string",
+      "description": "The workflow state.",
+      "enum": [
+        "NotSpecified",
+        "Completed",
+        "Enabled",
+        "Disabled",
+        "Deleted",
+        "Suspended"
+      ],
+      "x-ms-enum": {
+        "name": "WorkflowState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "NotSpecified",
+            "value": "NotSpecified",
+            "description": "NotSpecified"
+          },
+          {
+            "name": "Completed",
+            "value": "Completed",
+            "description": "Completed"
+          },
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Enabled"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Disabled"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted"
+          },
+          {
+            "name": "Suspended",
+            "value": "Suspended",
+            "description": "Suspended"
+          }
+        ]
+      }
+    },
+    "WorkloadProfile": {
+      "type": "object",
+      "description": "Workload profile to scope container app execution.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Workload profile type for the workloads to run on."
+        },
+        "enableFips": {
+          "type": "boolean",
+          "description": "Whether to use a FIPS-enabled OS. Supported only for dedicated workload profiles.",
+          "default": false
+        },
+        "workloadProfileType": {
+          "type": "string",
+          "description": "Workload profile type for the workloads to run on."
+        },
+        "minimumCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The minimum capacity."
+        },
+        "maximumCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum capacity."
+        }
+      },
+      "required": [
+        "name",
+        "workloadProfileType"
+      ]
+    },
+    "WorkloadProfileStatesProperties": {
+      "type": "object",
+      "description": "Workload Profile resource specific properties.",
+      "properties": {
+        "minimumCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum count of instances."
+        },
+        "maximumCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum count of nodes."
+        },
+        "currentCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Current count of nodes."
+        }
+      }
+    },
+    "workloadProfileStates": {
+      "type": "object",
+      "description": "Collection of all the workload Profile States for a Managed Environment..",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WorkloadProfileStatesProperties",
+          "description": "Workload Profile resource specific properties."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "workloadProfileStatesCollection": {
+      "type": "object",
+      "description": "Collection of workloadProfileStates",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The workloadProfileStates items on this page",
+          "items": {
+            "$ref": "#/definitions/workloadProfileStates"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json
@@ -406,7 +406,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -449,7 +449,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -492,7 +492,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {
@@ -531,7 +531,7 @@
             "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/LocationParameter"
           }
         ],
         "responses": {

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/preview/2026-03-02-preview/openapi.json
@@ -164,7 +164,7 @@
         "description": "Lists all of the available RP operations.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           }
         ],
         "responses": {
@@ -200,10 +200,10 @@
         "description": "List BuilderResource resources by subscription ID",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -216,7 +216,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -240,10 +240,10 @@
         "description": "Get all connectedEnvironments for a subscription.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -280,10 +280,10 @@
         "description": "Get the Container Apps in a given subscription.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -296,7 +296,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -323,10 +323,10 @@
         ],
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -360,10 +360,10 @@
         "description": "Get the Container Apps Jobs in a given subscription.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -400,10 +400,10 @@
         "description": "Gets the environment modes available to a subscription in a location.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
@@ -424,7 +424,7 @@
           }
         },
         "x-ms-examples": {
-          "AvailableEnvironmentModes_List": {
+          "List available environment modes by location": {
             "$ref": "./examples/AvailableEnvironmentModes_List.json"
           }
         },
@@ -443,10 +443,10 @@
         "description": "Get all available workload profiles for a location.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
@@ -462,7 +462,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -486,10 +486,10 @@
         "description": "Get all billingMeters for a location.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
@@ -525,10 +525,10 @@
         "description": "Gets, for the specified location, the current resource usage information as well as the limits under the subscription.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
             "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/LocationParameter"
@@ -568,10 +568,10 @@
         "description": "Get all Managed Environments for a subscription.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -584,7 +584,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -608,10 +608,10 @@
         "description": "Get the session pools in a given subscription.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           }
         ],
         "responses": {
@@ -624,7 +624,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -647,13 +647,13 @@
         "description": "List BuilderResource resources by resource group",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           }
         ],
         "responses": {
@@ -666,7 +666,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -689,13 +689,13 @@
         "description": "Get a BuilderResource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "builderName",
@@ -718,7 +718,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -736,13 +736,13 @@
         "description": "Create or update a BuilderResource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "builderName",
@@ -791,7 +791,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -814,13 +814,13 @@
         "description": "Update a BuilderResource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "builderName",
@@ -866,7 +866,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -889,13 +889,13 @@
         "description": "Delete a BuilderResource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "builderName",
@@ -929,7 +929,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -953,13 +953,13 @@
         "description": "List BuildResource resources by BuilderResource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "builderName",
@@ -982,7 +982,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1005,13 +1005,13 @@
         "description": "Get a BuildResource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "builderName",
@@ -1044,7 +1044,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1062,13 +1062,13 @@
         "description": "Create a BuildResource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "builderName",
@@ -1127,7 +1127,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1153,13 +1153,13 @@
         "description": "Delete a BuildResource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "builderName",
@@ -1203,7 +1203,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1227,13 +1227,13 @@
         "description": "Gets the token used to connect to the endpoint where source code can be uploaded for a build.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "builderName",
@@ -1266,7 +1266,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1286,13 +1286,13 @@
         "description": "Get all connectedEnvironments in a resource group.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           }
         ],
         "responses": {
@@ -1328,13 +1328,13 @@
         "description": "Get the properties of an connectedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -1372,13 +1372,13 @@
         "description": "Creates or updates an connectedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -1448,13 +1448,13 @@
         "description": "Patches a Managed Environment. Only patching of tags is supported currently",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -1502,13 +1502,13 @@
         "description": "Delete an connectedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -1568,13 +1568,13 @@
         "description": "Get the Certificates in a given connected environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -1594,7 +1594,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1619,13 +1619,13 @@
         "description": "Get the specified Certificate.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -1652,7 +1652,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1672,13 +1672,13 @@
         "description": "Create or Update a Certificate.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -1731,7 +1731,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1756,13 +1756,13 @@
         "description": "Patches a certificate. Currently only patching of tags is supported",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -1812,7 +1812,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1837,13 +1837,13 @@
         "description": "Deletes the specified Certificate.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -1881,7 +1881,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -1906,13 +1906,13 @@
         "description": "Checks if resource connectedEnvironmentName is available.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -1927,7 +1927,7 @@
             "description": "The check connectedEnvironmentName availability request.",
             "required": true,
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/CheckNameAvailabilityRequest"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/CheckNameAvailabilityRequest"
             }
           }
         ],
@@ -1935,7 +1935,7 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/CheckNameAvailabilityResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/CheckNameAvailabilityResponse"
             }
           },
           "default": {
@@ -1962,13 +1962,13 @@
         "description": "Get the Dapr Components for a connected environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -2012,13 +2012,13 @@
         "description": "Get a dapr component.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -2064,13 +2064,13 @@
         "description": "Creates or updates a Dapr Component in a connected environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -2123,7 +2123,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -2147,13 +2147,13 @@
         "description": "Delete a Dapr Component from a connected environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -2191,7 +2191,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -2216,13 +2216,13 @@
         "description": "List secrets for a dapr component",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -2270,13 +2270,13 @@
         "description": "Get all storages for a connectedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -2317,13 +2317,13 @@
         "description": "Get storage for a connectedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -2369,13 +2369,13 @@
         "description": "Create or update storage for a connectedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -2428,7 +2428,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -2452,13 +2452,13 @@
         "description": "Delete storage for a connectedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "connectedEnvironmentName",
@@ -2496,7 +2496,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -2521,13 +2521,13 @@
         "description": "Get the Container Apps in a given resource group.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           }
         ],
         "responses": {
@@ -2540,7 +2540,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -2564,13 +2564,13 @@
         "description": "Get the properties of a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -2594,7 +2594,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -2613,13 +2613,13 @@
         "description": "Create or update a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -2665,7 +2665,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -2707,13 +2707,13 @@
         "description": "Patches a Container App using JSON Merge Patch",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -2756,7 +2756,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -2780,13 +2780,13 @@
         "description": "Delete a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -2820,7 +2820,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -2845,13 +2845,13 @@
         "description": "Get the Container App AuthConfigs in a given resource group.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -2895,13 +2895,13 @@
         "description": "Get a AuthConfig of a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -2947,13 +2947,13 @@
         "description": "Create or update the AuthConfig for a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3014,13 +3014,13 @@
         "description": "Delete a Container App AuthConfig.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3067,13 +3067,13 @@
         "description": "List Container Apps Build resources by Container App",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3094,7 +3094,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -3117,13 +3117,13 @@
         "description": "Get a Container Apps Build resource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3154,7 +3154,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -3172,13 +3172,13 @@
         "description": "Delete a Container Apps Build resource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3220,7 +3220,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -3246,13 +3246,13 @@
         "description": "Get a revision of a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3301,13 +3301,13 @@
         "description": "A synchronous resource action.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3359,13 +3359,13 @@
         "description": "Get the properties of a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3411,13 +3411,13 @@
         "description": "Get the list of diagnostics for a given Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3462,13 +3462,13 @@
         "description": "Get a diagnostics result of a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3516,13 +3516,13 @@
         "description": "List the functions for a given Container App from the latest Revision.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3567,13 +3567,13 @@
         "description": "Get a specific function of a Container App from the latest Revision.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3623,13 +3623,13 @@
         "description": "Get auth token for a container app",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3653,7 +3653,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -3674,13 +3674,13 @@
         "description": "Get the Label History for a given Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3732,13 +3732,13 @@
         "description": "Get the history of a label.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3786,13 +3786,13 @@
         "description": "Delete the history of a label.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3842,13 +3842,13 @@
         "description": "Analyzes a custom hostname for a Container App",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3875,7 +3875,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -3896,13 +3896,13 @@
         "description": "List secrets for a container app",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3922,7 +3922,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -3942,13 +3942,13 @@
         "description": "List Container Apps Patch resources by ContainerApp.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -3976,7 +3976,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -3999,13 +3999,13 @@
         "description": "Get details for specific Container Apps Patch by patch name.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4036,7 +4036,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -4054,13 +4054,13 @@
         "description": "Delete specific Container Apps Patch by patch name.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4102,7 +4102,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -4126,13 +4126,13 @@
         "description": "Apply a Container Apps Patch resource with patch name.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4181,7 +4181,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -4206,13 +4206,13 @@
         "description": "Configure the Container Apps Patch skip option by patch name.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4260,7 +4260,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -4285,13 +4285,13 @@
         "description": "Gets a logic app extension resource.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4338,13 +4338,13 @@
         "description": "Create or update a Logic App extension resource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4406,13 +4406,13 @@
         "description": "Deletes a Logic App extension resource",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4461,13 +4461,13 @@
         "description": "Creates or updates the artifacts for the logic app",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4526,13 +4526,13 @@
         "description": "Proxies a the API call to the logic app backed by the container app.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4616,13 +4616,13 @@
         "description": "Gets logic app's connections.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4672,13 +4672,13 @@
         "description": "List the workflows for a logic app.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4731,13 +4731,13 @@
         "description": "Get workflow information by its name",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -4797,13 +4797,13 @@
         "description": "List container app resiliency policies.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "appName",
@@ -4848,13 +4848,13 @@
         "description": "Get container app resiliency policy.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "appName",
@@ -4902,13 +4902,13 @@
         "description": "Create or update container app resiliency policy.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "appName",
@@ -4971,13 +4971,13 @@
         "description": "Update container app resiliency policy.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "appName",
@@ -5034,13 +5034,13 @@
         "description": "Delete container app resiliency policy.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "appName",
@@ -5090,13 +5090,13 @@
         "description": "Get the Revisions for a given Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5147,13 +5147,13 @@
         "description": "Get a revision of a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5201,13 +5201,13 @@
         "description": "Activates a revision for a Container App",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5252,13 +5252,13 @@
         "description": "Deactivates a revision for a Container App",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5303,13 +5303,13 @@
         "description": "List the functions for a given Container App Revision.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5362,13 +5362,13 @@
         "description": "Get a specific function of a Container App Revision.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5430,13 +5430,13 @@
         ],
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5494,13 +5494,13 @@
         "description": "List replicas for a Container App Revision.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5548,13 +5548,13 @@
         "description": "Get a replica for a Container App Revision.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5609,13 +5609,13 @@
         "description": "Restarts a revision for a Container App",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5660,13 +5660,13 @@
         "description": "Get the Container App SourceControls in a given resource group.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5710,13 +5710,13 @@
         "description": "Get a SourceControl of a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5762,13 +5762,13 @@
         "description": "Create or update the SourceControl for a Container App.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5852,13 +5852,13 @@
         "description": "Delete a Container App SourceControl.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5945,13 +5945,13 @@
         "description": "Start a container app",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -5986,7 +5986,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -6012,13 +6012,13 @@
         "description": "Stop a container app",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "containerAppName",
@@ -6053,7 +6053,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -6079,13 +6079,13 @@
         "description": "Get the Container Apps Jobs in a given resource group.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           }
         ],
         "responses": {
@@ -6122,13 +6122,13 @@
         "description": "Get the properties of a Container Apps Job.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6168,13 +6168,13 @@
         "description": "Create or Update a Container Apps Job.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6251,13 +6251,13 @@
         "description": "Patches a Container Apps Job using JSON Merge Patch",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6325,13 +6325,13 @@
         "description": "Delete a Container Apps Job.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6392,13 +6392,13 @@
         "description": "Get the properties of a Container App Job.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6449,13 +6449,13 @@
         "description": "Get the list of diagnostics for a Container App Job.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6501,13 +6501,13 @@
         "description": "Get the diagnostics data for a Container App Job.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6557,13 +6557,13 @@
         "description": "Get a Container Apps Job's executions",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6615,13 +6615,13 @@
         "description": "Get details of a single job execution",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6671,13 +6671,13 @@
         "description": "Terminates execution of a running container apps job",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6742,13 +6742,13 @@
         "description": "List secrets for a container apps job",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6790,13 +6790,13 @@
         "description": "Resumes a suspended job",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6835,7 +6835,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -6861,13 +6861,13 @@
         "description": "Start a Container Apps Job",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -6937,13 +6937,13 @@
         "description": "Terminates execution of a running container apps job",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -7004,13 +7004,13 @@
         "description": "Suspends a job",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "jobName",
@@ -7049,7 +7049,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7075,13 +7075,13 @@
         "description": "Get all the Managed Environments in a resource group.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           }
         ],
         "responses": {
@@ -7094,7 +7094,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7118,13 +7118,13 @@
         "description": "Get the properties of a Managed Environment used to host container apps.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7144,7 +7144,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7163,13 +7163,13 @@
         "description": "Creates or updates a Managed Environment used to host container apps.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7215,7 +7215,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7242,13 +7242,13 @@
         "description": "Patches a Managed Environment using JSON Merge Patch",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7291,7 +7291,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7315,13 +7315,13 @@
         "description": "Delete a Managed Environment if it does not have any container apps.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7355,7 +7355,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7381,13 +7381,13 @@
         "description": "Get the Certificates in a given managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7407,7 +7407,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7432,13 +7432,13 @@
         "description": "Get the specified Certificate.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7465,7 +7465,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7485,13 +7485,13 @@
         "description": "Create or Update a Certificate.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7527,7 +7527,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7550,13 +7550,13 @@
         "description": "Patches a certificate. Currently only patching of tags is supported",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7592,7 +7592,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7612,13 +7612,13 @@
         "description": "Deletes the specified Certificate.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7645,7 +7645,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7666,13 +7666,13 @@
         "description": "Checks if resource name is available.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7687,7 +7687,7 @@
             "description": "The check name availability request.",
             "required": true,
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/CheckNameAvailabilityRequest"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/CheckNameAvailabilityRequest"
             }
           }
         ],
@@ -7695,13 +7695,13 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/CheckNameAvailabilityResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/CheckNameAvailabilityResponse"
             }
           },
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -7725,13 +7725,13 @@
         "description": "Get the Dapr Components for a managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7775,13 +7775,13 @@
         "description": "Get a dapr component.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7830,13 +7830,13 @@
         "description": "Creates or updates a Dapr Component in a Managed Environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7894,13 +7894,13 @@
         "description": "Delete a Dapr Component from a Managed Environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -7948,13 +7948,13 @@
         "description": "List secrets for a dapr component",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8002,13 +8002,13 @@
         "description": "Get the resiliency policies for a Dapr component.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8061,13 +8061,13 @@
         "description": "Get a Dapr component resiliency policy.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8122,13 +8122,13 @@
         "description": "Creates or updates a resiliency policy for a Dapr component.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8204,13 +8204,13 @@
         "description": "Delete a resiliency policy for a Dapr component.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8267,13 +8267,13 @@
         "description": "Get the Dapr subscriptions for a managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8318,13 +8318,13 @@
         "description": "Get a dapr subscription.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8377,13 +8377,13 @@
         "description": "Creates or updates a Dapr subscription in a Managed Environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8451,13 +8451,13 @@
         "description": "Delete a Dapr subscription from a Managed Environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8507,13 +8507,13 @@
         "description": "Get the properties of a Managed Environment used to host container apps.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8555,13 +8555,13 @@
         "description": "Get the list of diagnostics for a Managed Environment used to host container apps.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8603,13 +8603,13 @@
         "description": "Get the diagnostics data for a Managed Environment used to host container apps.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8657,13 +8657,13 @@
         "description": "Get the .NET Components for a managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8684,7 +8684,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -8711,13 +8711,13 @@
         "description": "Get a .NET Component.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8746,7 +8746,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -8768,13 +8768,13 @@
         "description": "Creates or updates a .NET Component in a Managed Environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8829,7 +8829,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -8856,13 +8856,13 @@
         "description": "Patches a .NET Component using JSON Merge Patch",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8914,7 +8914,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -8941,13 +8941,13 @@
         "description": "Delete a .NET Component.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -8987,7 +8987,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -9012,13 +9012,13 @@
         "description": "Checks if resource name is available.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9038,7 +9038,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -9059,13 +9059,13 @@
         "description": "Get the Managed Http Routes in a given managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9110,13 +9110,13 @@
         "description": "Get the specified Managed Http Route Config.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9166,13 +9166,13 @@
         "description": "Create or Update a Http Route Config.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9243,13 +9243,13 @@
         "description": "Patches an http route config resource. Only patching of tags is supported",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9307,13 +9307,13 @@
         "description": "Deletes the specified Managed Http Route.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9354,7 +9354,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -9379,13 +9379,13 @@
         "description": "Get the Java Components for a managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9406,7 +9406,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -9433,13 +9433,13 @@
         "description": "Get a Java Component.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9468,7 +9468,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -9490,13 +9490,13 @@
         "description": "Creates or updates a Java Component in a Managed Environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9551,7 +9551,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -9578,13 +9578,13 @@
         "description": "Patches a Java Component using JSON Merge Patch",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9636,7 +9636,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -9663,13 +9663,13 @@
         "description": "Delete a Java Component.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9709,7 +9709,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -9733,13 +9733,13 @@
         "description": "Gets all maintenance configurations in the specified Managed Environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9783,13 +9783,13 @@
         "description": "Gets the maintenance configuration of a ManagedEnvironment .",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9818,7 +9818,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -9836,13 +9836,13 @@
         "description": "Create or update the maintenance configuration for Managed Environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9904,13 +9904,13 @@
         "description": "Deletes the maintenance configuration of a ManagedEnvironment .",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9961,13 +9961,13 @@
         "description": "Get the Managed Certificates in a given managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -9987,7 +9987,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10012,13 +10012,13 @@
         "description": "Get the specified Managed Certificate.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10045,7 +10045,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10065,13 +10065,13 @@
         "description": "Create or Update a Managed Certificate.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10128,7 +10128,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10153,13 +10153,13 @@
         "description": "Patches a managed certificate. Oly patching of tags is supported",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10195,7 +10195,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10215,13 +10215,13 @@
         "description": "Deletes the specified Managed Certificate.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10248,7 +10248,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10270,13 +10270,13 @@
         "description": "List private endpoint connections for a given managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10297,7 +10297,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10322,13 +10322,13 @@
         "description": "Get a private endpoint connection for a given managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10356,7 +10356,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10376,13 +10376,13 @@
         "description": "Update the state of a private endpoint connection for a given managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10436,7 +10436,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10461,13 +10461,13 @@
         "description": "Delete a private endpoint connection for a given managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10506,7 +10506,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10532,13 +10532,13 @@
         "description": "List private link resources for a given managed environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10559,7 +10559,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10583,13 +10583,13 @@
         "description": "Get all storages for a managedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10630,13 +10630,13 @@
         "description": "Get storage for a managedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10685,13 +10685,13 @@
         "description": "Create or update storage for a managedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10755,13 +10755,13 @@
         "description": "Delete storage for a managedEnvironment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10808,13 +10808,13 @@
         "description": "Gets the current usage information as well as the limits for environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10859,13 +10859,13 @@
         "description": "Get all workload Profile States for a Managed Environment.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "environmentName",
@@ -10885,7 +10885,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10909,13 +10909,13 @@
         "description": "Get the session pools in a given resource group of a subscription.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           }
         ],
         "responses": {
@@ -10928,7 +10928,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -10952,13 +10952,13 @@
         "description": "Get the properties of a session pool.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "sessionPoolName",
@@ -10981,7 +10981,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -11003,13 +11003,13 @@
         "description": "Create or update a session pool with the given properties.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "sessionPoolName",
@@ -11058,7 +11058,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -11088,13 +11088,13 @@
         "description": "Patches a session pool using JSON merge patch",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "sessionPoolName",
@@ -11140,7 +11140,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -11164,13 +11164,13 @@
         "description": "Delete the session pool with the given name.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "sessionPoolName",
@@ -11204,7 +11204,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -11229,13 +11229,13 @@
         "description": "Fetch the MCP server credentials of a session pool.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "sessionPoolName",
@@ -11258,7 +11258,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -11279,13 +11279,13 @@
         "description": "Rotate and fetch the rotated MCP server credentials of a session pool.",
         "parameters": [
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
           },
           {
-            "$ref": "../../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
           },
           {
             "name": "sessionPoolName",
@@ -11308,7 +11308,7 @@
           "default": {
             "description": "An unexpected error response.",
             "schema": {
-              "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
             }
           }
         },
@@ -11478,7 +11478,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -11601,7 +11601,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -11689,7 +11689,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -11769,7 +11769,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -12092,7 +12092,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -12338,7 +12338,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -12511,13 +12511,13 @@
           "x-ms-client-flatten": true
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         }
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
         }
       ]
     },
@@ -12526,7 +12526,7 @@
       "description": "The type used for update operations of the BuilderResource.",
       "properties": {
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         },
         "tags": {
@@ -12565,7 +12565,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
         }
       ]
     },
@@ -12927,7 +12927,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
         }
       ]
     },
@@ -13067,7 +13067,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -13188,7 +13188,7 @@
           "description": "The complex type of the extended location."
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "managed identities for the Container App to interact with other Azure services without maintaining any secrets or credentials in code."
         },
         "managedBy": {
@@ -13211,7 +13211,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
         }
       ]
     },
@@ -13227,7 +13227,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
         }
       ]
     },
@@ -13785,7 +13785,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -13801,7 +13801,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -13864,7 +13864,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -14465,7 +14465,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -14618,7 +14618,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -14848,7 +14848,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -15244,7 +15244,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -15458,7 +15458,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -15643,7 +15643,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
         }
       ]
     },
@@ -16258,7 +16258,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -16932,7 +16932,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -17154,13 +17154,13 @@
           "description": "The complex type of the extended location."
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         }
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
         }
       ]
     },
@@ -17328,7 +17328,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -17516,7 +17516,7 @@
           "description": "The complex type of the extended location."
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "Managed identities needed by a container app job to interact with other Azure services to not maintain any secrets or credentials in code."
         },
         "tags": {
@@ -17890,7 +17890,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -18166,7 +18166,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -18276,7 +18276,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -18291,7 +18291,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
         }
       ]
     },
@@ -18402,13 +18402,13 @@
           "description": "Kind of the Environment."
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         }
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
         }
       ]
     },
@@ -18590,7 +18590,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -19353,7 +19353,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -19510,7 +19510,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/Resource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/Resource"
         }
       ]
     },
@@ -19692,7 +19692,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -19856,7 +19856,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -20575,13 +20575,13 @@
           "x-ms-client-flatten": true
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         }
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
         }
       ]
     },
@@ -20777,7 +20777,7 @@
           ]
         },
         "identity": {
-          "$ref": "../../../../../../common-types/resource-management/v5/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "Managed identities needed by a session pool to interact with other Azure services to not maintain any secrets or credentials in code."
         },
         "properties": {
@@ -21029,7 +21029,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -21848,7 +21848,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },
@@ -22086,7 +22086,7 @@
       },
       "allOf": [
         {
-          "$ref": "../../../../../../common-types/resource-management/v5/types.json#/definitions/ProxyResource"
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
         }
       ]
     },

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/readme.md
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the app.
 
 ``` yaml
 openapi-type: arm
-tag: package-preview-2026-03-02-preview
+tag: package-2026-01-01
 ```
 
 ### Suppression

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/readme.md
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/readme.md
@@ -26,7 +26,7 @@ These are the global settings for the app.
 
 ``` yaml
 openapi-type: arm
-tag: package-2026-01-01
+tag: package-preview-2026-03-02-preview
 ```
 
 ### Suppression
@@ -48,6 +48,15 @@ directive:
       - $.definitions.ServiceBind.properties.customizedKeys
     reason: |
       Do not introduce breaking changes in GA services
+```
+
+### Tag: package-preview-2026-03-02-preview
+
+These settings apply only when `--tag=package-preview-2026-03-02-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-preview-2026-03-02-preview'
+input-file:
+  - preview/2026-03-02-preview/openapi.json
 ```
 
 ### Tag: package-preview-2025-10-02-preview

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/routes.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/routes.tsp
@@ -29,7 +29,7 @@ interface AvailableWorkloadProfilesOperationGroup {
   get is ArmProviderActionSync<
     Response = AvailableWorkloadProfilesCollection,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter
+    Parameters = LocationResourceParameter
   >;
 }
 
@@ -48,7 +48,7 @@ interface AvailableEnvironmentModesOperationGroup {
   list is ArmProviderActionSync<
     Response = AvailableEnvironmentModesCollection,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter,
+    Parameters = LocationResourceParameter,
     Error = DefaultErrorResponse
   >;
 }
@@ -66,7 +66,7 @@ interface BillingMetersOperationGroup {
   get is ArmProviderActionSync<
     Response = BillingMeterCollection,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter,
+    Parameters = LocationResourceParameter,
     Error = DefaultErrorResponse
   >;
 }
@@ -99,7 +99,7 @@ interface UsagesOperationGroup {
   list is ArmProviderActionSync<
     Response = ListUsagesResult,
     Scope = SubscriptionActionScope,
-    Parameters = LocationParameter,
+    Parameters = LocationResourceParameter,
     Error = DefaultErrorResponse
   >;
 }

--- a/specification/app/resource-manager/Microsoft.App/ContainerApps/routes.tsp
+++ b/specification/app/resource-manager/Microsoft.App/ContainerApps/routes.tsp
@@ -2,12 +2,14 @@
 
 import "@azure-tools/typespec-azure-core";
 import "@typespec/rest";
+import "@typespec/versioning";
 import "./models.tsp";
 import "@azure-tools/typespec-azure-resource-manager";
 import "@typespec/openapi";
 
 using TypeSpec.Rest;
 using TypeSpec.Http;
+using TypeSpec.Versioning;
 using Azure.ResourceManager;
 using TypeSpec.OpenAPI;
 
@@ -28,6 +30,26 @@ interface AvailableWorkloadProfilesOperationGroup {
     Response = AvailableWorkloadProfilesCollection,
     Scope = SubscriptionActionScope,
     Parameters = LocationParameter
+  >;
+}
+
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-interface-requires-decorator" "This interface exposes a subscription-level provider operation rather than operations on an ARM resource."
+@added(Versions.v2026_03_02_preview)
+interface AvailableEnvironmentModesOperationGroup {
+  /**
+   * Gets the environment modes available to a subscription in a location.
+   */
+  @summary("Get available environment modes by location.")
+  @autoRoute
+  @get
+  @list
+  @action("availableManagedEnvironmentsModes")
+  @tag("AvailableEnvironmentModes")
+  list is ArmProviderActionSync<
+    Response = AvailableEnvironmentModesCollection,
+    Scope = SubscriptionActionScope,
+    Parameters = LocationParameter,
+    Error = DefaultErrorResponse
   >;
 }
 


### PR DESCRIPTION
## Summary

Bootstraps Microsoft.App Container Apps api-version **2026-03-02-preview** and adds the location-scoped `AvailableEnvironmentModes` list API.

- Carries the complete `2025-10-02-preview` API surface and examples forward with no feature exclusions.
- Route: `GET /subscriptions/{subscriptionId}/providers/Microsoft.App/locations/{location}/availableManagedEnvironmentsModes`.
- Returns the environment modes available to a subscription in the requested region.
- Models each result as an Azure proxy resource with immutable `location` and read-only `properties.displayName` / `properties.description`.
- Exposes the collection as an ARM pageable list operation.
- Uses ARM common-types v6 for the new preview version while preserving v5 for `2025-10-02-preview`.
- Version-gated with `@added(Versions.v2026_03_02_preview)` so `2025-10-02-preview` remains unchanged.

## Changes

| File | Type |
|------|------|
| `ContainerApps/main.tsp` | Adds `2026-03-02-preview` |
| `ContainerApps/routes.tsp` | TypeSpec operation |
| `ContainerApps/models.tsp` | TypeSpec response models |
| `ContainerApps/back-compatible.tsp` | Operation group/client location |
| `ContainerApps/readme.md` | AutoRest package tag |
| `ContainerApps/examples/2026-03-02-preview/` | Carried-forward and new source examples |
| `ContainerApps/preview/2026-03-02-preview/` | Generated Swagger and examples |

## Validation

- `tsp compile . --warn-as-error`
- `tsp format`
- Verified 225 source examples and 225 generated examples.
- Verified no copied example retains `api-version=2025-10-02-preview`.
- Confirmed the existing `preview/2025-10-02-preview` output remains unchanged.

## Service implementation

- [2026-03-02-preview controller](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Containerapps?path=/src/Microsoft.ContainerApps/Microsoft.ContainerApps.WebApi/Controllers/Version20260302preview/AvailableEnvironmentModesController.cs)
- [2026-03-02-preview response view](https://msazure.visualstudio.com/One/_git/AAPT-Antares-Containerapps?path=/src/Microsoft.ContainerApps/Microsoft.ContainerApps.WebApi/Views/Version20260302preview/AvailableEnvironmentModesView.cs)

The response item IDs and types intentionally match the service implementation:
`/subscriptions/{subscriptionId}/providers/Microsoft.App/availableManagedEnvironmentsModes/{name}`
and `Microsoft.App/availableManagedEnvironmentsModes`. This follows the existing
`availableManagedEnvironmentsWorkloadProfileTypes` catalog contract even though the
collection is queried through a location-scoped route.

## Purpose of this PR

- [ ] New resource provider.
- [x] New API version for an existing resource provider.
- [ ] Update existing version for a new feature.
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing OpenAPI spec to TypeSpec spec.
- [ ] Other, please clarify:
