### PR TITLE
Add telemetryConfig to SandboxGroup

### DIFF
--- a/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
@@ -142,8 +142,19 @@ model TelemetryEndpoint {
   @identifiers(#["name"])
   columns?: LogColumn[];
 
-  /** Whether to parse JSON log lines and merge their top-level keys into the output record. Reserved keys, and keys already produced by an entry in `columns`, are not overwritten. Requires `ContainerStdoutStderr` in `data`. */
-  dynamicJsonColumns?: boolean = false;
+  /** Whether to parse JSON log lines and merge their top-level keys into the output record. Reserved keys, and keys already produced by an entry in `columns`, are not overwritten. Requires `ContainerStdoutStderr` in `data`. Defaults to `Disabled` when not specified. */
+  dynamicJsonColumns?: DynamicJsonColumnsMode;
+}
+
+/** Whether JSON log lines are parsed into additional output columns. */
+union DynamicJsonColumnsMode {
+  string,
+
+  /** Top-level keys of JSON log lines are merged into the output record. */
+  Enabled: "Enabled",
+
+  /** Log lines are written to the output record without JSON parsing. */
+  Disabled: "Disabled",
 }
 
 /** A telemetry endpoint that accepts the OpenTelemetry Protocol (OTLP). */

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
@@ -171,7 +171,7 @@ model OtlpTelemetryEndpoint extends TelemetryEndpoint {
   protocol: TelemetryProtocol;
 
   /** The authentication used when sending telemetry to the endpoint. When omitted, requests are sent without an authentication header. */
-  auth?: TelemetryHeaderAuth;
+  authentication?: TelemetryHeaderAuth;
 }
 
 /** A telemetry endpoint that sends telemetry to an Application Insights resource. */
@@ -180,7 +180,7 @@ model ApplicationInsightsTelemetryEndpoint extends TelemetryEndpoint {
   kind: "ApplicationInsights";
 
   /** The authentication used when sending telemetry to the endpoint. */
-  auth: TelemetryApplicationInsightsAuth;
+  authentication: TelemetryApplicationInsightsAuth;
 }
 
 /** A telemetry endpoint that sends telemetry to an Azure Monitor Log Analytics workspace through the Logs Ingestion API. */
@@ -189,16 +189,16 @@ model LogAnalyticsTelemetryEndpoint extends TelemetryEndpoint {
   kind: "LogAnalytics";
 
   /** The URL of the data collection endpoint that receives the telemetry. */
-  dceEndpoint: url;
+  dataCollectionEndpoint: url;
 
   /** The immutable ID of the data collection rule that processes the telemetry. */
-  dcrImmutableId: string;
+  dataCollectionRuleImmutableId: string;
 
   /** The name of the target stream in the data collection rule. */
   tableName: string;
 
   /** The managed identity used to authenticate to the data collection endpoint. */
-  auth: TelemetryAuth;
+  authentication: TelemetryAuth;
 }
 
 /** A category of telemetry that can be sent to a telemetry endpoint. */
@@ -250,31 +250,31 @@ model TelemetryApplicationInsightsAuth {
   secretKeyName: string;
 }
 
-/** The kind of managed identity used to authenticate to a telemetry endpoint. */
-union TelemetryAuthKind {
+/** The type of managed identity used to authenticate to a telemetry endpoint. */
+union TelemetryAuthType {
   string,
 
   /** A user-assigned managed identity. */
-  ManagedIdentity: "ManagedIdentity",
+  UserAssigned: "UserAssigned",
 
   /** The system-assigned managed identity of the sandbox group. */
-  SystemAssignedManagedIdentity: "SystemAssignedManagedIdentity",
+  SystemAssigned: "SystemAssigned",
 }
 
 /** The managed identity used to authenticate to a telemetry endpoint. */
-@discriminator("kind")
+@discriminator("type")
 model TelemetryAuth {
-  /** The kind of managed identity used to authenticate to the telemetry endpoint. */
-  kind: TelemetryAuthKind;
+  /** The type of managed identity used to authenticate to the telemetry endpoint. */
+  type: TelemetryAuthType;
 }
 
 /** Authentication that uses a user-assigned managed identity. */
-model TelemetryManagedIdentityAuth extends TelemetryAuth {
-  /** The kind of managed identity used to authenticate to the telemetry endpoint. */
-  kind: "ManagedIdentity";
+model TelemetryUserAssignedIdentityAuth extends TelemetryAuth {
+  /** The type of managed identity used to authenticate to the telemetry endpoint. */
+  type: "UserAssigned";
 
   /** The resource ID of the user-assigned managed identity. The identity must be assigned to the sandbox group. */
-  identity: armResourceIdentifier<[
+  identityResourceId: armResourceIdentifier<[
     {
       type: "Microsoft.ManagedIdentity/userAssignedIdentities";
     }
@@ -282,9 +282,9 @@ model TelemetryManagedIdentityAuth extends TelemetryAuth {
 }
 
 /** Authentication that uses the system-assigned managed identity of the sandbox group. */
-model TelemetrySystemAssignedManagedIdentityAuth extends TelemetryAuth {
-  /** The kind of managed identity used to authenticate to the telemetry endpoint. */
-  kind: "SystemAssignedManagedIdentity";
+model TelemetrySystemAssignedIdentityAuth extends TelemetryAuth {
+  /** The type of managed identity used to authenticate to the telemetry endpoint. */
+  type: "SystemAssigned";
 }
 
 /** The kind of a custom log output column. */

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
@@ -106,8 +106,9 @@ model SandboxGroupPatchProperties {
 
 /** The telemetry configuration for sandboxes in a sandbox group. */
 model TelemetryConfig {
-  /** The endpoints that sandbox telemetry is sent to. */
+  /** The endpoints that sandbox telemetry is sent to. At least one endpoint must be specified. */
   @identifiers(#[])
+  @minItems(1)
   endpoints?: TelemetryEndpoint[];
 
   /** The interval, in seconds, at which sandbox metrics are collected. Defaults to 15 seconds when not specified. */
@@ -135,7 +136,8 @@ model TelemetryEndpoint {
   /** The kind of the telemetry endpoint. */
   kind: TelemetryEndpointKind;
 
-  /** The categories of telemetry sent to this endpoint. When empty, every category is sent. */
+  /** The categories of telemetry sent to this endpoint. At least one category must be specified. */
+  @minItems(1)
   data: TelemetryData[];
 
   /** A custom output schema for log records. Applies to `ContainerStdoutStderr` telemetry, and additionally to `Metrics` telemetry on an OpenTelemetry Protocol endpoint. When omitted, records are written in their default shape. */

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
@@ -106,9 +106,9 @@ model SandboxGroupPatchProperties {
 
 /** The telemetry configuration for sandboxes in a sandbox group. */
 model TelemetryConfig {
-  /** The endpoints that sandbox telemetry is sent to. At least one endpoint must be specified. */
+  /** The endpoints that sandbox telemetry is sent to. */
   @identifiers(#[])
-  endpoints: TelemetryEndpoint[];
+  endpoints?: TelemetryEndpoint[];
 
   /** The interval, in seconds, at which sandbox metrics are collected. Defaults to 15 seconds when not specified. */
   @minValue(2)
@@ -138,9 +138,9 @@ model TelemetryEndpoint {
   /** The categories of telemetry sent to this endpoint. When empty, every category is sent. */
   data: TelemetryData[];
 
-  /** A custom output schema for log records, keyed by the name of the output column to produce. Applies to `ContainerStdoutStderr` telemetry, and additionally to `Metrics` telemetry on an OpenTelemetry Protocol endpoint. When omitted, records are written in their default shape. */
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Output column names are chosen by the customer, so the schema is an open key/value map."
-  columns?: Record<LogColumnDef>;
+  /** A custom output schema for log records. Applies to `ContainerStdoutStderr` telemetry, and additionally to `Metrics` telemetry on an OpenTelemetry Protocol endpoint. When omitted, records are written in their default shape. */
+  @identifiers(#["name"])
+  columns?: LogColumn[];
 
   /** Whether to parse JSON log lines and merge their top-level keys into the output record. Reserved keys, and keys already produced by an entry in `columns`, are not overwritten. Requires `ContainerStdoutStderr` in `data`. */
   dynamicJsonColumns?: boolean = false;
@@ -209,10 +209,10 @@ union TelemetryData {
 union TelemetryProtocol {
   string,
 
-  /** gRPC. */
+  /** Telemetry is sent over gRPC. */
   Grpc: "Grpc",
 
-  /** HTTP. */
+  /** Telemetry is sent over HTTP with a protobuf payload. */
   Http: "Http",
 }
 
@@ -225,8 +225,7 @@ model TelemetryHeaderAuth {
   secretId: string;
 
   /** The key within the sandbox group secret whose value is sent as the header value. */
-  #suppress "@azure-tools/typespec-azure-resource-manager/secret-prop" "This is the name of a key within the referenced secret, not the secret value, and it is returned in read responses."
-  secretKey: string;
+  secretKeyName: string;
 }
 
 /** Authentication for an Application Insights telemetry endpoint. */
@@ -235,8 +234,7 @@ model TelemetryApplicationInsightsAuth {
   secretId: string;
 
   /** The key within the sandbox group secret whose value is the Application Insights connection string. */
-  #suppress "@azure-tools/typespec-azure-resource-manager/secret-prop" "This is the name of a key within the referenced secret, not the secret value, and it is returned in read responses."
-  secretKey: string;
+  secretKeyName: string;
 }
 
 /** The kind of managed identity used to authenticate to a telemetry endpoint. */
@@ -277,7 +275,7 @@ model TelemetrySystemAssignedManagedIdentityAuth extends TelemetryAuth {
 }
 
 /** The kind of a custom log output column. */
-union LogColumnDefKind {
+union LogColumnKind {
   string,
 
   /** A column whose value is a literal string. */
@@ -289,13 +287,16 @@ union LogColumnDefKind {
 
 /** A single column in a custom log output schema. */
 @discriminator("kind")
-model LogColumnDef {
+model LogColumn {
+  /** The name of the output column to produce. */
+  name: string;
+
   /** The kind of the custom log output column. */
-  kind: LogColumnDefKind;
+  kind: LogColumnKind;
 }
 
 /** A custom log output column whose value is a literal string. */
-model ValueLogColumnDef extends LogColumnDef {
+model ValueLogColumn extends LogColumn {
   /** The kind of the custom log output column. */
   kind: "Value";
 
@@ -304,7 +305,7 @@ model ValueLogColumnDef extends LogColumnDef {
 }
 
 /** A custom log output column whose value is resolved from a sandbox attribute. */
-model RefLogColumnDef extends LogColumnDef {
+model RefLogColumn extends LogColumn {
   /** The kind of the custom log output column. */
   kind: "Ref";
 

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/SandboxGroup.tsp
@@ -34,6 +34,9 @@ model SandboxGroupProperties {
   @visibility(Lifecycle.Read)
   defaultDomain?: string;
 
+  /** The telemetry configuration for sandboxes in the sandbox group. When omitted, telemetry is not forwarded to any endpoint. */
+  telemetryConfig?: TelemetryConfig;
+
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "Description is on the referenced type to avoid emitting a sibling of $ref."
   @visibility(Lifecycle.Read)
   provisioningState?: SandboxGroupProvisioningState;
@@ -95,5 +98,236 @@ model SandboxGroupPatch {
 
 /** SandboxGroup resource specific properties for patch requests. */
 model SandboxGroupPatchProperties {
-  ...PickProperties<SandboxGroupProperties, "environmentId">;
+  ...PickProperties<
+    SandboxGroupProperties,
+    "environmentId" | "telemetryConfig"
+  >;
+}
+
+/** The telemetry configuration for sandboxes in a sandbox group. */
+model TelemetryConfig {
+  /** The endpoints that sandbox telemetry is sent to. At least one endpoint must be specified. */
+  @identifiers(#[])
+  endpoints: TelemetryEndpoint[];
+
+  /** The interval, in seconds, at which sandbox metrics are collected. Defaults to 15 seconds when not specified. */
+  @minValue(2)
+  metricsIntervalSeconds?: int32;
+}
+
+/** The kind of a telemetry endpoint. */
+union TelemetryEndpointKind {
+  string,
+
+  /** An endpoint that accepts the OpenTelemetry Protocol (OTLP). */
+  OTLP: "OTLP",
+
+  /** An Application Insights resource. */
+  ApplicationInsights: "ApplicationInsights",
+
+  /** An Azure Monitor Log Analytics workspace, written through the Logs Ingestion API. */
+  LogAnalytics: "LogAnalytics",
+}
+
+/** A destination that sandbox telemetry is sent to. */
+@discriminator("kind")
+model TelemetryEndpoint {
+  /** The kind of the telemetry endpoint. */
+  kind: TelemetryEndpointKind;
+
+  /** The categories of telemetry sent to this endpoint. When empty, every category is sent. */
+  data: TelemetryData[];
+
+  /** A custom output schema for log records, keyed by the name of the output column to produce. Applies to `ContainerStdoutStderr` telemetry, and additionally to `Metrics` telemetry on an OpenTelemetry Protocol endpoint. When omitted, records are written in their default shape. */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "Output column names are chosen by the customer, so the schema is an open key/value map."
+  columns?: Record<LogColumnDef>;
+
+  /** Whether to parse JSON log lines and merge their top-level keys into the output record. Reserved keys, and keys already produced by an entry in `columns`, are not overwritten. Requires `ContainerStdoutStderr` in `data`. */
+  dynamicJsonColumns?: boolean = false;
+}
+
+/** A telemetry endpoint that accepts the OpenTelemetry Protocol (OTLP). */
+model OtlpTelemetryEndpoint extends TelemetryEndpoint {
+  /** The kind of the telemetry endpoint. */
+  kind: "OTLP";
+
+  /** The URL of the OpenTelemetry Protocol endpoint. */
+  endpoint: url;
+
+  /** The protocol used to send telemetry to the endpoint. */
+  protocol: TelemetryProtocol;
+
+  /** The authentication used when sending telemetry to the endpoint. When omitted, requests are sent without an authentication header. */
+  auth?: TelemetryHeaderAuth;
+}
+
+/** A telemetry endpoint that sends telemetry to an Application Insights resource. */
+model ApplicationInsightsTelemetryEndpoint extends TelemetryEndpoint {
+  /** The kind of the telemetry endpoint. */
+  kind: "ApplicationInsights";
+
+  /** The authentication used when sending telemetry to the endpoint. */
+  auth: TelemetryApplicationInsightsAuth;
+}
+
+/** A telemetry endpoint that sends telemetry to an Azure Monitor Log Analytics workspace through the Logs Ingestion API. */
+model LogAnalyticsTelemetryEndpoint extends TelemetryEndpoint {
+  /** The kind of the telemetry endpoint. */
+  kind: "LogAnalytics";
+
+  /** The URL of the data collection endpoint that receives the telemetry. */
+  dceEndpoint: url;
+
+  /** The immutable ID of the data collection rule that processes the telemetry. */
+  dcrImmutableId: string;
+
+  /** The name of the target stream in the data collection rule. */
+  tableName: string;
+
+  /** The managed identity used to authenticate to the data collection endpoint. */
+  auth: TelemetryAuth;
+}
+
+/** A category of telemetry that can be sent to a telemetry endpoint. */
+union TelemetryData {
+  string,
+
+  /** Standard output and standard error written by containers in the sandbox. */
+  ContainerStdoutStderr: "ContainerStdoutStderr",
+
+  /** OpenTelemetry data emitted by containers in the sandbox. */
+  ContainerOtel: "ContainerOtel",
+
+  /** Resource usage metrics for the sandbox. */
+  Metrics: "Metrics",
+
+  /** A record of each decision made by the network egress policy of the sandbox. */
+  NetworkEgressDecisions: "NetworkEgressDecisions",
+}
+
+/** The protocol used to send telemetry to an OpenTelemetry Protocol endpoint. */
+union TelemetryProtocol {
+  string,
+
+  /** gRPC. */
+  Grpc: "Grpc",
+
+  /** HTTP. */
+  Http: "Http",
+}
+
+/** Authentication for an OpenTelemetry Protocol telemetry endpoint. The referenced secret value is sent as an HTTP request header. */
+model TelemetryHeaderAuth {
+  /** The name of the HTTP request header to send, for example `Authorization`. */
+  headerName: string;
+
+  /** The name of the sandbox group secret that holds the header value. */
+  secretId: string;
+
+  /** The key within the sandbox group secret whose value is sent as the header value. */
+  #suppress "@azure-tools/typespec-azure-resource-manager/secret-prop" "This is the name of a key within the referenced secret, not the secret value, and it is returned in read responses."
+  secretKey: string;
+}
+
+/** Authentication for an Application Insights telemetry endpoint. */
+model TelemetryApplicationInsightsAuth {
+  /** The name of the sandbox group secret that holds the Application Insights connection string. */
+  secretId: string;
+
+  /** The key within the sandbox group secret whose value is the Application Insights connection string. */
+  #suppress "@azure-tools/typespec-azure-resource-manager/secret-prop" "This is the name of a key within the referenced secret, not the secret value, and it is returned in read responses."
+  secretKey: string;
+}
+
+/** The kind of managed identity used to authenticate to a telemetry endpoint. */
+union TelemetryAuthKind {
+  string,
+
+  /** A user-assigned managed identity. */
+  ManagedIdentity: "ManagedIdentity",
+
+  /** The system-assigned managed identity of the sandbox group. */
+  SystemAssignedManagedIdentity: "SystemAssignedManagedIdentity",
+}
+
+/** The managed identity used to authenticate to a telemetry endpoint. */
+@discriminator("kind")
+model TelemetryAuth {
+  /** The kind of managed identity used to authenticate to the telemetry endpoint. */
+  kind: TelemetryAuthKind;
+}
+
+/** Authentication that uses a user-assigned managed identity. */
+model TelemetryManagedIdentityAuth extends TelemetryAuth {
+  /** The kind of managed identity used to authenticate to the telemetry endpoint. */
+  kind: "ManagedIdentity";
+
+  /** The resource ID of the user-assigned managed identity. The identity must be assigned to the sandbox group. */
+  identity: armResourceIdentifier<[
+    {
+      type: "Microsoft.ManagedIdentity/userAssignedIdentities";
+    }
+  ]>;
+}
+
+/** Authentication that uses the system-assigned managed identity of the sandbox group. */
+model TelemetrySystemAssignedManagedIdentityAuth extends TelemetryAuth {
+  /** The kind of managed identity used to authenticate to the telemetry endpoint. */
+  kind: "SystemAssignedManagedIdentity";
+}
+
+/** The kind of a custom log output column. */
+union LogColumnDefKind {
+  string,
+
+  /** A column whose value is a literal string. */
+  Value: "Value",
+
+  /** A column whose value is resolved from a sandbox attribute. */
+  Ref: "Ref",
+}
+
+/** A single column in a custom log output schema. */
+@discriminator("kind")
+model LogColumnDef {
+  /** The kind of the custom log output column. */
+  kind: LogColumnDefKind;
+}
+
+/** A custom log output column whose value is a literal string. */
+model ValueLogColumnDef extends LogColumnDef {
+  /** The kind of the custom log output column. */
+  kind: "Value";
+
+  /** The literal value written to every log record. */
+  value: string;
+}
+
+/** A custom log output column whose value is resolved from a sandbox attribute. */
+model RefLogColumnDef extends LogColumnDef {
+  /** The kind of the custom log output column. */
+  kind: "Ref";
+
+  /** The sandbox attribute to resolve. */
+  refName: LogColumnRef;
+}
+
+/** A sandbox attribute that a custom log output column can reference. */
+union LogColumnRef {
+  string,
+
+  /** The contents of the container log line. */
+  LogContent: "LogContent",
+
+  /** The container output stream the log line was written to, either `stdout` or `stderr`. */
+  LogStream: "LogStream",
+
+  /** The ID of the sandbox that produced the record. */
+  SandboxId: "SandboxId",
+
+  /** The Azure region the sandbox is running in. */
+  Region: "Region",
+
+  /** The name of the container that produced the record. */
+  ContainerName: "ContainerName",
 }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Update.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Update.json
@@ -14,15 +14,29 @@
           "endpoints": [
             {
               "kind": "LogAnalytics",
-              "dceEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
-              "dcrImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
+              "dataCollectionEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
+              "dataCollectionRuleImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
               "tableName": "Custom-SandboxLogs_CL",
-              "auth": {
-                "kind": "SystemAssignedManagedIdentity"
+              "authentication": {
+                "type": "UserAssigned",
+                "identityResourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleidentity"
               },
               "data": [
                 "ContainerStdoutStderr",
                 "Metrics"
+              ]
+            },
+            {
+              "kind": "OTLP",
+              "endpoint": "https://example-collector.contoso.com/otlp",
+              "protocol": "Grpc",
+              "authentication": {
+                "headerName": "Authorization",
+                "secretId": "telemetry-secrets",
+                "secretKeyName": "collectorToken"
+              },
+              "data": [
+                "ContainerOtel"
               ]
             }
           ],
@@ -48,15 +62,29 @@
             "endpoints": [
               {
                 "kind": "LogAnalytics",
-                "dceEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
-                "dcrImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
+                "dataCollectionEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
+                "dataCollectionRuleImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
                 "tableName": "Custom-SandboxLogs_CL",
-                "auth": {
-                  "kind": "SystemAssignedManagedIdentity"
+                "authentication": {
+                  "type": "UserAssigned",
+                  "identityResourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleidentity"
                 },
                 "data": [
                   "ContainerStdoutStderr",
                   "Metrics"
+                ]
+              },
+              {
+                "kind": "OTLP",
+                "endpoint": "https://example-collector.contoso.com/otlp",
+                "protocol": "Grpc",
+                "authentication": {
+                  "headerName": "Authorization",
+                  "secretId": "telemetry-secrets",
+                  "secretKeyName": "collectorToken"
+                },
+                "data": [
+                  "ContainerOtel"
                 ]
               }
             ],

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Update.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/examples/2026-07-01/SandboxGroups_Update.json
@@ -9,7 +9,25 @@
         "environment": "test"
       },
       "properties": {
-        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv"
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+        "telemetryConfig": {
+          "endpoints": [
+            {
+              "kind": "LogAnalytics",
+              "dceEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
+              "dcrImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
+              "tableName": "Custom-SandboxLogs_CL",
+              "auth": {
+                "kind": "SystemAssignedManagedIdentity"
+              },
+              "data": [
+                "ContainerStdoutStderr",
+                "Metrics"
+              ]
+            }
+          ],
+          "metricsIntervalSeconds": 30
+        }
       }
     }
   },
@@ -26,6 +44,24 @@
         "properties": {
           "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
           "defaultDomain": "icycliff-79e92900.eastus.azurecontainerapps.io",
+          "telemetryConfig": {
+            "endpoints": [
+              {
+                "kind": "LogAnalytics",
+                "dceEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
+                "dcrImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
+                "tableName": "Custom-SandboxLogs_CL",
+                "auth": {
+                  "kind": "SystemAssignedManagedIdentity"
+                },
+                "data": [
+                  "ContainerStdoutStderr",
+                  "Metrics"
+                ]
+              }
+            ],
+            "metricsIntervalSeconds": 30
+          },
           "provisioningState": "Succeeded"
         }
       }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
@@ -625,6 +625,188 @@
     }
   },
   "definitions": {
+    "ApplicationInsightsTelemetryEndpoint": {
+      "type": "object",
+      "description": "A telemetry endpoint that sends telemetry to an Application Insights resource.",
+      "properties": {
+        "auth": {
+          "$ref": "#/definitions/TelemetryApplicationInsightsAuth",
+          "description": "The authentication used when sending telemetry to the endpoint."
+        }
+      },
+      "required": [
+        "auth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/TelemetryEndpoint"
+        }
+      ],
+      "x-ms-discriminator-value": "ApplicationInsights"
+    },
+    "LogAnalyticsTelemetryEndpoint": {
+      "type": "object",
+      "description": "A telemetry endpoint that sends telemetry to an Azure Monitor Log Analytics workspace through the Logs Ingestion API.",
+      "properties": {
+        "dceEndpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the data collection endpoint that receives the telemetry."
+        },
+        "dcrImmutableId": {
+          "type": "string",
+          "description": "The immutable ID of the data collection rule that processes the telemetry."
+        },
+        "tableName": {
+          "type": "string",
+          "description": "The name of the target stream in the data collection rule."
+        },
+        "auth": {
+          "$ref": "#/definitions/TelemetryAuth",
+          "description": "The managed identity used to authenticate to the data collection endpoint."
+        }
+      },
+      "required": [
+        "dceEndpoint",
+        "dcrImmutableId",
+        "tableName",
+        "auth"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/TelemetryEndpoint"
+        }
+      ],
+      "x-ms-discriminator-value": "LogAnalytics"
+    },
+    "LogColumnDef": {
+      "type": "object",
+      "description": "A single column in a custom log output schema.",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/LogColumnDefKind",
+          "description": "The kind of the custom log output column."
+        }
+      },
+      "discriminator": "kind",
+      "required": [
+        "kind"
+      ]
+    },
+    "LogColumnDefKind": {
+      "type": "string",
+      "description": "The kind of a custom log output column.",
+      "enum": [
+        "Value",
+        "Ref"
+      ],
+      "x-ms-enum": {
+        "name": "LogColumnDefKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Value",
+            "value": "Value",
+            "description": "A column whose value is a literal string."
+          },
+          {
+            "name": "Ref",
+            "value": "Ref",
+            "description": "A column whose value is resolved from a sandbox attribute."
+          }
+        ]
+      }
+    },
+    "LogColumnRef": {
+      "type": "string",
+      "description": "A sandbox attribute that a custom log output column can reference.",
+      "enum": [
+        "LogContent",
+        "LogStream",
+        "SandboxId",
+        "Region",
+        "ContainerName"
+      ],
+      "x-ms-enum": {
+        "name": "LogColumnRef",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "LogContent",
+            "value": "LogContent",
+            "description": "The contents of the container log line."
+          },
+          {
+            "name": "LogStream",
+            "value": "LogStream",
+            "description": "The container output stream the log line was written to, either `stdout` or `stderr`."
+          },
+          {
+            "name": "SandboxId",
+            "value": "SandboxId",
+            "description": "The ID of the sandbox that produced the record."
+          },
+          {
+            "name": "Region",
+            "value": "Region",
+            "description": "The Azure region the sandbox is running in."
+          },
+          {
+            "name": "ContainerName",
+            "value": "ContainerName",
+            "description": "The name of the container that produced the record."
+          }
+        ]
+      }
+    },
+    "OtlpTelemetryEndpoint": {
+      "type": "object",
+      "description": "A telemetry endpoint that accepts the OpenTelemetry Protocol (OTLP).",
+      "properties": {
+        "endpoint": {
+          "type": "string",
+          "format": "uri",
+          "description": "The URL of the OpenTelemetry Protocol endpoint."
+        },
+        "protocol": {
+          "$ref": "#/definitions/TelemetryProtocol",
+          "description": "The protocol used to send telemetry to the endpoint."
+        },
+        "auth": {
+          "$ref": "#/definitions/TelemetryHeaderAuth",
+          "description": "The authentication used when sending telemetry to the endpoint. When omitted, requests are sent without an authentication header."
+        }
+      },
+      "required": [
+        "endpoint",
+        "protocol"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/TelemetryEndpoint"
+        }
+      ],
+      "x-ms-discriminator-value": "OTLP"
+    },
+    "RefLogColumnDef": {
+      "type": "object",
+      "description": "A custom log output column whose value is resolved from a sandbox attribute.",
+      "properties": {
+        "refName": {
+          "$ref": "#/definitions/LogColumnRef",
+          "description": "The sandbox attribute to resolve."
+        }
+      },
+      "required": [
+        "refName"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/LogColumnDef"
+        }
+      ],
+      "x-ms-discriminator-value": "Ref"
+    },
     "SandboxGroup": {
       "type": "object",
       "description": "A SandboxGroup resource, representing a group of sandboxes that share configuration defaults and quotas.",
@@ -693,6 +875,10 @@
               }
             ]
           }
+        },
+        "telemetryConfig": {
+          "$ref": "#/definitions/TelemetryConfig",
+          "description": "The telemetry configuration for sandboxes in the sandbox group. When omitted, telemetry is not forwarded to any endpoint."
         }
       }
     },
@@ -716,6 +902,10 @@
           "type": "string",
           "description": "The default domain of the linked Azure Container Apps environment. Sandbox endpoints use subdomains of this domain. This read-only property is populated by the service and is omitted when no environment is linked.",
           "readOnly": true
+        },
+        "telemetryConfig": {
+          "$ref": "#/definitions/TelemetryConfig",
+          "description": "The telemetry configuration for sandboxes in the sandbox group. When omitted, telemetry is not forwarded to any endpoint."
         },
         "provisioningState": {
           "$ref": "#/definitions/SandboxGroupProvisioningState",
@@ -771,6 +961,288 @@
         ]
       },
       "readOnly": true
+    },
+    "TelemetryApplicationInsightsAuth": {
+      "type": "object",
+      "description": "Authentication for an Application Insights telemetry endpoint.",
+      "properties": {
+        "secretId": {
+          "type": "string",
+          "description": "The name of the sandbox group secret that holds the Application Insights connection string."
+        },
+        "secretKey": {
+          "type": "string",
+          "description": "The key within the sandbox group secret whose value is the Application Insights connection string."
+        }
+      },
+      "required": [
+        "secretId",
+        "secretKey"
+      ]
+    },
+    "TelemetryAuth": {
+      "type": "object",
+      "description": "The managed identity used to authenticate to a telemetry endpoint.",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/TelemetryAuthKind",
+          "description": "The kind of managed identity used to authenticate to the telemetry endpoint."
+        }
+      },
+      "discriminator": "kind",
+      "required": [
+        "kind"
+      ]
+    },
+    "TelemetryAuthKind": {
+      "type": "string",
+      "description": "The kind of managed identity used to authenticate to a telemetry endpoint.",
+      "enum": [
+        "ManagedIdentity",
+        "SystemAssignedManagedIdentity"
+      ],
+      "x-ms-enum": {
+        "name": "TelemetryAuthKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ManagedIdentity",
+            "value": "ManagedIdentity",
+            "description": "A user-assigned managed identity."
+          },
+          {
+            "name": "SystemAssignedManagedIdentity",
+            "value": "SystemAssignedManagedIdentity",
+            "description": "The system-assigned managed identity of the sandbox group."
+          }
+        ]
+      }
+    },
+    "TelemetryConfig": {
+      "type": "object",
+      "description": "The telemetry configuration for sandboxes in a sandbox group.",
+      "properties": {
+        "endpoints": {
+          "type": "array",
+          "description": "The endpoints that sandbox telemetry is sent to. At least one endpoint must be specified.",
+          "items": {
+            "$ref": "#/definitions/TelemetryEndpoint"
+          },
+          "x-ms-identifiers": []
+        },
+        "metricsIntervalSeconds": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The interval, in seconds, at which sandbox metrics are collected. Defaults to 15 seconds when not specified.",
+          "minimum": 2
+        }
+      },
+      "required": [
+        "endpoints"
+      ]
+    },
+    "TelemetryData": {
+      "type": "string",
+      "description": "A category of telemetry that can be sent to a telemetry endpoint.",
+      "enum": [
+        "ContainerStdoutStderr",
+        "ContainerOtel",
+        "Metrics",
+        "NetworkEgressDecisions"
+      ],
+      "x-ms-enum": {
+        "name": "TelemetryData",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ContainerStdoutStderr",
+            "value": "ContainerStdoutStderr",
+            "description": "Standard output and standard error written by containers in the sandbox."
+          },
+          {
+            "name": "ContainerOtel",
+            "value": "ContainerOtel",
+            "description": "OpenTelemetry data emitted by containers in the sandbox."
+          },
+          {
+            "name": "Metrics",
+            "value": "Metrics",
+            "description": "Resource usage metrics for the sandbox."
+          },
+          {
+            "name": "NetworkEgressDecisions",
+            "value": "NetworkEgressDecisions",
+            "description": "A record of each decision made by the network egress policy of the sandbox."
+          }
+        ]
+      }
+    },
+    "TelemetryEndpoint": {
+      "type": "object",
+      "description": "A destination that sandbox telemetry is sent to.",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/TelemetryEndpointKind",
+          "description": "The kind of the telemetry endpoint."
+        },
+        "data": {
+          "type": "array",
+          "description": "The categories of telemetry sent to this endpoint. When empty, every category is sent.",
+          "items": {
+            "$ref": "#/definitions/TelemetryData"
+          }
+        },
+        "columns": {
+          "type": "object",
+          "description": "A custom output schema for log records, keyed by the name of the output column to produce. Applies to `ContainerStdoutStderr` telemetry, and additionally to `Metrics` telemetry on an OpenTelemetry Protocol endpoint. When omitted, records are written in their default shape.",
+          "additionalProperties": {
+            "$ref": "#/definitions/LogColumnDef"
+          }
+        },
+        "dynamicJsonColumns": {
+          "type": "boolean",
+          "description": "Whether to parse JSON log lines and merge their top-level keys into the output record. Reserved keys, and keys already produced by an entry in `columns`, are not overwritten. Requires `ContainerStdoutStderr` in `data`.",
+          "default": false
+        }
+      },
+      "discriminator": "kind",
+      "required": [
+        "kind",
+        "data"
+      ]
+    },
+    "TelemetryEndpointKind": {
+      "type": "string",
+      "description": "The kind of a telemetry endpoint.",
+      "enum": [
+        "OTLP",
+        "ApplicationInsights",
+        "LogAnalytics"
+      ],
+      "x-ms-enum": {
+        "name": "TelemetryEndpointKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "OTLP",
+            "value": "OTLP",
+            "description": "An endpoint that accepts the OpenTelemetry Protocol (OTLP)."
+          },
+          {
+            "name": "ApplicationInsights",
+            "value": "ApplicationInsights",
+            "description": "An Application Insights resource."
+          },
+          {
+            "name": "LogAnalytics",
+            "value": "LogAnalytics",
+            "description": "An Azure Monitor Log Analytics workspace, written through the Logs Ingestion API."
+          }
+        ]
+      }
+    },
+    "TelemetryHeaderAuth": {
+      "type": "object",
+      "description": "Authentication for an OpenTelemetry Protocol telemetry endpoint. The referenced secret value is sent as an HTTP request header.",
+      "properties": {
+        "headerName": {
+          "type": "string",
+          "description": "The name of the HTTP request header to send, for example `Authorization`."
+        },
+        "secretId": {
+          "type": "string",
+          "description": "The name of the sandbox group secret that holds the header value."
+        },
+        "secretKey": {
+          "type": "string",
+          "description": "The key within the sandbox group secret whose value is sent as the header value."
+        }
+      },
+      "required": [
+        "headerName",
+        "secretId",
+        "secretKey"
+      ]
+    },
+    "TelemetryManagedIdentityAuth": {
+      "type": "object",
+      "description": "Authentication that uses a user-assigned managed identity.",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the user-assigned managed identity. The identity must be assigned to the sandbox group.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "identity"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/TelemetryAuth"
+        }
+      ],
+      "x-ms-discriminator-value": "ManagedIdentity"
+    },
+    "TelemetryProtocol": {
+      "type": "string",
+      "description": "The protocol used to send telemetry to an OpenTelemetry Protocol endpoint.",
+      "enum": [
+        "Grpc",
+        "Http"
+      ],
+      "x-ms-enum": {
+        "name": "TelemetryProtocol",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Grpc",
+            "value": "Grpc",
+            "description": "gRPC."
+          },
+          {
+            "name": "Http",
+            "value": "Http",
+            "description": "HTTP."
+          }
+        ]
+      }
+    },
+    "TelemetrySystemAssignedManagedIdentityAuth": {
+      "type": "object",
+      "description": "Authentication that uses the system-assigned managed identity of the sandbox group.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/TelemetryAuth"
+        }
+      ],
+      "x-ms-discriminator-value": "SystemAssignedManagedIdentity"
+    },
+    "ValueLogColumnDef": {
+      "type": "object",
+      "description": "A custom log output column whose value is a literal string.",
+      "properties": {
+        "value": {
+          "type": "string",
+          "description": "The literal value written to every log record."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/LogColumnDef"
+        }
+      ],
+      "x-ms-discriminator-value": "Value"
     },
     "VnetConnection": {
       "type": "object",

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
@@ -644,6 +644,30 @@
       ],
       "x-ms-discriminator-value": "ApplicationInsights"
     },
