### PR TITLE
Update generated SDK PR labels and draft state

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -380,7 +380,7 @@ stages:
         - ${{ if endsWith(parameters.TriggerSource, '-release') }}:
           - task: PowerShell@2
             displayName: Add auto-release label
-            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['SpecRepoCommit'], 'main'), not(endsWith(variables['SdkRepoName'], '-pr')))
+            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SpecRepoCommit'], 'main'), not(endsWith(variables['SdkRepoName'], '-pr')))
             inputs:
               pwsh: true
               workingDirectory: $(SdkRepoDirectory)
@@ -397,7 +397,7 @@ stages:
               $prUrl = "https://github.com/Azure/$(SdkRepoName)/pull/$(Submitted.PullRequest.Number)"
               Write-Host "Pull request created: $prUrl"
               Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
-              $prStatus = if (('$(SpecRepoCommit)' -eq 'main') -and $${{ endsWith(parameters.TriggerSource, '-release') }}) { 'ready for review' } else { 'draft' }
+              $prStatus = if ($$(OpenSdkPullRequestAsDraft)) { 'draft' } else { 'ready for review' }
               Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
             condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
             displayName: "Set pull request URL variable"

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -317,6 +317,10 @@ stages:
             }
             Write-Host "Branch name is set to: $sdkPrBranchName"
             Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"
+
+            $openAsDraft = '$(SpecRepoCommit)' -ne 'main'
+            Write-Host "Open SDK pull request as draft: $openAsDraft"
+            Write-Host "##vso[task.setvariable variable=OpenSdkPullRequestAsDraft]$openAsDraft"
           workingDirectory: $(SdkRepoDirectory)
           displayName: "Create SDK PR branch variable"
 
@@ -370,30 +374,29 @@ stages:
               -AuthToken "$(GH_TOKEN)"
               -PRTitle "$(PrTitle)-generated-from-$(Build.DefinitionName)-$(Build.BuildId)"
               -PRBody "$(GeneratedSDKInformation)  $(ReleasePlanInfo)"
-              -OpenAsDraft $${{ not(endsWith(parameters.TriggerSource, '-release')) }}
+              -OpenAsDraft $$(OpenSdkPullRequestAsDraft)
               -UpdateExistingPullRequest $true
 
-        - ${{ if endsWith(parameters.TriggerSource, '-release') }}:
-          - task: PowerShell@2
-            displayName: Add auto-release label
-            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
-            inputs:
-              pwsh: true
-              workingDirectory: $(SdkRepoDirectory)
-              filePath: $(SdkRepoDirectory)/eng/common/scripts/Add-IssueLabels.ps1
-              arguments: >
-                -RepoOwner "azure"
-                -RepoName "$(SdkRepoName)"
-                -IssueNumber "$(Submitted.PullRequest.Number)"
-                -Labels "auto-release"
-                -AuthToken "$(GH_TOKEN)"
+        - task: PowerShell@2
+          displayName: Add auto-release label
+          condition: and(succeeded(), eq(variables['HasChanges'], 'true'), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['SpecRepoCommit'], 'main'), not(endsWith(variables['SdkRepoName'], '-pr')))
+          inputs:
+            pwsh: true
+            workingDirectory: $(SdkRepoDirectory)
+            filePath: $(SdkRepoDirectory)/eng/common/scripts/Add-IssueLabels.ps1
+            arguments: >
+              -RepoOwner "azure"
+              -RepoName "$(SdkRepoName)"
+              -IssueNumber "$(Submitted.PullRequest.Number)"
+              -Labels "auto-release"
+              -AuthToken "$(GH_TOKEN)"
 
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
           - pwsh: |
               $prUrl = "https://github.com/Azure/$(SdkRepoName)/pull/$(Submitted.PullRequest.Number)"
               Write-Host "Pull request created: $prUrl"
               Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
