### PR TITLE
[AzureResilienceManagement] Add resource feasibility reviews to ValidateForFailover

### DIFF
--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/examples/2026-08-31-preview/RecoveryPlanActions_ValidateForFailover_MaximumSet_Gen.json
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/examples/2026-08-31-preview/RecoveryPlanActions_ValidateForFailover_MaximumSet_Gen.json
@@ -98,6 +98,31 @@
               "qualificationState": "Qualified",
               "notQualifiedReasons": [
                 "ResourceInNotProtectedState"
+              ],
+              "resourceFeasibilityReviews": [
+                {
+                  "feasibilityType": "SkuCapacity",
+                  "resourceType": "Microsoft.Compute/virtualMachines",
+                  "currentTargetSku": {
+                    "sku": "Standard_D4s_v5",
+                    "vCpu": 4,
+                    "ram": 16,
+                    "monthlyPrice": 219.0,
+                    "currency": "USD",
+                    "offeringId": "bc713d38-e184-4631-9d42-2bf64f1d0131"
+                  },
+                  "status": "Flagged",
+                  "recommendedTargetSkus": [
+                    {
+                      "sku": "Standard_D8s_v5",
+                      "vCpu": 8,
+                      "ram": 32,
+                      "monthlyPrice": 438.0,
+                      "currency": "USD",
+                      "offeringId": "3996b909-b8d8-46f9-9e40-3a35fb687662"
+                    }
+                  ]
+                }
               ]
             }
           }

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/recoveryPlan/recoveryActions.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/recoveryPlan/recoveryActions.tsp
@@ -80,6 +80,12 @@ model OperationQualificationDetails {
 
   @doc("Reasons for resource not qualified for the operation.")
   notQualifiedReasons?: string[];
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("Advisory resource feasibility reviews. Absent when no review was evaluated for this resource.")
+  @identifiers(#["feasibilityType", "resourceType"])
+  @maxItems(10)
+  resourceFeasibilityReviews?: ResourceFeasibilityReview[];
 }
 
 @doc("Details of resource and its qualification for an operation")
@@ -118,4 +124,91 @@ model RecoveryActionRequest {
   @doc("User-provided input for the action.")
   @maxLength(100)
   description?: string;
+}
+
+@added(Versions.v2026_08_31_preview)
+@doc("The resource feasibility review category for a recovery resource.")
+union ResourceFeasibilityReviewType {
+  @added(Versions.v2026_08_31_preview)
+  @doc("SKU capacity availability check in the target region or zone.")
+  SkuCapacity: "SkuCapacity",
+
+  string,
+}
+
+@added(Versions.v2026_08_31_preview)
+@doc("Outcome of a resource feasibility review for a recovery resource.")
+union ResourceFeasibilityReviewStatus {
+  @added(Versions.v2026_08_31_preview)
+  @doc("The review could not complete. Advisory only; it never blocks failover.")
+  Unavailable: "Unavailable",
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("The review identified no risk.")
+  Passed: "Passed",
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("The review identified a risk the operator should consider.")
+  Flagged: "Flagged",
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("The review did not apply to this resource and was skipped.")
+  NotApplicable: "NotApplicable",
+
+  string,
+}
+
+@added(Versions.v2026_08_31_preview)
+@doc("SKU details for a resource feasibility review, used for both the current target SKU and the recommended alternate SKUs.")
+model SkuDetails {
+  @added(Versions.v2026_08_31_preview)
+  @doc("The Azure SKU name.")
+  sku: string;
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("Number of virtual CPUs for the SKU. Absent when SKU specifications are unavailable.")
+  vCpu?: int32;
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("Memory in GiB for the SKU. Absent when SKU specifications are unavailable.")
+  ram?: int32;
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("Estimated monthly price. Absent when pricing is unavailable.")
+  monthlyPrice?: float64;
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("ISO 4217 currency code for `monthlyPrice`.")
+  currency?: string;
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("Identifier of the Azure offering used to estimate `monthlyPrice`.")
+  offeringId?: string;
+}
+
+@added(Versions.v2026_08_31_preview)
+@doc("Result of a single feasibility review performed against one resource in a recovery plan.")
+model ResourceFeasibilityReview {
+  @added(Versions.v2026_08_31_preview)
+  @doc("The resource feasibility review type.")
+  feasibilityType: ResourceFeasibilityReviewType;
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("Fully qualified ARM resource type evaluated, e.g. `Microsoft.Compute/virtualMachines`.")
+  @pattern("^[a-zA-Z0-9]+\\.[a-zA-Z0-9]+(/[a-zA-Z0-9]+)+$")
+  resourceType: string;
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("The SKU the resource is currently configured to recover into, enriched for comparison against the recommendations. Absent when it could not be resolved, and always absent on `Passed` and `NotApplicable` reviews.")
+  currentTargetSku?: SkuDetails;
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("Outcome of this feasibility review.")
+  status: ResourceFeasibilityReviewStatus;
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("Alternative SKUs surfaced for this review. Absent or empty means a `Flagged` review has no alternatives, an `Unavailable` review has no applicable recommendations to surface, or the review has a minimal `Passed` / `NotApplicable` outcome. Callers should treat an absent array and an empty array identically.")
+  @identifiers(#["sku"])
+  @maxItems(5)
+  recommendedTargetSkus?: SkuDetails[];
 }

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/examples/RecoveryPlanActions_ValidateForFailover_MaximumSet_Gen.json
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/examples/RecoveryPlanActions_ValidateForFailover_MaximumSet_Gen.json
@@ -98,6 +98,31 @@
               "qualificationState": "Qualified",
               "notQualifiedReasons": [
                 "ResourceInNotProtectedState"
+              ],
+              "resourceFeasibilityReviews": [
+                {
+                  "feasibilityType": "SkuCapacity",
+                  "resourceType": "Microsoft.Compute/virtualMachines",
+                  "currentTargetSku": {
+                    "sku": "Standard_D4s_v5",
+                    "vCpu": 4,
+                    "ram": 16,
+                    "monthlyPrice": 219.0,
+                    "currency": "USD",
+                    "offeringId": "bc713d38-e184-4631-9d42-2bf64f1d0131"
+                  },
+                  "status": "Flagged",
+                  "recommendedTargetSkus": [
+                    {
+                      "sku": "Standard_D8s_v5",
+                      "vCpu": 8,
+                      "ram": 32,
+                      "monthlyPrice": 438.0,
+                      "currency": "USD",
+                      "offeringId": "3996b909-b8d8-46f9-9e40-3a35fb687662"
+                    }
+                  ]
+                }
               ]
             }
           }

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/openapi.json
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/openapi.json
@@ -8805,6 +8805,18 @@
           "items": {
             "type": "string"
           }