+    "DynamicJsonColumnsMode": {
+      "type": "string",
+      "description": "Whether JSON log lines are parsed into additional output columns.",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "DynamicJsonColumnsMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Top-level keys of JSON log lines are merged into the output record."
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Log lines are written to the output record without JSON parsing."
+          }
+        ]
+      }
+    },
     "LogAnalyticsTelemetryEndpoint": {
       "type": "object",
       "description": "A telemetry endpoint that sends telemetry to an Azure Monitor Log Analytics workspace through the Logs Ingestion API.",
@@ -1105,9 +1129,8 @@
           ]
         },
         "dynamicJsonColumns": {
-          "type": "boolean",
-          "description": "Whether to parse JSON log lines and merge their top-level keys into the output record. Reserved keys, and keys already produced by an entry in `columns`, are not overwritten. Requires `ContainerStdoutStderr` in `data`.",
-          "default": false
+          "$ref": "#/definitions/DynamicJsonColumnsMode",
+          "description": "Whether to parse JSON log lines and merge their top-level keys into the output record. Reserved keys, and keys already produced by an entry in `columns`, are not overwritten. Requires `ContainerStdoutStderr` in `data`. Defaults to `Disabled` when not specified."
         }
       },
       "discriminator": "kind",

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
@@ -1053,7 +1053,8 @@
       "properties": {
         "endpoints": {
           "type": "array",
-          "description": "The endpoints that sandbox telemetry is sent to.",
+          "description": "The endpoints that sandbox telemetry is sent to. At least one endpoint must be specified.",
+          "minItems": 1,
           "items": {
             "$ref": "#/definitions/TelemetryEndpoint"
           },
@@ -1113,7 +1114,8 @@
         },
         "data": {
           "type": "array",
-          "description": "The categories of telemetry sent to this endpoint. When empty, every category is sent.",
+          "description": "The categories of telemetry sent to this endpoint. At least one category must be specified.",
+          "minItems": 1,
           "items": {
             "$ref": "#/definitions/TelemetryData"
           }

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
@@ -679,21 +679,26 @@
       ],
       "x-ms-discriminator-value": "LogAnalytics"
     },
