### PR TITLE
[KubernetesConfiguration] Add contextual C# extension type names

### DIFF
--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensionTypes/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensionTypes/client.tsp
@@ -59,11 +59,7 @@ using Microsoft.KubernetesConfiguration;
 );
 // C# fixes: rename interface to avoid namespace conflict (§4.9)
 @@clientName(ExtensionTypes, "ExtensionTypeInterface", "csharp");
-@@clientName(
-  ExtensionType,
-  "KubernetesConfigurationExtensionType",
-  "csharp"
-);
+@@clientName(ExtensionType, "KubernetesConfigurationExtensionType", "csharp");
 @@clientName(
   ExtensionTypeProperties,
   "KubernetesConfigurationExtensionTypeProperties",

--- a/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensionTypes/client.tsp
+++ b/specification/kubernetesconfiguration/resource-manager/Microsoft.KubernetesConfiguration/extensionTypes/client.tsp
@@ -60,32 +60,57 @@ using Microsoft.KubernetesConfiguration;
 // C# fixes: rename interface to avoid namespace conflict (§4.9)
 @@clientName(ExtensionTypes, "ExtensionTypeInterface", "csharp");
 @@clientName(
+  ExtensionType,
+  "KubernetesConfigurationExtensionType",
+  "csharp"
+);
+@@clientName(
+  ExtensionTypeProperties,
+  "KubernetesConfigurationExtensionTypeProperties",
+  "csharp"
+);
+@@clientName(
   ClusterScopeSettingsProperties.allowMultipleInstances,
   "IsMultipleInstancesAllowed",
   "csharp"
 );
 @@clientName(
   ClusterScopeSettings,
-  "ExtensionTypeClusterScopeSettings",
+  "KubernetesConfigurationExtensionTypeClusterScopeSettings",
   "csharp"
 );
 @@clientName(
   ClusterScopeSettingsProperties,
-  "ExtensionTypeClusterScopeSettingsProperties",
+  "KubernetesConfigurationExtensionTypeClusterScopeSettingsProperties",
   "csharp"
 );
 @@clientName(
   ExtensionTypePropertiesPlanInfo,
-  "ExtensionTypePlanInfo",
+  "KubernetesConfigurationExtensionTypePlanInfo",
   "csharp"
 );
 @@clientName(
   ExtensionTypePropertiesSupportedScopes,
-  "ExtensionTypeSupportedScopes",
+  "KubernetesConfigurationExtensionTypeSupportedScopes",
+  "csharp"
+);
+@@clientName(
+  ExtensionTypeVersionForReleaseTrain,
+  "KubernetesConfigurationExtensionTypeVersionForReleaseTrain",
+  "csharp"
+);
+@@clientName(
+  ExtensionTypeVersionForReleaseTrainProperties,
+  "KubernetesConfigurationExtensionTypeVersionForReleaseTrainProperties",
   "csharp"
 );
 @@clientName(
   ExtensionTypeVersionForReleaseTrainPropertiesUnsupportedKubernetesVersions,
-  "ExtensionTypeUnsupportedKubernetesVersions",
+  "KubernetesConfigurationExtensionTypeUnsupportedKubernetesVersions",
+  "csharp"
+);
+@@clientName(
+  ExtensionTypeVersionUnsupportedKubernetesMatrixItem,
+  "KubernetesConfigurationExtensionTypeVersionUnsupportedKubernetesMatrixItem",
   "csharp"
 );


### PR DESCRIPTION
## Summary
- add KubernetesConfiguration context to C# extension type data and model names
- preserve the existing cluster- and location-scoped resource projection names
- limit the customization to client.tsp

SDK PR: https://github.com/Azure/azure-sdk-for-net/pull/62197