### PR TITLE
AzureResilienceManagement: add NeedsAttention provisioning state

### DIFF
--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/common/common.tsp
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/models/common/common.tsp
@@ -45,6 +45,10 @@ union ProvisioningState {
 
   @doc("Change accepted for processing")
   Accepted: "Accepted",
+
+  @added(Versions.v2026_08_31_preview)
+  @doc("The resource needs attention from the user.")
+  NeedsAttention: "NeedsAttention",
 }
 
 /**

--- a/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/openapi.json
+++ b/specification/azureresiliencemanagement/resource-manager/Microsoft.AzureResilienceManagement/AzureResilienceManagement/preview/2026-08-31-preview/openapi.json
@@ -8821,7 +8821,8 @@
         "Provisioning",
         "Updating",
         "Deleting",
-        "Accepted"
+        "Accepted",
+        "NeedsAttention"
       ],
       "x-ms-enum": {
         "name": "ProvisioningState",
@@ -8861,6 +8862,11 @@
             "name": "Accepted",
             "value": "Accepted",
             "description": "Change accepted for processing"
+          },
+          {
+            "name": "NeedsAttention",
+            "value": "NeedsAttention",
+            "description": "The resource needs attention from the user."
           }
         ]
       },


### PR DESCRIPTION
## Summary

Adds a new `NeedsAttention` value to the `ProvisioningState` union for the AzureResilienceManagement resource provider, available starting in the **2026-08-31-preview** API version.

## Changes

- **`models/common/common.tsp`** — Added `NeedsAttention: "NeedsAttention"` to the `ProvisioningState` union, gated with `@added(Versions.v2026_08_31_preview)` so it only surfaces in the latest preview version.
- **`preview/2026-08-31-preview/openapi.json`** — Regenerated from TypeSpec; the `ProvisioningState` enum now includes `NeedsAttention` in this version only.

## API version behavior

| Version | `ProvisioningState` values |
| --- | --- |
| 2026-06-01-preview (and earlier) | Succeeded, Failed, Canceled, Provisioning, Updating, Deleting, Accepted |
| **2026-08-31-preview** | …same as above **+ NeedsAttention** |

Since `ProvisioningState` is a shared type, the new state is available to all resources in 2026-08-31-preview (recoveryResource, drillResource, usagePlan, goalTemplate, etc.).

## Validation

- ✅ `tsp compile .` — succeeded
- ✅ `azsdk_run_typespec_validation` — succeeded
- ✅ Verified `NeedsAttention` appears only in `2026-08-31-preview/openapi.json`; earlier versions unchanged

## Notes

- Non-breaking change — a new enum value added only to the newest preview version via `@added`.
- No example files required updates (enum value addition, not a new API version).