-    "LogColumnDef": {
+    "LogColumn": {
       "type": "object",
       "description": "A single column in a custom log output schema.",
       "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the output column to produce."
+        },
         "kind": {
-          "$ref": "#/definitions/LogColumnDefKind",
+          "$ref": "#/definitions/LogColumnKind",
           "description": "The kind of the custom log output column."
         }
       },
       "discriminator": "kind",
       "required": [
+        "name",
         "kind"
       ]
     },
-    "LogColumnDefKind": {
+    "LogColumnKind": {
       "type": "string",
       "description": "The kind of a custom log output column.",
       "enum": [
@@ -701,7 +706,7 @@
         "Ref"
       ],
       "x-ms-enum": {
-        "name": "LogColumnDefKind",
+        "name": "LogColumnKind",
         "modelAsString": true,
         "values": [
           {
@@ -788,7 +793,7 @@
       ],
       "x-ms-discriminator-value": "OTLP"
     },
-    "RefLogColumnDef": {
+    "RefLogColumn": {
       "type": "object",
       "description": "A custom log output column whose value is resolved from a sandbox attribute.",
       "properties": {
@@ -802,7 +807,7 @@
       ],
       "allOf": [
         {
-          "$ref": "#/definitions/LogColumnDef"
+          "$ref": "#/definitions/LogColumn"
         }
       ],
       "x-ms-discriminator-value": "Ref"
@@ -970,14 +975,14 @@
           "type": "string",
           "description": "The name of the sandbox group secret that holds the Application Insights connection string."
         },
-        "secretKey": {
+        "secretKeyName": {
           "type": "string",
           "description": "The key within the sandbox group secret whose value is the Application Insights connection string."
         }
       },
       "required": [
         "secretId",
-        "secretKey"
+        "secretKeyName"
       ]
     },
     "TelemetryAuth": {
@@ -1024,7 +1029,7 @@
       "properties": {
         "endpoints": {
           "type": "array",
-          "description": "The endpoints that sandbox telemetry is sent to. At least one endpoint must be specified.",
+          "description": "The endpoints that sandbox telemetry is sent to.",
           "items": {
             "$ref": "#/definitions/TelemetryEndpoint"
           },
@@ -1036,10 +1041,7 @@
           "description": "The interval, in seconds, at which sandbox metrics are collected. Defaults to 15 seconds when not specified.",
           "minimum": 2
         }
-      },
-      "required": [
-        "endpoints"
-      ]
+      }
     },
     "TelemetryData": {
       "type": "string",
@@ -1093,11 +1095,14 @@
           }
         },
         "columns": {
-          "type": "object",
-          "description": "A custom output schema for log records, keyed by the name of the output column to produce. Applies to `ContainerStdoutStderr` telemetry, and additionally to `Metrics` telemetry on an OpenTelemetry Protocol endpoint. When omitted, records are written in their default shape.",
-          "additionalProperties": {
-            "$ref": "#/definitions/LogColumnDef"
-          }
+          "type": "array",
+          "description": "A custom output schema for log records. Applies to `ContainerStdoutStderr` telemetry, and additionally to `Metrics` telemetry on an OpenTelemetry Protocol endpoint. When omitted, records are written in their default shape.",
+          "items": {
+            "$ref": "#/definitions/LogColumn"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
         },
         "dynamicJsonColumns": {
           "type": "boolean",
@@ -1153,7 +1158,7 @@
           "type": "string",
           "description": "The name of the sandbox group secret that holds the header value."
         },
-        "secretKey": {
+        "secretKeyName": {
           "type": "string",
           "description": "The key within the sandbox group secret whose value is sent as the header value."
         }
@@ -1161,7 +1166,7 @@
       "required": [
         "headerName",
         "secretId",
-        "secretKey"
+        "secretKeyName"
       ]
     },
     "TelemetryManagedIdentityAuth": {
@@ -1205,12 +1210,12 @@
           {
             "name": "Grpc",
             "value": "Grpc",
-            "description": "gRPC."
+            "description": "Telemetry is sent over gRPC."
           },
           {
             "name": "Http",
             "value": "Http",
-            "description": "HTTP."
+            "description": "Telemetry is sent over HTTP with a protobuf payload."
           }
         ]
       }
@@ -1225,7 +1230,7 @@
       ],
       "x-ms-discriminator-value": "SystemAssignedManagedIdentity"
     },
