### PR TITLE
[Discovery] Java client-name overrides for update / cancelRun (data-plane)

### DIFF
--- a/specification/discovery/Discovery.Workspace/client.tsp
+++ b/specification/discovery/Discovery.Workspace/client.tsp
@@ -79,6 +79,18 @@ using Azure.ClientGenerator.Core;
 );
 
 // Retired pre-GA PUT ops are create-or-update; name them accurately so the GA PATCH ops can be `update`.
-@@clientName(Microsoft.Discovery.Workspace.Conversations.update, "createOrUpdate", "java");
-@@clientName(Microsoft.Discovery.Workspace.Tasks.update, "createOrUpdate", "java");
-@@clientName(Microsoft.Discovery.Workspace.Tools.cancelRun, "cancelRunSync", "java");
+@@clientName(
+  Microsoft.Discovery.Workspace.Conversations.update,
+  "createOrUpdate",
+  "java"
+);
+@@clientName(
+  Microsoft.Discovery.Workspace.Tasks.update,
+  "createOrUpdate",
+  "java"
+);
+@@clientName(
+  Microsoft.Discovery.Workspace.Tools.cancelRun,
+  "cancelRunSync",
+  "java"
+);

--- a/specification/discovery/Discovery.Workspace/client.tsp
+++ b/specification/discovery/Discovery.Workspace/client.tsp
@@ -60,3 +60,25 @@ using Azure.ClientGenerator.Core;
   "DiscoveryInvestigationsClient",
   "csharp"
 );
+
+// Java operation names
+@@clientName(
+  Microsoft.Discovery.Workspace.Conversations.stableUpdate,
+  "update",
+  "java"
+);
+@@clientName(
+  Microsoft.Discovery.Workspace.Tasks.stableUpdate,
+  "update",
+  "java"
+);
+@@clientName(
+  Microsoft.Discovery.Workspace.Tools.cancelRunLro,
+  "cancelRun",
+  "java"
+);
+
+// Retired pre-GA PUT ops are create-or-update; name them accurately so the GA PATCH ops can be `update`.
+@@clientName(Microsoft.Discovery.Workspace.Conversations.update, "createOrUpdate", "java");
+@@clientName(Microsoft.Discovery.Workspace.Tasks.update, "createOrUpdate", "java");
+@@clientName(Microsoft.Discovery.Workspace.Tools.cancelRun, "cancelRunSync", "java");


### PR DESCRIPTION
Adds Java-scoped `@clientName` overrides in `Discovery.Workspace/client.tsp` so the GA data-plane operations surface the intended Java method names, and disambiguates the retired pre-GA operations to avoid a `duplicate-client-name` conflict.

**Java naming (GA operations):**
- `Conversations.stableUpdate` -> `update`
- `Tasks.stableUpdate` -> `update`
- `Tools.cancelRunLro` -> `cancelRun` (LRO -> `beginCancelRun` in Java)

**Disambiguation (retired `@removed(2026-06-01)` operations):**
- `Conversations.update` / `Tasks.update` (PUT create-or-update) -> `createOrUpdate`
- `Tools.cancelRun` (sync cancel) -> `cancelRunSync`

All overrides are scoped to `"java"`; C#/Python surfaces and the wire (routes, verbs, api-version) are unchanged. Validated by regenerating `azure-ai-discovery` and running the full playback suite (68/68 passing).

Related SDK PR: Azure/azure-sdk-for-java#49932
