### PR TITLE
Require all Tier 1 language approvals for package name changes

### DIFF
--- a/.github/protected-labels.yml
+++ b/.github/protected-labels.yml
@@ -64,3 +64,17 @@ package-name-approved-all:
   management-plane:
     - ArthurMa1978
     - m-nash
+
+# Tier 1 languages: all must approve package names for cross-language alignment.
+tier1:
+  data-plane:
+    - dotnet
+    - java
+    - python
+    - typescript
+  management-plane:
+    - dotnet
+    - java
+    - python
+    - typescript
+    - go

--- a/.github/workflows/src/package-name-approval/PACKAGE-NAME-REVIEW-PROCESS.md
+++ b/.github/workflows/src/package-name-approval/PACKAGE-NAME-REVIEW-PROCESS.md
@@ -25,20 +25,30 @@ When a PR modifies any `tspconfig.yaml` file, the analyze-code workflow:
 
 1. Identifies which languages have package name configuration
 2. Runs `tsp compile --emit @azure-tools/typespec-metadata` to extract package names and namespaces
-3. Determines if the service is data-plane or management-plane (from the emitter metadata)
-4. For management-plane PRs, validates package name format against language-specific naming rules (defined in `.github/package-name-format-rules.yml`)
-5. Uploads results for the status workflow
+3. Compares against the base branch to detect only **changed** package names
+4. Determines if the service is data-plane or management-plane (from the emitter metadata)
+5. For management-plane PRs, validates package name format against language-specific naming rules (defined in `.github/package-name-format-rules.yml`)
+6. Uploads results for the status workflow
+
+### Tier 1 Language Requirement
+
+When any package name change is detected (even for a single language), **all Tier 1 language architects** are notified and must approve. This ensures cross-language naming alignment.
+
+- **Data plane Tier 1:** .NET, Java, Python, TypeScript
+- **Management plane Tier 1:** .NET, Java, Python, TypeScript, Go
+
+Languages with configuration in `tspconfig.yaml` show their proposed package name. Languages without configuration show "(not yet configured)" — architects still approve to confirm naming alignment.
 
 ### Status + Approval
 
-The status workflow posts the package name review comment (showing both package name and namespace per language), applies `package-name-<lang>-pending` labels, and validates architect approval labels.
+The status workflow posts the package name review comment (showing both package name and namespace per language), applies `package-name-<lang>-pending` labels for all Tier 1 languages, and validates architect approval labels.
 
 - **Data plane:** Each language architect approves their language by applying `package-name-<lang>-approved`
 - **Management plane:** ArthurMa1978 or m-nash can apply `package-name-approved-all` to approve all languages at once
 
 ### Status Check
 
-A required status check (`Package Name Approval`) blocks merge until all pending package names are approved. The check:
+A required status check (`Package Name Approval`) blocks merge until all Tier 1 pending package names are approved. The check:
 
 - Passes when all `package-name-*-pending` labels have corresponding `package-name-*-approved` labels
 - Fails when any pending package name lacks approval

--- a/.github/workflows/src/package-name-approval/approvers.js
+++ b/.github/workflows/src/package-name-approval/approvers.js
@@ -5,6 +5,7 @@ import yaml from "js-yaml";
  * @typedef {Object} ApproversConfig
  * @property {Record<string, string[]>} [data-plane]
  * @property {{ all?: string[] }} [management-plane]
+ * @property {{ "data-plane"?: string[], "management-plane"?: string[] }} [tier1]
  */
 
 const PROTECTED_LABELS_PATH = ".github/protected-labels.yml";
@@ -83,10 +84,16 @@ export async function loadApproversConfig(path = PROTECTED_LABELS_PATH) {
     dataPlane.global = [...new Set([...(dataPlane.global ?? []), ...globalApprovers])];
   }
 
+  // Parse tier1 configuration
+  const tier1Config = /** @type {{ "data-plane"?: string[], "management-plane"?: string[] }} */ (
+    config["tier1"] ?? {}
+  );
+
   return {
     "data-plane": dataPlane,
     // Intentionally unions all mgmt approvers into one list - any mgmt approver
     // for any language can approve any other language on mgmt plane.
     "management-plane": { all: mgmtAll },
+    tier1: tier1Config,
   };
 }