+        },
+        "resourceFeasibilityReviews": {
+          "type": "array",
+          "description": "Advisory resource feasibility reviews. Absent when no review was evaluated for this resource.",
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/definitions/ResourceFeasibilityReview"
+          },
+          "x-ms-identifiers": [
+            "feasibilityType",
+            "resourceType"
+          ]
         }
       },
       "required": [
@@ -10550,6 +10562,99 @@
       ],
       "x-ms-discriminator-value": "CustomRunbook"
     },
+    "ResourceFeasibilityReview": {
+      "type": "object",
+      "description": "Result of a single feasibility review performed against one resource in a recovery plan.",
+      "properties": {
+        "feasibilityType": {
+          "$ref": "#/definitions/ResourceFeasibilityReviewType",
+          "description": "The resource feasibility review type."
+        },
+        "resourceType": {
+          "type": "string",
+          "description": "Fully qualified ARM resource type evaluated, e.g. `Microsoft.Compute/virtualMachines`.",
+          "pattern": "^[a-zA-Z0-9]+\\.[a-zA-Z0-9]+(/[a-zA-Z0-9]+)+$"
+        },
+        "currentTargetSku": {
+          "$ref": "#/definitions/SkuDetails",
+          "description": "The SKU the resource is currently configured to recover into, enriched for comparison against the recommendations. Absent when it could not be resolved, and always absent on `Passed` and `NotApplicable` reviews."
+        },
+        "status": {
+          "$ref": "#/definitions/ResourceFeasibilityReviewStatus",
+          "description": "Outcome of this feasibility review."
+        },
+        "recommendedTargetSkus": {
+          "type": "array",
+          "description": "Alternative SKUs surfaced for this review. Absent or empty means a `Flagged` review has no alternatives, an `Unavailable` review has no applicable recommendations to surface, or the review has a minimal `Passed` / `NotApplicable` outcome. Callers should treat an absent array and an empty array identically.",
+          "maxItems": 5,
+          "items": {
+            "$ref": "#/definitions/SkuDetails"
+          },
+          "x-ms-identifiers": [
+            "sku"
+          ]
+        }
+      },
+      "required": [
+        "feasibilityType",
+        "resourceType",
+        "status"
+      ]
+    },
+    "ResourceFeasibilityReviewStatus": {
+      "type": "string",
+      "description": "Outcome of a resource feasibility review for a recovery resource.",
+      "enum": [
+        "Unavailable",
+        "Passed",
+        "Flagged",
+        "NotApplicable"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceFeasibilityReviewStatus",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unavailable",
+            "value": "Unavailable",
+            "description": "The review could not complete. Advisory only; it never blocks failover."
+          },
+          {
+            "name": "Passed",
+            "value": "Passed",
+            "description": "The review identified no risk."
+          },
+          {
+            "name": "Flagged",
+            "value": "Flagged",
+            "description": "The review identified a risk the operator should consider."
+          },
+          {
+            "name": "NotApplicable",
+            "value": "NotApplicable",
+            "description": "The review did not apply to this resource and was skipped."
+          }
+        ]
+      }
+    },
+    "ResourceFeasibilityReviewType": {
+      "type": "string",
+      "description": "The resource feasibility review category for a recovery resource.",
+      "enum": [
+        "SkuCapacity"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceFeasibilityReviewType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "SkuCapacity",
+            "value": "SkuCapacity",
+            "description": "SKU capacity availability check in the target region or zone."
+          }
+        ]
+      }
+    },
     "ResourceInclusionState": {
       "type": "string",
       "description": "A state type that indicates inclusion of the resource with respect to the resiliency support.",
@@ -11044,6 +11149,42 @@
       },
       "required": [
         "serviceLevelIndicatorResourceId"
+      ]
+    },
+    "SkuDetails": {
+      "type": "object",
+      "description": "SKU details for a resource feasibility review, used for both the current target SKU and the recommended alternate SKUs.",
+      "properties": {
+        "sku": {
+          "type": "string",
+          "description": "The Azure SKU name."
+        },
+        "vCpu": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of virtual CPUs for the SKU. Absent when SKU specifications are unavailable."
+        },
+        "ram": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Memory in GiB for the SKU. Absent when SKU specifications are unavailable."
+        },
+        "monthlyPrice": {
+          "type": "number",
+          "format": "double",
+          "description": "Estimated monthly price. Absent when pricing is unavailable."
+        },
+        "currency": {
+          "type": "string",
+          "description": "ISO 4217 currency code for `monthlyPrice`."
+        },
+        "offeringId": {
+          "type": "string",
+          "description": "Identifier of the Azure offering used to estimate `monthlyPrice`."
+        }
+      },
+      "required": [
+        "sku"
       ]
     },
     "SliAttentionStatus": {


### PR DESCRIPTION
Adds advisory SKU capacity feasibility reviews to the recovery resource qualification contract for 2026-08-31-preview.

- ResourceFeasibilityReviewType union (SkuCapacity)
- ResourceFeasibilityReviewStatus union (Flagged, Passed, NotApplicable, Unavailable)
- SkuDetails model describing a SKU and its enrichment
- ResourceFeasibilityReview model
- Optional resourceFeasibilityReviews on OperationQualificationDetails, capped at 10

All declarations are gated with @added(Versions.v2026_08_31_preview), so the four earlier preview versions are unchanged.

monthlyPrice uses decimal rather than a bit-sized float to avoid binary floating-point rounding on a monetary value, matching the Microsoft.Commerce and Microsoft.Consumption precedent; the azure-core no-generic-numeric rule is suppressed with that justification. resourceType carries an ARM resource type @pattern. recommendedTargetSkus is optional for symmetry with currentTargetSku, and the doc states that callers should treat an absent and an empty array identically.

Also updates the ValidateForFailover MaximumSet example to demonstrate a Flagged review, and regenerates openapi.json.

# Choose a PR Template

Switch to "Preview" on this description then select one of the choices below.

<a href="?expand=1&template=data_plane_template.md">Click here</a> to open a PR for a Data Plane API.

<a href="?expand=1&template=control_plane_template.md">Click here</a> to open a PR for a Control Plane (ARM) API.

<a href="?expand=1&template=sdk_configuration_template.md">Click here</a> to open a PR for only SDK configuration.