-    "ValueLogColumnDef": {
+    "ValueLogColumn": {
       "type": "object",
       "description": "A custom log output column whose value is a literal string.",
       "properties": {
@@ -1239,7 +1244,7 @@
       ],
       "allOf": [
         {
-          "$ref": "#/definitions/LogColumnDef"
+          "$ref": "#/definitions/LogColumn"
         }
       ],
       "x-ms-discriminator-value": "Value"

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/devcompute.json
@@ -629,13 +629,13 @@
       "type": "object",
       "description": "A telemetry endpoint that sends telemetry to an Application Insights resource.",
       "properties": {
-        "auth": {
+        "authentication": {
           "$ref": "#/definitions/TelemetryApplicationInsightsAuth",
           "description": "The authentication used when sending telemetry to the endpoint."
         }
       },
       "required": [
-        "auth"
+        "authentication"
       ],
       "allOf": [
         {
@@ -672,12 +672,12 @@
       "type": "object",
       "description": "A telemetry endpoint that sends telemetry to an Azure Monitor Log Analytics workspace through the Logs Ingestion API.",
       "properties": {
-        "dceEndpoint": {
+        "dataCollectionEndpoint": {
           "type": "string",
           "format": "uri",
           "description": "The URL of the data collection endpoint that receives the telemetry."
         },
-        "dcrImmutableId": {
+        "dataCollectionRuleImmutableId": {
           "type": "string",
           "description": "The immutable ID of the data collection rule that processes the telemetry."
         },
@@ -685,16 +685,16 @@
           "type": "string",
           "description": "The name of the target stream in the data collection rule."
         },
-        "auth": {
+        "authentication": {
           "$ref": "#/definitions/TelemetryAuth",
           "description": "The managed identity used to authenticate to the data collection endpoint."
         }
       },
       "required": [
-        "dceEndpoint",
-        "dcrImmutableId",
+        "dataCollectionEndpoint",
+        "dataCollectionRuleImmutableId",
         "tableName",
-        "auth"
+        "authentication"
       ],
       "allOf": [
         {
@@ -801,7 +801,7 @@
           "$ref": "#/definitions/TelemetryProtocol",
           "description": "The protocol used to send telemetry to the endpoint."
         },
-        "auth": {
+        "authentication": {
           "$ref": "#/definitions/TelemetryHeaderAuth",
           "description": "The authentication used when sending telemetry to the endpoint. When omitted, requests are sent without an authentication header."
         }
@@ -1013,35 +1013,35 @@
       "type": "object",
       "description": "The managed identity used to authenticate to a telemetry endpoint.",
       "properties": {
-        "kind": {
-          "$ref": "#/definitions/TelemetryAuthKind",
-          "description": "The kind of managed identity used to authenticate to the telemetry endpoint."
+        "type": {
+          "$ref": "#/definitions/TelemetryAuthType",
+          "description": "The type of managed identity used to authenticate to the telemetry endpoint."
         }
       },
-      "discriminator": "kind",
+      "discriminator": "type",
       "required": [
-        "kind"
+        "type"
       ]
     },
-    "TelemetryAuthKind": {
+    "TelemetryAuthType": {
       "type": "string",
-      "description": "The kind of managed identity used to authenticate to a telemetry endpoint.",
+      "description": "The type of managed identity used to authenticate to a telemetry endpoint.",
       "enum": [
-        "ManagedIdentity",
-        "SystemAssignedManagedIdentity"
+        "UserAssigned",
+        "SystemAssigned"
       ],
       "x-ms-enum": {
-        "name": "TelemetryAuthKind",
+        "name": "TelemetryAuthType",
         "modelAsString": true,
         "values": [
           {
-            "name": "ManagedIdentity",
-            "value": "ManagedIdentity",
+            "name": "UserAssigned",
+            "value": "UserAssigned",
             "description": "A user-assigned managed identity."
           },
           {
-            "name": "SystemAssignedManagedIdentity",
-            "value": "SystemAssignedManagedIdentity",
+            "name": "SystemAssigned",
+            "value": "SystemAssigned",
             "description": "The system-assigned managed identity of the sandbox group."
           }
         ]
@@ -1194,33 +1194,6 @@
         "secretKeyName"
       ]
     },
-    "TelemetryManagedIdentityAuth": {
-      "type": "object",
-      "description": "Authentication that uses a user-assigned managed identity.",
-      "properties": {
-        "identity": {
-          "type": "string",
-          "format": "arm-id",
-          "description": "The resource ID of the user-assigned managed identity. The identity must be assigned to the sandbox group.",
-          "x-ms-arm-id-details": {
-            "allowedResources": [
-              {
-                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
-              }
-            ]
-          }
-        }
-      },
-      "required": [
-        "identity"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/TelemetryAuth"
-        }
-      ],
-      "x-ms-discriminator-value": "ManagedIdentity"
-    },
     "TelemetryProtocol": {
       "type": "string",
       "description": "The protocol used to send telemetry to an OpenTelemetry Protocol endpoint.",
@@ -1245,7 +1218,7 @@
         ]
       }
     },
-    "TelemetrySystemAssignedManagedIdentityAuth": {
+    "TelemetrySystemAssignedIdentityAuth": {
       "type": "object",
       "description": "Authentication that uses the system-assigned managed identity of the sandbox group.",
       "allOf": [
@@ -1253,7 +1226,34 @@
           "$ref": "#/definitions/TelemetryAuth"
         }
       ],
-      "x-ms-discriminator-value": "SystemAssignedManagedIdentity"
+      "x-ms-discriminator-value": "SystemAssigned"
+    },
+    "TelemetryUserAssignedIdentityAuth": {
+      "type": "object",
+      "description": "Authentication that uses a user-assigned managed identity.",
+      "properties": {
+        "identityResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "The resource ID of the user-assigned managed identity. The identity must be assigned to the sandbox group.",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.ManagedIdentity/userAssignedIdentities"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "identityResourceId"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/TelemetryAuth"
+        }
+      ],
+      "x-ms-discriminator-value": "UserAssigned"
     },
     "ValueLogColumn": {
       "type": "object",

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Update.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Update.json
@@ -14,15 +14,29 @@
           "endpoints": [
             {
               "kind": "LogAnalytics",
-              "dceEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
-              "dcrImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
+              "dataCollectionEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
+              "dataCollectionRuleImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
               "tableName": "Custom-SandboxLogs_CL",
-              "auth": {
-                "kind": "SystemAssignedManagedIdentity"
+              "authentication": {
+                "type": "UserAssigned",
+                "identityResourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleidentity"
               },
               "data": [
                 "ContainerStdoutStderr",
                 "Metrics"
+              ]
+            },
+            {
+              "kind": "OTLP",
+              "endpoint": "https://example-collector.contoso.com/otlp",
+              "protocol": "Grpc",
+              "authentication": {
+                "headerName": "Authorization",
+                "secretId": "telemetry-secrets",
+                "secretKeyName": "collectorToken"
+              },
+              "data": [
+                "ContainerOtel"
               ]
             }
           ],
@@ -48,15 +62,29 @@
             "endpoints": [
               {
                 "kind": "LogAnalytics",
-                "dceEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
-                "dcrImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
+                "dataCollectionEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
+                "dataCollectionRuleImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
                 "tableName": "Custom-SandboxLogs_CL",
-                "auth": {
-                  "kind": "SystemAssignedManagedIdentity"
+                "authentication": {
+                  "type": "UserAssigned",
+                  "identityResourceId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/exampleidentity"
                 },
                 "data": [
                   "ContainerStdoutStderr",
                   "Metrics"
+                ]
+              },
+              {
+                "kind": "OTLP",
+                "endpoint": "https://example-collector.contoso.com/otlp",
+                "protocol": "Grpc",
+                "authentication": {
+                  "headerName": "Authorization",
+                  "secretId": "telemetry-secrets",
+                  "secretKeyName": "collectorToken"
+                },
+                "data": [
+                  "ContainerOtel"
                 ]
               }
             ],

--- a/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Update.json
+++ b/specification/app/resource-manager/Microsoft.App/DevCompute/stable/2026-07-01/examples/SandboxGroups_Update.json
@@ -9,7 +9,25 @@
         "environment": "test"
       },
       "properties": {
-        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv"
+        "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
+        "telemetryConfig": {
+          "endpoints": [
+            {
+              "kind": "LogAnalytics",
+              "dceEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
+              "dcrImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
+              "tableName": "Custom-SandboxLogs_CL",
+              "auth": {
+                "kind": "SystemAssignedManagedIdentity"
+              },
+              "data": [
+                "ContainerStdoutStderr",
+                "Metrics"
+              ]
+            }
+          ],
+          "metricsIntervalSeconds": 30
+        }
       }
     }
   },
@@ -26,6 +44,24 @@
         "properties": {
           "environmentId": "/subscriptions/34adfa4f-cedf-4dc0-ba29-b6d1a69ab345/resourceGroups/examplerg/providers/Microsoft.App/managedEnvironments/exampleenv",
           "defaultDomain": "icycliff-79e92900.eastus.azurecontainerapps.io",
+          "telemetryConfig": {
+            "endpoints": [
+              {
+                "kind": "LogAnalytics",
+                "dceEndpoint": "https://example-dce-a1b2.eastus-1.ingest.monitor.azure.com",
+                "dcrImmutableId": "dcr-8c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f",
+                "tableName": "Custom-SandboxLogs_CL",
+                "auth": {
+                  "kind": "SystemAssignedManagedIdentity"
+                },
+                "data": [
+                  "ContainerStdoutStderr",
+                  "Metrics"
+                ]
+              }
+            ],
+            "metricsIntervalSeconds": 30
+          },
           "provisioningState": "Succeeded"
         }
       }


### PR DESCRIPTION
# ARM (Control Plane) API Specification Update Pull Request

## Purpose of this PR

- [ ] New resource provider.
- [ ] New API version for an existing resource provider.
- [ ] Update existing version for a new feature.
- [ ] Update existing version to fix OpenAPI spec quality issues in S360.
- [ ] Convert existing OpenAPI spec to TypeSpec spec.
- [x] Other, please clarify:
  - This is a minor additive update to the unreleased `2026-07-01` API on its release branch. It adds `telemetryConfig` as a read/write SandboxGroup property, available on both create-or-update (PUT) and update (PATCH) requests, so customers can configure where telemetry for sandboxes in a sandbox group is sent.

## Due diligence checklist

- [x] I confirm this PR is modifying Azure Resource Manager (ARM) related specifications, and not data plane related specifications.
- [x] I have reviewed the [Resource Provider guidelines](https://aka.ms/rpguidelines), including the [ARM resource provider contract](https://aka.ms/azurerpc) and [REST guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md).
- [ ] A [release plan](https://aka.ms/azsdkdocs/release-plans) has been created.

## What this adds

`SandboxGroupProperties.telemetryConfig` is optional and read/write. It is also picked into
`SandboxGroupPatchProperties`, so PUT and PATCH share a single type and description.

`TelemetryConfig` carries `endpoints` (at least one) and an optional `metricsIntervalSeconds`
(minimum 2, defaults to 15 when omitted).

`TelemetryEndpoint` is polymorphic on a `kind` discriminator, with three endpoint kinds:

| `kind` | Destination | Authentication |
|---|---|---|
| `OTLP` | An endpoint that accepts the OpenTelemetry Protocol. | Optional secret reference sent as an HTTP header. |
| `ApplicationInsights` | An Application Insights resource. | Secret reference holding the connection string. |
| `LogAnalytics` | An Azure Monitor Log Analytics workspace, written through the Logs Ingestion API. | User-assigned or system-assigned managed identity. |

Every endpoint declares the telemetry categories it receives (`data`), and optionally a custom log
output schema (`columns`) and `dynamicJsonColumns`.

Supporting types: `TelemetryData`, `TelemetryProtocol`, `TelemetryHeaderAuth`,
`TelemetryApplicationInsightsAuth`, `TelemetryAuth` (`ManagedIdentity` /
`SystemAssignedManagedIdentity`), `LogColumn` (`Value` / `Ref`), `LogColumnRef`, and
`DynamicJsonColumnsMode`.

## Relationship to the Azure Dev Compute data-plane specification

This contract was derived from the ADC data-plane telemetry specification so that customers see one
coherent feature across both planes. The shapes below intentionally differ, because the ARM linter
applies rules that do not run against data-plane specifications, and because ARM has its own
modelling conventions. The service maps between the two representations.

| Area | Data-plane shape | ARM shape in this PR | Reason |
|---|---|---|---|
| `columns` | Map keyed by output column name | Array of objects carrying a `name` property | ARM does not allow open maps outside `tags`, `delegatedResources` and `userAssignedIdentities` (`RPC-Policy-V1-05`, `RPC-Put-V1-23`) |
| Secret key property | `secretKey` | `secretKeyName` | The ARM linter requires any property whose name ends in a sensitive keyword to be annotated `x-ms-secret`, which would make it write-only. This value is a key *name*, not a secret, and must be returned on read, so the property is named to reflect that |
| `dynamicJsonColumns` | Boolean | Extensible enum `Enabled` / `Disabled` | ARM prefers extensible enums over booleans so further modes can be added without a breaking change |
| `endpoints` | Required | Optional, `minItems: 1` | Properties reachable from a PATCH request body must not be required. The minimum item count keeps the "at least one endpoint" requirement enforceable |
| Polymorphism | Discriminated union | `@discriminator("kind")` base model with derived models | Emits `discriminator` + `allOf` + `x-ms-discriminator-value`, which ARM tooling and the SDK generators consume |
| Generated type names | `LogColumnDefValueLogColumnDef`, `TelemetryEndpointOtlpTelemetryEndpoint`, and similar | `ValueLogColumn`, `OtlpTelemetryEndpoint`, and similar | Readable names in the generated SDKs |

## Intentional exclusions

- The `LogAnalyticsLegacy` endpoint kind is deliberately **not** included. Because it was the only
  consumer of the polymorphic telemetry secret reference, the `AppSecret` / `secretRef` variant and
  the `workspaceId` property are likewise absent from this contract.
- `publicNetworkAccess` remains out of scope for this specification work.

## Additional information

- **No suppressions are introduced by this PR.** Every linter finding was resolved by changing the
  contract rather than silencing the rule.
- No secret material is placed in the contract. `secretId` names a sandbox group secret and
  `secretKeyName` names a key within that secret; both are returned in read responses.
- `TelemetryManagedIdentityAuth.identity` is typed as an ARM resource identifier restricted to
  `Microsoft.ManagedIdentity/userAssignedIdentities`.
- `endpoints` and `data` both carry `minItems: 1`, matching the service behaviour, which rejects an
  empty list in either position.
- Descriptions are written for external Azure customers and describe the contract only. The
  sandbox-group-level configuration is described neutrally as the telemetry configuration for
  sandboxes in the group; sandbox-level precedence is not asserted.
- The stable OpenAPI document and the linked `SandboxGroups_Update` example are regenerated from
  TypeSpec. The example demonstrates configuring telemetry through PATCH.