--- a/.github/workflows/src/package-name-approval/detect-namespaces.js
+++ b/.github/workflows/src/package-name-approval/detect-namespaces.js
@@ -254,6 +254,10 @@ export default async function detectNamespaces({ context, core }) {
   const packageNamesFound = {};
   /** @type {Record<string, string>} */
   const namespacesFound = {};
+  /** @type {Record<string, string>} */
+  const allConfiguredPackageNames = {};
+  /** @type {Record<string, string>} */
+  const allConfiguredNamespaces = {};
   let isMgmt = false;
   let isDataPlane = false;
 
@@ -272,6 +276,12 @@ export default async function detectNamespaces({ context, core }) {
     const prResult = await runMetadataEmitter(tspConfigDir, entrypoint, core);
     if (prResult.isMgmt) isMgmt = true;
     if (prResult.isDataPlane) isDataPlane = true;
+
+    // Track ALL configured package names from PR head (before filtering).
+    // Used by post-results.js to distinguish "configured but unchanged" from
+    // "not configured at all" when showing Tier 1 language approval table.
+    Object.assign(allConfiguredPackageNames, prResult.packageNames);
+    Object.assign(allConfiguredNamespaces, prResult.namespaces);
 
     // Compile base branch version for comparison (uses same emitter mechanism)
     const baseResult = basePath ? await compileBaseVersion(basePath, baseRefDir, core) : null;
@@ -311,6 +321,8 @@ export default async function detectNamespaces({ context, core }) {
   const results = {
     namespacesFound: packageNamesFound,
     namespaces: namespacesFound,
+    allConfiguredPackageNames,
+    allConfiguredNamespaces,
     formatResults,
     isMgmt,
     isDataPlane,

--- a/.github/workflows/src/package-name-approval/post-results.js
+++ b/.github/workflows/src/package-name-approval/post-results.js
@@ -254,7 +254,9 @@ export default async function postResults({ github, context, core }) {
     // name changes were found). A missing artifact from a failed workflow run does NOT mean
     // config was reverted — it could be a compilation or detection failure.
     // The conclusion is available directly from the workflow_run event payload.
-    const workflowConclusion = context.payload.workflow_run?.conclusion;
+    const workflowConclusion = /** @type {{ workflow_run?: { conclusion?: string } }} */ (
+      context.payload
+    ).workflow_run?.conclusion;
     if (workflowConclusion !== "success") {
       core.info(
         `Code workflow run ${run_id} concluded with "${workflowConclusion}", skipping cleanup`,

--- a/.github/workflows/src/package-name-approval/post-results.js
+++ b/.github/workflows/src/package-name-approval/post-results.js
@@ -199,7 +199,7 @@ function buildCommentBody({
     } else if (isConfigured) {
       displayName = `\`${configuredName}\``;
       displayNs = `\`${allConfiguredNamespaces?.[language] ?? "—"}\``;
-      status = "✅ Unchanged";
+      status = "⏳ Pending _(unchanged)_";
     } else {
       displayName = "_(not yet configured)_";
       displayNs = "—";
@@ -336,21 +336,13 @@ export default async function postResults({ github, context, core }) {
     const approvedLabel = `package-name-${language}-approved`;
     if (existingLabels.includes(approvedLabel)) continue;
 
-    // Skip pending for languages that are configured but unchanged (state 2)
-    const isChanged = language in results.namespacesFound;
-    const isConfigured = language in results.allConfiguredPackageNames;
-    if (isConfigured && !isChanged) continue;
-
+    // All Tier 1 languages get pending — even configured-unchanged ones need to
+    // re-confirm alignment when any other language's name changes.
     labelsToAdd.add(`package-name-${language}-pending`);
   }
 
-  // Don't re-add package-name-review-required if everything needing approval is already approved
-  const languagesNeedingApproval = allLanguages.filter((lang) => {
-    const isChanged = lang in results.namespacesFound;
-    const isConfigured = lang in results.allConfiguredPackageNames;
-    return isChanged || !isConfigured;
-  });
-  const allApproved = languagesNeedingApproval.length > 0 && languagesNeedingApproval.every((lang) =>
+  // Don't re-add package-name-review-required if all Tier 1 languages are already approved
+  const allApproved = allLanguages.length > 0 && allLanguages.every((lang) =>
     existingLabels.includes(`package-name-${lang}-approved`),
   );
   if (allApproved) {

--- a/.github/workflows/src/package-name-approval/post-results.js
+++ b/.github/workflows/src/package-name-approval/post-results.js
@@ -256,6 +256,21 @@ export default async function postResults({ github, context, core }) {
   if (!results) {
     core.info("No package name results to process");
 
+    // Only clean up labels if the code workflow completed successfully (meaning no package
+    // name changes were found). A missing artifact from a failed workflow run does NOT mean
+    // config was reverted — it could be a compilation or detection failure.
+    const { data: workflowRun } = await github.rest.actions.getWorkflowRun({
+      owner,
+      repo,
+      run_id,
+    });
+    if (workflowRun.conclusion !== "success") {
+      core.info(
+        `Code workflow run ${run_id} concluded with "${workflowRun.conclusion}", skipping cleanup`,
+      );
+      return;
+    }
+
     // Clean up if package-name labels were previously applied but config was reverted.
     // Without this, removing package name entries from tspconfig leaves stale pending
     // labels and a blocking status check.
@@ -350,8 +365,22 @@ export default async function postResults({ github, context, core }) {
       // No previous entry (!prev) means first detection — treat as new pending (no reset)
     }
 
-    // Only remove global approval labels if any language was actually reset
+    // If any Tier 1 language name changed, reset ALL Tier 1 approvals for cross-language
+    // re-review. This ensures architects re-confirm naming alignment across the board.
     if (resetLanguages.length > 0) {
+      const tier1 = results.isMgmt ? TIER1_MGMT : TIER1_DATA_PLANE;
+      for (const lang of tier1) {
+        if (resetLanguages.includes(lang)) continue; // already reset above
+        const approvedLabel = `package-name-${lang}-approved`;
+        if (existingLabels.includes(approvedLabel)) {
+          core.info(
+            `Resetting ${lang} approval for cross-language re-review (${resetLanguages.join(", ")} changed)`,
+          );
+          await removeLabelIfPresent(github, owner, repo, issue_number, approvedLabel);
+          existingLabels.splice(existingLabels.indexOf(approvedLabel), 1);
+          resetLanguages.push(lang);
+        }
+      }
       for (const label of ["package-name-approved-all", "package-name-approved"]) {
         if (existingLabels.includes(label)) {
           await removeLabelIfPresent(github, owner, repo, issue_number, label);

--- a/.github/workflows/src/package-name-approval/post-results.js
+++ b/.github/workflows/src/package-name-approval/post-results.js
@@ -248,7 +248,50 @@ export default async function postResults({ github, context, core }) {
   const results = await downloadNamespaceResults(github, core, owner, repo, run_id);
 
   if (!results) {
-    core.info("No package name results to process, exiting gracefully");
+    core.info("No package name results to process");
+
+    // Clean up if package-name labels were previously applied but config was reverted.
+    // Without this, removing package name entries from tspconfig leaves stale pending
+    // labels and a blocking status check.
+    const { data: pr } = await github.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: issue_number,
+    });
+    const existingLabels = pr.labels.map(
+      (/** @type {{ name?: string }} */ label) => label.name ?? "",
+    );
+
+    if (existingLabels.includes("package-name-review-required")) {
+      core.info("Cleaning up stale package-name labels (config was reverted)");
+      const packageNameLabels = existingLabels.filter(
+        (l) => l.startsWith("package-name-"),
+      );
+      for (const label of packageNameLabels) {
+        await removeLabelIfPresent(github, owner, repo, issue_number, label);
+      }
+
+      // Update status check to success
+      await github.rest.repos.createCommitStatus({
+        owner,
+        repo,
+        sha: pr.head.sha,
+        state: "success",
+        context: "Package Name Approval",
+        description: "No package name review required (config reverted)",
+      });
+
+      // Update bot comment
+      await commentOrUpdate(
+        github,
+        core,
+        owner,
+        repo,
+        issue_number,
+        "## Package Name Review\n\n✅ No package name changes detected. Previously detected package name configuration was reverted.\n\n<!-- package-name-review-bot -->",
+        "package-name-review-bot",
+      );
+    }
     return;
   }
 

--- a/.github/workflows/src/package-name-approval/post-results.js
+++ b/.github/workflows/src/package-name-approval/post-results.js
@@ -25,6 +25,8 @@ const FormatValidationResultSchema = z.object({
 const NamespaceResultsSchema = z.object({
   namespacesFound: z.record(z.string(), z.string()),
   namespaces: z.record(z.string(), z.string()).optional().default({}),
+  allConfiguredPackageNames: z.record(z.string(), z.string()).optional().default({}),
+  allConfiguredNamespaces: z.record(z.string(), z.string()).optional().default({}),
   formatResults: z.array(FormatValidationResultSchema).optional().default([]),
   isMgmt: z.boolean(),
   isDataPlane: z.boolean(),
@@ -142,6 +144,8 @@ export function parseCommentTable(body) {
  * @param {import("./approvers.js").ApproversConfig} params.approversConfig
  * @param {Record<string, string>} params.namespacesFound
  * @param {Record<string, string>} [params.namespaces] - Language namespaces (distinct from package names).
+ * @param {Record<string, string>} [params.allConfiguredPackageNames] - All package names from PR head (pre-filter), for showing configured-but-unchanged languages.
+ * @param {Record<string, string>} [params.allConfiguredNamespaces] - All namespaces from PR head (pre-filter).
  * @param {z.infer<typeof FormatValidationResultSchema>[]} params.formatResults
  * @param {boolean} params.isMgmt
  * @param {string} params.baseRef
@@ -153,6 +157,8 @@ function buildCommentBody({
   approversConfig,
   namespacesFound,
   namespaces,
+  allConfiguredPackageNames,
+  allConfiguredNamespaces,
   formatResults,
   isMgmt,
   baseRef,
@@ -172,15 +178,36 @@ function buildCommentBody({
   }
 
   for (const language of allLanguages) {
-    const packageName = namespacesFound[language];
-    const isConfigured = packageName !== undefined;
-    const displayName = isConfigured ? `\`${packageName}\`` : "_(not yet configured)_";
-    const ns = isConfigured ? (namespaces?.[language] ?? "—") : "—";
-    const displayNs = isConfigured ? `\`${ns}\`` : "—";
+    const changedName = namespacesFound[language];
+    const configuredName = allConfiguredPackageNames?.[language];
+    const isChanged = changedName !== undefined;
+    const isConfigured = configuredName !== undefined;
+
+    // Three states:
+    // 1. Changed: show new name, pending approval
+    // 2. Configured but unchanged: show existing name, no approval needed
+    // 3. Not configured: show "(not yet configured)", pending approval
+    let displayName;
+    let displayNs;
+    let status;
+
+    if (isChanged) {
+      displayName = `\`${changedName}\``;
+      displayNs = `\`${namespaces?.[language] ?? "—"}\``;
+      const preserved = preservedApprovals?.get(language);
+      status = preserved?.status ?? "⏳ Pending";
+    } else if (isConfigured) {
+      displayName = `\`${configuredName}\``;
+      displayNs = `\`${allConfiguredNamespaces?.[language] ?? "—"}\``;
+      status = "✅ Unchanged";
+    } else {
+      displayName = "_(not yet configured)_";
+      displayNs = "—";
+      status = "⏳ Pending";
+    }
+
     const formatResult = formatMap.get(language);
-    const formatStatus = !isConfigured ? "—" : !formatResult ? "—" : formatResult.valid ? "✅" : "⚠️ Invalid";
-    const preserved = preservedApprovals?.get(language);
-    const status = preserved?.status ?? "⏳ Pending";
+    const formatStatus = !isChanged ? "—" : !formatResult ? "—" : formatResult.valid ? "✅" : "⚠️ Invalid";
     body += `| ${language} | ${displayName} | ${displayNs} | ${formatStatus} | ${status} | ${getApprovers(
       approversConfig,
       isMgmt,
@@ -292,12 +319,10 @@ export default async function postResults({ github, context, core }) {
     return;
   }
 
-  // Require approval from ALL Tier 1 language architects, not just languages with
-  // detected config changes. This prevents names being approved for a subset of
-  // languages without cross-language alignment (e.g., Discovery SDK was approved
-  // for TypeScript only, but .NET architect later flagged the name as problematic).
+  // Use Tier 1 order first for consistent table rendering, then any extra detected languages
   const tier1 = results.isMgmt ? TIER1_MGMT : TIER1_DATA_PLANE;
-  const allLanguages = [...new Set([...tier1, ...languages])];
+  const extraLanguages = languages.filter((l) => !tier1.includes(l));
+  const allLanguages = [...tier1, ...extraLanguages];
 
   const labelsToAdd = new Set(["package-name-review-required"]);
   if (results.isMgmt) {
@@ -309,16 +334,26 @@ export default async function postResults({ github, context, core }) {
   for (const language of allLanguages) {
     // Skip adding pending label if language is already approved
     const approvedLabel = `package-name-${language}-approved`;
-    if (!existingLabels.includes(approvedLabel)) {
-      labelsToAdd.add(`package-name-${language}-pending`);
-    }
+    if (existingLabels.includes(approvedLabel)) continue;
+
+    // Skip pending for languages that are configured but unchanged (state 2)
+    const isChanged = language in results.namespacesFound;
+    const isConfigured = language in results.allConfiguredPackageNames;
+    if (isConfigured && !isChanged) continue;
+
+    labelsToAdd.add(`package-name-${language}-pending`);
   }
 
-  // Don't re-add package-name-review-required if everything is already approved
-  const allApproved = allLanguages.every((lang) =>
+  // Don't re-add package-name-review-required if everything needing approval is already approved
+  const languagesNeedingApproval = allLanguages.filter((lang) => {
+    const isChanged = lang in results.namespacesFound;
+    const isConfigured = lang in results.allConfiguredPackageNames;
+    return isChanged || !isConfigured;
+  });
+  const allApproved = languagesNeedingApproval.length > 0 && languagesNeedingApproval.every((lang) =>
     existingLabels.includes(`package-name-${lang}-approved`),
   );
-  if (allApproved && allLanguages.length > 0) {
+  if (allApproved) {
     labelsToAdd.delete("package-name-review-required");
   }
 
@@ -337,6 +372,8 @@ export default async function postResults({ github, context, core }) {
     approversConfig,
     namespacesFound: results.namespacesFound,
     namespaces: results.namespaces,
+    allConfiguredPackageNames: results.allConfiguredPackageNames,
+    allConfiguredNamespaces: results.allConfiguredNamespaces,
     formatResults: results.formatResults,
     isMgmt: results.isMgmt,
     baseRef: pr.base.ref,

--- a/.github/workflows/src/package-name-approval/post-results.js
+++ b/.github/workflows/src/package-name-approval/post-results.js
@@ -8,12 +8,6 @@ import { extractInputs } from "../context.js";
 import { loadApproversConfig } from "./approvers.js";
 import { removeLabelIfPresent } from "./labels.js";
 
-// All Tier 1 languages must approve package names regardless of which languages
-// have configuration in tspconfig.yaml. This prevents names being approved for a
-// subset of languages without cross-language alignment.
-const TIER1_DATA_PLANE = ["dotnet", "java", "python", "typescript"];
-const TIER1_MGMT = ["dotnet", "java", "python", "typescript", "go"];
-
 const FormatValidationResultSchema = z.object({
   valid: z.boolean(),
   namespace: z.string(),
@@ -259,14 +253,11 @@ export default async function postResults({ github, context, core }) {
     // Only clean up labels if the code workflow completed successfully (meaning no package
     // name changes were found). A missing artifact from a failed workflow run does NOT mean
     // config was reverted — it could be a compilation or detection failure.
-    const { data: workflowRun } = await github.rest.actions.getWorkflowRun({
-      owner,
-      repo,
-      run_id,
-    });
-    if (workflowRun.conclusion !== "success") {
+    // The conclusion is available directly from the workflow_run event payload.
+    const workflowConclusion = context.payload.workflow_run?.conclusion;
+    if (workflowConclusion !== "success") {
       core.info(
-        `Code workflow run ${run_id} concluded with "${workflowRun.conclusion}", skipping cleanup`,
+        `Code workflow run ${run_id} concluded with "${workflowConclusion}", skipping cleanup`,
       );
       return;
     }
@@ -300,16 +291,21 @@ export default async function postResults({ github, context, core }) {
         description: "No package name review required (config reverted)",
       });
 
-      // Update bot comment
-      await commentOrUpdate(
-        github,
-        core,
+      // Delete the bot comment — configuration was reverted, table is no longer relevant
+      const comments = await github.paginate(github.rest.issues.listComments, {
         owner,
         repo,
         issue_number,
-        "## Package Name Review\n\n✅ No package name changes detected. Previously detected package name configuration was reverted.\n\n<!-- package-name-review-bot -->",
-        "package-name-review-bot",
+        per_page: PER_PAGE_MAX,
+      });
+      const botComment = comments.find(
+        (/** @type {{ user?: { type?: string } | null, body?: string }} */ comment) =>
+          comment.user?.type === "Bot" &&
+          (comment.body?.includes("<!-- package-name-review-bot -->") ?? false),
       );
+      if (botComment) {
+        await github.rest.issues.deleteComment({ owner, repo, comment_id: botComment.id });
+      }
     }
     return;
   }
@@ -362,13 +358,22 @@ export default async function postResults({ github, context, core }) {
         core.info(`Package name unchanged for ${language}: "${newNs}", preserving approval`);
         preservedApprovals.set(language, prev);
       }
-      // No previous entry (!prev) means first detection — treat as new pending (no reset)
+      // No previous entry (!prev) means first detection — treat as new pending (no reset).
+      // This covers the "not yet configured" → "configured" transition: parseCommentTable
+      // cannot parse rows without backtick-wrapped names, so prev will be undefined.
+      // By design, adding a NEW language config does not cascade-reset other approvals —
+      // only CHANGING an existing name triggers cross-language re-review.
     }
 
     // If any Tier 1 language name changed, reset ALL Tier 1 approvals for cross-language
     // re-review. This ensures architects re-confirm naming alignment across the board.
+    // Note: resetLanguages.push(lang) below is safe — we iterate `tier1`, not `resetLanguages`.
+    // After this loop, resetLanguages contains both originally-changed AND cascade-reset languages,
+    // which buildCommentBody uses to display the reset warning.
     if (resetLanguages.length > 0) {
-      const tier1 = results.isMgmt ? TIER1_MGMT : TIER1_DATA_PLANE;
+      const tier1 = results.isMgmt
+        ? (approversConfig.tier1?.["management-plane"] ?? [])
+        : (approversConfig.tier1?.["data-plane"] ?? []);
       for (const lang of tier1) {
         if (resetLanguages.includes(lang)) continue; // already reset above
         const approvedLabel = `package-name-${lang}-approved`;
@@ -396,7 +401,9 @@ export default async function postResults({ github, context, core }) {
   }
 
   // Use Tier 1 order first for consistent table rendering, then any extra detected languages
-  const tier1 = results.isMgmt ? TIER1_MGMT : TIER1_DATA_PLANE;
+  const tier1 = results.isMgmt
+    ? (approversConfig.tier1?.["management-plane"] ?? [])
+    : (approversConfig.tier1?.["data-plane"] ?? []);
   const extraLanguages = languages.filter((l) => !tier1.includes(l));
   const allLanguages = [...tier1, ...extraLanguages];
 

--- a/.github/workflows/src/package-name-approval/post-results.js
+++ b/.github/workflows/src/package-name-approval/post-results.js
@@ -8,6 +8,12 @@ import { extractInputs } from "../context.js";
 import { loadApproversConfig } from "./approvers.js";
 import { removeLabelIfPresent } from "./labels.js";
 
+// All Tier 1 languages must approve package names regardless of which languages
+// have configuration in tspconfig.yaml. This prevents names being approved for a
+// subset of languages without cross-language alignment.
+const TIER1_DATA_PLANE = ["dotnet", "java", "python", "typescript"];
+const TIER1_MGMT = ["dotnet", "java", "python", "typescript", "go"];
+
 const FormatValidationResultSchema = z.object({
   valid: z.boolean(),
   namespace: z.string(),
@@ -141,6 +147,7 @@ export function parseCommentTable(body) {
  * @param {string} params.baseRef
  * @param {string[]} [params.resetLanguages] - Languages whose approvals were reset on this push.
  * @param {Map<string, { namespace: string, status: string }>} [params.preservedApprovals] - Approval statuses preserved from the previous comment for unchanged package names.
+ * @param {string[]} params.allLanguages - All Tier 1 languages that require approval.
  */
 function buildCommentBody({
   approversConfig,
@@ -151,6 +158,7 @@ function buildCommentBody({
   baseRef,
   resetLanguages,
   preservedApprovals,
+  allLanguages,
 }) {
   const planeType = isMgmt ? "Management Plane" : "Data Plane";
   let body = `## Package Name Review Required\n\n**Plane:** ${planeType}\n\n`;
@@ -163,13 +171,17 @@ function buildCommentBody({
     formatMap.set(r.language, r);
   }
 
-  for (const [language, packageName] of Object.entries(namespacesFound)) {
-    const ns = namespaces?.[language] ?? "—";
+  for (const language of allLanguages) {
+    const packageName = namespacesFound[language];
+    const isConfigured = packageName !== undefined;
+    const displayName = isConfigured ? `\`${packageName}\`` : "_(not yet configured)_";
+    const ns = isConfigured ? (namespaces?.[language] ?? "—") : "—";
+    const displayNs = isConfigured ? `\`${ns}\`` : "—";
     const formatResult = formatMap.get(language);
-    const formatStatus = !formatResult ? "—" : formatResult.valid ? "✅" : "⚠️ Invalid";
+    const formatStatus = !isConfigured ? "—" : !formatResult ? "—" : formatResult.valid ? "✅" : "⚠️ Invalid";
     const preserved = preservedApprovals?.get(language);
     const status = preserved?.status ?? "⏳ Pending";
-    body += `| ${language} | \`${packageName}\` | \`${ns}\` | ${formatStatus} | ${status} | ${getApprovers(
+    body += `| ${language} | ${displayName} | ${displayNs} | ${formatStatus} | ${status} | ${getApprovers(
       approversConfig,
       isMgmt,
       language,
@@ -280,6 +292,13 @@ export default async function postResults({ github, context, core }) {
     return;
   }
 
+  // Require approval from ALL Tier 1 language architects, not just languages with
+  // detected config changes. This prevents names being approved for a subset of
+  // languages without cross-language alignment (e.g., Discovery SDK was approved
+  // for TypeScript only, but .NET architect later flagged the name as problematic).
+  const tier1 = results.isMgmt ? TIER1_MGMT : TIER1_DATA_PLANE;
+  const allLanguages = [...new Set([...tier1, ...languages])];
+
   const labelsToAdd = new Set(["package-name-review-required"]);
   if (results.isMgmt) {
     labelsToAdd.add("Mgmt");
@@ -287,7 +306,7 @@ export default async function postResults({ github, context, core }) {
   if (results.isDataPlane) {
     labelsToAdd.add("data-plane");
   }
-  for (const language of languages) {
+  for (const language of allLanguages) {
     // Skip adding pending label if language is already approved
     const approvedLabel = `package-name-${language}-approved`;
     if (!existingLabels.includes(approvedLabel)) {
@@ -296,10 +315,10 @@ export default async function postResults({ github, context, core }) {
   }
 
   // Don't re-add package-name-review-required if everything is already approved
-  const allApproved = languages.every((lang) =>
+  const allApproved = allLanguages.every((lang) =>
     existingLabels.includes(`package-name-${lang}-approved`),
   );
-  if (allApproved && languages.length > 0) {
+  if (allApproved && allLanguages.length > 0) {
     labelsToAdd.delete("package-name-review-required");
   }
 
@@ -323,6 +342,7 @@ export default async function postResults({ github, context, core }) {
     baseRef: pr.base.ref,
     resetLanguages,
     preservedApprovals,
+    allLanguages,
   });
 
   await commentOrUpdate(github, core, owner, repo, issue_number, body, "package-name-review-bot");

--- a/.github/workflows/src/package-name-approval/post-results.js
+++ b/.github/workflows/src/package-name-approval/post-results.js
@@ -207,7 +207,13 @@ function buildCommentBody({
     }
 
     const formatResult = formatMap.get(language);
-    const formatStatus = !isChanged ? "—" : !formatResult ? "—" : formatResult.valid ? "✅" : "⚠️ Invalid";
+    const formatStatus = !isChanged
+      ? "—"
+      : !formatResult
+        ? "—"
+        : formatResult.valid
+          ? "✅"
+          : "⚠️ Invalid";
     body += `| ${language} | ${displayName} | ${displayNs} | ${formatStatus} | ${status} | ${getApprovers(
       approversConfig,
       isMgmt,
@@ -264,9 +270,7 @@ export default async function postResults({ github, context, core }) {
 
     if (existingLabels.includes("package-name-review-required")) {
       core.info("Cleaning up stale package-name labels (config was reverted)");
-      const packageNameLabels = existingLabels.filter(
-        (l) => l.startsWith("package-name-"),
-      );
+      const packageNameLabels = existingLabels.filter((l) => l.startsWith("package-name-"));
       for (const label of packageNameLabels) {
         await removeLabelIfPresent(github, owner, repo, issue_number, label);
       }
@@ -385,9 +389,9 @@ export default async function postResults({ github, context, core }) {
   }
 
   // Don't re-add package-name-review-required if all Tier 1 languages are already approved
-  const allApproved = allLanguages.length > 0 && allLanguages.every((lang) =>
-    existingLabels.includes(`package-name-${lang}-approved`),
-  );
+  const allApproved =
+    allLanguages.length > 0 &&
+    allLanguages.every((lang) => existingLabels.includes(`package-name-${lang}-approved`));
   if (allApproved) {
     labelsToAdd.delete("package-name-review-required");
   }

--- a/.github/workflows/src/package-name-approval/validate-approval.js
+++ b/.github/workflows/src/package-name-approval/validate-approval.js
@@ -184,28 +184,37 @@ async function handleLabeled({
   );
 
   if (botComment?.body) {
-    let body = botComment.body;
-    // Update the triggered language(s) first
-    for (const lang of langsToApprove) {
-      const rowRegex = new RegExp(
-        `(\\| ${lang}[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending(?:\\s*_\\(unchanged\\)_)?\\s*(\\|)`,
-        "gi",
-      );
-      body = body.replace(rowRegex, `$1 ✅ Approved by @${actor} $2`);
-    }
+    // Update comment table using structural parsing (split by | to find Status column)
+    // rather than fragile regex that breaks when status text changes.
+    const lines = botComment.body.split("\n");
+    const langsToUpdate = new Set(langsToApprove.map((l) => l.toLowerCase()));
+
     // Also update any other languages that have approved labels but may have been
     // missed due to concurrent workflow runs (race condition between label events).
     const approvedLangs = labels
       .filter((label) => label.startsWith("package-name-") && label.endsWith("-approved"))
       .map((label) => label.replace("package-name-", "").replace("-approved", ""))
       .filter((lang) => lang !== "approved" && lang !== "all");
-    for (const lang of approvedLangs) {
-      const rowRegex = new RegExp(
-        `(\\| ${lang}[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending(?:\\s*_\\(unchanged\\)_)?\\s*(\\|)`,
-        "gi",
-      );
-      body = body.replace(rowRegex, `$1 ✅ Approved $2`);
+    const langsToReconcile = new Set(approvedLangs.map((l) => l.toLowerCase()));
+
+    for (let i = 0; i < lines.length; i++) {
+      const cells = lines[i].split("|");
+      // Table rows have format: "" | Language | Package | Namespace | Format | Status | Approvers | ""
+      if (cells.length < 7) continue;
+      const langCell = cells[1].trim().toLowerCase();
+      const statusCell = cells[5];
+      if (!statusCell || statusCell.includes("Approved")) continue;
+
+      if (langsToUpdate.has(langCell)) {
+        cells[5] = ` ✅ Approved by @${actor} `;
+        lines[i] = cells.join("|");
+      } else if (langsToReconcile.has(langCell)) {
+        cells[5] = ` ✅ Approved `;
+        lines[i] = cells.join("|");
+      }
     }
+
+    const body = lines.join("\n");
     await github.rest.issues.updateComment({
       owner,
       repo,

--- a/.github/workflows/src/package-name-approval/validate-approval.js
+++ b/.github/workflows/src/package-name-approval/validate-approval.js
@@ -188,7 +188,7 @@ async function handleLabeled({
     // Update the triggered language(s) first
     for (const lang of langsToApprove) {
       const rowRegex = new RegExp(
-        `(\\| ${lang}[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending (\\|)`,
+        `(\\| ${lang}[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending(?:\\s*_\\(unchanged\\)_)?\\s*(\\|)`,
         "gi",
       );
       body = body.replace(rowRegex, `$1 ✅ Approved by @${actor} $2`);
@@ -201,7 +201,7 @@ async function handleLabeled({
       .filter((lang) => lang !== "approved" && lang !== "all");
     for (const lang of approvedLangs) {
       const rowRegex = new RegExp(
-        `(\\| ${lang}[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending (\\|)`,
+        `(\\| ${lang}[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending(?:\\s*_\\(unchanged\\)_)?\\s*(\\|)`,
         "gi",
       );
       body = body.replace(rowRegex, `$1 ✅ Approved $2`);

--- a/.github/workflows/test/package-name-approval/post-results.test.js
+++ b/.github/workflows/test/package-name-approval/post-results.test.js
@@ -436,41 +436,50 @@ describe("post-results", () => {
       expect(result.has("python")).toBe(false);
     });
 
-    it("validate-approval regex should match unchanged status rows", () => {
+    it("structural table update should approve unchanged and pending status rows", () => {
       const body = [
         "| dotnet | `Azure.Messaging.EventGrid` | `Azure.Messaging.EventGrid` | — | ⏳ Pending _(unchanged)_ | @approver1 |",
         "| java | `azure-messaging-eventgrid` | `com.azure.messaging.eventgrid` | — | ⏳ Pending | @approver2 |",
       ].join("\n");
 
-      // This is the updated regex from validate-approval.js
-      const dotnetRegex = new RegExp(
-        `(\\| dotnet[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending(?:\\s*_\\(unchanged\\)_)?\\s*(\\|)`,
-        "gi",
-      );
-      const javaRegex = new RegExp(
-        `(\\| java[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending(?:\\s*_\\(unchanged\\)_)?\\s*(\\|)`,
-        "gi",
-      );
+      // Simulate structural table update (same logic as validate-approval.js)
+      const lines = body.split("\n");
+      const langsToUpdate = new Set(["dotnet", "java"]);
+      for (let i = 0; i < lines.length; i++) {
+        const cells = lines[i].split("|");
+        if (cells.length < 7) continue;
+        const langCell = cells[1].trim().toLowerCase();
+        const statusCell = cells[5];
+        if (!statusCell || statusCell.includes("Approved")) continue;
+        if (langsToUpdate.has(langCell)) {
+          cells[5] = " ✅ Approved by @architect ";
+          lines[i] = cells.join("|");
+        }
+      }
+      const result = lines.join("\n");
 
-      const result = body
-        .replace(dotnetRegex, "$1 ✅ Approved by @approver1 $2")
-        .replace(javaRegex, "$1 ✅ Approved by @approver2 $2");
-
-      expect(result).toContain("✅ Approved by @approver1");
-      expect(result).toContain("✅ Approved by @approver2");
+      expect(result).toContain("✅ Approved by @architect");
       expect(result).not.toContain("⏳ Pending");
     });
 
-    it("validate-approval regex should not match already approved rows", () => {
+    it("structural table update should not modify already approved rows", () => {
       const body =
         "| dotnet | `Azure.Foo` | `Azure.Foo` | — | ✅ Approved by @someone | @approver1 |";
 
-      const regex = new RegExp(
-        `(\\| dotnet[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending(?:\\s*_\\(unchanged\\)_)?\\s*(\\|)`,
-        "gi",
-      );
+      const lines = body.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        const cells = lines[i].split("|");
+        if (cells.length < 7) continue;
+        const statusCell = cells[5];
+        if (!statusCell || statusCell.includes("Approved")) continue;
+        cells[5] = " ✅ Approved by @other ";
+        lines[i] = cells.join("|");
+      }
+      const result = lines.join("\n");
 
-      expect(regex.test(body)).toBe(false);
+      // Should remain unchanged — already approved
+      expect(result).toContain("Approved by @someone");
+      expect(result).not.toContain("Approved by @other");
     });
   });
 });

--- a/.github/workflows/test/package-name-approval/post-results.test.js
+++ b/.github/workflows/test/package-name-approval/post-results.test.js
@@ -416,4 +416,61 @@ describe("post-results", () => {
       expect(labelsToAdd.has("package-name-review-required")).toBe(true);
     });
   });
+
+  describe("three-state Tier 1 rendering", () => {
+    it("should parse unchanged status from table rows", () => {
+      const body = [
+        "| Language | Package Name | Namespace | Format | Status | Approvers |",
+        "|----------|--------------|-----------|--------|--------|----------|",
+        "| dotnet | `Azure.Messaging.EventGrid` | `Azure.Messaging.EventGrid` | — | ⏳ Pending _(unchanged)_ | @approver1 |",
+        "| java | `azure-messaging-eventgrid` | `com.azure.messaging.eventgrid` | — | ⏳ Pending | @approver2 |",
+        "| python | _(not yet configured)_ | — | — | ⏳ Pending | @approver3 |",
+      ].join("\n");
+
+      const result = parseCommentTable(body);
+
+      // parseCommentTable only matches rows with backtick-wrapped package names
+      // "not yet configured" rows are not parseable (by design — they have no name to track)
+      expect(result.get("dotnet")?.status).toBe("⏳ Pending _(unchanged)_");
+      expect(result.get("java")?.status).toBe("⏳ Pending");
+      expect(result.has("python")).toBe(false);
+    });
+
+    it("validate-approval regex should match unchanged status rows", () => {
+      const body = [
+        "| dotnet | `Azure.Messaging.EventGrid` | `Azure.Messaging.EventGrid` | — | ⏳ Pending _(unchanged)_ | @approver1 |",
+        "| java | `azure-messaging-eventgrid` | `com.azure.messaging.eventgrid` | — | ⏳ Pending | @approver2 |",
+      ].join("\n");
+
+      // This is the updated regex from validate-approval.js
+      const dotnetRegex = new RegExp(
+        `(\\| dotnet[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending(?:\\s*_\\(unchanged\\)_)?\\s*(\\|)`,
+        "gi",
+      );
+      const javaRegex = new RegExp(
+        `(\\| java[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending(?:\\s*_\\(unchanged\\)_)?\\s*(\\|)`,
+        "gi",
+      );
+
+      const result = body
+        .replace(dotnetRegex, "$1 ✅ Approved by @approver1 $2")
+        .replace(javaRegex, "$1 ✅ Approved by @approver2 $2");
+
+      expect(result).toContain("✅ Approved by @approver1");
+      expect(result).toContain("✅ Approved by @approver2");
+      expect(result).not.toContain("⏳ Pending");
+    });
+
+    it("validate-approval regex should not match already approved rows", () => {
+      const body =
+        "| dotnet | `Azure.Foo` | `Azure.Foo` | — | ✅ Approved by @someone | @approver1 |";
+
+      const regex = new RegExp(
+        `(\\| dotnet[^|]*\\|[^|]+\\|[^|]+\\|[^|]+\\|) ⏳ Pending(?:\\s*_\\(unchanged\\)_)?\\s*(\\|)`,
+        "gi",
+      );
+
+      expect(regex.test(body)).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

When a service team adds package name config for only a subset of languages (e.g., TypeScript only), only that language's architect gets notified and approves. The spec PR merges, and later when other languages try to release, architects discover the name doesn't fit their conventions (see: Discovery SDK / `Azure.AI.Discovery`).

## Solution

When **any** language's package name changes, require **all Tier 1 language architects** to approve:

- **Data plane Tier 1:** dotnet, java, python, typescript
- **Management plane Tier 1:** dotnet, java, python, typescript, go

### Scenario 1: New service, only one language configured

A service team opens a spec PR with only TypeScript in tspconfig:

| Language | Package Name | Status |
|----------|-------------|--------|
| typescript | `@azure/ai-discovery` | ⏳ Pending |
| dotnet | _(not yet configured)_ | ⏳ Pending |
| java | _(not yet configured)_ | ⏳ Pending |
| python | _(not yet configured)_ | ⏳ Pending |

**Before this PR:** Only TypeScript architect got pinged → approved → merged. .NET architect later flagged `Azure.AI.Discovery` as problematic.

**After this PR:** All 4 architects must approve. Naming alignment confirmed before merge.

### Scenario 2: Existing service, new language added

A service already has .NET's `Azure.Foo.Bar` on main (approved in a prior PR). Now they add TypeScript config with `@azure/foo-baz`:

| Language | Package Name | Status |
|----------|-------------|--------|
| dotnet | `Azure.Foo.Bar` | ⏳ Pending _(unchanged)_ |
| typescript | `@azure/foo-baz` | ⏳ Pending |
| java | _(not yet configured)_ | ⏳ Pending |
| python | _(not yet configured)_ | ⏳ Pending |

All Tier 1 must re-approve — the .NET architect's prior approval was without knowledge of the TS name. They need to see both names together and confirm alignment (e.g., why `baz` not `bar`?).

### What changes

1. **`detect-namespaces.js`**: Exports `allConfiguredPackageNames` (full PR head package names, pre-filter) alongside the changed-only results. Used to distinguish "configured but unchanged" from "not configured at all" in the review table.

2. **`post-results.js`**: After detecting changed package names, expands approval requirement to all Tier 1 languages. Applies `package-name-<lang>-pending` for every Tier 1 language. Comment table shows three visual states:
   - **Changed:** new/modified name, `⏳ Pending`
   - **Configured, unchanged:** existing name from main, `⏳ Pending (unchanged)`
   - **Not configured:** no tspconfig entry, `⏳ Pending`, shows _(not yet configured)_

3. **`PACKAGE-NAME-REVIEW-PROCESS.md`**: Documents the Tier 1 requirement and updated detection flow.

### What doesn't change

- `detect-namespaces.js` still only fires when package names actually change (base vs head comparison)
- `status-check.js` still gates on pending labels (naturally blocks until all Tier 1 approve)
- `validate-approval.js` still handles authorized label management
- `package-name-approved-all` shortcut still works for mgmt plane
- Deterministic table order: Tier 1 languages listed first in consistent order

## Context

From team discussion: Discovery SDK had only TypeScript in tspconfig → only JS architect (Jeff) got pinged → approved → merged. Later Michael Nash flagged `Azure.AI.Discovery` as problematic for .NET. We agreed all Tier 1 architects must weigh in on naming regardless of which languages have config.