-              $prStatus = "${{ iif(endsWith(parameters.TriggerSource, '-release'), 'ready for review', 'draft') }}"
+              $prStatus = if ('$(SpecRepoCommit)' -eq 'main') { 'ready for review' } else { 'draft' }
               Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
             condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
             displayName: "Set pull request URL variable"

--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -318,7 +318,7 @@ stages:
             Write-Host "Branch name is set to: $sdkPrBranchName"
             Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"
 
-            $openAsDraft = '$(SpecRepoCommit)' -ne 'main'
+            $openAsDraft = ('$(SpecRepoCommit)' -ne 'main') -or $${{ not(endsWith(parameters.TriggerSource, '-release')) }}
             Write-Host "Open SDK pull request as draft: $openAsDraft"
             Write-Host "##vso[task.setvariable variable=OpenSdkPullRequestAsDraft]$openAsDraft"
           workingDirectory: $(SdkRepoDirectory)
@@ -377,26 +377,27 @@ stages:
               -OpenAsDraft $$(OpenSdkPullRequestAsDraft)
               -UpdateExistingPullRequest $true
 
-        - task: PowerShell@2
-          displayName: Add auto-release label
-          condition: and(succeeded(), eq(variables['HasChanges'], 'true'), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['SpecRepoCommit'], 'main'), not(endsWith(variables['SdkRepoName'], '-pr')))
-          inputs:
-            pwsh: true
-            workingDirectory: $(SdkRepoDirectory)
-            filePath: $(SdkRepoDirectory)/eng/common/scripts/Add-IssueLabels.ps1
-            arguments: >
-              -RepoOwner "azure"
-              -RepoName "$(SdkRepoName)"
-              -IssueNumber "$(Submitted.PullRequest.Number)"
-              -Labels "auto-release"
-              -AuthToken "$(GH_TOKEN)"
+        - ${{ if endsWith(parameters.TriggerSource, '-release') }}:
+          - task: PowerShell@2
+            displayName: Add auto-release label
+            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables['SpecRepoCommit'], 'main'), not(endsWith(variables['SdkRepoName'], '-pr')))
+            inputs:
+              pwsh: true
+              workingDirectory: $(SdkRepoDirectory)
+              filePath: $(SdkRepoDirectory)/eng/common/scripts/Add-IssueLabels.ps1
+              arguments: >
+                -RepoOwner "azure"
+                -RepoName "$(SdkRepoName)"
+                -IssueNumber "$(Submitted.PullRequest.Number)"
+                -Labels "auto-release"
+                -AuthToken "$(GH_TOKEN)"
 
         - ${{ if ne(parameters.ReleasePlanWorkItemId, 0) }}:
           - pwsh: |
               $prUrl = "https://github.com/Azure/$(SdkRepoName)/pull/$(Submitted.PullRequest.Number)"
               Write-Host "Pull request created: $prUrl"
               Write-Host "##vso[task.setvariable variable=PullRequestUrl]$prUrl"
-              $prStatus = if ('$(SpecRepoCommit)' -eq 'main') { 'ready for review' } else { 'draft' }
+              $prStatus = if (('$(SpecRepoCommit)' -eq 'main') -and $${{ endsWith(parameters.TriggerSource, '-release') }}) { 'ready for review' } else { 'draft' }
               Write-Host "##vso[task.setvariable variable=SdkPrStatus]$prStatus"
             condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), not(endsWith(variables['SdkRepoName'], '-pr')))
             displayName: "Set pull request URL variable"


### PR DESCRIPTION
## Summary
- preserve the existing `TriggerSource` `-release` gate for generated SDK PR readiness and labeling
- add the `auto-release` label only for release-triggered non-PR runs when `SpecRepoCommit` is `main`
- create generated SDK pull requests as drafts when the trigger is not a release or `SpecRepoCommit` is not `main`
- reuse the computed draft decision for the release-plan SDK PR status

## Validation
- `git diff --check`
- static checks for the release trigger, build reason, commit, label, and draft conditions
- [test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6727079&view=results)