### PR TITLE
Add CloudHealth 2026-09-01-preview API version

### DIFF
--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/AuthenticationSettings_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/AuthenticationSettings_CreateOrUpdate.json
@@ -1,0 +1,62 @@
+{
+  "title": "AuthenticationSettings_CreateOrUpdate",
+  "operationId": "AuthenticationSettings_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "authenticationSettingName": "default-auth",
+    "resource": {
+      "properties": {
+        "managedIdentityName": "SystemAssigned",
+        "displayName": "Default managed identity",
+        "authenticationKind": "ManagedIdentity"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "Default managed identity",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/authenticationSettings/default-auth",
+        "name": "default-auth",
+        "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "Default managed identity",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/authenticationSettings/default-auth",
+        "name": "default-auth",
+        "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/AuthenticationSettings_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/AuthenticationSettings_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "AuthenticationSettings_Delete",
+  "operationId": "AuthenticationSettings_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "authenticationSettingName": "default-auth"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/AuthenticationSettings_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/AuthenticationSettings_Get.json
@@ -1,0 +1,34 @@
+{
+  "title": "AuthenticationSettings_Get",
+  "operationId": "AuthenticationSettings_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "authenticationSettingName": "default-auth"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "Default managed identity",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/authenticationSettings/default-auth",
+        "name": "default-auth",
+        "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/AuthenticationSettings_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/AuthenticationSettings_ListByHealthModel.json
@@ -1,0 +1,56 @@
+{
+  "title": "AuthenticationSettings_ListByHealthModel",
+  "operationId": "AuthenticationSettings_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "managedIdentityName": "SystemAssigned",
+              "provisioningState": "Succeeded",
+              "displayName": "Default managed identity",
+              "authenticationKind": "ManagedIdentity"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/authenticationSettings/default-auth",
+            "name": "default-auth",
+            "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "managedIdentityName": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/online-store-identity",
+              "provisioningState": "Succeeded",
+              "displayName": "User-assigned managed identity",
+              "authenticationKind": "ManagedIdentity"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/authenticationSettings/user-assigned-auth",
+            "name": "user-assigned-auth",
+            "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/DiscoveryRules_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/DiscoveryRules_CreateOrUpdate.json
@@ -1,0 +1,82 @@
+{
+  "title": "DiscoveryRules_CreateOrUpdate",
+  "operationId": "DiscoveryRules_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "discoveryRuleName": "discover-web-apps",
+    "resource": {
+      "properties": {
+        "authenticationSetting": "default-auth",
+        "displayName": "Discover web apps",
+        "discoverRelationships": "Enabled",
+        "addRecommendedSignals": "Enabled",
+        "specification": {
+          "kind": "ResourceGraphQuery",
+          "resourceGraphQuery": "resources | where type =~ 'microsoft.web/sites' and resourceGroup =~ 'online-store-rg' | project id, name, location"
+        },
+        "addResourceHealthSignal": "Enabled"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "default-auth",
+          "provisioningState": "Succeeded",
+          "displayName": "Discover web apps",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where type =~ 'microsoft.web/sites' and resourceGroup =~ 'online-store-rg' | project id, name, location"
+          },
+          "addResourceHealthSignal": "Enabled",
+          "entityName": "online-store-web-apps"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/discoveryRules/discover-web-apps",
+        "name": "discover-web-apps",
+        "type": "Microsoft.CloudHealth/healthmodels/discoveryRules",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "default-auth",
+          "provisioningState": "Succeeded",
+          "displayName": "Discover web apps",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where type =~ 'microsoft.web/sites' and resourceGroup =~ 'online-store-rg' | project id, name, location"
+          },
+          "addResourceHealthSignal": "Enabled",
+          "entityName": "online-store-web-apps"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/discoveryRules/discover-web-apps",
+        "name": "discover-web-apps",
+        "type": "Microsoft.CloudHealth/healthmodels/discoveryRules",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/DiscoveryRules_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/DiscoveryRules_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "DiscoveryRules_Delete",
+  "operationId": "DiscoveryRules_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "discoveryRuleName": "discover-web-apps"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/DiscoveryRules_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/DiscoveryRules_Get.json
@@ -1,0 +1,48 @@
+{
+  "title": "DiscoveryRules_Get",
+  "operationId": "DiscoveryRules_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "discoveryRuleName": "discover-web-apps"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "default-auth",
+          "provisioningState": "Succeeded",
+          "displayName": "Discover web apps",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where type =~ 'microsoft.web/sites' and resourceGroup =~ 'online-store-rg' | project id, name, location"
+          },
+          "addResourceHealthSignal": "Enabled",
+          "error": {
+            "message": "The discovery query failed because the authentication setting 'default-auth' does not have Reader access to the target scope.",
+            "context": [
+              "scope: /subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg",
+              "authenticationSetting: default-auth"
+            ]
+          },
+          "entityName": "online-store-web-apps"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/discoveryRules/discover-web-apps",
+        "name": "discover-web-apps",
+        "type": "Microsoft.CloudHealth/healthmodels/discoveryRules",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/DiscoveryRules_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/DiscoveryRules_ListByHealthModel.json
@@ -1,0 +1,70 @@
+{
+  "title": "DiscoveryRules_ListByHealthModel",
+  "operationId": "DiscoveryRules_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "authenticationSetting": "default-auth",
+              "provisioningState": "Succeeded",
+              "displayName": "Discover web apps",
+              "discoverRelationships": "Enabled",
+              "addRecommendedSignals": "Enabled",
+              "specification": {
+                "kind": "ResourceGraphQuery",
+                "resourceGraphQuery": "resources | where type =~ 'microsoft.web/sites' and resourceGroup =~ 'online-store-rg' | project id, name, location"
+              },
+              "addResourceHealthSignal": "Enabled",
+              "entityName": "online-store-web-apps"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/discoveryRules/discover-web-apps",
+            "name": "discover-web-apps",
+            "type": "Microsoft.CloudHealth/healthmodels/discoveryRules",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "authenticationSetting": "default-auth",
+              "provisioningState": "Succeeded",
+              "displayName": "Discover Application Insights topology",
+              "discoverRelationships": "Enabled",
+              "addRecommendedSignals": "Enabled",
+              "specification": {
+                "kind": "ApplicationInsightsTopology",
+                "applicationInsightsResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/components/online-store-ai"
+              },
+              "addResourceHealthSignal": "Disabled",
+              "entityName": "online-store-topology"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/discoveryRules/discover-app-topology",
+            "name": "discover-app-topology",
+            "type": "Microsoft.CloudHealth/healthmodels/discoveryRules",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_AddDataAnnotation.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_AddDataAnnotation.json
@@ -1,0 +1,33 @@
+{
+  "title": "Entities_AddDataAnnotation",
+  "operationId": "Entities_AddDataAnnotation",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "web-frontend",
+    "body": {
+      "annotationDetails": {
+        "environment": "production",
+        "deploymentId": "deploy-2026-05-04-001",
+        "changedBy": "release-pipeline"
+      },
+      "description": "Deployed release 2.4.1 to the web frontend."
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "annotationId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "annotationDetails": {
+          "environment": "production",
+          "deploymentId": "deploy-2026-05-04-001",
+          "changedBy": "release-pipeline"
+        },
+        "description": "Deployed release 2.4.1 to the web frontend.",
+        "createdAt": "2026-05-04T14:30:00Z"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_CreateOrUpdate.json
@@ -1,0 +1,672 @@
+{
+  "title": "Entities_CreateOrUpdate",
+  "operationId": "Entities_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "orders-api",
+    "resource": {
+      "properties": {
+        "displayName": "Orders API",
+        "canvasPosition": {
+          "x": 360,
+          "y": 240
+        },
+        "icon": {
+          "iconName": "Kubernetes"
+        },
+        "healthObjective": 99.9,
+        "impact": "Standard",
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        },
+        "signalGroups": {
+          "azureResource": {
+            "authenticationSetting": "default-auth",
+            "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ContainerService/managedClusters/online-store-aks",
+            "azureResourceKind": "managedClusters",
+            "signals": [
+              {
+                "signalKind": "AzureResourceMetric",
+                "name": "node-cpu",
+                "displayName": "Node CPU utilization",
+                "refreshInterval": "PT1M",
+                "dataUnit": "Percent",
+                "metricNamespace": "Microsoft.ContainerService/managedClusters",
+                "metricName": "node_cpu_usage_percentage",
+                "timeGrain": "PT5M",
+                "aggregationType": "Average",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 70
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 90
+                  }
+                }
+              }
+            ],
+            "resourceHealth": {
+              "enabled": "Enabled"
+            }
+          },
+          "azureMonitorWorkspace": {
+            "authenticationSetting": "default-auth",
+            "azureMonitorWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Monitor/accounts/online-store-amw",
+            "signals": [
+              {
+                "signalKind": "PrometheusMetricsQuery",
+                "name": "error-rate",
+                "displayName": "HTTP 5xx error rate",
+                "refreshInterval": "PT1M",
+                "dataUnit": "Percent",
+                "queryText": "sum(rate(http_requests_total{job=\"orders-api\", code=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"orders-api\"}[5m])) * 100",
+                "timeGrain": "PT5M",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 1
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 5
+                  }
+                }
+              },
+              {
+                "signalKind": "PrometheusMetricsQuery",
+                "name": "p95-latency",
+                "displayName": "p95 request latency",
+                "refreshInterval": "PT1M",
+                "dataUnit": "MilliSeconds",
+                "queryText": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"orders-api\"}[5m]))) * 1000",
+                "timeGrain": "PT5M",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 300
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 800
+                  }
+                }
+              },
+              {
+                "signalKind": "PrometheusMetricsQuery",
+                "name": "pod-cpu",
+                "signalDefinitionName": "pod-cpu-usage",
+                "displayName": "Pod CPU utilization",
+                "refreshInterval": "PT1M",
+                "dataUnit": "Percent",
+                "queryText": "sum(rate(container_cpu_usage_seconds_total{namespace=\"online-store\", pod=~\"orders-api-.*\"}[5m])) * 100",
+                "timeGrain": "PT5M",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 70
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 90
+                  }
+                }
+              }
+            ]
+          },
+          "azureLogAnalytics": {
+            "authenticationSetting": "default-auth",
+            "logAnalyticsWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.OperationalInsights/workspaces/online-store-law",
+            "signals": [
+              {
+                "signalKind": "LogAnalyticsQuery",
+                "name": "unhealthy-pods",
+                "displayName": "Unhealthy pods",
+                "refreshInterval": "PT5M",
+                "dataUnit": "Count",
+                "queryText": "KubePodInventory | where TimeGenerated > ago(5m) | where Namespace == 'online-store' | where PodStatus != 'Running' | summarize unhealthyPods = dcount(Name)",
+                "timeGrain": "PT5M",
+                "valueColumnName": "unhealthyPods",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 0
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 2
+                  }
+                }
+              }
+            ]
+          },
+          "dependencies": {
+            "aggregationType": "MinHealthy",
+            "unit": "Percentage",
+            "degradedThreshold": 100,
+            "unhealthyThreshold": 50,
+            "ignoreUnknown": true
+          }
+        },
+        "signalAggregationGroups": [
+          {
+            "name": "latency-and-errors",
+            "displayName": "Latency and errors",
+            "aggregationType": "WorstOf",
+            "members": [
+              "error-rate",
+              "p95-latency"
+            ]
+          },
+          {
+            "name": "compute-utilization",
+            "displayName": "Compute utilization",
+            "aggregationType": "MinHealthy",
+            "members": [
+              "node-cpu",
+              "pod-cpu"
+            ],
+            "unhealthyThreshold": 50,
+            "unit": "Percentage",
+            "ignoreUnknown": true
+          }
+        ],
+        "alerts": {
+          "unhealthy": {
+            "severity": "Sev1",
+            "description": "Orders API is unhealthy.",
+            "actionGroupIds": [
+              "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+            ]
+          },
+          "degraded": {
+            "severity": "Sev3",
+            "description": "Orders API is degraded.",
+            "actionGroupIds": [
+              "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "Orders API",
+          "canvasPosition": {
+            "x": 360,
+            "y": 240
+          },
+          "icon": {
+            "iconName": "Kubernetes"
+          },
+          "healthObjective": 99.9,
+          "impact": "Standard",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "default-auth",
+              "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ContainerService/managedClusters/online-store-aks",
+              "azureResourceKind": "managedClusters",
+              "signals": [
+                {
+                  "signalKind": "AzureResourceMetric",
+                  "name": "node-cpu",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 41.2,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Node CPU utilization",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "metricNamespace": "Microsoft.ContainerService/managedClusters",
+                  "metricName": "node_cpu_usage_percentage",
+                  "timeGrain": "PT5M",
+                  "aggregationType": "Average",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ],
+              "resourceHealth": {
+                "enabled": "Enabled",
+                "signalName": "resourcehealth-availabilitystate",
+                "status": {
+                  "healthState": "Healthy",
+                  "reportedAt": "2026-05-04T09:30:00.000Z",
+                  "availabilityState": "Available",
+                  "summary": "The managed cluster is available."
+                }
+              }
+            },
+            "azureMonitorWorkspace": {
+              "authenticationSetting": "default-auth",
+              "azureMonitorWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Monitor/accounts/online-store-amw",
+              "signals": [
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "error-rate",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 0.4,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "HTTP 5xx error rate",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "sum(rate(http_requests_total{job=\"orders-api\", code=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"orders-api\"}[5m])) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 1
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 5
+                    }
+                  }
+                },
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "p95-latency",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 180,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "p95 request latency",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "MilliSeconds",
+                  "queryText": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"orders-api\"}[5m]))) * 1000",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 300
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 800
+                    }
+                  }
+                },
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "pod-cpu",
+                  "signalDefinitionName": "pod-cpu-usage",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 45.3,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Pod CPU utilization",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "sum(rate(container_cpu_usage_seconds_total{namespace=\"online-store\", pod=~\"orders-api-.*\"}[5m])) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            },
+            "azureLogAnalytics": {
+              "authenticationSetting": "default-auth",
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.OperationalInsights/workspaces/online-store-law",
+              "signals": [
+                {
+                  "signalKind": "LogAnalyticsQuery",
+                  "name": "unhealthy-pods",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 0,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Unhealthy pods",
+                  "refreshInterval": "PT5M",
+                  "dataUnit": "Count",
+                  "queryText": "KubePodInventory | where TimeGenerated > ago(5m) | where Namespace == 'online-store' | where PodStatus != 'Running' | summarize unhealthyPods = dcount(Name)",
+                  "timeGrain": "PT5M",
+                  "valueColumnName": "unhealthyPods",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 0
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 2
+                    }
+                  }
+                }
+              ]
+            },
+            "dependencies": {
+              "aggregationType": "MinHealthy",
+              "unit": "Percentage",
+              "degradedThreshold": 100,
+              "unhealthyThreshold": 50,
+              "ignoreUnknown": true
+            }
+          },
+          "signalAggregationGroups": [
+            {
+              "name": "latency-and-errors",
+              "displayName": "Latency and errors",
+              "aggregationType": "WorstOf",
+              "members": [
+                "error-rate",
+                "p95-latency"
+              ],
+              "aggregatedHealthState": "Healthy"
+            },
+            {
+              "name": "compute-utilization",
+              "displayName": "Compute utilization",
+              "aggregationType": "MinHealthy",
+              "members": [
+                "node-cpu",
+                "pod-cpu"
+              ],
+              "unhealthyThreshold": 50,
+              "unit": "Percentage",
+              "ignoreUnknown": true,
+              "aggregatedHealthState": "Healthy"
+            }
+          ],
+          "alerts": {
+            "unhealthy": {
+              "severity": "Sev1",
+              "description": "Orders API is unhealthy.",
+              "actionGroupIds": [
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+              ]
+            },
+            "degraded": {
+              "severity": "Sev3",
+              "description": "Orders API is degraded.",
+              "actionGroupIds": [
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "healthState": "Healthy"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/orders-api",
+        "name": "orders-api",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "displayName": "Orders API",
+          "canvasPosition": {
+            "x": 360,
+            "y": 240
+          },
+          "icon": {
+            "iconName": "Kubernetes"
+          },
+          "healthObjective": 99.9,
+          "impact": "Standard",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "default-auth",
+              "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ContainerService/managedClusters/online-store-aks",
+              "azureResourceKind": "managedClusters",
+              "signals": [
+                {
+                  "signalKind": "AzureResourceMetric",
+                  "name": "node-cpu",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 41.2,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Node CPU utilization",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "metricNamespace": "Microsoft.ContainerService/managedClusters",
+                  "metricName": "node_cpu_usage_percentage",
+                  "timeGrain": "PT5M",
+                  "aggregationType": "Average",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ],
+              "resourceHealth": {
+                "enabled": "Enabled",
+                "signalName": "resourcehealth-availabilitystate",
+                "status": {
+                  "healthState": "Healthy",
+                  "reportedAt": "2026-05-04T09:30:00.000Z",
+                  "availabilityState": "Available",
+                  "summary": "The managed cluster is available."
+                }
+              }
+            },
+            "azureMonitorWorkspace": {
+              "authenticationSetting": "default-auth",
+              "azureMonitorWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Monitor/accounts/online-store-amw",
+              "signals": [
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "error-rate",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 0.4,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "HTTP 5xx error rate",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "sum(rate(http_requests_total{job=\"orders-api\", code=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"orders-api\"}[5m])) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 1
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 5
+                    }
+                  }
+                },
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "p95-latency",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 180,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "p95 request latency",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "MilliSeconds",
+                  "queryText": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"orders-api\"}[5m]))) * 1000",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 300
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 800
+                    }
+                  }
+                },
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "pod-cpu",
+                  "signalDefinitionName": "pod-cpu-usage",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 45.3,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Pod CPU utilization",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "sum(rate(container_cpu_usage_seconds_total{namespace=\"online-store\", pod=~\"orders-api-.*\"}[5m])) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            },
+            "azureLogAnalytics": {
+              "authenticationSetting": "default-auth",
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.OperationalInsights/workspaces/online-store-law",
+              "signals": [
+                {
+                  "signalKind": "LogAnalyticsQuery",
+                  "name": "unhealthy-pods",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 0,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Unhealthy pods",
+                  "refreshInterval": "PT5M",
+                  "dataUnit": "Count",
+                  "queryText": "KubePodInventory | where TimeGenerated > ago(5m) | where Namespace == 'online-store' | where PodStatus != 'Running' | summarize unhealthyPods = dcount(Name)",
+                  "timeGrain": "PT5M",
+                  "valueColumnName": "unhealthyPods",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 0
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 2
+                    }
+                  }
+                }
+              ]
+            },
+            "dependencies": {
+              "aggregationType": "MinHealthy",
+              "unit": "Percentage",
+              "degradedThreshold": 100,
+              "unhealthyThreshold": 50,
+              "ignoreUnknown": true
+            }
+          },
+          "signalAggregationGroups": [
+            {
+              "name": "latency-and-errors",
+              "displayName": "Latency and errors",
+              "aggregationType": "WorstOf",
+              "members": [
+                "error-rate",
+                "p95-latency"
+              ],
+              "aggregatedHealthState": "Healthy"
+            },
+            {
+              "name": "compute-utilization",
+              "displayName": "Compute utilization",
+              "aggregationType": "MinHealthy",
+              "members": [
+                "node-cpu",
+                "pod-cpu"
+              ],
+              "unhealthyThreshold": 50,
+              "unit": "Percentage",
+              "ignoreUnknown": true,
+              "aggregatedHealthState": "Healthy"
+            }
+          ],
+          "alerts": {
+            "unhealthy": {
+              "severity": "Sev1",
+              "description": "Orders API is unhealthy.",
+              "actionGroupIds": [
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+              ]
+            },
+            "degraded": {
+              "severity": "Sev3",
+              "description": "Orders API is degraded.",
+              "actionGroupIds": [
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "healthState": "Healthy"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/orders-api",
+        "name": "orders-api",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Entities_Delete",
+  "operationId": "Entities_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "catalog-storage"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_Get.json
@@ -1,0 +1,132 @@
+{
+  "title": "Entities_Get",
+  "operationId": "Entities_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "orders-db"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "Orders Database",
+          "canvasPosition": {
+            "x": 480,
+            "y": 360
+          },
+          "icon": {
+            "iconName": "SQLDatabase"
+          },
+          "healthObjective": 99.5,
+          "impact": "Standard",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "default-auth",
+              "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Sql/servers/online-store-sql/databases/orders",
+              "signals": [
+                {
+                  "signalKind": "AzureResourceMetric",
+                  "name": "sql-cpu",
+                  "signalDefinitionName": "sql-cpu-percent",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 38.5,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "CPU utilization",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "metricNamespace": "Microsoft.Sql/servers/databases",
+                  "metricName": "cpu_percent",
+                  "timeGrain": "PT5M",
+                  "aggregationType": "Average",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                },
+                {
+                  "signalKind": "AzureResourceMetric",
+                  "name": "sql-dtu",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 52.1,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "DTU consumption",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "metricNamespace": "Microsoft.Sql/servers/databases",
+                  "metricName": "dtu_consumption_percent",
+                  "timeGrain": "PT5M",
+                  "aggregationType": "Average",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 75
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ],
+              "resourceHealth": {
+                "enabled": "Enabled",
+                "signalName": "resourcehealth-availabilitystate",
+                "status": {
+                  "healthState": "Healthy",
+                  "reportedAt": "2026-05-04T09:30:00.000Z",
+                  "availabilityState": "Available",
+                  "summary": "The database is available."
+                }
+              }
+            },
+            "dependencies": {
+              "aggregationType": "WorstOf"
+            }
+          },
+          "signalAggregationGroups": [
+            {
+              "name": "capacity",
+              "displayName": "Database capacity",
+              "aggregationType": "WorstOf",
+              "members": [
+                "sql-cpu",
+                "sql-dtu"
+              ],
+              "aggregatedHealthState": "Healthy"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "healthState": "Healthy"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/orders-db",
+        "name": "orders-db",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_GetDataAnnotations.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_GetDataAnnotations.json
@@ -1,0 +1,43 @@
+{
+  "title": "Entities_GetDataAnnotations",
+  "operationId": "Entities_GetDataAnnotations",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "web-frontend",
+    "body": {
+      "startAt": "2026-05-03T00:00:00Z",
+      "endAt": "2026-05-04T23:59:59Z"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "entityName": "web-frontend",
+        "annotations": [
+          {
+            "annotationId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "createdAt": "2026-05-04T14:30:00Z",
+            "annotationDetails": {
+              "environment": "production",
+              "deploymentId": "deploy-2026-05-04-001",
+              "changedBy": "release-pipeline"
+            },
+            "description": "Deployed release 2.4.1 to the web frontend."
+          },
+          {
+            "annotationId": "b2c3d4e5-f6a7-8901-bcde-f21234567890",
+            "createdAt": "2026-05-04T03:15:00Z",
+            "annotationDetails": {
+              "changeType": "ScaleOut",
+              "instanceCount": "6"
+            },
+            "description": "Scaled out the web frontend to 6 instances."
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_GetHistory.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_GetHistory.json
@@ -1,0 +1,50 @@
+{
+  "title": "Entities_GetHistory",
+  "operationId": "Entities_GetHistory",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "web-frontend",
+    "body": {
+      "startAt": "2026-05-03T09:30:00Z",
+      "endAt": "2026-05-04T09:30:00Z",
+      "top": 100
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "entityName": "web-frontend",
+        "history": [
+          {
+            "previousState": "Healthy",
+            "newState": "Degraded",
+            "occurredAt": "2026-05-03T14:30:00Z",
+            "reason": "SignalTransition"
+          },
+          {
+            "previousState": "Degraded",
+            "newState": "Unhealthy",
+            "occurredAt": "2026-05-03T18:45:00Z",
+            "reason": "ChildEntityTransition"
+          },
+          {
+            "previousState": "Unhealthy",
+            "newState": "Degraded",
+            "occurredAt": "2026-05-03T22:15:00Z",
+            "reason": "ChildEntityTransition"
+          },
+          {
+            "previousState": "Degraded",
+            "newState": "Healthy",
+            "occurredAt": "2026-05-04T02:30:00Z",
+            "reason": "SignalTransition"
+          }
+        ],
+        "nextMarker": "eyJsYXN0VGltZXN0YW1wIjoiMjAyNi0wNS0wNFQwMjozMDowMFoifQ=="
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_GetSignalHistory.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_GetSignalHistory.json
@@ -1,0 +1,63 @@
+{
+  "title": "Entities_GetSignalHistory",
+  "operationId": "Entities_GetSignalHistory",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "web-frontend",
+    "body": {
+      "signalName": "http-5xx",
+      "startAt": "2026-05-03T09:30:00Z",
+      "endAt": "2026-05-04T09:30:00Z",
+      "top": 7
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "entityName": "web-frontend",
+        "signalName": "http-5xx",
+        "history": [
+          {
+            "occurredAt": "2026-05-03T10:00:00Z",
+            "value": 0,
+            "healthState": "Healthy"
+          },
+          {
+            "occurredAt": "2026-05-03T14:00:00Z",
+            "value": 3,
+            "healthState": "Healthy"
+          },
+          {
+            "occurredAt": "2026-05-03T18:00:00Z",
+            "value": 12,
+            "healthState": "Degraded"
+          },
+          {
+            "occurredAt": "2026-05-03T22:00:00Z",
+            "value": 27,
+            "healthState": "Unhealthy"
+          },
+          {
+            "occurredAt": "2026-05-04T02:00:00Z",
+            "value": 8,
+            "healthState": "Degraded"
+          },
+          {
+            "occurredAt": "2026-05-04T06:00:00Z",
+            "value": 1,
+            "healthState": "Healthy"
+          },
+          {
+            "occurredAt": "2026-05-04T09:00:00Z",
+            "value": 0,
+            "healthState": "Healthy"
+          }
+        ],
+        "nextMarker": "eyJsYXN0VGltZXN0YW1wIjoiMjAyNi0wNS0wNFQwOTowMDowMFoifQ=="
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_GetSignalRecommendations.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_GetSignalRecommendations.json
@@ -1,0 +1,89 @@
+{
+  "title": "Entities_GetSignalRecommendations",
+  "operationId": "Entities_GetSignalRecommendations",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "orders-db"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "recommendedSignals": [
+          {
+            "signalId": "sql-cpu-percent",
+            "metricNamespace": "Microsoft.Sql/servers/databases",
+            "metricName": "cpu_percent",
+            "aggregationType": "Average",
+            "unit": "Percent",
+            "timeGrain": "PT5M",
+            "evaluationRules": {
+              "degradedRule": {
+                "operator": "GreaterThan",
+                "threshold": 70
+              },
+              "unhealthyRule": {
+                "operator": "GreaterThan",
+                "threshold": 90
+              }
+            }
+          },
+          {
+            "signalId": "sql-dtu-consumption",
+            "metricNamespace": "Microsoft.Sql/servers/databases",
+            "metricName": "dtu_consumption_percent",
+            "aggregationType": "Average",
+            "unit": "Percent",
+            "timeGrain": "PT5M",
+            "evaluationRules": {
+              "degradedRule": {
+                "operator": "GreaterThan",
+                "threshold": 75
+              },
+              "unhealthyRule": {
+                "operator": "GreaterThan",
+                "threshold": 90
+              }
+            }
+          }
+        ],
+        "recommendedConfigurations": [
+          {
+            "signalId": "sql-storage-percent",
+            "metricNamespace": "Microsoft.Sql/servers/databases",
+            "metricName": "storage_percent",
+            "aggregationType": "Maximum",
+            "unit": "Percent",
+            "timeGrain": "PT15M",
+            "evaluationRules": {
+              "degradedRule": {
+                "operator": "GreaterThan",
+                "threshold": 80
+              },
+              "unhealthyRule": {
+                "operator": "GreaterThan",
+                "threshold": 95
+              }
+            }
+          },
+          {
+            "signalId": "sql-deadlocks",
+            "metricNamespace": "Microsoft.Sql/servers/databases",
+            "metricName": "deadlock",
+            "aggregationType": "Total",
+            "unit": "Count",
+            "timeGrain": "PT5M",
+            "evaluationRules": {
+              "unhealthyRule": {
+                "operator": "GreaterThan",
+                "threshold": 0
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_IngestHealthReport.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_IngestHealthReport.json
@@ -1,0 +1,31 @@
+{
+  "title": "Entities_IngestHealthReport",
+  "operationId": "Entities_IngestHealthReport",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "orders-api",
+    "body": {
+      "signalName": "error-rate",
+      "healthState": "Unhealthy",
+      "value": 6.5,
+      "evaluationRules": {
+        "degradedRule": {
+          "operator": "GreaterThan",
+          "threshold": 1
+        },
+        "unhealthyRule": {
+          "operator": "GreaterThan",
+          "threshold": 5
+        }
+      },
+      "expiresInMinutes": 60,
+      "additionalContext": "Elevated 5xx error rate during the checkout traffic spike."
+    }
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Entities_ListByHealthModel.json
@@ -1,0 +1,557 @@
+{
+  "title": "Entities_ListByHealthModel",
+  "operationId": "Entities_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "Online Store",
+              "canvasPosition": {
+                "x": 120,
+                "y": 40
+              },
+              "icon": {
+                "iconName": "Globe"
+              },
+              "healthObjective": 99.9,
+              "impact": "Standard",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "signalGroups": {
+                "dependencies": {
+                  "aggregationType": "WorstOf"
+                }
+              },
+              "provisioningState": "Succeeded",
+              "healthState": "Healthy"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/storefront",
+            "name": "storefront",
+            "type": "Microsoft.CloudHealth/healthmodels/entities",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Web Frontend",
+              "canvasPosition": {
+                "x": 240,
+                "y": 120
+              },
+              "icon": {
+                "iconName": "AppService"
+              },
+              "healthObjective": 99.9,
+              "impact": "Standard",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "signalGroups": {
+                "azureResource": {
+                  "authenticationSetting": "default-auth",
+                  "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Web/sites/online-store-web",
+                  "azureResourceKind": "app",
+                  "signals": [
+                    {
+                      "signalKind": "AzureResourceMetric",
+                      "name": "http-5xx",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 0,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "HTTP 5xx errors",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Count",
+                      "metricNamespace": "Microsoft.Web/sites",
+                      "metricName": "Http5xx",
+                      "timeGrain": "PT5M",
+                      "aggregationType": "Total",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 5
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 20
+                        }
+                      }
+                    },
+                    {
+                      "signalKind": "AzureResourceMetric",
+                      "name": "response-time",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 0.42,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "Average response time",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Seconds",
+                      "metricNamespace": "Microsoft.Web/sites",
+                      "metricName": "AverageResponseTime",
+                      "timeGrain": "PT5M",
+                      "aggregationType": "Average",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 1
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 3
+                        }
+                      }
+                    }
+                  ],
+                  "resourceHealth": {
+                    "enabled": "Enabled",
+                    "signalName": "resourcehealth-availabilitystate",
+                    "status": {
+                      "healthState": "Healthy",
+                      "reportedAt": "2026-05-04T09:30:00.000Z",
+                      "availabilityState": "Available",
+                      "summary": "The App Service is available."
+                    }
+                  }
+                },
+                "azureLogAnalytics": {
+                  "authenticationSetting": "default-auth",
+                  "logAnalyticsWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.OperationalInsights/workspaces/online-store-law",
+                  "signals": [
+                    {
+                      "signalKind": "LogAnalyticsQuery",
+                      "name": "failed-request-rate",
+                      "status": {
+                        "healthState": "Degraded",
+                        "value": 2.3,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "Failed request rate",
+                      "refreshInterval": "PT5M",
+                      "dataUnit": "Percent",
+                      "queryText": "requests | where timestamp > ago(5m) | summarize failureRate = 100.0 * countif(success == false) / count()",
+                      "timeGrain": "PT5M",
+                      "valueColumnName": "failureRate",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 1
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 5
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dependencies": {
+                  "aggregationType": "WorstOf"
+                }
+              },
+              "alerts": {
+                "unhealthy": {
+                  "severity": "Sev1",
+                  "description": "Web frontend is unhealthy.",
+                  "actionGroupIds": [
+                    "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+                  ]
+                },
+                "degraded": {
+                  "severity": "Sev3",
+                  "description": "Web frontend is degraded.",
+                  "actionGroupIds": [
+                    "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+                  ]
+                }
+              },
+              "provisioningState": "Succeeded",
+              "healthState": "Degraded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/web-frontend",
+            "name": "web-frontend",
+            "type": "Microsoft.CloudHealth/healthmodels/entities",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Orders API",
+              "canvasPosition": {
+                "x": 360,
+                "y": 240
+              },
+              "icon": {
+                "iconName": "Kubernetes"
+              },
+              "healthObjective": 99.9,
+              "impact": "Standard",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "signalGroups": {
+                "azureResource": {
+                  "authenticationSetting": "default-auth",
+                  "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ContainerService/managedClusters/online-store-aks",
+                  "azureResourceKind": "managedClusters",
+                  "signals": [
+                    {
+                      "signalKind": "AzureResourceMetric",
+                      "name": "node-cpu",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 41.2,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "Node CPU utilization",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "metricNamespace": "Microsoft.ContainerService/managedClusters",
+                      "metricName": "node_cpu_usage_percentage",
+                      "timeGrain": "PT5M",
+                      "aggregationType": "Average",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 70
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    }
+                  ],
+                  "resourceHealth": {
+                    "enabled": "Enabled",
+                    "signalName": "resourcehealth-availabilitystate",
+                    "status": {
+                      "healthState": "Healthy",
+                      "reportedAt": "2026-05-04T09:30:00.000Z",
+                      "availabilityState": "Available",
+                      "summary": "The managed cluster is available."
+                    }
+                  }
+                },
+                "azureMonitorWorkspace": {
+                  "authenticationSetting": "default-auth",
+                  "azureMonitorWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Monitor/accounts/online-store-amw",
+                  "signals": [
+                    {
+                      "signalKind": "PrometheusMetricsQuery",
+                      "name": "error-rate",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 0.4,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "HTTP 5xx error rate",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "queryText": "sum(rate(http_requests_total{job=\"orders-api\", code=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"orders-api\"}[5m])) * 100",
+                      "timeGrain": "PT5M",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 1
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 5
+                        }
+                      }
+                    },
+                    {
+                      "signalKind": "PrometheusMetricsQuery",
+                      "name": "p95-latency",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 180,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "p95 request latency",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "MilliSeconds",
+                      "queryText": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"orders-api\"}[5m]))) * 1000",
+                      "timeGrain": "PT5M",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 300
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 800
+                        }
+                      }
+                    },
+                    {
+                      "signalKind": "PrometheusMetricsQuery",
+                      "name": "pod-cpu",
+                      "signalDefinitionName": "pod-cpu-usage",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 45.3,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "Pod CPU utilization",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "queryText": "sum(rate(container_cpu_usage_seconds_total{namespace=\"online-store\", pod=~\"orders-api-.*\"}[5m])) * 100",
+                      "timeGrain": "PT5M",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 70
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    }
+                  ]
+                },
+                "azureLogAnalytics": {
+                  "authenticationSetting": "default-auth",
+                  "logAnalyticsWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.OperationalInsights/workspaces/online-store-law",
+                  "signals": [
+                    {
+                      "signalKind": "LogAnalyticsQuery",
+                      "name": "unhealthy-pods",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 0,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "Unhealthy pods",
+                      "refreshInterval": "PT5M",
+                      "dataUnit": "Count",
+                      "queryText": "KubePodInventory | where TimeGenerated > ago(5m) | where Namespace == 'online-store' | where PodStatus != 'Running' | summarize unhealthyPods = dcount(Name)",
+                      "timeGrain": "PT5M",
+                      "valueColumnName": "unhealthyPods",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 0
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 2
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dependencies": {
+                  "aggregationType": "MinHealthy",
+                  "unit": "Percentage",
+                  "degradedThreshold": 100,
+                  "unhealthyThreshold": 50,
+                  "ignoreUnknown": true
+                }
+              },
+              "signalAggregationGroups": [
+                {
+                  "name": "latency-and-errors",
+                  "displayName": "Latency and errors",
+                  "aggregationType": "WorstOf",
+                  "members": [
+                    "error-rate",
+                    "p95-latency"
+                  ],
+                  "aggregatedHealthState": "Healthy"
+                },
+                {
+                  "name": "compute-utilization",
+                  "displayName": "Compute utilization",
+                  "aggregationType": "MinHealthy",
+                  "members": [
+                    "node-cpu",
+                    "pod-cpu"
+                  ],
+                  "unhealthyThreshold": 50,
+                  "unit": "Percentage",
+                  "ignoreUnknown": true,
+                  "aggregatedHealthState": "Healthy"
+                }
+              ],
+              "alerts": {
+                "unhealthy": {
+                  "severity": "Sev1",
+                  "description": "Orders API is unhealthy.",
+                  "actionGroupIds": [
+                    "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+                  ]
+                },
+                "degraded": {
+                  "severity": "Sev3",
+                  "description": "Orders API is degraded.",
+                  "actionGroupIds": [
+                    "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+                  ]
+                }
+              },
+              "provisioningState": "Succeeded",
+              "healthState": "Healthy"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/orders-api",
+            "name": "orders-api",
+            "type": "Microsoft.CloudHealth/healthmodels/entities",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Orders Database",
+              "canvasPosition": {
+                "x": 480,
+                "y": 360
+              },
+              "icon": {
+                "iconName": "SQLDatabase"
+              },
+              "healthObjective": 99.5,
+              "impact": "Standard",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "signalGroups": {
+                "azureResource": {
+                  "authenticationSetting": "default-auth",
+                  "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Sql/servers/online-store-sql/databases/orders",
+                  "signals": [
+                    {
+                      "signalKind": "AzureResourceMetric",
+                      "name": "sql-cpu",
+                      "signalDefinitionName": "sql-cpu-percent",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 38.5,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "CPU utilization",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "metricNamespace": "Microsoft.Sql/servers/databases",
+                      "metricName": "cpu_percent",
+                      "timeGrain": "PT5M",
+                      "aggregationType": "Average",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 70
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    },
+                    {
+                      "signalKind": "AzureResourceMetric",
+                      "name": "sql-dtu",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 52.1,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "DTU consumption",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "metricNamespace": "Microsoft.Sql/servers/databases",
+                      "metricName": "dtu_consumption_percent",
+                      "timeGrain": "PT5M",
+                      "aggregationType": "Average",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 75
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    }
+                  ],
+                  "resourceHealth": {
+                    "enabled": "Enabled",
+                    "signalName": "resourcehealth-availabilitystate",
+                    "status": {
+                      "healthState": "Healthy",
+                      "reportedAt": "2026-05-04T09:30:00.000Z",
+                      "availabilityState": "Available",
+                      "summary": "The database is available."
+                    }
+                  }
+                },
+                "dependencies": {
+                  "aggregationType": "WorstOf"
+                }
+              },
+              "signalAggregationGroups": [
+                {
+                  "name": "capacity",
+                  "displayName": "Database capacity",
+                  "aggregationType": "WorstOf",
+                  "members": [
+                    "sql-cpu",
+                    "sql-dtu"
+                  ],
+                  "aggregatedHealthState": "Healthy"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "healthState": "Healthy"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/orders-db",
+            "name": "orders-db",
+            "type": "Microsoft.CloudHealth/healthmodels/entities",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_Create.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_Create.json
@@ -1,0 +1,82 @@
+{
+  "title": "HealthModels_Create",
+  "operationId": "HealthModels_Create",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "resource": {
+      "properties": {},
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "tags": {
+        "environment": "production",
+        "team": "online-store"
+      },
+      "location": "eastus"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "11111111-1111-1111-1111-111111111111",
+          "tenantId": "22222222-2222-2222-2222-222222222222"
+        },
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        },
+        "location": "eastus",
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+        "name": "online-store",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/b3f8c2a1-4d5e-6f70-8192-a3b4c5d6e7f8?api-version=2026-09-01-preview"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "11111111-1111-1111-1111-111111111111",
+          "tenantId": "22222222-2222-2222-2222-222222222222"
+        },
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        },
+        "location": "eastus",
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+        "name": "online-store",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "HealthModels_Delete",
+  "operationId": "HealthModels_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_Get.json
@@ -1,0 +1,40 @@
+{
+  "title": "HealthModels_Get",
+  "operationId": "HealthModels_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "11111111-1111-1111-1111-111111111111",
+          "tenantId": "22222222-2222-2222-2222-222222222222"
+        },
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        },
+        "location": "eastus",
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+        "name": "online-store",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_ListByResourceGroup.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_ListByResourceGroup.json
@@ -1,0 +1,73 @@
+{
+  "title": "HealthModels_ListByResourceGroup",
+  "operationId": "HealthModels_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "11111111-1111-1111-1111-111111111111",
+              "tenantId": "22222222-2222-2222-2222-222222222222"
+            },
+            "tags": {
+              "environment": "production",
+              "team": "online-store"
+            },
+            "location": "eastus",
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+            "name": "online-store",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/online-store-identity": {
+                  "principalId": "33333333-3333-3333-3333-333333333333",
+                  "clientId": "44444444-4444-4444-4444-444444444444"
+                }
+              }
+            },
+            "tags": {
+              "environment": "staging",
+              "team": "online-store"
+            },
+            "location": "eastus",
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store-staging",
+            "name": "online-store-staging",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_ListBySubscription.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_ListBySubscription.json
@@ -1,0 +1,72 @@
+{
+  "title": "HealthModels_ListBySubscription",
+  "operationId": "HealthModels_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "11111111-1111-1111-1111-111111111111",
+              "tenantId": "22222222-2222-2222-2222-222222222222"
+            },
+            "tags": {
+              "environment": "production",
+              "team": "online-store"
+            },
+            "location": "eastus",
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+            "name": "online-store",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/online-store-identity": {
+                  "principalId": "33333333-3333-3333-3333-333333333333",
+                  "clientId": "44444444-4444-4444-4444-444444444444"
+                }
+              }
+            },
+            "tags": {
+              "environment": "staging",
+              "team": "online-store"
+            },
+            "location": "eastus",
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store-staging",
+            "name": "online-store-staging",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_Update.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/HealthModels_Update.json
@@ -1,0 +1,53 @@
+{
+  "title": "HealthModels_Update",
+  "operationId": "HealthModels_Update",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "properties": {
+      "tags": {
+        "environment": "production",
+        "team": "online-store",
+        "tier": "gold"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "11111111-1111-1111-1111-111111111111",
+          "tenantId": "22222222-2222-2222-2222-222222222222"
+        },
+        "tags": {
+          "environment": "production",
+          "team": "online-store",
+          "tier": "gold"
+        },
+        "location": "eastus",
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+        "name": "online-store",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/c4a9d3b2-5e6f-7081-92a3-b4c5d6e7f809?api-version=2026-09-01-preview"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Operations_List.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Operations_List.json
@@ -1,0 +1,59 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-09-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.CloudHealth/healthmodels/read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft CloudHealth",
+              "resource": "Health models",
+              "operation": "Get Health Model",
+              "description": "Gets a health model."
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.CloudHealth/healthmodels/write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft CloudHealth",
+              "resource": "Health models",
+              "operation": "Create or Update Health Model",
+              "description": "Creates or updates a health model."
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.CloudHealth/healthmodels/delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft CloudHealth",
+              "resource": "Health models",
+              "operation": "Delete Health Model",
+              "description": "Deletes a health model."
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.CloudHealth/operations/read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft CloudHealth",
+              "resource": "Operations",
+              "operation": "List Operations",
+              "description": "Lists the available operations."
+            },
+            "origin": "user,system"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Relationships_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Relationships_CreateOrUpdate.json
@@ -1,0 +1,74 @@
+{
+  "title": "Relationships_CreateOrUpdate",
+  "operationId": "Relationships_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "relationshipName": "web-frontend-to-orders-api",
+    "resource": {
+      "properties": {
+        "displayName": "Web Frontend depends on Orders API",
+        "parentEntityName": "web-frontend",
+        "childEntityName": "orders-api",
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "Web Frontend depends on Orders API",
+          "parentEntityName": "web-frontend",
+          "childEntityName": "orders-api",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/web-frontend-to-orders-api",
+        "name": "web-frontend-to-orders-api",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "displayName": "Web Frontend depends on Orders API",
+          "parentEntityName": "web-frontend",
+          "childEntityName": "orders-api",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/web-frontend-to-orders-api",
+        "name": "web-frontend-to-orders-api",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Relationships_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Relationships_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Relationships_Delete",
+  "operationId": "Relationships_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "relationshipName": "orders-api-to-catalog-storage"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Relationships_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Relationships_Get.json
@@ -1,0 +1,38 @@
+{
+  "title": "Relationships_Get",
+  "operationId": "Relationships_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "relationshipName": "web-frontend-to-orders-api"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "Web Frontend depends on Orders API",
+          "parentEntityName": "web-frontend",
+          "childEntityName": "orders-api",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/web-frontend-to-orders-api",
+        "name": "web-frontend-to-orders-api",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Relationships_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/Relationships_ListByHealthModel.json
@@ -1,0 +1,133 @@
+{
+  "title": "Relationships_ListByHealthModel",
+  "operationId": "Relationships_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "Online Store depends on Web Frontend",
+              "parentEntityName": "storefront",
+              "childEntityName": "web-frontend",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/storefront-to-web-frontend",
+            "name": "storefront-to-web-frontend",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Web Frontend depends on Orders API",
+              "parentEntityName": "web-frontend",
+              "childEntityName": "orders-api",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/web-frontend-to-orders-api",
+            "name": "web-frontend-to-orders-api",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Orders API depends on Orders Database",
+              "parentEntityName": "orders-api",
+              "childEntityName": "orders-db",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/orders-api-to-orders-db",
+            "name": "orders-api-to-orders-db",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Orders API depends on Order Queue",
+              "parentEntityName": "orders-api",
+              "childEntityName": "order-queue",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/orders-api-to-order-queue",
+            "name": "orders-api-to-order-queue",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Orders API depends on Catalog Storage",
+              "parentEntityName": "orders-api",
+              "childEntityName": "catalog-storage",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/orders-api-to-catalog-storage",
+            "name": "orders-api-to-catalog-storage",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/SignalDefinitions_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/SignalDefinitions_CreateOrUpdate.json
@@ -1,0 +1,119 @@
+{
+  "title": "SignalDefinitions_CreateOrUpdate",
+  "operationId": "SignalDefinitions_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "signalDefinitionName": "sql-cpu-percent",
+    "resource": {
+      "properties": {
+        "displayName": "SQL CPU utilization",
+        "signalKind": "AzureResourceMetric",
+        "refreshInterval": "PT1M",
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        },
+        "dataUnit": "Percent",
+        "metricNamespace": "Microsoft.Sql/servers/databases",
+        "metricName": "cpu_percent",
+        "timeGrain": "PT5M",
+        "aggregationType": "Average",
+        "evaluationRules": {
+          "degradedRule": {
+            "operator": "GreaterThan",
+            "threshold": 70
+          },
+          "unhealthyRule": {
+            "operator": "Dynamic",
+            "sensitivity": "Medium"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "SQL CPU utilization",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "dataUnit": "Percent",
+          "metricNamespace": "Microsoft.Sql/servers/databases",
+          "metricName": "cpu_percent",
+          "timeGrain": "PT5M",
+          "aggregationType": "Average",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "GreaterThan",
+              "threshold": 70
+            },
+            "unhealthyRule": {
+              "operator": "Dynamic",
+              "sensitivity": "Medium"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/sql-cpu-percent",
+        "name": "sql-cpu-percent",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "displayName": "SQL CPU utilization",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "dataUnit": "Percent",
+          "metricNamespace": "Microsoft.Sql/servers/databases",
+          "metricName": "cpu_percent",
+          "timeGrain": "PT5M",
+          "aggregationType": "Average",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "GreaterThan",
+              "threshold": 70
+            },
+            "unhealthyRule": {
+              "operator": "Dynamic",
+              "sensitivity": "Medium"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/sql-cpu-percent",
+        "name": "sql-cpu-percent",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/SignalDefinitions_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/SignalDefinitions_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "SignalDefinitions_Delete",
+  "operationId": "SignalDefinitions_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "signalDefinitionName": "sql-cpu-percent"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/SignalDefinitions_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/SignalDefinitions_Get.json
@@ -1,0 +1,53 @@
+{
+  "title": "SignalDefinitions_Get",
+  "operationId": "SignalDefinitions_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "signalDefinitionName": "sql-cpu-percent"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "SQL CPU utilization",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "dataUnit": "Percent",
+          "metricNamespace": "Microsoft.Sql/servers/databases",
+          "metricName": "cpu_percent",
+          "timeGrain": "PT5M",
+          "aggregationType": "Average",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "GreaterThan",
+              "threshold": 70
+            },
+            "unhealthyRule": {
+              "operator": "Dynamic",
+              "sensitivity": "Medium"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/sql-cpu-percent",
+        "name": "sql-cpu-percent",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/SignalDefinitions_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/examples/2026-09-01-preview/SignalDefinitions_ListByHealthModel.json
@@ -1,0 +1,129 @@
+{
+  "title": "SignalDefinitions_ListByHealthModel",
+  "operationId": "SignalDefinitions_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "SQL CPU utilization",
+              "signalKind": "AzureResourceMetric",
+              "refreshInterval": "PT1M",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "dataUnit": "Percent",
+              "metricNamespace": "Microsoft.Sql/servers/databases",
+              "metricName": "cpu_percent",
+              "timeGrain": "PT5M",
+              "aggregationType": "Average",
+              "evaluationRules": {
+                "degradedRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 70
+                },
+                "unhealthyRule": {
+                  "operator": "Dynamic",
+                  "sensitivity": "Medium"
+                }
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/sql-cpu-percent",
+            "name": "sql-cpu-percent",
+            "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Failed request rate",
+              "signalKind": "LogAnalyticsQuery",
+              "refreshInterval": "PT5M",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "dataUnit": "Percent",
+              "queryText": "requests | where timestamp > ago(5m) | summarize failureRate = 100.0 * countif(success == false) / count()",
+              "timeGrain": "PT5M",
+              "valueColumnName": "failureRate",
+              "evaluationRules": {
+                "degradedRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 1
+                },
+                "unhealthyRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 5
+                }
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/app-failed-requests",
+            "name": "app-failed-requests",
+            "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Pod CPU utilization",
+              "signalKind": "PrometheusMetricsQuery",
+              "refreshInterval": "PT1M",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "dataUnit": "Percent",
+              "queryText": "sum(rate(container_cpu_usage_seconds_total{namespace=\"online-store\", pod=~\"orders-api-.*\"}[5m])) * 100",
+              "timeGrain": "PT5M",
+              "evaluationRules": {
+                "degradedRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 70
+                },
+                "unhealthyRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 90
+                }
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/pod-cpu-usage",
+            "name": "pod-cpu-usage",
+            "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/main.tsp
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/main.tsp
@@ -28,6 +28,9 @@ enum Versions {
 
   @doc("2026-05-01-preview")
   v2026_05_01_preview: "2026-05-01-preview",
+
+  @doc("2026-09-01-preview")
+  v2026_09_01_preview: "2026-09-01-preview",
 }
 
 alias ProviderName = "Microsoft.CloudHealth";
@@ -109,6 +112,11 @@ scalar signalDefinitionName extends string;
 @pattern(proxyResourceNameRegex)
 @doc("Type for signal name.")
 scalar signalName extends string;
+
+@added(Versions.v2026_09_01_preview)
+@pattern(proxyResourceNameRegex)
+@doc("Name of a signal aggregation group. Must be unique within an entity. Independent of signal names.")
+scalar signalAggregationGroupName extends string;
 
 @doc("A signal definition in a health model")
 @parentResource(HealthModel)
@@ -217,6 +225,7 @@ model ThresholdRuleV2 {
   sensitivity?: DynamicThresholdSensitivity;
 
   @added(Versions.v2026_05_01_preview)
+  @removed(Versions.v2026_09_01_preview)
   @doc("ISO 8601 duration for the historical look-back window used by dynamic threshold computation. Only applicable when operator is Dynamic.")
   lookBackWindow?: LookBackWindow;
 }
@@ -571,6 +580,13 @@ model EntityProperties {
   @doc("Signal groups which are assigned to this entity")
   signalGroups?: SignalGroups;
 
+  @added(Versions.v2026_09_01_preview)
+  @doc("Logical aggregation groups over the signals on this entity. Overlap is allowed: the same signal may appear in more than one group's members. Each group is evaluated independently according to its strategy, and a shared signal can contribute to multiple group states and related per-group telemetry. Group states contribute alongside any ungrouped signals and the dependency-aggregated child health to the entity's overall worst-of composite.")
+  @minItems(1)
+  @maxItems(20)
+  @identifiers(#["name"])
+  signalAggregationGroups?: SignalAggregationGroup[];
+
   @visibility(Lifecycle.Read)
   @doc("Discovered by which discovery rule. If set, the entity cannot be deleted manually.")
   discoveredBy?: discoveryRuleName;
@@ -728,7 +744,8 @@ model DependenciesSignalGroup {
 @doc("Properties for dependent entities, i.e. child entities")
 model DependenciesSignalGroupV2 {
   @doc("Aggregation type for child dependencies.")
-  aggregationType: DependenciesAggregationType = DependenciesAggregationType.WorstOf;
+  @typeChangedFrom(Versions.v2026_09_01_preview, DependenciesAggregationType)
+  aggregationType: AggregationType = AggregationType.WorstOf;
 
   @doc("Degraded threshold for aggregation. For MinHealthy: parent is degraded when healthy count/percentage falls to or below this value. For MaxNotHealthy: parent is degraded when not-healthy count/percentage reaches or exceeds this value. Optional — if not set, there is no degraded state (transitions directly from Healthy to Unhealthy).")
   @minValue(0)
@@ -739,13 +756,57 @@ model DependenciesSignalGroupV2 {
   unhealthyThreshold?: float64;
 
   @doc("Unit type for the aggregation thresholds. Required when aggregationType is MinHealthy or MaxNotHealthy.")
-  unit?: DependenciesAggregationUnit;
+  @typeChangedFrom(Versions.v2026_09_01_preview, DependenciesAggregationUnit)
+  unit?: AggregationUnit;
 
   @doc("If true, children with Unknown health state are excluded from aggregation calculations. Defaults to true.")
   ignoreUnknown?: boolean = true;
 }
 
+@added(Versions.v2026_09_01_preview)
+@doc("A logical group of signals on an entity, evaluated under a configurable aggregation strategy. Groups are independent even when they share members. Each group's aggregated state is one of the inputs to the entity's composite health computation alongside any signals not declared in any group's members[].")
+model SignalAggregationGroup {
+  @doc("Name of the aggregation group. Unique within the entity.")
+  name: signalAggregationGroupName;
+
+  @doc("Display name")
+  @minLength(1)
+  @maxLength(260)
+  displayName?: string;
+
+  @doc("Aggregation strategy applied across the members of this group.")
+  aggregationType?: AggregationType = AggregationType.WorstOf;
+
+  @doc("Names of signals on this entity which are members of the group. Members are matched by name; references to signals that do not currently exist on the entity are accepted (typically for pre-declared external signals) and surfaced via 'unresolvedMembers'. A signal may be listed in multiple groups; no duplicates within this list.")
+  @minItems(1)
+  @maxItems(50)
+  members: signalName[];
+
+  @doc("Degraded threshold for threshold-bearing strategies (MinHealthy, MaxNotHealthy). For MinHealthy: group is degraded when the healthy member count/percentage falls to or below this value. For MaxNotHealthy: group is degraded when the not-healthy member count/percentage reaches or exceeds this value. Optional — if not set, the group transitions directly between Healthy and Unhealthy. MUST NOT be set when aggregationType is WorstOf or BestOf.")
+  @minValue(0)
+  degradedThreshold?: float64;
+
+  @doc("Unhealthy threshold for threshold-bearing strategies. Required when aggregationType is MinHealthy or MaxNotHealthy; MUST NOT be set otherwise.")
+  @minValue(0)
+  unhealthyThreshold?: float64;
+
+  @doc("Unit type for the thresholds. Required when aggregationType is MinHealthy or MaxNotHealthy; MUST NOT be set otherwise.")
+  unit?: AggregationUnit;
+
+  @doc("If true (default), members reporting Unknown are excluded from the aggregation. For MinHealthy and MaxNotHealthy this flag affects the denominator/count and is meaningful. For WorstOf and BestOf the flag has no observable effect: under WorstOf, Unknown=0 is the lowest severity and can never beat any non-Unknown member in a Max() so filtering it changes nothing observable; under BestOf, Unknown is unconditionally excluded by the strategy itself irrespective of the flag. The flag is retained on the contract for vocabulary symmetry across all four strategies.")
+  ignoreUnknown?: boolean = true;
+
+  @visibility(Lifecycle.Read)
+  @doc("Computed aggregated health state of the group as of the last entity evaluation. Unknown if no resolvable members or all members filtered out.")
+  aggregatedHealthState?: HealthState;
+
+  @visibility(Lifecycle.Read)
+  @doc("Members listed in 'members' that do not currently resolve to a signal on this entity at the time of the last entity evaluation. Treated as Unknown during aggregation. Empty/omitted when every member resolves.")
+  unresolvedMembers?: signalName[];
+}
+
 @doc("Aggregation type for child dependencies.")
+@removed(Versions.v2026_09_01_preview)
 union DependenciesAggregationType {
   string,
 
@@ -774,6 +835,44 @@ union DependenciesAggregationUnit {
   Absolute: "Absolute",
 
   @doc("Threshold is a percentage of entities (0-100).")
+  Percentage: "Percentage",
+}
+
+@doc("Aggregation strategy for combining a set of health states into one.")
+@added(Versions.v2026_09_01_preview)
+union AggregationType {
+  string,
+
+  @doc("Worst health state across members is propagated. Default behavior.")
+  WorstOf: "WorstOf",
+
+  @removed(Versions.v2026_01_01_preview)
+  @doc("Based on configurable thresholds.")
+  Thresholds: "Thresholds",
+
+  @added(Versions.v2026_09_01_preview)
+  @doc("Best (least severe) health state across the non-Unknown members is propagated. Unknown members are excluded from the selection; if every member is Unknown the group resolves to Unknown. The 'ignoreUnknown' flag has no observable effect for this strategy and is documented as such.")
+  BestOf: "BestOf",
+
+  @added(Versions.v2026_01_01_preview)
+  @doc("Healthy if the count/percentage of healthy members meets the threshold.")
+  MinHealthy: "MinHealthy",
+
+  @added(Versions.v2026_01_01_preview)
+  @doc("Healthy if the count/percentage of not-healthy members stays below the threshold.")
+  MaxNotHealthy: "MaxNotHealthy",
+}
+
+@added(Versions.v2026_01_01_preview)
+@doc("Unit type for the thresholds used by threshold-bearing aggregation strategies.")
+@renamedFrom(Versions.v2026_09_01_preview, "DependenciesAggregationUnit")
+union AggregationUnit {
+  string,
+
+  @doc("Threshold is an absolute count of members.")
+  Absolute: "Absolute",
+
+  @doc("Threshold is a percentage of members (0-100).")
   Percentage: "Percentage",
 }
 
@@ -1185,8 +1284,9 @@ model DiscoveryRuleProperties {
   numberOfDiscoveredEntities?: int32;
 
   @visibility(Lifecycle.Read)
+  @madeOptional(Versions.v2026_09_01_preview)
   @doc("Name of the entity which represents the discovery rule. Note: It might take a few minutes after creating the discovery rule until the entity is created.")
-  entityName: string;
+  entityName?: string;
 }
 
 @added(Versions.v2026_01_01_preview)

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/cloudhealth.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/cloudhealth.json
@@ -1,0 +1,4864 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Microsoft.CloudHealth",
+    "version": "2026-09-01-preview",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "host": "management.azure.com",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "HealthModels"
+    },
+    {
+      "name": "SignalDefinitions"
+    },
+    {
+      "name": "AuthenticationSettings"
+    },
+    {
+      "name": "Entities"
+    },
+    {
+      "name": "Relationships"
+    },
+    {
+      "name": "DiscoveryRules"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.CloudHealth/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": [
+          "Operations"
+        ],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Operations_List": {
+            "$ref": "./examples/Operations_List.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.CloudHealth/healthmodels": {
+      "get": {
+        "operationId": "HealthModels_ListBySubscription",
+        "tags": [
+          "HealthModels"
+        ],
+        "description": "List HealthModel resources by subscription ID",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HealthModelListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "HealthModels_ListBySubscription": {
+            "$ref": "./examples/HealthModels_ListBySubscription.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels": {
+      "get": {
+        "operationId": "HealthModels_ListByResourceGroup",
+        "tags": [
+          "HealthModels"
+        ],
+        "description": "List HealthModel resources by resource group",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HealthModelListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "HealthModels_ListByResourceGroup": {
+            "$ref": "./examples/HealthModels_ListByResourceGroup.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}": {
+      "get": {
+        "operationId": "HealthModels_Get",
+        "tags": [
+          "HealthModels"
+        ],
+        "description": "Get a HealthModel",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HealthModel"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "HealthModels_Get": {
+            "$ref": "./examples/HealthModels_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "HealthModels_Create",
+        "tags": [
+          "HealthModels"
+        ],
+        "description": "Create a HealthModel",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HealthModel"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'HealthModel' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/HealthModel"
+            }
+          },
+          "201": {
+            "description": "Resource 'HealthModel' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/HealthModel"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "HealthModels_Create": {
+            "$ref": "./examples/HealthModels_Create.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "patch": {
+        "operationId": "HealthModels_Update",
+        "tags": [
+          "HealthModels"
+        ],
+        "description": "Update a HealthModel",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "properties",
+            "in": "body",
+            "description": "The resource properties to be updated.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HealthModelUpdate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/HealthModel"
+            }
+          },
+          "202": {
+            "description": "Resource update request accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "HealthModels_Update": {
+            "$ref": "./examples/HealthModels_Update.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "HealthModels_Delete",
+        "tags": [
+          "HealthModels"
+        ],
+        "description": "Delete a HealthModel",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "HealthModels_Delete": {
+            "$ref": "./examples/HealthModels_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/authenticationsettings": {
+      "get": {
+        "operationId": "AuthenticationSettings_ListByHealthModel",
+        "tags": [
+          "AuthenticationSettings"
+        ],
+        "description": "List AuthenticationSetting resources by HealthModel",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthenticationSettingListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AuthenticationSettings_ListByHealthModel": {
+            "$ref": "./examples/AuthenticationSettings_ListByHealthModel.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/authenticationsettings/{authenticationSettingName}": {
+      "get": {
+        "operationId": "AuthenticationSettings_Get",
+        "tags": [
+          "AuthenticationSettings"
+        ],
+        "description": "Get a AuthenticationSetting",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "authenticationSettingName",
+            "in": "path",
+            "description": "Name of the authentication setting. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/AuthenticationSetting"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AuthenticationSettings_Get": {
+            "$ref": "./examples/AuthenticationSettings_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "AuthenticationSettings_CreateOrUpdate",
+        "tags": [
+          "AuthenticationSettings"
+        ],
+        "description": "Create a AuthenticationSetting",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "authenticationSettingName",
+            "in": "path",
+            "description": "Name of the authentication setting. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AuthenticationSetting"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'AuthenticationSetting' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AuthenticationSetting"
+            }
+          },
+          "201": {
+            "description": "Resource 'AuthenticationSetting' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/AuthenticationSetting"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AuthenticationSettings_CreateOrUpdate": {
+            "$ref": "./examples/AuthenticationSettings_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "AuthenticationSettings_Delete",
+        "tags": [
+          "AuthenticationSettings"
+        ],
+        "description": "Delete a AuthenticationSetting",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "authenticationSettingName",
+            "in": "path",
+            "description": "Name of the authentication setting. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "AuthenticationSettings_Delete": {
+            "$ref": "./examples/AuthenticationSettings_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/discoveryrules": {
+      "get": {
+        "operationId": "DiscoveryRules_ListByHealthModel",
+        "tags": [
+          "DiscoveryRules"
+        ],
+        "description": "List DiscoveryRule resources by HealthModel",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "timestamp",
+            "in": "query",
+            "description": "Timestamp to use for the operation. When specified, the version of the resource at this point in time is retrieved. If not specified, the latest version is used.",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DiscoveryRuleListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DiscoveryRules_ListByHealthModel": {
+            "$ref": "./examples/DiscoveryRules_ListByHealthModel.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/discoveryrules/{discoveryRuleName}": {
+      "get": {
+        "operationId": "DiscoveryRules_Get",
+        "tags": [
+          "DiscoveryRules"
+        ],
+        "description": "Get a DiscoveryRule",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "discoveryRuleName",
+            "in": "path",
+            "description": "Name of the discovery rule. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DiscoveryRule"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DiscoveryRules_Get": {
+            "$ref": "./examples/DiscoveryRules_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "DiscoveryRules_CreateOrUpdate",
+        "tags": [
+          "DiscoveryRules"
+        ],
+        "description": "Create a DiscoveryRule",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "discoveryRuleName",
+            "in": "path",
+            "description": "Name of the discovery rule. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DiscoveryRule"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'DiscoveryRule' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DiscoveryRule"
+            }
+          },
+          "201": {
+            "description": "Resource 'DiscoveryRule' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/DiscoveryRule"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DiscoveryRules_CreateOrUpdate": {
+            "$ref": "./examples/DiscoveryRules_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "DiscoveryRules_Delete",
+        "tags": [
+          "DiscoveryRules"
+        ],
+        "description": "Delete a DiscoveryRule",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "discoveryRuleName",
+            "in": "path",
+            "description": "Name of the discovery rule. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "DiscoveryRules_Delete": {
+            "$ref": "./examples/DiscoveryRules_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/entities": {
+      "get": {
+        "operationId": "Entities_ListByHealthModel",
+        "tags": [
+          "Entities"
+        ],
+        "description": "List Entity resources by HealthModel",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "timestamp",
+            "in": "query",
+            "description": "Timestamp to use for the operation. When specified, the version of the resource at this point in time is retrieved. If not specified, the latest version is used.",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EntityListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Entities_ListByHealthModel": {
+            "$ref": "./examples/Entities_ListByHealthModel.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/entities/{entityName}": {
+      "get": {
+        "operationId": "Entities_Get",
+        "tags": [
+          "Entities"
+        ],
+        "description": "Get a Entity",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Name of the entity. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Entity"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Entities_Get": {
+            "$ref": "./examples/Entities_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Entities_CreateOrUpdate",
+        "tags": [
+          "Entities"
+        ],
+        "description": "Create a Entity",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Name of the entity. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Entity"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Entity' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Entity"
+            }
+          },
+          "201": {
+            "description": "Resource 'Entity' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Entity"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Entities_CreateOrUpdate": {
+            "$ref": "./examples/Entities_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Entities_Delete",
+        "tags": [
+          "Entities"
+        ],
+        "description": "Delete a Entity",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Name of the entity. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Entities_Delete": {
+            "$ref": "./examples/Entities_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/entities/{entityName}/addDataAnnotation": {
+      "post": {
+        "operationId": "Entities_AddDataAnnotation",
+        "tags": [
+          "Entities"
+        ],
+        "description": "Add a data annotation to an entity",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Name of the entity. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AddDataAnnotationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/DataAnnotation"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Entities_AddDataAnnotation": {
+            "$ref": "./examples/Entities_AddDataAnnotation.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/entities/{entityName}/getDataAnnotations": {
+      "post": {
+        "operationId": "Entities_GetDataAnnotations",
+        "tags": [
+          "Entities"
+        ],
+        "description": "Retrieve data annotations for an entity",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Name of the entity. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/GetDataAnnotationsRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GetDataAnnotationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Entities_GetDataAnnotations": {
+            "$ref": "./examples/Entities_GetDataAnnotations.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/entities/{entityName}/getHistory": {
+      "post": {
+        "operationId": "Entities_GetHistory",
+        "tags": [
+          "Entities"
+        ],
+        "description": "Retrieve the health state transition history for an entity",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Name of the entity. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/EntityHistoryRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/EntityHistoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Entities_GetHistory": {
+            "$ref": "./examples/Entities_GetHistory.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/entities/{entityName}/getSignalHistory": {
+      "post": {
+        "operationId": "Entities_GetSignalHistory",
+        "tags": [
+          "Entities"
+        ],
+        "description": "Retrieve the time series history for a signal on an entity",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Name of the entity. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SignalHistoryRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SignalHistoryResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Entities_GetSignalHistory": {
+            "$ref": "./examples/Entities_GetSignalHistory.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/entities/{entityName}/getSignalRecommendations": {
+      "post": {
+        "operationId": "Entities_GetSignalRecommendations",
+        "tags": [
+          "Entities"
+        ],
+        "description": "Get recommended signal configurations for a given Entity (only applicable for Entities representing Azure resources)",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Name of the entity. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/GetSignalRecommendationsResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Entities_GetSignalRecommendations": {
+            "$ref": "./examples/Entities_GetSignalRecommendations.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/entities/{entityName}/ingestHealthReport": {
+      "post": {
+        "operationId": "Entities_IngestHealthReport",
+        "tags": [
+          "Entities"
+        ],
+        "description": "Ingest a health report for a specific signal on an entity (the entity must already exist)",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Name of the entity. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "description": "The content of the action request",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/HealthReportRequest"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Action completed successfully."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Entities_IngestHealthReport": {
+            "$ref": "./examples/Entities_IngestHealthReport.json"
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/relationships": {
+      "get": {
+        "operationId": "Relationships_ListByHealthModel",
+        "tags": [
+          "Relationships"
+        ],
+        "description": "List Relationship resources by HealthModel",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "timestamp",
+            "in": "query",
+            "description": "Timestamp to use for the operation. When specified, the version of the resource at this point in time is retrieved. If not specified, the latest version is used.",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/RelationshipListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Relationships_ListByHealthModel": {
+            "$ref": "./examples/Relationships_ListByHealthModel.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/relationships/{relationshipName}": {
+      "get": {
+        "operationId": "Relationships_Get",
+        "tags": [
+          "Relationships"
+        ],
+        "description": "Get a Relationship",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "relationshipName",
+            "in": "path",
+            "description": "Name of the relationship. Must be unique within a health model. For example, a concatenation of parentEntityName and childEntityName can be used as the name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Relationship"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Relationships_Get": {
+            "$ref": "./examples/Relationships_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "Relationships_CreateOrUpdate",
+        "tags": [
+          "Relationships"
+        ],
+        "description": "Create a Relationship",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "relationshipName",
+            "in": "path",
+            "description": "Name of the relationship. Must be unique within a health model. For example, a concatenation of parentEntityName and childEntityName can be used as the name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Relationship"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Relationship' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Relationship"
+            }
+          },
+          "201": {
+            "description": "Resource 'Relationship' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Relationship"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Relationships_CreateOrUpdate": {
+            "$ref": "./examples/Relationships_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Relationships_Delete",
+        "tags": [
+          "Relationships"
+        ],
+        "description": "Delete a Relationship",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "relationshipName",
+            "in": "path",
+            "description": "Name of the relationship. Must be unique within a health model. For example, a concatenation of parentEntityName and childEntityName can be used as the name.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Relationships_Delete": {
+            "$ref": "./examples/Relationships_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/signaldefinitions": {
+      "get": {
+        "operationId": "SignalDefinitions_ListByHealthModel",
+        "tags": [
+          "SignalDefinitions"
+        ],
+        "description": "List SignalDefinition resources by HealthModel",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "timestamp",
+            "in": "query",
+            "description": "Timestamp to use for the operation. When specified, the version of the resource at this point in time is retrieved. If not specified, the latest version is used.",
+            "required": false,
+            "type": "string",
+            "format": "date-time"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SignalDefinitionListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SignalDefinitions_ListByHealthModel": {
+            "$ref": "./examples/SignalDefinitions_ListByHealthModel.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.CloudHealth/healthmodels/{healthModelName}/signaldefinitions/{signalDefinitionName}": {
+      "get": {
+        "operationId": "SignalDefinitions_Get",
+        "tags": [
+          "SignalDefinitions"
+        ],
+        "description": "Get a SignalDefinition",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "signalDefinitionName",
+            "in": "path",
+            "description": "Name of the signal definition. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/SignalDefinition"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SignalDefinitions_Get": {
+            "$ref": "./examples/SignalDefinitions_Get.json"
+          }
+        }
+      },
+      "put": {
+        "operationId": "SignalDefinitions_CreateOrUpdate",
+        "tags": [
+          "SignalDefinitions"
+        ],
+        "description": "Create a SignalDefinition",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "signalDefinitionName",
+            "in": "path",
+            "description": "Name of the signal definition. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SignalDefinition"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'SignalDefinition' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SignalDefinition"
+            }
+          },
+          "201": {
+            "description": "Resource 'SignalDefinition' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/SignalDefinition"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SignalDefinitions_CreateOrUpdate": {
+            "$ref": "./examples/SignalDefinitions_CreateOrUpdate.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "SignalDefinitions_Delete",
+        "tags": [
+          "SignalDefinitions"
+        ],
+        "description": "Delete a SignalDefinition",
+        "parameters": [
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../../common-types/resource-management/v6/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "healthModelName",
+            "in": "path",
+            "description": "Name of health model resource",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z][a-zA-Z0-9-]{1,42}[a-zA-Z0-9]$"
+          },
+          {
+            "name": "signalDefinitionName",
+            "in": "path",
+            "description": "Name of the signal definition. Must be unique within a health model.",
+            "required": true,
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "SignalDefinitions_Delete": {
+            "$ref": "./examples/SignalDefinitions_Delete.json"
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "definitions": {
+    "AddDataAnnotationRequest": {
+      "type": "object",
+      "description": "Request body for adding a data annotation.",
+      "properties": {
+        "annotationDetails": {
+          "type": "object",
+          "description": "Annotation details as a dynamic key-value pair bag. Service-enforced limits: a maximum of 10 entries per annotation and a maximum value length of 256 characters. Requests exceeding these limits will be rejected with a 400 response.",
+          "additionalProperties": {
+            "$ref": "#/definitions/string256"
+          }
+        },
+        "description": {
+          "$ref": "#/definitions/string4096",
+          "description": "Optional description of the annotation"
+        }
+      },
+      "required": [
+        "annotationDetails"
+      ]
+    },
+    "AggregationUnit": {
+      "type": "string",
+      "description": "Unit type for the thresholds used by threshold-bearing aggregation strategies.",
+      "enum": [
+        "Absolute",
+        "Percentage"
+      ],
+      "x-ms-enum": {
+        "name": "AggregationUnit",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Absolute",
+            "value": "Absolute",
+            "description": "Threshold is an absolute count of members."
+          },
+          {
+            "name": "Percentage",
+            "value": "Percentage",
+            "description": "Threshold is a percentage of members (0-100)."
+          }
+        ]
+      }
+    },
+    "AlertConfiguration": {
+      "type": "object",
+      "description": "Alert configuration details",
+      "properties": {
+        "severity": {
+          "$ref": "#/definitions/AlertSeverity",
+          "description": "The severity of triggered alert."
+        },
+        "description": {
+          "type": "string",
+          "description": "The alert rule description.",
+          "minLength": 1,
+          "maxLength": 1000
+        },
+        "actionGroupIds": {
+          "type": "array",
+          "description": "Optional list of action group resource IDs to be notified when the alert is triggered.",
+          "minItems": 1,
+          "maxItems": 5,
+          "items": {
+            "type": "string",
+            "format": "arm-id",
+            "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+            "x-ms-arm-id-details": {
+              "allowedResources": [
+                {
+                  "type": "Microsoft.Insights/actionGroups"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "required": [
+        "severity"
+      ]
+    },
+    "AlertSeverity": {
+      "type": "string",
+      "description": "Severity of an alert",
+      "enum": [
+        "Sev0",
+        "Sev1",
+        "Sev2",
+        "Sev3",
+        "Sev4"
+      ],
+      "x-ms-enum": {
+        "name": "AlertSeverity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Sev0",
+            "value": "Sev0",
+            "description": "Critical"
+          },
+          {
+            "name": "Sev1",
+            "value": "Sev1",
+            "description": "Error"
+          },
+          {
+            "name": "Sev2",
+            "value": "Sev2",
+            "description": "Warning"
+          },
+          {
+            "name": "Sev3",
+            "value": "Sev3",
+            "description": "Informational"
+          },
+          {
+            "name": "Sev4",
+            "value": "Sev4",
+            "description": "Verbose"
+          }
+        ]
+      }
+    },
+    "ApplicationInsightsTopologySpecification": {
+      "type": "object",
+      "description": "Discovery rule specification for an Application Insights topology query",
+      "properties": {
+        "applicationInsightsResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Application Insights resource ID",
+          "x-ms-arm-id-details": {
+            "allowedResources": [
+              {
+                "type": "Microsoft.Insights/components"
+              }
+            ]
+          }
+        }
+      },
+      "required": [
+        "applicationInsightsResourceId"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/DiscoveryRuleSpecification"
+        }
+      ],
+      "x-ms-discriminator-value": "ApplicationInsightsTopology"
+    },
+    "AuthenticationKind": {
+      "type": "string",
+      "description": "Supported kinds of authentication settings as discriminator",
+      "enum": [
+        "ManagedIdentity"
+      ],
+      "x-ms-enum": {
+        "name": "AuthenticationKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ManagedIdentity",
+            "value": "ManagedIdentity"
+          }
+        ]
+      }
+    },
+    "AuthenticationSetting": {
+      "type": "object",
+      "description": "An authentication setting in a health model",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/AuthenticationSettingProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "AuthenticationSettingListResult": {
+      "type": "object",
+      "description": "The response of a AuthenticationSetting list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The AuthenticationSetting items on this page",
+          "items": {
+            "$ref": "#/definitions/AuthenticationSetting"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "AuthenticationSettingProperties": {
+      "type": "object",
+      "description": "Authentication setting properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/HealthModelProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name",
+          "minLength": 1,
+          "maxLength": 260
+        },
+        "authenticationKind": {
+          "$ref": "#/definitions/AuthenticationKind",
+          "description": "Kind of the authentication setting"
+        }
+      },
+      "discriminator": "authenticationKind",
+      "required": [
+        "authenticationKind"
+      ]
+    },
+    "AzureMonitorWorkspaceResourceId": {
+      "type": "string",
+      "format": "arm-id",
+      "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.Monitor/accounts"
+          }
+        ]
+      }
+    },
+    "AzureMonitorWorkspaceSignals": {
+      "type": "object",
+      "description": "A grouping of Azure Monitor workspace signals.",
+      "properties": {
+        "authenticationSetting": {
+          "$ref": "#/definitions/authenticationSettingName",
+          "description": "Reference to the name of the authentication setting which is used for querying the data source."
+        },
+        "azureMonitorWorkspaceResourceId": {
+          "$ref": "#/definitions/AzureMonitorWorkspaceResourceId",
+          "description": "Azure Monitor workspace resource ID."
+        },
+        "signals": {
+          "type": "array",
+          "description": "Signals assigned to this signal group.",
+          "maxItems": 50,
+          "items": {
+            "$ref": "#/definitions/PrometheusMetricsSignal"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "authenticationSetting",
+        "azureMonitorWorkspaceResourceId"
+      ]
+    },
+    "AzureResourceHealthSignal": {
+      "type": "object",
+      "description": "Azure resource health signal configuration",
+      "properties": {
+        "enabled": {
+          "type": "string",
+          "description": "Whether to automatically add a signal for the Azure resource's availability state from Azure Resource Health. Defaults to Enabled.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "name": "ResourceHealthAvailabilityStateSignalBehavior",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Automatically add resource health availability state signal"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Do not automatically add resource health availability state signal"
+              }
+            ]
+          }
+        },
+        "signalName": {
+          "$ref": "#/definitions/string256",
+          "description": "The unique name of the Azure resource health signal. System assigned.",
+          "readOnly": true
+        },
+        "status": {
+          "$ref": "#/definitions/AzureResourceHealthSignalStatus",
+          "description": "Current status of the Azure resource health signal.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureResourceHealthSignalStatus": {
+      "type": "object",
+      "description": "Status of an Azure Resource Health signal, including availability information reported by Azure Resource Health.",
+      "properties": {
+        "healthState": {
+          "$ref": "#/definitions/HealthState",
+          "description": "Health state of this signal",
+          "readOnly": true
+        },
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "Reported value of the signal",
+          "readOnly": true
+        },
+        "reportedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the value was reported",
+          "readOnly": true
+        },
+        "error": {
+          "type": "string",
+          "description": "Error message if the signal status cannot be retrieved",
+          "readOnly": true
+        },
+        "additionalContext": {
+          "$ref": "#/definitions/string4096",
+          "description": "Additional context as provided by the submitter"
+        },
+        "availabilityState": {
+          "$ref": "#/definitions/ResourceHealthAvailabilityState",
+          "description": "Availability state of the Azure resource as reported by Azure Resource Health.",
+          "readOnly": true
+        },
+        "category": {
+          "$ref": "#/definitions/ResourceHealthCategory",
+          "description": "Whether the status changing event was planned or unplanned.",
+          "readOnly": true
+        },
+        "detailedStatus": {
+          "$ref": "#/definitions/string4096",
+          "description": "Detailed status of the Azure resource as reported by Azure Resource Health.",
+          "readOnly": true
+        },
+        "summary": {
+          "type": "string",
+          "description": "Human-readable summary of the current availability state from Azure Resource Health.",
+          "readOnly": true
+        },
+        "reasonType": {
+          "$ref": "#/definitions/ResourceHealthReasonType",
+          "description": "Reason type for the current availability state (e.g. 'Unplanned', 'Planned', 'UserInitiated').",
+          "readOnly": true
+        },
+        "reasonChronicity": {
+          "$ref": "#/definitions/ResourceHealthReasonChronicity",
+          "description": "Whether the current availability state is 'Persistent' or 'Transient'.",
+          "readOnly": true
+        },
+        "availabilityReportedTime": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when Azure Resource Health observed the current availability state.",
+          "readOnly": true
+        }
+      }
+    },
+    "AzureResourceSignal": {
+      "type": "object",
+      "description": "An Azure Resource Metric signal instance assigned to an entity.",
+      "properties": {
+        "metricNamespace": {
+          "type": "string",
+          "description": "Metric namespace",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "metricName": {
+          "type": "string",
+          "description": "Name of the metric",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "timeGrain": {
+          "type": "string",
+          "description": "Time range of signal. ISO duration format like PT10M.",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "aggregationType": {
+          "$ref": "#/definitions/MetricAggregationType",
+          "description": "Type of aggregation to apply to the metric"
+        },
+        "dimensionFilter": {
+          "type": "string",
+          "description": "Optional: Dimension filter to apply to the dimension. Must only be set if also Dimension is set.",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name",
+          "minLength": 1,
+          "maxLength": 260
+        },
+        "refreshInterval": {
+          "type": "string",
+          "description": "Interval in which the signal is being evaluated. Defaults to PT1M (1 minute).",
+          "default": "PT1M",
+          "enum": [
+            "PT1M",
+            "PT5M",
+            "PT10M",
+            "PT15M",
+            "PT30M",
+            "PT1H",
+            "PT2H"
+          ],
+          "x-ms-enum": {
+            "name": "RefreshInterval",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "PT1M",
+                "value": "PT1M",
+                "description": "One Minute"
+              },
+              {
+                "name": "PT5M",
+                "value": "PT5M",
+                "description": "Five Minutes"
+              },
+              {
+                "name": "PT10M",
+                "value": "PT10M",
+                "description": "Ten Minutes"
+              },
+              {
+                "name": "PT15M",
+                "value": "PT15M",
+                "description": "Fifteen Minutes"
+              },
+              {
+                "name": "PT30M",
+                "value": "PT30M",
+                "description": "Thirty Minutes"
+              },
+              {
+                "name": "PT1H",
+                "value": "PT1H",
+                "description": "One Hour"
+              },
+              {
+                "name": "PT2H",
+                "value": "PT2H",
+                "description": "Two Hours"
+              }
+            ]
+          }
+        },
+        "dataUnit": {
+          "type": "string",
+          "description": "Unit of the signal result (e.g. Bytes, MilliSeconds, Percent, Count))",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "evaluationRules": {
+          "$ref": "#/definitions/EvaluationRule",
+          "description": "Evaluation rules for the signal definition"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SignalInstanceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureResourceMetric"
+    },
+    "AzureResourceSignals": {
+      "type": "object",
+      "description": "A grouping of Azure resource signals",
+      "properties": {
+        "authenticationSetting": {
+          "$ref": "#/definitions/authenticationSettingName",
+          "description": "Reference to the name of the authentication setting which is used for querying the data source."
+        },
+        "azureResourceId": {
+          "type": "string",
+          "format": "arm-id",
+          "description": "Azure resource ID",
+          "x-ms-arm-id-details": {
+            "allowedResources": []
+          }
+        },
+        "azureResourceKind": {
+          "type": "string",
+          "description": "Azure resource kind (e.g., 'functionapp'). Populated by the UI for icon rendering. Can be null if not populated.",
+          "minLength": 0,
+          "maxLength": 256
+        },
+        "signals": {
+          "type": "array",
+          "description": "Signals assigned to this group.",
+          "maxItems": 50,
+          "items": {
+            "$ref": "#/definitions/AzureResourceSignal"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "resourceHealth": {
+          "$ref": "#/definitions/AzureResourceHealthSignal",
+          "description": "Optional configuration for automatically adding a signal based on the resource's availability state in Azure Resource Health."
+        }
+      },
+      "required": [
+        "authenticationSetting",
+        "azureResourceId"
+      ]
+    },
+    "DataAnnotation": {
+      "type": "object",
+      "description": "A single data annotation on an entity",
+      "properties": {
+        "annotationId": {
+          "type": "string",
+          "description": "Auto-assigned identifier for the annotation",
+          "maxLength": 256,
+          "readOnly": true
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the annotation was created",
+          "readOnly": true
+        },
+        "annotationDetails": {
+          "type": "object",
+          "description": "Annotation details as a dynamic key-value pair bag. Service-enforced limits: a maximum of 10 entries per annotation and a maximum value length of 256 characters. Requests exceeding these limits will be rejected with a 400 response.",
+          "additionalProperties": {
+            "$ref": "#/definitions/string256"
+          }
+        },
+        "description": {
+          "$ref": "#/definitions/string4096",
+          "description": "Optional description of the annotation"
+        }
+      },
+      "required": [
+        "annotationDetails"
+      ]
+    },
+    "DependenciesSignalGroupV2": {
+      "type": "object",
+      "description": "Properties for dependent entities, i.e. child entities",
+      "properties": {
+        "aggregationType": {
+          "type": "string",
+          "description": "Aggregation type for child dependencies.",
+          "default": "WorstOf",
+          "enum": [
+            "WorstOf",
+            "BestOf",
+            "MinHealthy",
+            "MaxNotHealthy"
+          ],
+          "x-ms-enum": {
+            "name": "AggregationType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "WorstOf",
+                "value": "WorstOf",
+                "description": "Worst health state across members is propagated. Default behavior."
+              },
+              {
+                "name": "BestOf",
+                "value": "BestOf",
+                "description": "Best (least severe) health state across the non-Unknown members is propagated. Unknown members are excluded from the selection; if every member is Unknown the group resolves to Unknown. The 'ignoreUnknown' flag has no observable effect for this strategy and is documented as such."
+              },
+              {
+                "name": "MinHealthy",
+                "value": "MinHealthy",
+                "description": "Healthy if the count/percentage of healthy members meets the threshold."
+              },
+              {
+                "name": "MaxNotHealthy",
+                "value": "MaxNotHealthy",
+                "description": "Healthy if the count/percentage of not-healthy members stays below the threshold."
+              }
+            ]
+          }
+        },
+        "degradedThreshold": {
+          "type": "number",
+          "format": "double",
+          "description": "Degraded threshold for aggregation. For MinHealthy: parent is degraded when healthy count/percentage falls to or below this value. For MaxNotHealthy: parent is degraded when not-healthy count/percentage reaches or exceeds this value. Optional — if not set, there is no degraded state (transitions directly from Healthy to Unhealthy).",
+          "minimum": 0
+        },
+        "unhealthyThreshold": {
+          "type": "number",
+          "format": "double",
+          "description": "Unhealthy threshold for aggregation. For MinHealthy: parent is unhealthy when healthy count/percentage falls to or below this value. For MaxNotHealthy: parent is unhealthy when not-healthy count/percentage reaches or exceeds this value. Required when aggregationType is MinHealthy or MaxNotHealthy.",
+          "minimum": 0
+        },
+        "unit": {
+          "$ref": "#/definitions/AggregationUnit",
+          "description": "Unit type for the aggregation thresholds. Required when aggregationType is MinHealthy or MaxNotHealthy."
+        },
+        "ignoreUnknown": {
+          "type": "boolean",
+          "description": "If true, children with Unknown health state are excluded from aggregation calculations. Defaults to true.",
+          "default": true
+        }
+      },
+      "required": [
+        "aggregationType"
+      ]
+    },
+    "DiscoveryError": {
+      "type": "object",
+      "description": "Error details for a failed discovery operation",
+      "properties": {
+        "message": {
+          "type": "string",
+          "description": "Error message",
+          "readOnly": true
+        },
+        "context": {
+          "type": "array",
+          "description": "Additional context information, like resource IDs or query details",
+          "items": {
+            "type": "string"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "message"
+      ]
+    },
+    "DiscoveryRule": {
+      "type": "object",
+      "description": "A discovery rule which automatically finds entities and relationships in a health model based on an Azure Resource Graph query",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/DiscoveryRuleProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "DiscoveryRuleKind": {
+      "type": "string",
+      "description": "Discovery rule specification kind discriminator",
+      "enum": [
+        "ResourceGraphQuery",
+        "ApplicationInsightsTopology"
+      ],
+      "x-ms-enum": {
+        "name": "DiscoveryRuleKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "ResourceGraphQuery",
+            "value": "ResourceGraphQuery",
+            "description": "Azure Resource Graph query based discovery"
+          },
+          {
+            "name": "ApplicationInsightsTopology",
+            "value": "ApplicationInsightsTopology",
+            "description": "Application Insights topology based discovery"
+          }
+        ]
+      }
+    },
+    "DiscoveryRuleListResult": {
+      "type": "object",
+      "description": "The response of a DiscoveryRule list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The DiscoveryRule items on this page",
+          "items": {
+            "$ref": "#/definitions/DiscoveryRule"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "DiscoveryRuleProperties": {
+      "type": "object",
+      "description": "Discovery rule properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/HealthModelProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name",
+          "minLength": 1,
+          "maxLength": 260
+        },
+        "authenticationSetting": {
+          "$ref": "#/definitions/authenticationSettingName",
+          "description": "Reference to the name of the authentication setting which is used for querying Azure Resource Graph. The same authentication setting will also be assigned to any discovered entities."
+        },
+        "discoverRelationships": {
+          "$ref": "#/definitions/DiscoveryRuleRelationshipDiscoveryBehavior",
+          "description": "Whether to create relationships between the discovered entities based on a set of built-in rules. These relationships cannot be manually deleted."
+        },
+        "addRecommendedSignals": {
+          "$ref": "#/definitions/DiscoveryRuleRecommendedSignalsBehavior",
+          "description": "Whether to add all recommended signals to the discovered entities."
+        },
+        "specification": {
+          "$ref": "#/definitions/DiscoveryRuleSpecification",
+          "description": "Specification of the discovery rule defining how entities are discovered."
+        },
+        "addResourceHealthSignal": {
+          "type": "string",
+          "description": "Whether to automatically add a signal for the Azure resource's availability state from Azure Resource Health to the discovered entities. Defaults to `Enabled`: discovery rules updated via this API version without setting this field will begin emitting a Resource Health availability signal. Pass `Disabled` to preserve pre-`2026-05-01-preview` behavior.",
+          "default": "Enabled",
+          "enum": [
+            "Enabled",
+            "Disabled"
+          ],
+          "x-ms-enum": {
+            "name": "ResourceHealthAvailabilityStateSignalBehavior",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Enabled",
+                "value": "Enabled",
+                "description": "Automatically add resource health availability state signal"
+              },
+              {
+                "name": "Disabled",
+                "value": "Disabled",
+                "description": "Do not automatically add resource health availability state signal"
+              }
+            ]
+          }
+        },
+        "error": {
+          "$ref": "#/definitions/DiscoveryError",
+          "description": "Error details if the last discovery operation failed.",
+          "readOnly": true
+        },
+        "entityName": {
+          "type": "string",
+          "description": "Name of the entity which represents the discovery rule. Note: It might take a few minutes after creating the discovery rule until the entity is created.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "authenticationSetting",
+        "discoverRelationships",
+        "addRecommendedSignals",
+        "specification"
+      ]
+    },
+    "DiscoveryRuleRecommendedSignalsBehavior": {
+      "type": "string",
+      "description": "Discovery rule recommended signal behavior",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "DiscoveryRuleRecommendedSignalsBehavior",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Automatically add recommended signals"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Do not automatically add recommended signals"
+          }
+        ]
+      }
+    },
+    "DiscoveryRuleRelationshipDiscoveryBehavior": {
+      "type": "string",
+      "description": "Discovery rule relationship discovery behavior",
+      "enum": [
+        "Enabled",
+        "Disabled"
+      ],
+      "x-ms-enum": {
+        "name": "DiscoveryRuleRelationshipDiscoveryBehavior",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Enabled",
+            "value": "Enabled",
+            "description": "Automatically attempt to discover relationships"
+          },
+          {
+            "name": "Disabled",
+            "value": "Disabled",
+            "description": "Do not automatically attempt to discover relationships"
+          }
+        ]
+      }
+    },
+    "DiscoveryRuleSpecification": {
+      "type": "object",
+      "description": "Base model for discovery rule specifications",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/DiscoveryRuleKind",
+          "description": "Kind of the discovery rule specification"
+        }
+      },
+      "discriminator": "kind",
+      "required": [
+        "kind"
+      ]
+    },
+    "DynamicThresholdSensitivity": {
+      "type": "string",
+      "description": "Sensitivity level for dynamic threshold detection",
+      "enum": [
+        "Low",
+        "Medium",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "DynamicThresholdSensitivity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Low",
+            "value": "Low",
+            "description": "Low sensitivity — fewer anomalies detected, wider threshold band"
+          },
+          {
+            "name": "Medium",
+            "value": "Medium",
+            "description": "Medium sensitivity — balanced detection"
+          },
+          {
+            "name": "High",
+            "value": "High",
+            "description": "High sensitivity — more anomalies detected, tighter threshold band"
+          }
+        ]
+      }
+    },
+    "Entity": {
+      "type": "object",
+      "description": "An entity (aka node) of a health model",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/EntityProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "EntityAlerts": {
+      "type": "object",
+      "description": "Alert configuration for an entity",
+      "properties": {
+        "unhealthy": {
+          "$ref": "#/definitions/AlertConfiguration",
+          "description": "Alert to be triggered on state change to unhealthy"
+        },
+        "degraded": {
+          "$ref": "#/definitions/AlertConfiguration",
+          "description": "Alert to be triggered on state change to degraded"
+        }
+      }
+    },
+    "EntityCoordinates": {
+      "type": "object",
+      "description": "Visual position of the entity",
+      "properties": {
+        "x": {
+          "type": "number",
+          "format": "float",
+          "description": "X Coordinate"
+        },
+        "y": {
+          "type": "number",
+          "format": "float",
+          "description": "Y Coordinate"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ]
+    },
+    "EntityHistoryRequest": {
+      "type": "object",
+      "description": "Request body for getting entity health history",
+      "properties": {
+        "startAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start time for the history query. Defaults to 24 hours ago if not specified."
+        },
+        "endAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "End time for the history query. Defaults to now if not specified."
+        },
+        "top": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of health state transitions to return per page. Defaults to 1000.",
+          "default": 1000,
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "nextMarker": {
+          "$ref": "#/definitions/string4096",
+          "description": "An opaque string value that identifies the portion of the result set to be returned with the next operation. Must not be combined with startAt or endAt."
+        }
+      }
+    },
+    "EntityHistoryResponse": {
+      "type": "object",
+      "description": "Response containing entity health state transitions",
+      "properties": {
+        "entityName": {
+          "$ref": "#/definitions/entityName",
+          "description": "Name of the entity"
+        },
+        "history": {
+          "type": "array",
+          "description": "List of health state transitions",
+          "items": {
+            "$ref": "#/definitions/HealthStateTransition"
+          },
+          "x-ms-identifiers": [
+            "occurredAt"
+          ]
+        },
+        "nextMarker": {
+          "$ref": "#/definitions/string4096",
+          "description": "An opaque string value that identifies the portion of the result set to be returned with the next operation."
+        }
+      },
+      "required": [
+        "entityName",
+        "history"
+      ]
+    },
+    "EntityListResult": {
+      "type": "object",
+      "description": "The response of a Entity list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Entity items on this page",
+          "items": {
+            "$ref": "#/definitions/Entity"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "EntityProperties": {
+      "type": "object",
+      "description": "Properties which are common across all kinds of entities",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/HealthModelProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name",
+          "minLength": 1,
+          "maxLength": 260
+        },
+        "canvasPosition": {
+          "$ref": "#/definitions/EntityCoordinates",
+          "description": "Positioning of the entity on the model canvas"
+        },
+        "icon": {
+          "$ref": "#/definitions/IconDefinition",
+          "description": "Visual icon definition. If not set, a default icon is used."
+        },
+        "healthObjective": {
+          "type": "number",
+          "format": "float",
+          "description": "Health objective as a percentage of time the entity should be healthy.",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "impact": {
+          "type": "string",
+          "description": "Impact of the entity in health state propagation",
+          "default": "Standard",
+          "enum": [
+            "Standard",
+            "Limited",
+            "Suppressed"
+          ],
+          "x-ms-enum": {
+            "name": "EntityImpact",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "Standard",
+                "value": "Standard",
+                "description": "Standard impact"
+              },
+              {
+                "name": "Limited",
+                "value": "Limited",
+                "description": "Limited impact"
+              },
+              {
+                "name": "Suppressed",
+                "value": "Suppressed",
+                "description": "Suppressed impact"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "type": "object",
+          "description": "Optional set of tags (key-value pairs)",
+          "additionalProperties": {
+            "$ref": "#/definitions/string4096"
+          }
+        },
+        "signalGroups": {
+          "$ref": "#/definitions/SignalGroups",
+          "description": "Signal groups which are assigned to this entity"
+        },
+        "signalAggregationGroups": {
+          "type": "array",
+          "description": "Logical aggregation groups over the signals on this entity. Overlap is allowed: the same signal may appear in more than one group's members. Each group is evaluated independently according to its strategy, and a shared signal can contribute to multiple group states and related per-group telemetry. Group states contribute alongside any ungrouped signals and the dependency-aggregated child health to the entity's overall worst-of composite.",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "$ref": "#/definitions/SignalAggregationGroup"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        },
+        "discoveredBy": {
+          "$ref": "#/definitions/discoveryRuleName",
+          "description": "Discovered by which discovery rule. If set, the entity cannot be deleted manually.",
+          "readOnly": true
+        },
+        "healthState": {
+          "$ref": "#/definitions/HealthState",
+          "description": "Health state of this entity",
+          "readOnly": true
+        },
+        "alerts": {
+          "$ref": "#/definitions/EntityAlerts",
+          "description": "Alert configuration for this entity"
+        }
+      }
+    },
+    "EvaluationRule": {
+      "type": "object",
+      "description": "Evaluation rule for a signal definition",
+      "properties": {
+        "degradedRule": {
+          "$ref": "#/definitions/ThresholdRuleV2",
+          "description": "Degraded rule with static threshold."
+        },
+        "unhealthyRule": {
+          "$ref": "#/definitions/ThresholdRuleV2",
+          "description": "Unhealthy rule with static threshold."
+        }
+      },
+      "required": [
+        "unhealthyRule"
+      ]
+    },
+    "ExternalSignal": {
+      "type": "object",
+      "description": "An externally submitted signal instance assigned to an entity.",
+      "properties": {
+        "evaluationRules": {
+          "$ref": "#/definitions/EvaluationRule",
+          "description": "Evaluation rules for the external signal as submitted."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SignalInstanceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "External"
+    },
+    "ExternalSignalGroup": {
+      "type": "object",
+      "description": "A grouping of externally submitted signals.",
+      "properties": {
+        "signals": {
+          "type": "array",
+          "description": "Signals assigned to this signal group.",
+          "items": {
+            "$ref": "#/definitions/ExternalSignal"
+          },
+          "readOnly": true,
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      }
+    },
+    "GetDataAnnotationsRequest": {
+      "type": "object",
+      "description": "Request body for querying data annotations",
+      "properties": {
+        "startAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start of UTC time range. Defaults to 24 hours ago if not specified."
+        },
+        "endAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "End of UTC time range. Defaults to now if not specified."
+        },
+        "top": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of annotations to return per page. Defaults to 100.",
+          "default": 100,
+          "minimum": 1,
+          "maximum": 100
+        },
+        "nextMarker": {
+          "$ref": "#/definitions/string4096",
+          "description": "An opaque string value that identifies the portion of the result set to be returned with the next operation. Must not be combined with startAt or endAt."
+        }
+      }
+    },
+    "GetDataAnnotationsResponse": {
+      "type": "object",
+      "description": "Response containing data annotations for an entity",
+      "properties": {
+        "entityName": {
+          "$ref": "#/definitions/entityName",
+          "description": "Name of the entity"
+        },
+        "annotations": {
+          "type": "array",
+          "description": "List of data annotations",
+          "items": {
+            "$ref": "#/definitions/DataAnnotation"
+          },
+          "x-ms-identifiers": [
+            "annotationId"
+          ]
+        },
+        "nextMarker": {
+          "$ref": "#/definitions/string4096",
+          "description": "An opaque string value that identifies the portion of the result set to be returned with the next operation."
+        }
+      },
+      "required": [
+        "entityName",
+        "annotations"
+      ]
+    },
+    "GetSignalRecommendationsResponse": {
+      "type": "object",
+      "description": "Response from `getSignalRecommendations` containing two independent suggestion streams for the Azure resource type represented by the target Entity. `recommendedSignals` lists signals broadly recommended to be enabled by default; `recommendedConfigurations` lists additional metrics that are not broadly applicable but, if a caller chooses to monitor one of them, ship with suggested starting-point thresholds. The two arrays are independent — items are not paired by index, and callers should treat them as two separate suggestion streams.",
+      "properties": {
+        "recommendedSignals": {
+          "type": "array",
+          "description": "Signals that are broadly recommended to be enabled by default for health models monitoring an Entity of this resource type. Each entry is a complete signal configuration (metric, aggregation, thresholds) ready to be added to a health model. Independent of `recommendedConfigurations` — not paired by index.",
+          "items": {
+            "$ref": "#/definitions/SignalConfiguration"
+          },
+          "x-ms-identifiers": [
+            "signalId"
+          ]
+        },
+        "recommendedConfigurations": {
+          "type": "array",
+          "description": "Additional signal configurations for metrics that are not broadly applicable to every health model for an Entity of this resource type, but if a caller chooses to monitor one of these metrics, the provided thresholds are suggested as a starting point. Independent of `recommendedSignals` — not paired by index.",
+          "items": {
+            "$ref": "#/definitions/SignalConfiguration"
+          },
+          "x-ms-identifiers": [
+            "signalId"
+          ]
+        }
+      },
+      "required": [
+        "recommendedSignals",
+        "recommendedConfigurations"
+      ]
+    },
+    "HealthModel": {
+      "type": "object",
+      "description": "A HealthModel resource",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/HealthModelProperties",
+          "description": "The resource-specific properties for this resource."
+        },
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "HealthModelListResult": {
+      "type": "object",
+      "description": "The response of a HealthModel list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The HealthModel items on this page",
+          "items": {
+            "$ref": "#/definitions/HealthModel"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "HealthModelProperties": {
+      "type": "object",
+      "description": "HealthModel properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/HealthModelProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        }
+      }
+    },
+    "HealthModelProvisioningState": {
+      "type": "string",
+      "description": "Health Model provisioning states",
+      "enum": [
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Creating",
+        "Deleting"
+      ],
+      "x-ms-enum": {
+        "name": "HealthModelProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          },
+          {
+            "name": "Creating",
+            "value": "Creating"
+          },
+          {
+            "name": "Deleting",
+            "value": "Deleting"
+          }
+        ]
+      },
+      "readOnly": true
+    },
+    "HealthModelUpdate": {
+      "type": "object",
+      "description": "The type used for update operations of the HealthModel.",
+      "properties": {
+        "identity": {
+          "$ref": "../../../../../../common-types/resource-management/v6/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The managed service identities assigned to this resource."
+        },
+        "tags": {
+          "type": "object",
+          "description": "Resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "HealthReportEvaluationRule": {
+      "type": "object",
+      "description": "Evaluation rules for the health report",
+      "properties": {
+        "degradedRule": {
+          "$ref": "#/definitions/ThresholdRuleV2",
+          "description": "Degraded rule with static threshold."
+        },
+        "unhealthyRule": {
+          "$ref": "#/definitions/ThresholdRuleV2",
+          "description": "Unhealthy rule with static threshold."
+        }
+      },
+      "required": [
+        "unhealthyRule"
+      ]
+    },
+    "HealthReportRequest": {
+      "type": "object",
+      "description": "Health report that's submitted for a specific signal",
+      "properties": {
+        "signalName": {
+          "$ref": "#/definitions/signalName",
+          "description": "Name of the entity signal to report health for"
+        },
+        "healthState": {
+          "$ref": "#/definitions/HealthState",
+          "description": "Health state to report for the signal"
+        },
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "Reported value of the signal"
+        },
+        "evaluationRules": {
+          "$ref": "#/definitions/HealthReportEvaluationRule",
+          "description": "Evaluation rules that were used to determine the reported health state"
+        },
+        "expiresInMinutes": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of minutes until the health report expires. Defaults to 60 (1 hour) if not specified.",
+          "default": 60,
+          "minimum": 1,
+          "maximum": 10080
+        },
+        "additionalContext": {
+          "$ref": "#/definitions/string4096",
+          "description": "Optional additional context or description for the health report"
+        }
+      },
+      "required": [
+        "signalName",
+        "healthState"
+      ]
+    },
+    "HealthState": {
+      "type": "string",
+      "description": "Health state of an entity",
+      "enum": [
+        "Healthy",
+        "Degraded",
+        "Unhealthy",
+        "Unknown",
+        "Deleted"
+      ],
+      "x-ms-enum": {
+        "name": "HealthState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Healthy",
+            "value": "Healthy",
+            "description": "Healthy status"
+          },
+          {
+            "name": "Degraded",
+            "value": "Degraded",
+            "description": "Degraded status"
+          },
+          {
+            "name": "Unhealthy",
+            "value": "Unhealthy",
+            "description": "Unhealthy status"
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "Unknown status"
+          },
+          {
+            "name": "Deleted",
+            "value": "Deleted",
+            "description": "Deleted status"
+          }
+        ]
+      }
+    },
+    "HealthStateTransition": {
+      "type": "object",
+      "description": "A health state transition record",
+      "properties": {
+        "previousState": {
+          "$ref": "#/definitions/HealthState",
+          "description": "Previous health state before the transition"
+        },
+        "newState": {
+          "$ref": "#/definitions/HealthState",
+          "description": "New health state after the transition"
+        },
+        "occurredAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the transition occurred"
+        },
+        "reason": {
+          "$ref": "#/definitions/string4096",
+          "description": "Reason of the transition"
+        }
+      },
+      "required": [
+        "previousState",
+        "newState",
+        "occurredAt"
+      ]
+    },
+    "IconDefinition": {
+      "type": "object",
+      "description": "Visual icon definition of an entity",
+      "properties": {
+        "iconName": {
+          "type": "string",
+          "description": "Name of the built-in icon, or 'Custom' to use customData",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "customData": {
+          "type": "string",
+          "description": "Custom data. Base64-encoded SVG data. If set, this overrides the built-in icon.",
+          "minLength": 1,
+          "maxLength": 5000
+        }
+      },
+      "required": [
+        "iconName"
+      ]
+    },
+    "LogAnalyticsQuerySignalDefinitionProperties": {
+      "type": "object",
+      "description": "Log Analytics Query Signal Definition properties",
+      "properties": {
+        "queryText": {
+          "type": "string",
+          "description": "Query text in KQL syntax",
+          "minLength": 1,
+          "maxLength": 5000
+        },
+        "timeGrain": {
+          "type": "string",
+          "description": "Time range of signal. ISO duration format like PT10M. If not specified, the KQL query must define a time range.",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "valueColumnName": {
+          "type": "string",
+          "description": "Name of the column in the result set to evaluate against the thresholds. Defaults to the first column in the result set if not specified. The column must be numeric.",
+          "minLength": 1,
+          "maxLength": 100
+        }
+      },
+      "required": [
+        "queryText"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/SignalDefinitionProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "LogAnalyticsQuery"
+    },
+    "LogAnalyticsSignal": {
+      "type": "object",
+      "description": "A Log Analytics Query signal instance assigned to an entity.",
+      "properties": {
+        "queryText": {
+          "type": "string",
+          "description": "Query text in KQL syntax",
+          "minLength": 1,
+          "maxLength": 5000
+        },
+        "timeGrain": {
+          "type": "string",
+          "description": "Time range of signal. ISO duration format like PT10M. If not specified, the KQL query must define a time range.",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "valueColumnName": {
+          "type": "string",
+          "description": "Name of the column in the result set to evaluate against the thresholds. Defaults to the first column in the result set if not specified. The column must be numeric.",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name",
+          "minLength": 1,
+          "maxLength": 260
+        },
+        "refreshInterval": {
+          "type": "string",
+          "description": "Interval in which the signal is being evaluated. Defaults to PT1M (1 minute).",
+          "default": "PT1M",
+          "enum": [
+            "PT1M",
+            "PT5M",
+            "PT10M",
+            "PT15M",
+            "PT30M",
+            "PT1H",
+            "PT2H"
+          ],
+          "x-ms-enum": {
+            "name": "RefreshInterval",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "PT1M",
+                "value": "PT1M",
+                "description": "One Minute"
+              },
+              {
+                "name": "PT5M",
+                "value": "PT5M",
+                "description": "Five Minutes"
+              },
+              {
+                "name": "PT10M",
+                "value": "PT10M",
+                "description": "Ten Minutes"
+              },
+              {
+                "name": "PT15M",
+                "value": "PT15M",
+                "description": "Fifteen Minutes"
+              },
+              {
+                "name": "PT30M",
+                "value": "PT30M",
+                "description": "Thirty Minutes"
+              },
+              {
+                "name": "PT1H",
+                "value": "PT1H",
+                "description": "One Hour"
+              },
+              {
+                "name": "PT2H",
+                "value": "PT2H",
+                "description": "Two Hours"
+              }
+            ]
+          }
+        },
+        "dataUnit": {
+          "type": "string",
+          "description": "Unit of the signal result (e.g. Bytes, MilliSeconds, Percent, Count))",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "evaluationRules": {
+          "$ref": "#/definitions/EvaluationRule",
+          "description": "Evaluation rules for the signal definition"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SignalInstanceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "LogAnalyticsQuery"
+    },
+    "LogAnalyticsSignals": {
+      "type": "object",
+      "description": "A grouping of Log Analytics workspace signals.",
+      "properties": {
+        "authenticationSetting": {
+          "$ref": "#/definitions/authenticationSettingName",
+          "description": "Reference to the name of the authentication setting which is used for querying the data source."
+        },
+        "logAnalyticsWorkspaceResourceId": {
+          "$ref": "#/definitions/LogAnalyticsWorkspaceResourceId",
+          "description": "Log Analytics workspace resource ID."
+        },
+        "signals": {
+          "type": "array",
+          "description": "Signals assigned to this group.",
+          "maxItems": 50,
+          "items": {
+            "$ref": "#/definitions/LogAnalyticsSignal"
+          },
+          "x-ms-identifiers": [
+            "name"
+          ]
+        }
+      },
+      "required": [
+        "authenticationSetting",
+        "logAnalyticsWorkspaceResourceId"
+      ]
+    },
+    "LogAnalyticsWorkspaceResourceId": {
+      "type": "string",
+      "format": "arm-id",
+      "description": "A type definition that refers the id to an Azure Resource Manager resource.",
+      "x-ms-arm-id-details": {
+        "allowedResources": [
+          {
+            "type": "Microsoft.OperationalInsights/workspaces"
+          }
+        ]
+      }
+    },
+    "ManagedIdentityAuthenticationSettingProperties": {
+      "type": "object",
+      "description": "Authentication setting properties for Azure Managed Identity",
+      "properties": {
+        "managedIdentityName": {
+          "type": "string",
+          "description": "Name of the managed identity to use. Either 'SystemAssigned' or the resourceId of a user-assigned identity.",
+          "minLength": 1,
+          "maxLength": 500
+        }
+      },
+      "required": [
+        "managedIdentityName"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/AuthenticationSettingProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "ManagedIdentity"
+    },
+    "MetricAggregationType": {
+      "type": "string",
+      "description": "Metric aggregation type",
+      "enum": [
+        "None",
+        "Average",
+        "Count",
+        "Minimum",
+        "Maximum",
+        "Total"
+      ],
+      "x-ms-enum": {
+        "name": "MetricAggregationType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "Average",
+            "value": "Average"
+          },
+          {
+            "name": "Count",
+            "value": "Count"
+          },
+          {
+            "name": "Minimum",
+            "value": "Minimum"
+          },
+          {
+            "name": "Maximum",
+            "value": "Maximum"
+          },
+          {
+            "name": "Total",
+            "value": "Total"
+          }
+        ]
+      }
+    },
+    "PrometheusMetricsSignal": {
+      "type": "object",
+      "description": "A Prometheus Metrics Query signal instance assigned to an entity.",
+      "properties": {
+        "queryText": {
+          "type": "string",
+          "description": "Query text in PromQL syntax",
+          "minLength": 1,
+          "maxLength": 5000
+        },
+        "timeGrain": {
+          "type": "string",
+          "description": "Time range of signal. ISO duration format like PT10M.",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name",
+          "minLength": 1,
+          "maxLength": 260
+        },
+        "refreshInterval": {
+          "type": "string",
+          "description": "Interval in which the signal is being evaluated. Defaults to PT1M (1 minute).",
+          "default": "PT1M",
+          "enum": [
+            "PT1M",
+            "PT5M",
+            "PT10M",
+            "PT15M",
+            "PT30M",
+            "PT1H",
+            "PT2H"
+          ],
+          "x-ms-enum": {
+            "name": "RefreshInterval",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "PT1M",
+                "value": "PT1M",
+                "description": "One Minute"
+              },
+              {
+                "name": "PT5M",
+                "value": "PT5M",
+                "description": "Five Minutes"
+              },
+              {
+                "name": "PT10M",
+                "value": "PT10M",
+                "description": "Ten Minutes"
+              },
+              {
+                "name": "PT15M",
+                "value": "PT15M",
+                "description": "Fifteen Minutes"
+              },
+              {
+                "name": "PT30M",
+                "value": "PT30M",
+                "description": "Thirty Minutes"
+              },
+              {
+                "name": "PT1H",
+                "value": "PT1H",
+                "description": "One Hour"
+              },
+              {
+                "name": "PT2H",
+                "value": "PT2H",
+                "description": "Two Hours"
+              }
+            ]
+          }
+        },
+        "dataUnit": {
+          "type": "string",
+          "description": "Unit of the signal result (e.g. Bytes, MilliSeconds, Percent, Count))",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "evaluationRules": {
+          "$ref": "#/definitions/EvaluationRule",
+          "description": "Evaluation rules for the signal definition"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SignalInstanceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "PrometheusMetricsQuery"
+    },
+    "PrometheusMetricsSignalDefinitionProperties": {
+      "type": "object",
+      "description": "Prometheus Metrics Signal Definition properties",
+      "properties": {
+        "queryText": {
+          "type": "string",
+          "description": "Query text in PromQL syntax",
+          "minLength": 1,
+          "maxLength": 5000
+        },
+        "timeGrain": {
+          "type": "string",
+          "description": "Time range of signal. ISO duration format like PT10M.",
+          "minLength": 1,
+          "maxLength": 100
+        }
+      },
+      "required": [
+        "queryText"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/SignalDefinitionProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "PrometheusMetricsQuery"
+    },
+    "Relationship": {
+      "type": "object",
+      "description": "A relationship (aka edge) between two entities in a health model",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/RelationshipProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "RelationshipListResult": {
+      "type": "object",
+      "description": "The response of a Relationship list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The Relationship items on this page",
+          "items": {
+            "$ref": "#/definitions/Relationship"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "RelationshipProperties": {
+      "type": "object",
+      "description": "Relationship properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/HealthModelProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name",
+          "minLength": 1,
+          "maxLength": 260
+        },
+        "parentEntityName": {
+          "$ref": "#/definitions/entityName",
+          "description": "Resource name of the parent entity",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "childEntityName": {
+          "$ref": "#/definitions/entityName",
+          "description": "Resource name of the child entity",
+          "x-ms-mutability": [
+            "read",
+            "create"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Optional set of tags (key-value pairs)",
+          "additionalProperties": {
+            "$ref": "#/definitions/string4096"
+          }
+        },
+        "discoveredBy": {
+          "$ref": "#/definitions/discoveryRuleName",
+          "description": "Discovered by which discovery rule. If set, the relationship cannot be deleted manually.",
+          "readOnly": true
+        }
+      },
+      "required": [
+        "parentEntityName",
+        "childEntityName"
+      ]
+    },
+    "ResourceGraphQuerySpecification": {
+      "type": "object",
+      "description": "Discovery rule specification for an Azure Resource Graph query",
+      "properties": {
+        "resourceGraphQuery": {
+          "type": "string",
+          "description": "Azure Resource Graph query text in KQL syntax. The query must return at least a column named 'id' which contains the resource ID of the discovered resources.",
+          "minLength": 1,
+          "maxLength": 5000
+        }
+      },
+      "required": [
+        "resourceGraphQuery"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/DiscoveryRuleSpecification"
+        }
+      ],
+      "x-ms-discriminator-value": "ResourceGraphQuery"
+    },
+    "ResourceHealthAvailabilityState": {
+      "type": "string",
+      "description": "Availability state of an Azure resource as reported by Azure Resource Health.",
+      "enum": [
+        "Available",
+        "Unavailable",
+        "Degraded",
+        "Unknown"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceHealthAvailabilityState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Available",
+            "value": "Available",
+            "description": "The resource is available."
+          },
+          {
+            "name": "Unavailable",
+            "value": "Unavailable",
+            "description": "The resource is unavailable."
+          },
+          {
+            "name": "Degraded",
+            "value": "Degraded",
+            "description": "The resource is degraded."
+          },
+          {
+            "name": "Unknown",
+            "value": "Unknown",
+            "description": "The resource availability state is unknown."
+          }
+        ]
+      }
+    },
+    "ResourceHealthCategory": {
+      "type": "string",
+      "description": "Whether an Azure Resource Health status changing event was planned or unplanned.",
+      "enum": [
+        "Planned",
+        "Unplanned"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceHealthCategory",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Planned",
+            "value": "Planned",
+            "description": "The event was planned."
+          },
+          {
+            "name": "Unplanned",
+            "value": "Unplanned",
+            "description": "The event was unplanned."
+          }
+        ]
+      }
+    },
+    "ResourceHealthReasonChronicity": {
+      "type": "string",
+      "description": "Whether the current Azure Resource Health availability state is persistent or transient.",
+      "enum": [
+        "Persistent",
+        "Transient"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceHealthReasonChronicity",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Persistent",
+            "value": "Persistent",
+            "description": "Persistent state."
+          },
+          {
+            "name": "Transient",
+            "value": "Transient",
+            "description": "Transient state."
+          }
+        ]
+      }
+    },
+    "ResourceHealthReasonType": {
+      "type": "string",
+      "description": "Reason type for the current Azure Resource Health availability state.",
+      "enum": [
+        "Unplanned",
+        "Planned",
+        "UserInitiated"
+      ],
+      "x-ms-enum": {
+        "name": "ResourceHealthReasonType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Unplanned",
+            "value": "Unplanned",
+            "description": "Unplanned reason."
+          },
+          {
+            "name": "Planned",
+            "value": "Planned",
+            "description": "Planned reason."
+          },
+          {
+            "name": "UserInitiated",
+            "value": "UserInitiated",
+            "description": "User-initiated reason."
+          }
+        ]
+      }
+    },
+    "ResourceMetricSignalDefinitionProperties": {
+      "type": "object",
+      "description": "Azure Resource Metric Signal Definition properties",
+      "properties": {
+        "metricNamespace": {
+          "type": "string",
+          "description": "Metric namespace",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "metricName": {
+          "type": "string",
+          "description": "Name of the metric",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "timeGrain": {
+          "type": "string",
+          "description": "Time range of signal. ISO duration format like PT10M.",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "aggregationType": {
+          "$ref": "#/definitions/MetricAggregationType",
+          "description": "Type of aggregation to apply to the metric"
+        },
+        "dimensionFilter": {
+          "type": "string",
+          "description": "Optional: Dimension filter to apply to the dimension. Must only be set if also Dimension is set.",
+          "minLength": 1,
+          "maxLength": 256
+        }
+      },
+      "required": [
+        "metricNamespace",
+        "metricName",
+        "timeGrain",
+        "aggregationType"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/SignalDefinitionProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "AzureResourceMetric"
+    },
+    "SignalAggregationGroup": {
+      "type": "object",
+      "description": "A logical group of signals on an entity, evaluated under a configurable aggregation strategy. Groups are independent even when they share members. Each group's aggregated state is one of the inputs to the entity's composite health computation alongside any signals not declared in any group's members[].",
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/signalAggregationGroupName",
+          "description": "Name of the aggregation group. Unique within the entity."
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name",
+          "minLength": 1,
+          "maxLength": 260
+        },
+        "aggregationType": {
+          "type": "string",
+          "description": "Aggregation strategy applied across the members of this group.",
+          "default": "WorstOf",
+          "enum": [
+            "WorstOf",
+            "BestOf",
+            "MinHealthy",
+            "MaxNotHealthy"
+          ],
+          "x-ms-enum": {
+            "name": "AggregationType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "WorstOf",
+                "value": "WorstOf",
+                "description": "Worst health state across members is propagated. Default behavior."
+              },
+              {
+                "name": "BestOf",
+                "value": "BestOf",
+                "description": "Best (least severe) health state across the non-Unknown members is propagated. Unknown members are excluded from the selection; if every member is Unknown the group resolves to Unknown. The 'ignoreUnknown' flag has no observable effect for this strategy and is documented as such."
+              },
+              {
+                "name": "MinHealthy",
+                "value": "MinHealthy",
+                "description": "Healthy if the count/percentage of healthy members meets the threshold."
+              },
+              {
+                "name": "MaxNotHealthy",
+                "value": "MaxNotHealthy",
+                "description": "Healthy if the count/percentage of not-healthy members stays below the threshold."
+              }
+            ]
+          }
+        },
+        "members": {
+          "type": "array",
+          "description": "Names of signals on this entity which are members of the group. Members are matched by name; references to signals that do not currently exist on the entity are accepted (typically for pre-declared external signals) and surfaced via 'unresolvedMembers'. A signal may be listed in multiple groups; no duplicates within this list.",
+          "minItems": 1,
+          "maxItems": 50,
+          "items": {
+            "$ref": "#/definitions/signalName"
+          }
+        },
+        "degradedThreshold": {
+          "type": "number",
+          "format": "double",
+          "description": "Degraded threshold for threshold-bearing strategies (MinHealthy, MaxNotHealthy). For MinHealthy: group is degraded when the healthy member count/percentage falls to or below this value. For MaxNotHealthy: group is degraded when the not-healthy member count/percentage reaches or exceeds this value. Optional — if not set, the group transitions directly between Healthy and Unhealthy. MUST NOT be set when aggregationType is WorstOf or BestOf.",
+          "minimum": 0
+        },
+        "unhealthyThreshold": {
+          "type": "number",
+          "format": "double",
+          "description": "Unhealthy threshold for threshold-bearing strategies. Required when aggregationType is MinHealthy or MaxNotHealthy; MUST NOT be set otherwise.",
+          "minimum": 0
+        },
+        "unit": {
+          "$ref": "#/definitions/AggregationUnit",
+          "description": "Unit type for the thresholds. Required when aggregationType is MinHealthy or MaxNotHealthy; MUST NOT be set otherwise."
+        },
+        "ignoreUnknown": {
+          "type": "boolean",
+          "description": "If true (default), members reporting Unknown are excluded from the aggregation. For MinHealthy and MaxNotHealthy this flag affects the denominator/count and is meaningful. For WorstOf and BestOf the flag has no observable effect: under WorstOf, Unknown=0 is the lowest severity and can never beat any non-Unknown member in a Max() so filtering it changes nothing observable; under BestOf, Unknown is unconditionally excluded by the strategy itself irrespective of the flag. The flag is retained on the contract for vocabulary symmetry across all four strategies.",
+          "default": true
+        },
+        "aggregatedHealthState": {
+          "$ref": "#/definitions/HealthState",
+          "description": "Computed aggregated health state of the group as of the last entity evaluation. Unknown if no resolvable members or all members filtered out.",
+          "readOnly": true
+        },
+        "unresolvedMembers": {
+          "type": "array",
+          "description": "Members listed in 'members' that do not currently resolve to a signal on this entity at the time of the last entity evaluation. Treated as Unknown during aggregation. Empty/omitted when every member resolves.",
+          "items": {
+            "$ref": "#/definitions/signalName"
+          },
+          "readOnly": true
+        }
+      },
+      "required": [
+        "name",
+        "members"
+      ]
+    },
+    "SignalConfiguration": {
+      "type": "object",
+      "description": "A signal configuration for an Azure resource type",
+      "properties": {
+        "signalId": {
+          "type": "string",
+          "description": "Unique identifier of the recommended signal configuration.",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "metricNamespace": {
+          "type": "string",
+          "description": "Metric namespace (e.g. 'microsoft.compute/virtualmachines').",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "metricName": {
+          "type": "string",
+          "description": "Name of the metric (e.g. 'Percentage CPU').",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "aggregationType": {
+          "$ref": "#/definitions/MetricAggregationType",
+          "description": "Type of aggregation to apply to the metric."
+        },
+        "unit": {
+          "type": "string",
+          "description": "Unit of the metric (e.g. Percent, Bytes, Count).",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "timeGrain": {
+          "type": "string",
+          "description": "Time range of the metric. ISO 8601 duration format (e.g. 'PT5M').",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "dimensionFilter": {
+          "type": "string",
+          "description": "Optional dimension filter to apply to the metric.",
+          "minLength": 1,
+          "maxLength": 256
+        },
+        "evaluationRules": {
+          "$ref": "#/definitions/EvaluationRule",
+          "description": "Evaluation rules with recommended thresholds."
+        }
+      },
+      "required": [
+        "signalId"
+      ]
+    },
+    "SignalDefinition": {
+      "type": "object",
+      "description": "A signal definition in a health model",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/SignalDefinitionProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../../common-types/resource-management/v6/types.json#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "SignalDefinitionListResult": {
+      "type": "object",
+      "description": "The response of a SignalDefinition list operation.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "The SignalDefinition items on this page",
+          "items": {
+            "$ref": "#/definitions/SignalDefinition"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "format": "uri",
+          "description": "The link to the next page of items"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "SignalDefinitionProperties": {
+      "type": "object",
+      "description": "SignalDefinition properties",
+      "properties": {
+        "provisioningState": {
+          "$ref": "#/definitions/HealthModelProvisioningState",
+          "description": "The status of the last operation.",
+          "readOnly": true
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Display name",
+          "minLength": 1,
+          "maxLength": 260
+        },
+        "signalKind": {
+          "$ref": "#/definitions/SignalKind",
+          "description": "Kind of the signal definition"
+        },
+        "refreshInterval": {
+          "type": "string",
+          "description": "Interval in which the signal is being evaluated. Defaults to PT1M (1 minute).",
+          "default": "PT1M",
+          "enum": [
+            "PT1M",
+            "PT5M",
+            "PT10M",
+            "PT15M",
+            "PT30M",
+            "PT1H",
+            "PT2H"
+          ],
+          "x-ms-enum": {
+            "name": "RefreshInterval",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "PT1M",
+                "value": "PT1M",
+                "description": "One Minute"
+              },
+              {
+                "name": "PT5M",
+                "value": "PT5M",
+                "description": "Five Minutes"
+              },
+              {
+                "name": "PT10M",
+                "value": "PT10M",
+                "description": "Ten Minutes"
+              },
+              {
+                "name": "PT15M",
+                "value": "PT15M",
+                "description": "Fifteen Minutes"
+              },
+              {
+                "name": "PT30M",
+                "value": "PT30M",
+                "description": "Thirty Minutes"
+              },
+              {
+                "name": "PT1H",
+                "value": "PT1H",
+                "description": "One Hour"
+              },
+              {
+                "name": "PT2H",
+                "value": "PT2H",
+                "description": "Two Hours"
+              }
+            ]
+          }
+        },
+        "tags": {
+          "type": "object",
+          "description": "Optional set of tags (key-value pairs)",
+          "additionalProperties": {
+            "$ref": "#/definitions/string4096"
+          }
+        },
+        "dataUnit": {
+          "type": "string",
+          "description": "Unit of the signal result (e.g. Bytes, MilliSeconds, Percent, Count))",
+          "minLength": 1,
+          "maxLength": 100
+        },
+        "evaluationRules": {
+          "$ref": "#/definitions/EvaluationRule",
+          "description": "Evaluation rules for the signal definition"
+        }
+      },
+      "discriminator": "signalKind",
+      "required": [
+        "signalKind",
+        "evaluationRules"
+      ]
+    },
+    "SignalGroups": {
+      "type": "object",
+      "description": "Contains various signal groups that can be assigned to an entity",
+      "properties": {
+        "azureResource": {
+          "$ref": "#/definitions/AzureResourceSignals",
+          "description": "Azure Resource Signal Group"
+        },
+        "azureLogAnalytics": {
+          "$ref": "#/definitions/LogAnalyticsSignals",
+          "description": "Log Analytics Signal Group"
+        },
+        "azureMonitorWorkspace": {
+          "$ref": "#/definitions/AzureMonitorWorkspaceSignals",
+          "description": "Azure Monitor Workspace Signal Group"
+        },
+        "dependencies": {
+          "$ref": "#/definitions/DependenciesSignalGroupV2",
+          "description": "Settings for dependency signals to control how the health state of child entities influences the health state of the parent entity."
+        },
+        "external": {
+          "$ref": "#/definitions/ExternalSignalGroup",
+          "description": "List of signals which have been externally submitted for this entity.",
+          "readOnly": true
+        }
+      }
+    },
+    "SignalHistoryDataPoint": {
+      "type": "object",
+      "description": "A data point in the signal time series",
+      "properties": {
+        "occurredAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the data point"
+        },
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "Signal value at this point in time"
+        },
+        "healthState": {
+          "$ref": "#/definitions/HealthState",
+          "description": "Health state at this point in time"
+        },
+        "additionalContext": {
+          "$ref": "#/definitions/string4096",
+          "description": "Additional context as provided by the submitter"
+        }
+      },
+      "required": [
+        "occurredAt",
+        "healthState"
+      ]
+    },
+    "SignalHistoryRequest": {
+      "type": "object",
+      "description": "Request body for getting signal history",
+      "properties": {
+        "signalName": {
+          "$ref": "#/definitions/signalName",
+          "description": "Name of the signal to get history for"
+        },
+        "startAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Start time for the history query. Defaults to 24 hours ago if not specified."
+        },
+        "endAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "End time for the history query. Defaults to now if not specified."
+        },
+        "top": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of data points to return per page. Defaults to 1000.",
+          "default": 1000,
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "nextMarker": {
+          "$ref": "#/definitions/string4096",
+          "description": "An opaque string value that identifies the portion of the result set to be returned with the next operation. Must not be combined with startAt or endAt."
+        }
+      },
+      "required": [
+        "signalName"
+      ]
+    },
+    "SignalHistoryResponse": {
+      "type": "object",
+      "description": "Response containing signal history",
+      "properties": {
+        "entityName": {
+          "$ref": "#/definitions/entityName",
+          "description": "Name of the entity"
+        },
+        "signalName": {
+          "$ref": "#/definitions/signalName",
+          "description": "Name of the signal"
+        },
+        "history": {
+          "type": "array",
+          "description": "Signal history data points",
+          "items": {
+            "$ref": "#/definitions/SignalHistoryDataPoint"
+          },
+          "x-ms-identifiers": [
+            "occurredAt"
+          ]
+        },
+        "nextMarker": {
+          "$ref": "#/definitions/string4096",
+          "description": "An opaque string value that identifies the portion of the result set to be returned with the next operation."
+        }
+      },
+      "required": [
+        "entityName",
+        "signalName",
+        "history"
+      ]
+    },
+    "SignalInstanceProperties": {
+      "type": "object",
+      "description": "Additional properties for signal instances assigned to an entity",
+      "properties": {
+        "signalKind": {
+          "$ref": "#/definitions/SignalKind",
+          "description": "Kind of the signal instance"
+        },
+        "name": {
+          "$ref": "#/definitions/signalName",
+          "description": "Unique name of the signal within the entity."
+        },
+        "signalDefinitionName": {
+          "$ref": "#/definitions/signalDefinitionName",
+          "description": "Optional reference to a signal definition that provides default values."
+        },
+        "status": {
+          "$ref": "#/definitions/SignalStatus",
+          "description": "Current status of the signal.",
+          "readOnly": true
+        }
+      },
+      "discriminator": "signalKind",
+      "required": [
+        "signalKind",
+        "name"
+      ]
+    },
+    "SignalKind": {
+      "type": "string",
+      "description": "Supported signal kinds as discriminator",
+      "enum": [
+        "AzureResourceMetric",
+        "LogAnalyticsQuery",
+        "PrometheusMetricsQuery",
+        "External"
+      ],
+      "x-ms-enum": {
+        "name": "SignalKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AzureResourceMetric",
+            "value": "AzureResourceMetric"
+          },
+          {
+            "name": "LogAnalyticsQuery",
+            "value": "LogAnalyticsQuery"
+          },
+          {
+            "name": "PrometheusMetricsQuery",
+            "value": "PrometheusMetricsQuery"
+          },
+          {
+            "name": "ExternalSignal",
+            "value": "External"
+          }
+        ]
+      }
+    },
+    "SignalOperator": {
+      "type": "string",
+      "description": "Signal operator",
+      "enum": [
+        "GreaterThan",
+        "LessThan",
+        "LessThanOrEqual",
+        "GreaterThanOrEqual",
+        "Equal",
+        "NotEqual",
+        "Dynamic"
+      ],
+      "x-ms-enum": {
+        "name": "SignalOperator",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "GreaterThan",
+            "value": "GreaterThan",
+            "description": "Greater than"
+          },
+          {
+            "name": "LessThan",
+            "value": "LessThan",
+            "description": "Less than"
+          },
+          {
+            "name": "LessThanOrEqual",
+            "value": "LessThanOrEqual",
+            "description": "Less than or equal to"
+          },
+          {
+            "name": "GreaterThanOrEqual",
+            "value": "GreaterThanOrEqual",
+            "description": "Greater than or equal to"
+          },
+          {
+            "name": "Equal",
+            "value": "Equal",
+            "description": "Equal to"
+          },
+          {
+            "name": "NotEqual",
+            "value": "NotEqual",
+            "description": "Not equal to"
+          },
+          {
+            "name": "Dynamic",
+            "value": "Dynamic",
+            "description": "Dynamic threshold — uses deviation from a ML-computed baseline to determine health state transitions. Only valid for the unhealthy threshold rule. Requires `sensitivity` and `lookBackWindow` on the rule; `threshold` is ignored."
+          }
+        ]
+      }
+    },
+    "SignalStatus": {
+      "type": "object",
+      "description": "Status of a signal",
+      "properties": {
+        "healthState": {
+          "$ref": "#/definitions/HealthState",
+          "description": "Health state of this signal",
+          "readOnly": true
+        },
+        "value": {
+          "type": "number",
+          "format": "double",
+          "description": "Reported value of the signal",
+          "readOnly": true
+        },
+        "reportedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp when the value was reported",
+          "readOnly": true
+        },
+        "error": {
+          "type": "string",
+          "description": "Error message if the signal status cannot be retrieved",
+          "readOnly": true
+        },
+        "additionalContext": {
+          "$ref": "#/definitions/string4096",
+          "description": "Additional context as provided by the submitter"
+        }
+      }
+    },
+    "ThresholdRuleV2": {
+      "type": "object",
+      "description": "Threshold-based evaluation rule for a signal definition",
+      "properties": {
+        "operator": {
+          "$ref": "#/definitions/SignalOperator",
+          "description": "Operator how to compare the signal value with the threshold"
+        },
+        "threshold": {
+          "type": "number",
+          "format": "double",
+          "description": "Threshold value"
+        },
+        "sensitivity": {
+          "$ref": "#/definitions/DynamicThresholdSensitivity",
+          "description": "Sensitivity level for dynamic threshold detection. Only applicable when operator is Dynamic."
+        }
+      },
+      "required": [
+        "operator"
+      ]
+    },
+    "authenticationSettingName": {
+      "type": "string",
+      "description": "Type for authentication setting resource name.",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+    },
+    "discoveryRuleName": {
+      "type": "string",
+      "description": "Type for discovery rule resource name.",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+    },
+    "entityName": {
+      "type": "string",
+      "description": "Type for entity resource name.",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+    },
+    "signalAggregationGroupName": {
+      "type": "string",
+      "description": "Name of a signal aggregation group. Must be unique within an entity. Independent of signal names.",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+    },
+    "signalDefinitionName": {
+      "type": "string",
+      "description": "Type for signal definition resource name.",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+    },
+    "signalName": {
+      "type": "string",
+      "description": "Type for signal name.",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{1,258}[a-zA-Z0-9]$"
+    },
+    "string256": {
+      "type": "string",
+      "description": "String with max length validation of 256 characters",
+      "maxLength": 256
+    },
+    "string4096": {
+      "type": "string",
+      "description": "String with max length validation of 4096 characters",
+      "maxLength": 4096
+    }
+  },
+  "parameters": {}
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/AuthenticationSettings_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/AuthenticationSettings_CreateOrUpdate.json
@@ -1,0 +1,62 @@
+{
+  "title": "AuthenticationSettings_CreateOrUpdate",
+  "operationId": "AuthenticationSettings_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "authenticationSettingName": "default-auth",
+    "resource": {
+      "properties": {
+        "managedIdentityName": "SystemAssigned",
+        "displayName": "Default managed identity",
+        "authenticationKind": "ManagedIdentity"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "Default managed identity",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/authenticationSettings/default-auth",
+        "name": "default-auth",
+        "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "Default managed identity",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/authenticationSettings/default-auth",
+        "name": "default-auth",
+        "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/AuthenticationSettings_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/AuthenticationSettings_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "AuthenticationSettings_Delete",
+  "operationId": "AuthenticationSettings_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "authenticationSettingName": "default-auth"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/AuthenticationSettings_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/AuthenticationSettings_Get.json
@@ -1,0 +1,34 @@
+{
+  "title": "AuthenticationSettings_Get",
+  "operationId": "AuthenticationSettings_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "authenticationSettingName": "default-auth"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "managedIdentityName": "SystemAssigned",
+          "provisioningState": "Succeeded",
+          "displayName": "Default managed identity",
+          "authenticationKind": "ManagedIdentity"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/authenticationSettings/default-auth",
+        "name": "default-auth",
+        "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/AuthenticationSettings_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/AuthenticationSettings_ListByHealthModel.json
@@ -1,0 +1,56 @@
+{
+  "title": "AuthenticationSettings_ListByHealthModel",
+  "operationId": "AuthenticationSettings_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "managedIdentityName": "SystemAssigned",
+              "provisioningState": "Succeeded",
+              "displayName": "Default managed identity",
+              "authenticationKind": "ManagedIdentity"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/authenticationSettings/default-auth",
+            "name": "default-auth",
+            "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "managedIdentityName": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/online-store-identity",
+              "provisioningState": "Succeeded",
+              "displayName": "User-assigned managed identity",
+              "authenticationKind": "ManagedIdentity"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/authenticationSettings/user-assigned-auth",
+            "name": "user-assigned-auth",
+            "type": "Microsoft.CloudHealth/healthmodels/authenticationSettings",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/DiscoveryRules_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/DiscoveryRules_CreateOrUpdate.json
@@ -1,0 +1,82 @@
+{
+  "title": "DiscoveryRules_CreateOrUpdate",
+  "operationId": "DiscoveryRules_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "discoveryRuleName": "discover-web-apps",
+    "resource": {
+      "properties": {
+        "authenticationSetting": "default-auth",
+        "displayName": "Discover web apps",
+        "discoverRelationships": "Enabled",
+        "addRecommendedSignals": "Enabled",
+        "specification": {
+          "kind": "ResourceGraphQuery",
+          "resourceGraphQuery": "resources | where type =~ 'microsoft.web/sites' and resourceGroup =~ 'online-store-rg' | project id, name, location"
+        },
+        "addResourceHealthSignal": "Enabled"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "default-auth",
+          "provisioningState": "Succeeded",
+          "displayName": "Discover web apps",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where type =~ 'microsoft.web/sites' and resourceGroup =~ 'online-store-rg' | project id, name, location"
+          },
+          "addResourceHealthSignal": "Enabled",
+          "entityName": "online-store-web-apps"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/discoveryRules/discover-web-apps",
+        "name": "discover-web-apps",
+        "type": "Microsoft.CloudHealth/healthmodels/discoveryRules",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "default-auth",
+          "provisioningState": "Succeeded",
+          "displayName": "Discover web apps",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where type =~ 'microsoft.web/sites' and resourceGroup =~ 'online-store-rg' | project id, name, location"
+          },
+          "addResourceHealthSignal": "Enabled",
+          "entityName": "online-store-web-apps"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/discoveryRules/discover-web-apps",
+        "name": "discover-web-apps",
+        "type": "Microsoft.CloudHealth/healthmodels/discoveryRules",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/DiscoveryRules_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/DiscoveryRules_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "DiscoveryRules_Delete",
+  "operationId": "DiscoveryRules_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "discoveryRuleName": "discover-web-apps"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/DiscoveryRules_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/DiscoveryRules_Get.json
@@ -1,0 +1,48 @@
+{
+  "title": "DiscoveryRules_Get",
+  "operationId": "DiscoveryRules_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "discoveryRuleName": "discover-web-apps"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "authenticationSetting": "default-auth",
+          "provisioningState": "Succeeded",
+          "displayName": "Discover web apps",
+          "discoverRelationships": "Enabled",
+          "addRecommendedSignals": "Enabled",
+          "specification": {
+            "kind": "ResourceGraphQuery",
+            "resourceGraphQuery": "resources | where type =~ 'microsoft.web/sites' and resourceGroup =~ 'online-store-rg' | project id, name, location"
+          },
+          "addResourceHealthSignal": "Enabled",
+          "error": {
+            "message": "The discovery query failed because the authentication setting 'default-auth' does not have Reader access to the target scope.",
+            "context": [
+              "scope: /subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg",
+              "authenticationSetting: default-auth"
+            ]
+          },
+          "entityName": "online-store-web-apps"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/discoveryRules/discover-web-apps",
+        "name": "discover-web-apps",
+        "type": "Microsoft.CloudHealth/healthmodels/discoveryRules",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/DiscoveryRules_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/DiscoveryRules_ListByHealthModel.json
@@ -1,0 +1,70 @@
+{
+  "title": "DiscoveryRules_ListByHealthModel",
+  "operationId": "DiscoveryRules_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "authenticationSetting": "default-auth",
+              "provisioningState": "Succeeded",
+              "displayName": "Discover web apps",
+              "discoverRelationships": "Enabled",
+              "addRecommendedSignals": "Enabled",
+              "specification": {
+                "kind": "ResourceGraphQuery",
+                "resourceGraphQuery": "resources | where type =~ 'microsoft.web/sites' and resourceGroup =~ 'online-store-rg' | project id, name, location"
+              },
+              "addResourceHealthSignal": "Enabled",
+              "entityName": "online-store-web-apps"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/discoveryRules/discover-web-apps",
+            "name": "discover-web-apps",
+            "type": "Microsoft.CloudHealth/healthmodels/discoveryRules",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "authenticationSetting": "default-auth",
+              "provisioningState": "Succeeded",
+              "displayName": "Discover Application Insights topology",
+              "discoverRelationships": "Enabled",
+              "addRecommendedSignals": "Enabled",
+              "specification": {
+                "kind": "ApplicationInsightsTopology",
+                "applicationInsightsResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/components/online-store-ai"
+              },
+              "addResourceHealthSignal": "Disabled",
+              "entityName": "online-store-topology"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/discoveryRules/discover-app-topology",
+            "name": "discover-app-topology",
+            "type": "Microsoft.CloudHealth/healthmodels/discoveryRules",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_AddDataAnnotation.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_AddDataAnnotation.json
@@ -1,0 +1,33 @@
+{
+  "title": "Entities_AddDataAnnotation",
+  "operationId": "Entities_AddDataAnnotation",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "web-frontend",
+    "body": {
+      "annotationDetails": {
+        "environment": "production",
+        "deploymentId": "deploy-2026-05-04-001",
+        "changedBy": "release-pipeline"
+      },
+      "description": "Deployed release 2.4.1 to the web frontend."
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "annotationId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "annotationDetails": {
+          "environment": "production",
+          "deploymentId": "deploy-2026-05-04-001",
+          "changedBy": "release-pipeline"
+        },
+        "description": "Deployed release 2.4.1 to the web frontend.",
+        "createdAt": "2026-05-04T14:30:00Z"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_CreateOrUpdate.json
@@ -1,0 +1,672 @@
+{
+  "title": "Entities_CreateOrUpdate",
+  "operationId": "Entities_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "orders-api",
+    "resource": {
+      "properties": {
+        "displayName": "Orders API",
+        "canvasPosition": {
+          "x": 360,
+          "y": 240
+        },
+        "icon": {
+          "iconName": "Kubernetes"
+        },
+        "healthObjective": 99.9,
+        "impact": "Standard",
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        },
+        "signalGroups": {
+          "azureResource": {
+            "authenticationSetting": "default-auth",
+            "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ContainerService/managedClusters/online-store-aks",
+            "azureResourceKind": "managedClusters",
+            "signals": [
+              {
+                "signalKind": "AzureResourceMetric",
+                "name": "node-cpu",
+                "displayName": "Node CPU utilization",
+                "refreshInterval": "PT1M",
+                "dataUnit": "Percent",
+                "metricNamespace": "Microsoft.ContainerService/managedClusters",
+                "metricName": "node_cpu_usage_percentage",
+                "timeGrain": "PT5M",
+                "aggregationType": "Average",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 70
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 90
+                  }
+                }
+              }
+            ],
+            "resourceHealth": {
+              "enabled": "Enabled"
+            }
+          },
+          "azureMonitorWorkspace": {
+            "authenticationSetting": "default-auth",
+            "azureMonitorWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Monitor/accounts/online-store-amw",
+            "signals": [
+              {
+                "signalKind": "PrometheusMetricsQuery",
+                "name": "error-rate",
+                "displayName": "HTTP 5xx error rate",
+                "refreshInterval": "PT1M",
+                "dataUnit": "Percent",
+                "queryText": "sum(rate(http_requests_total{job=\"orders-api\", code=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"orders-api\"}[5m])) * 100",
+                "timeGrain": "PT5M",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 1
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 5
+                  }
+                }
+              },
+              {
+                "signalKind": "PrometheusMetricsQuery",
+                "name": "p95-latency",
+                "displayName": "p95 request latency",
+                "refreshInterval": "PT1M",
+                "dataUnit": "MilliSeconds",
+                "queryText": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"orders-api\"}[5m]))) * 1000",
+                "timeGrain": "PT5M",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 300
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 800
+                  }
+                }
+              },
+              {
+                "signalKind": "PrometheusMetricsQuery",
+                "name": "pod-cpu",
+                "signalDefinitionName": "pod-cpu-usage",
+                "displayName": "Pod CPU utilization",
+                "refreshInterval": "PT1M",
+                "dataUnit": "Percent",
+                "queryText": "sum(rate(container_cpu_usage_seconds_total{namespace=\"online-store\", pod=~\"orders-api-.*\"}[5m])) * 100",
+                "timeGrain": "PT5M",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 70
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 90
+                  }
+                }
+              }
+            ]
+          },
+          "azureLogAnalytics": {
+            "authenticationSetting": "default-auth",
+            "logAnalyticsWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.OperationalInsights/workspaces/online-store-law",
+            "signals": [
+              {
+                "signalKind": "LogAnalyticsQuery",
+                "name": "unhealthy-pods",
+                "displayName": "Unhealthy pods",
+                "refreshInterval": "PT5M",
+                "dataUnit": "Count",
+                "queryText": "KubePodInventory | where TimeGenerated > ago(5m) | where Namespace == 'online-store' | where PodStatus != 'Running' | summarize unhealthyPods = dcount(Name)",
+                "timeGrain": "PT5M",
+                "valueColumnName": "unhealthyPods",
+                "evaluationRules": {
+                  "degradedRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 0
+                  },
+                  "unhealthyRule": {
+                    "operator": "GreaterThan",
+                    "threshold": 2
+                  }
+                }
+              }
+            ]
+          },
+          "dependencies": {
+            "aggregationType": "MinHealthy",
+            "unit": "Percentage",
+            "degradedThreshold": 100,
+            "unhealthyThreshold": 50,
+            "ignoreUnknown": true
+          }
+        },
+        "signalAggregationGroups": [
+          {
+            "name": "latency-and-errors",
+            "displayName": "Latency and errors",
+            "aggregationType": "WorstOf",
+            "members": [
+              "error-rate",
+              "p95-latency"
+            ]
+          },
+          {
+            "name": "compute-utilization",
+            "displayName": "Compute utilization",
+            "aggregationType": "MinHealthy",
+            "members": [
+              "node-cpu",
+              "pod-cpu"
+            ],
+            "unhealthyThreshold": 50,
+            "unit": "Percentage",
+            "ignoreUnknown": true
+          }
+        ],
+        "alerts": {
+          "unhealthy": {
+            "severity": "Sev1",
+            "description": "Orders API is unhealthy.",
+            "actionGroupIds": [
+              "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+            ]
+          },
+          "degraded": {
+            "severity": "Sev3",
+            "description": "Orders API is degraded.",
+            "actionGroupIds": [
+              "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "Orders API",
+          "canvasPosition": {
+            "x": 360,
+            "y": 240
+          },
+          "icon": {
+            "iconName": "Kubernetes"
+          },
+          "healthObjective": 99.9,
+          "impact": "Standard",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "default-auth",
+              "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ContainerService/managedClusters/online-store-aks",
+              "azureResourceKind": "managedClusters",
+              "signals": [
+                {
+                  "signalKind": "AzureResourceMetric",
+                  "name": "node-cpu",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 41.2,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Node CPU utilization",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "metricNamespace": "Microsoft.ContainerService/managedClusters",
+                  "metricName": "node_cpu_usage_percentage",
+                  "timeGrain": "PT5M",
+                  "aggregationType": "Average",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ],
+              "resourceHealth": {
+                "enabled": "Enabled",
+                "signalName": "resourcehealth-availabilitystate",
+                "status": {
+                  "healthState": "Healthy",
+                  "reportedAt": "2026-05-04T09:30:00.000Z",
+                  "availabilityState": "Available",
+                  "summary": "The managed cluster is available."
+                }
+              }
+            },
+            "azureMonitorWorkspace": {
+              "authenticationSetting": "default-auth",
+              "azureMonitorWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Monitor/accounts/online-store-amw",
+              "signals": [
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "error-rate",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 0.4,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "HTTP 5xx error rate",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "sum(rate(http_requests_total{job=\"orders-api\", code=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"orders-api\"}[5m])) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 1
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 5
+                    }
+                  }
+                },
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "p95-latency",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 180,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "p95 request latency",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "MilliSeconds",
+                  "queryText": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"orders-api\"}[5m]))) * 1000",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 300
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 800
+                    }
+                  }
+                },
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "pod-cpu",
+                  "signalDefinitionName": "pod-cpu-usage",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 45.3,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Pod CPU utilization",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "sum(rate(container_cpu_usage_seconds_total{namespace=\"online-store\", pod=~\"orders-api-.*\"}[5m])) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            },
+            "azureLogAnalytics": {
+              "authenticationSetting": "default-auth",
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.OperationalInsights/workspaces/online-store-law",
+              "signals": [
+                {
+                  "signalKind": "LogAnalyticsQuery",
+                  "name": "unhealthy-pods",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 0,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Unhealthy pods",
+                  "refreshInterval": "PT5M",
+                  "dataUnit": "Count",
+                  "queryText": "KubePodInventory | where TimeGenerated > ago(5m) | where Namespace == 'online-store' | where PodStatus != 'Running' | summarize unhealthyPods = dcount(Name)",
+                  "timeGrain": "PT5M",
+                  "valueColumnName": "unhealthyPods",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 0
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 2
+                    }
+                  }
+                }
+              ]
+            },
+            "dependencies": {
+              "aggregationType": "MinHealthy",
+              "unit": "Percentage",
+              "degradedThreshold": 100,
+              "unhealthyThreshold": 50,
+              "ignoreUnknown": true
+            }
+          },
+          "signalAggregationGroups": [
+            {
+              "name": "latency-and-errors",
+              "displayName": "Latency and errors",
+              "aggregationType": "WorstOf",
+              "members": [
+                "error-rate",
+                "p95-latency"
+              ],
+              "aggregatedHealthState": "Healthy"
+            },
+            {
+              "name": "compute-utilization",
+              "displayName": "Compute utilization",
+              "aggregationType": "MinHealthy",
+              "members": [
+                "node-cpu",
+                "pod-cpu"
+              ],
+              "unhealthyThreshold": 50,
+              "unit": "Percentage",
+              "ignoreUnknown": true,
+              "aggregatedHealthState": "Healthy"
+            }
+          ],
+          "alerts": {
+            "unhealthy": {
+              "severity": "Sev1",
+              "description": "Orders API is unhealthy.",
+              "actionGroupIds": [
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+              ]
+            },
+            "degraded": {
+              "severity": "Sev3",
+              "description": "Orders API is degraded.",
+              "actionGroupIds": [
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "healthState": "Healthy"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/orders-api",
+        "name": "orders-api",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "displayName": "Orders API",
+          "canvasPosition": {
+            "x": 360,
+            "y": 240
+          },
+          "icon": {
+            "iconName": "Kubernetes"
+          },
+          "healthObjective": 99.9,
+          "impact": "Standard",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "default-auth",
+              "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ContainerService/managedClusters/online-store-aks",
+              "azureResourceKind": "managedClusters",
+              "signals": [
+                {
+                  "signalKind": "AzureResourceMetric",
+                  "name": "node-cpu",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 41.2,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Node CPU utilization",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "metricNamespace": "Microsoft.ContainerService/managedClusters",
+                  "metricName": "node_cpu_usage_percentage",
+                  "timeGrain": "PT5M",
+                  "aggregationType": "Average",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ],
+              "resourceHealth": {
+                "enabled": "Enabled",
+                "signalName": "resourcehealth-availabilitystate",
+                "status": {
+                  "healthState": "Healthy",
+                  "reportedAt": "2026-05-04T09:30:00.000Z",
+                  "availabilityState": "Available",
+                  "summary": "The managed cluster is available."
+                }
+              }
+            },
+            "azureMonitorWorkspace": {
+              "authenticationSetting": "default-auth",
+              "azureMonitorWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Monitor/accounts/online-store-amw",
+              "signals": [
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "error-rate",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 0.4,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "HTTP 5xx error rate",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "sum(rate(http_requests_total{job=\"orders-api\", code=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"orders-api\"}[5m])) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 1
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 5
+                    }
+                  }
+                },
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "p95-latency",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 180,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "p95 request latency",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "MilliSeconds",
+                  "queryText": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"orders-api\"}[5m]))) * 1000",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 300
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 800
+                    }
+                  }
+                },
+                {
+                  "signalKind": "PrometheusMetricsQuery",
+                  "name": "pod-cpu",
+                  "signalDefinitionName": "pod-cpu-usage",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 45.3,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Pod CPU utilization",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "queryText": "sum(rate(container_cpu_usage_seconds_total{namespace=\"online-store\", pod=~\"orders-api-.*\"}[5m])) * 100",
+                  "timeGrain": "PT5M",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ]
+            },
+            "azureLogAnalytics": {
+              "authenticationSetting": "default-auth",
+              "logAnalyticsWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.OperationalInsights/workspaces/online-store-law",
+              "signals": [
+                {
+                  "signalKind": "LogAnalyticsQuery",
+                  "name": "unhealthy-pods",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 0,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "Unhealthy pods",
+                  "refreshInterval": "PT5M",
+                  "dataUnit": "Count",
+                  "queryText": "KubePodInventory | where TimeGenerated > ago(5m) | where Namespace == 'online-store' | where PodStatus != 'Running' | summarize unhealthyPods = dcount(Name)",
+                  "timeGrain": "PT5M",
+                  "valueColumnName": "unhealthyPods",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 0
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 2
+                    }
+                  }
+                }
+              ]
+            },
+            "dependencies": {
+              "aggregationType": "MinHealthy",
+              "unit": "Percentage",
+              "degradedThreshold": 100,
+              "unhealthyThreshold": 50,
+              "ignoreUnknown": true
+            }
+          },
+          "signalAggregationGroups": [
+            {
+              "name": "latency-and-errors",
+              "displayName": "Latency and errors",
+              "aggregationType": "WorstOf",
+              "members": [
+                "error-rate",
+                "p95-latency"
+              ],
+              "aggregatedHealthState": "Healthy"
+            },
+            {
+              "name": "compute-utilization",
+              "displayName": "Compute utilization",
+              "aggregationType": "MinHealthy",
+              "members": [
+                "node-cpu",
+                "pod-cpu"
+              ],
+              "unhealthyThreshold": 50,
+              "unit": "Percentage",
+              "ignoreUnknown": true,
+              "aggregatedHealthState": "Healthy"
+            }
+          ],
+          "alerts": {
+            "unhealthy": {
+              "severity": "Sev1",
+              "description": "Orders API is unhealthy.",
+              "actionGroupIds": [
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+              ]
+            },
+            "degraded": {
+              "severity": "Sev3",
+              "description": "Orders API is degraded.",
+              "actionGroupIds": [
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+              ]
+            }
+          },
+          "provisioningState": "Succeeded",
+          "healthState": "Healthy"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/orders-api",
+        "name": "orders-api",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Entities_Delete",
+  "operationId": "Entities_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "catalog-storage"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_Get.json
@@ -1,0 +1,132 @@
+{
+  "title": "Entities_Get",
+  "operationId": "Entities_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "orders-db"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "Orders Database",
+          "canvasPosition": {
+            "x": 480,
+            "y": 360
+          },
+          "icon": {
+            "iconName": "SQLDatabase"
+          },
+          "healthObjective": 99.5,
+          "impact": "Standard",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "signalGroups": {
+            "azureResource": {
+              "authenticationSetting": "default-auth",
+              "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Sql/servers/online-store-sql/databases/orders",
+              "signals": [
+                {
+                  "signalKind": "AzureResourceMetric",
+                  "name": "sql-cpu",
+                  "signalDefinitionName": "sql-cpu-percent",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 38.5,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "CPU utilization",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "metricNamespace": "Microsoft.Sql/servers/databases",
+                  "metricName": "cpu_percent",
+                  "timeGrain": "PT5M",
+                  "aggregationType": "Average",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 70
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                },
+                {
+                  "signalKind": "AzureResourceMetric",
+                  "name": "sql-dtu",
+                  "status": {
+                    "healthState": "Healthy",
+                    "value": 52.1,
+                    "reportedAt": "2026-05-04T09:30:00.000Z"
+                  },
+                  "displayName": "DTU consumption",
+                  "refreshInterval": "PT1M",
+                  "dataUnit": "Percent",
+                  "metricNamespace": "Microsoft.Sql/servers/databases",
+                  "metricName": "dtu_consumption_percent",
+                  "timeGrain": "PT5M",
+                  "aggregationType": "Average",
+                  "evaluationRules": {
+                    "degradedRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 75
+                    },
+                    "unhealthyRule": {
+                      "operator": "GreaterThan",
+                      "threshold": 90
+                    }
+                  }
+                }
+              ],
+              "resourceHealth": {
+                "enabled": "Enabled",
+                "signalName": "resourcehealth-availabilitystate",
+                "status": {
+                  "healthState": "Healthy",
+                  "reportedAt": "2026-05-04T09:30:00.000Z",
+                  "availabilityState": "Available",
+                  "summary": "The database is available."
+                }
+              }
+            },
+            "dependencies": {
+              "aggregationType": "WorstOf"
+            }
+          },
+          "signalAggregationGroups": [
+            {
+              "name": "capacity",
+              "displayName": "Database capacity",
+              "aggregationType": "WorstOf",
+              "members": [
+                "sql-cpu",
+                "sql-dtu"
+              ],
+              "aggregatedHealthState": "Healthy"
+            }
+          ],
+          "provisioningState": "Succeeded",
+          "healthState": "Healthy"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/orders-db",
+        "name": "orders-db",
+        "type": "Microsoft.CloudHealth/healthmodels/entities",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_GetDataAnnotations.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_GetDataAnnotations.json
@@ -1,0 +1,43 @@
+{
+  "title": "Entities_GetDataAnnotations",
+  "operationId": "Entities_GetDataAnnotations",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "web-frontend",
+    "body": {
+      "startAt": "2026-05-03T00:00:00Z",
+      "endAt": "2026-05-04T23:59:59Z"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "entityName": "web-frontend",
+        "annotations": [
+          {
+            "annotationId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            "createdAt": "2026-05-04T14:30:00Z",
+            "annotationDetails": {
+              "environment": "production",
+              "deploymentId": "deploy-2026-05-04-001",
+              "changedBy": "release-pipeline"
+            },
+            "description": "Deployed release 2.4.1 to the web frontend."
+          },
+          {
+            "annotationId": "b2c3d4e5-f6a7-8901-bcde-f21234567890",
+            "createdAt": "2026-05-04T03:15:00Z",
+            "annotationDetails": {
+              "changeType": "ScaleOut",
+              "instanceCount": "6"
+            },
+            "description": "Scaled out the web frontend to 6 instances."
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_GetHistory.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_GetHistory.json
@@ -1,0 +1,50 @@
+{
+  "title": "Entities_GetHistory",
+  "operationId": "Entities_GetHistory",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "web-frontend",
+    "body": {
+      "startAt": "2026-05-03T09:30:00Z",
+      "endAt": "2026-05-04T09:30:00Z",
+      "top": 100
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "entityName": "web-frontend",
+        "history": [
+          {
+            "previousState": "Healthy",
+            "newState": "Degraded",
+            "occurredAt": "2026-05-03T14:30:00Z",
+            "reason": "SignalTransition"
+          },
+          {
+            "previousState": "Degraded",
+            "newState": "Unhealthy",
+            "occurredAt": "2026-05-03T18:45:00Z",
+            "reason": "ChildEntityTransition"
+          },
+          {
+            "previousState": "Unhealthy",
+            "newState": "Degraded",
+            "occurredAt": "2026-05-03T22:15:00Z",
+            "reason": "ChildEntityTransition"
+          },
+          {
+            "previousState": "Degraded",
+            "newState": "Healthy",
+            "occurredAt": "2026-05-04T02:30:00Z",
+            "reason": "SignalTransition"
+          }
+        ],
+        "nextMarker": "eyJsYXN0VGltZXN0YW1wIjoiMjAyNi0wNS0wNFQwMjozMDowMFoifQ=="
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_GetSignalHistory.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_GetSignalHistory.json
@@ -1,0 +1,63 @@
+{
+  "title": "Entities_GetSignalHistory",
+  "operationId": "Entities_GetSignalHistory",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "web-frontend",
+    "body": {
+      "signalName": "http-5xx",
+      "startAt": "2026-05-03T09:30:00Z",
+      "endAt": "2026-05-04T09:30:00Z",
+      "top": 7
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "entityName": "web-frontend",
+        "signalName": "http-5xx",
+        "history": [
+          {
+            "occurredAt": "2026-05-03T10:00:00Z",
+            "value": 0,
+            "healthState": "Healthy"
+          },
+          {
+            "occurredAt": "2026-05-03T14:00:00Z",
+            "value": 3,
+            "healthState": "Healthy"
+          },
+          {
+            "occurredAt": "2026-05-03T18:00:00Z",
+            "value": 12,
+            "healthState": "Degraded"
+          },
+          {
+            "occurredAt": "2026-05-03T22:00:00Z",
+            "value": 27,
+            "healthState": "Unhealthy"
+          },
+          {
+            "occurredAt": "2026-05-04T02:00:00Z",
+            "value": 8,
+            "healthState": "Degraded"
+          },
+          {
+            "occurredAt": "2026-05-04T06:00:00Z",
+            "value": 1,
+            "healthState": "Healthy"
+          },
+          {
+            "occurredAt": "2026-05-04T09:00:00Z",
+            "value": 0,
+            "healthState": "Healthy"
+          }
+        ],
+        "nextMarker": "eyJsYXN0VGltZXN0YW1wIjoiMjAyNi0wNS0wNFQwOTowMDowMFoifQ=="
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_GetSignalRecommendations.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_GetSignalRecommendations.json
@@ -1,0 +1,89 @@
+{
+  "title": "Entities_GetSignalRecommendations",
+  "operationId": "Entities_GetSignalRecommendations",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "orders-db"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "recommendedSignals": [
+          {
+            "signalId": "sql-cpu-percent",
+            "metricNamespace": "Microsoft.Sql/servers/databases",
+            "metricName": "cpu_percent",
+            "aggregationType": "Average",
+            "unit": "Percent",
+            "timeGrain": "PT5M",
+            "evaluationRules": {
+              "degradedRule": {
+                "operator": "GreaterThan",
+                "threshold": 70
+              },
+              "unhealthyRule": {
+                "operator": "GreaterThan",
+                "threshold": 90
+              }
+            }
+          },
+          {
+            "signalId": "sql-dtu-consumption",
+            "metricNamespace": "Microsoft.Sql/servers/databases",
+            "metricName": "dtu_consumption_percent",
+            "aggregationType": "Average",
+            "unit": "Percent",
+            "timeGrain": "PT5M",
+            "evaluationRules": {
+              "degradedRule": {
+                "operator": "GreaterThan",
+                "threshold": 75
+              },
+              "unhealthyRule": {
+                "operator": "GreaterThan",
+                "threshold": 90
+              }
+            }
+          }
+        ],
+        "recommendedConfigurations": [
+          {
+            "signalId": "sql-storage-percent",
+            "metricNamespace": "Microsoft.Sql/servers/databases",
+            "metricName": "storage_percent",
+            "aggregationType": "Maximum",
+            "unit": "Percent",
+            "timeGrain": "PT15M",
+            "evaluationRules": {
+              "degradedRule": {
+                "operator": "GreaterThan",
+                "threshold": 80
+              },
+              "unhealthyRule": {
+                "operator": "GreaterThan",
+                "threshold": 95
+              }
+            }
+          },
+          {
+            "signalId": "sql-deadlocks",
+            "metricNamespace": "Microsoft.Sql/servers/databases",
+            "metricName": "deadlock",
+            "aggregationType": "Total",
+            "unit": "Count",
+            "timeGrain": "PT5M",
+            "evaluationRules": {
+              "unhealthyRule": {
+                "operator": "GreaterThan",
+                "threshold": 0
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_IngestHealthReport.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_IngestHealthReport.json
@@ -1,0 +1,31 @@
+{
+  "title": "Entities_IngestHealthReport",
+  "operationId": "Entities_IngestHealthReport",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "entityName": "orders-api",
+    "body": {
+      "signalName": "error-rate",
+      "healthState": "Unhealthy",
+      "value": 6.5,
+      "evaluationRules": {
+        "degradedRule": {
+          "operator": "GreaterThan",
+          "threshold": 1
+        },
+        "unhealthyRule": {
+          "operator": "GreaterThan",
+          "threshold": 5
+        }
+      },
+      "expiresInMinutes": 60,
+      "additionalContext": "Elevated 5xx error rate during the checkout traffic spike."
+    }
+  },
+  "responses": {
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Entities_ListByHealthModel.json
@@ -1,0 +1,557 @@
+{
+  "title": "Entities_ListByHealthModel",
+  "operationId": "Entities_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "Online Store",
+              "canvasPosition": {
+                "x": 120,
+                "y": 40
+              },
+              "icon": {
+                "iconName": "Globe"
+              },
+              "healthObjective": 99.9,
+              "impact": "Standard",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "signalGroups": {
+                "dependencies": {
+                  "aggregationType": "WorstOf"
+                }
+              },
+              "provisioningState": "Succeeded",
+              "healthState": "Healthy"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/storefront",
+            "name": "storefront",
+            "type": "Microsoft.CloudHealth/healthmodels/entities",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Web Frontend",
+              "canvasPosition": {
+                "x": 240,
+                "y": 120
+              },
+              "icon": {
+                "iconName": "AppService"
+              },
+              "healthObjective": 99.9,
+              "impact": "Standard",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "signalGroups": {
+                "azureResource": {
+                  "authenticationSetting": "default-auth",
+                  "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Web/sites/online-store-web",
+                  "azureResourceKind": "app",
+                  "signals": [
+                    {
+                      "signalKind": "AzureResourceMetric",
+                      "name": "http-5xx",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 0,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "HTTP 5xx errors",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Count",
+                      "metricNamespace": "Microsoft.Web/sites",
+                      "metricName": "Http5xx",
+                      "timeGrain": "PT5M",
+                      "aggregationType": "Total",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 5
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 20
+                        }
+                      }
+                    },
+                    {
+                      "signalKind": "AzureResourceMetric",
+                      "name": "response-time",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 0.42,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "Average response time",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Seconds",
+                      "metricNamespace": "Microsoft.Web/sites",
+                      "metricName": "AverageResponseTime",
+                      "timeGrain": "PT5M",
+                      "aggregationType": "Average",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 1
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 3
+                        }
+                      }
+                    }
+                  ],
+                  "resourceHealth": {
+                    "enabled": "Enabled",
+                    "signalName": "resourcehealth-availabilitystate",
+                    "status": {
+                      "healthState": "Healthy",
+                      "reportedAt": "2026-05-04T09:30:00.000Z",
+                      "availabilityState": "Available",
+                      "summary": "The App Service is available."
+                    }
+                  }
+                },
+                "azureLogAnalytics": {
+                  "authenticationSetting": "default-auth",
+                  "logAnalyticsWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.OperationalInsights/workspaces/online-store-law",
+                  "signals": [
+                    {
+                      "signalKind": "LogAnalyticsQuery",
+                      "name": "failed-request-rate",
+                      "status": {
+                        "healthState": "Degraded",
+                        "value": 2.3,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "Failed request rate",
+                      "refreshInterval": "PT5M",
+                      "dataUnit": "Percent",
+                      "queryText": "requests | where timestamp > ago(5m) | summarize failureRate = 100.0 * countif(success == false) / count()",
+                      "timeGrain": "PT5M",
+                      "valueColumnName": "failureRate",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 1
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 5
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dependencies": {
+                  "aggregationType": "WorstOf"
+                }
+              },
+              "alerts": {
+                "unhealthy": {
+                  "severity": "Sev1",
+                  "description": "Web frontend is unhealthy.",
+                  "actionGroupIds": [
+                    "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+                  ]
+                },
+                "degraded": {
+                  "severity": "Sev3",
+                  "description": "Web frontend is degraded.",
+                  "actionGroupIds": [
+                    "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+                  ]
+                }
+              },
+              "provisioningState": "Succeeded",
+              "healthState": "Degraded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/web-frontend",
+            "name": "web-frontend",
+            "type": "Microsoft.CloudHealth/healthmodels/entities",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Orders API",
+              "canvasPosition": {
+                "x": 360,
+                "y": 240
+              },
+              "icon": {
+                "iconName": "Kubernetes"
+              },
+              "healthObjective": 99.9,
+              "impact": "Standard",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "signalGroups": {
+                "azureResource": {
+                  "authenticationSetting": "default-auth",
+                  "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ContainerService/managedClusters/online-store-aks",
+                  "azureResourceKind": "managedClusters",
+                  "signals": [
+                    {
+                      "signalKind": "AzureResourceMetric",
+                      "name": "node-cpu",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 41.2,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "Node CPU utilization",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "metricNamespace": "Microsoft.ContainerService/managedClusters",
+                      "metricName": "node_cpu_usage_percentage",
+                      "timeGrain": "PT5M",
+                      "aggregationType": "Average",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 70
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    }
+                  ],
+                  "resourceHealth": {
+                    "enabled": "Enabled",
+                    "signalName": "resourcehealth-availabilitystate",
+                    "status": {
+                      "healthState": "Healthy",
+                      "reportedAt": "2026-05-04T09:30:00.000Z",
+                      "availabilityState": "Available",
+                      "summary": "The managed cluster is available."
+                    }
+                  }
+                },
+                "azureMonitorWorkspace": {
+                  "authenticationSetting": "default-auth",
+                  "azureMonitorWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Monitor/accounts/online-store-amw",
+                  "signals": [
+                    {
+                      "signalKind": "PrometheusMetricsQuery",
+                      "name": "error-rate",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 0.4,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "HTTP 5xx error rate",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "queryText": "sum(rate(http_requests_total{job=\"orders-api\", code=~\"5..\"}[5m])) / sum(rate(http_requests_total{job=\"orders-api\"}[5m])) * 100",
+                      "timeGrain": "PT5M",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 1
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 5
+                        }
+                      }
+                    },
+                    {
+                      "signalKind": "PrometheusMetricsQuery",
+                      "name": "p95-latency",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 180,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "p95 request latency",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "MilliSeconds",
+                      "queryText": "histogram_quantile(0.95, sum by (le) (rate(http_request_duration_seconds_bucket{job=\"orders-api\"}[5m]))) * 1000",
+                      "timeGrain": "PT5M",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 300
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 800
+                        }
+                      }
+                    },
+                    {
+                      "signalKind": "PrometheusMetricsQuery",
+                      "name": "pod-cpu",
+                      "signalDefinitionName": "pod-cpu-usage",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 45.3,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "Pod CPU utilization",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "queryText": "sum(rate(container_cpu_usage_seconds_total{namespace=\"online-store\", pod=~\"orders-api-.*\"}[5m])) * 100",
+                      "timeGrain": "PT5M",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 70
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    }
+                  ]
+                },
+                "azureLogAnalytics": {
+                  "authenticationSetting": "default-auth",
+                  "logAnalyticsWorkspaceResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.OperationalInsights/workspaces/online-store-law",
+                  "signals": [
+                    {
+                      "signalKind": "LogAnalyticsQuery",
+                      "name": "unhealthy-pods",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 0,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "Unhealthy pods",
+                      "refreshInterval": "PT5M",
+                      "dataUnit": "Count",
+                      "queryText": "KubePodInventory | where TimeGenerated > ago(5m) | where Namespace == 'online-store' | where PodStatus != 'Running' | summarize unhealthyPods = dcount(Name)",
+                      "timeGrain": "PT5M",
+                      "valueColumnName": "unhealthyPods",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 0
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 2
+                        }
+                      }
+                    }
+                  ]
+                },
+                "dependencies": {
+                  "aggregationType": "MinHealthy",
+                  "unit": "Percentage",
+                  "degradedThreshold": 100,
+                  "unhealthyThreshold": 50,
+                  "ignoreUnknown": true
+                }
+              },
+              "signalAggregationGroups": [
+                {
+                  "name": "latency-and-errors",
+                  "displayName": "Latency and errors",
+                  "aggregationType": "WorstOf",
+                  "members": [
+                    "error-rate",
+                    "p95-latency"
+                  ],
+                  "aggregatedHealthState": "Healthy"
+                },
+                {
+                  "name": "compute-utilization",
+                  "displayName": "Compute utilization",
+                  "aggregationType": "MinHealthy",
+                  "members": [
+                    "node-cpu",
+                    "pod-cpu"
+                  ],
+                  "unhealthyThreshold": 50,
+                  "unit": "Percentage",
+                  "ignoreUnknown": true,
+                  "aggregatedHealthState": "Healthy"
+                }
+              ],
+              "alerts": {
+                "unhealthy": {
+                  "severity": "Sev1",
+                  "description": "Orders API is unhealthy.",
+                  "actionGroupIds": [
+                    "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+                  ]
+                },
+                "degraded": {
+                  "severity": "Sev3",
+                  "description": "Orders API is degraded.",
+                  "actionGroupIds": [
+                    "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Insights/actionGroups/online-store-oncall"
+                  ]
+                }
+              },
+              "provisioningState": "Succeeded",
+              "healthState": "Healthy"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/orders-api",
+            "name": "orders-api",
+            "type": "Microsoft.CloudHealth/healthmodels/entities",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Orders Database",
+              "canvasPosition": {
+                "x": 480,
+                "y": 360
+              },
+              "icon": {
+                "iconName": "SQLDatabase"
+              },
+              "healthObjective": 99.5,
+              "impact": "Standard",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "signalGroups": {
+                "azureResource": {
+                  "authenticationSetting": "default-auth",
+                  "azureResourceId": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.Sql/servers/online-store-sql/databases/orders",
+                  "signals": [
+                    {
+                      "signalKind": "AzureResourceMetric",
+                      "name": "sql-cpu",
+                      "signalDefinitionName": "sql-cpu-percent",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 38.5,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "CPU utilization",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "metricNamespace": "Microsoft.Sql/servers/databases",
+                      "metricName": "cpu_percent",
+                      "timeGrain": "PT5M",
+                      "aggregationType": "Average",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 70
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    },
+                    {
+                      "signalKind": "AzureResourceMetric",
+                      "name": "sql-dtu",
+                      "status": {
+                        "healthState": "Healthy",
+                        "value": 52.1,
+                        "reportedAt": "2026-05-04T09:30:00.000Z"
+                      },
+                      "displayName": "DTU consumption",
+                      "refreshInterval": "PT1M",
+                      "dataUnit": "Percent",
+                      "metricNamespace": "Microsoft.Sql/servers/databases",
+                      "metricName": "dtu_consumption_percent",
+                      "timeGrain": "PT5M",
+                      "aggregationType": "Average",
+                      "evaluationRules": {
+                        "degradedRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 75
+                        },
+                        "unhealthyRule": {
+                          "operator": "GreaterThan",
+                          "threshold": 90
+                        }
+                      }
+                    }
+                  ],
+                  "resourceHealth": {
+                    "enabled": "Enabled",
+                    "signalName": "resourcehealth-availabilitystate",
+                    "status": {
+                      "healthState": "Healthy",
+                      "reportedAt": "2026-05-04T09:30:00.000Z",
+                      "availabilityState": "Available",
+                      "summary": "The database is available."
+                    }
+                  }
+                },
+                "dependencies": {
+                  "aggregationType": "WorstOf"
+                }
+              },
+              "signalAggregationGroups": [
+                {
+                  "name": "capacity",
+                  "displayName": "Database capacity",
+                  "aggregationType": "WorstOf",
+                  "members": [
+                    "sql-cpu",
+                    "sql-dtu"
+                  ],
+                  "aggregatedHealthState": "Healthy"
+                }
+              ],
+              "provisioningState": "Succeeded",
+              "healthState": "Healthy"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/entities/orders-db",
+            "name": "orders-db",
+            "type": "Microsoft.CloudHealth/healthmodels/entities",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_Create.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_Create.json
@@ -1,0 +1,82 @@
+{
+  "title": "HealthModels_Create",
+  "operationId": "HealthModels_Create",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "resource": {
+      "properties": {},
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "tags": {
+        "environment": "production",
+        "team": "online-store"
+      },
+      "location": "eastus"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "11111111-1111-1111-1111-111111111111",
+          "tenantId": "22222222-2222-2222-2222-222222222222"
+        },
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        },
+        "location": "eastus",
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+        "name": "online-store",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "headers": {
+        "Azure-AsyncOperation": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/b3f8c2a1-4d5e-6f70-8192-a3b4c5d6e7f8?api-version=2026-09-01-preview"
+      },
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "11111111-1111-1111-1111-111111111111",
+          "tenantId": "22222222-2222-2222-2222-222222222222"
+        },
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        },
+        "location": "eastus",
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+        "name": "online-store",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_Delete.json
@@ -1,0 +1,18 @@
+{
+  "title": "HealthModels_Delete",
+  "operationId": "HealthModels_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_Get.json
@@ -1,0 +1,40 @@
+{
+  "title": "HealthModels_Get",
+  "operationId": "HealthModels_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "11111111-1111-1111-1111-111111111111",
+          "tenantId": "22222222-2222-2222-2222-222222222222"
+        },
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        },
+        "location": "eastus",
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+        "name": "online-store",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_ListByResourceGroup.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_ListByResourceGroup.json
@@ -1,0 +1,73 @@
+{
+  "title": "HealthModels_ListByResourceGroup",
+  "operationId": "HealthModels_ListByResourceGroup",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "11111111-1111-1111-1111-111111111111",
+              "tenantId": "22222222-2222-2222-2222-222222222222"
+            },
+            "tags": {
+              "environment": "production",
+              "team": "online-store"
+            },
+            "location": "eastus",
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+            "name": "online-store",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/online-store-identity": {
+                  "principalId": "33333333-3333-3333-3333-333333333333",
+                  "clientId": "44444444-4444-4444-4444-444444444444"
+                }
+              }
+            },
+            "tags": {
+              "environment": "staging",
+              "team": "online-store"
+            },
+            "location": "eastus",
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store-staging",
+            "name": "online-store-staging",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_ListBySubscription.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_ListBySubscription.json
@@ -1,0 +1,72 @@
+{
+  "title": "HealthModels_ListBySubscription",
+  "operationId": "HealthModels_ListBySubscription",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "type": "SystemAssigned",
+              "principalId": "11111111-1111-1111-1111-111111111111",
+              "tenantId": "22222222-2222-2222-2222-222222222222"
+            },
+            "tags": {
+              "environment": "production",
+              "team": "online-store"
+            },
+            "location": "eastus",
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+            "name": "online-store",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "provisioningState": "Succeeded"
+            },
+            "identity": {
+              "type": "UserAssigned",
+              "userAssignedIdentities": {
+                "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/online-store-identity": {
+                  "principalId": "33333333-3333-3333-3333-333333333333",
+                  "clientId": "44444444-4444-4444-4444-444444444444"
+                }
+              }
+            },
+            "tags": {
+              "environment": "staging",
+              "team": "online-store"
+            },
+            "location": "eastus",
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store-staging",
+            "name": "online-store-staging",
+            "type": "Microsoft.CloudHealth/healthmodels",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_Update.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/HealthModels_Update.json
@@ -1,0 +1,53 @@
+{
+  "title": "HealthModels_Update",
+  "operationId": "HealthModels_Update",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "properties": {
+      "tags": {
+        "environment": "production",
+        "team": "online-store",
+        "tier": "gold"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "provisioningState": "Succeeded"
+        },
+        "identity": {
+          "type": "SystemAssigned",
+          "principalId": "11111111-1111-1111-1111-111111111111",
+          "tenantId": "22222222-2222-2222-2222-222222222222"
+        },
+        "tags": {
+          "environment": "production",
+          "team": "online-store",
+          "tier": "gold"
+        },
+        "location": "eastus",
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store",
+        "name": "online-store",
+        "type": "Microsoft.CloudHealth/healthmodels",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/c4a9d3b2-5e6f-7081-92a3-b4c5d6e7f809?api-version=2026-09-01-preview"
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Operations_List.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Operations_List.json
@@ -1,0 +1,59 @@
+{
+  "title": "Operations_List",
+  "operationId": "Operations_List",
+  "parameters": {
+    "api-version": "2026-09-01-preview"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "name": "Microsoft.CloudHealth/healthmodels/read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft CloudHealth",
+              "resource": "Health models",
+              "operation": "Get Health Model",
+              "description": "Gets a health model."
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.CloudHealth/healthmodels/write",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft CloudHealth",
+              "resource": "Health models",
+              "operation": "Create or Update Health Model",
+              "description": "Creates or updates a health model."
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.CloudHealth/healthmodels/delete",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft CloudHealth",
+              "resource": "Health models",
+              "operation": "Delete Health Model",
+              "description": "Deletes a health model."
+            },
+            "origin": "user,system"
+          },
+          {
+            "name": "Microsoft.CloudHealth/operations/read",
+            "isDataAction": false,
+            "display": {
+              "provider": "Microsoft CloudHealth",
+              "resource": "Operations",
+              "operation": "List Operations",
+              "description": "Lists the available operations."
+            },
+            "origin": "user,system"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Relationships_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Relationships_CreateOrUpdate.json
@@ -1,0 +1,74 @@
+{
+  "title": "Relationships_CreateOrUpdate",
+  "operationId": "Relationships_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "relationshipName": "web-frontend-to-orders-api",
+    "resource": {
+      "properties": {
+        "displayName": "Web Frontend depends on Orders API",
+        "parentEntityName": "web-frontend",
+        "childEntityName": "orders-api",
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "Web Frontend depends on Orders API",
+          "parentEntityName": "web-frontend",
+          "childEntityName": "orders-api",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/web-frontend-to-orders-api",
+        "name": "web-frontend-to-orders-api",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "displayName": "Web Frontend depends on Orders API",
+          "parentEntityName": "web-frontend",
+          "childEntityName": "orders-api",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/web-frontend-to-orders-api",
+        "name": "web-frontend-to-orders-api",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Relationships_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Relationships_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "Relationships_Delete",
+  "operationId": "Relationships_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "relationshipName": "orders-api-to-catalog-storage"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Relationships_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Relationships_Get.json
@@ -1,0 +1,38 @@
+{
+  "title": "Relationships_Get",
+  "operationId": "Relationships_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "relationshipName": "web-frontend-to-orders-api"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "Web Frontend depends on Orders API",
+          "parentEntityName": "web-frontend",
+          "childEntityName": "orders-api",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/web-frontend-to-orders-api",
+        "name": "web-frontend-to-orders-api",
+        "type": "Microsoft.CloudHealth/healthmodels/relationships",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Relationships_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/Relationships_ListByHealthModel.json
@@ -1,0 +1,133 @@
+{
+  "title": "Relationships_ListByHealthModel",
+  "operationId": "Relationships_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "Online Store depends on Web Frontend",
+              "parentEntityName": "storefront",
+              "childEntityName": "web-frontend",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/storefront-to-web-frontend",
+            "name": "storefront-to-web-frontend",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Web Frontend depends on Orders API",
+              "parentEntityName": "web-frontend",
+              "childEntityName": "orders-api",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/web-frontend-to-orders-api",
+            "name": "web-frontend-to-orders-api",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Orders API depends on Orders Database",
+              "parentEntityName": "orders-api",
+              "childEntityName": "orders-db",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/orders-api-to-orders-db",
+            "name": "orders-api-to-orders-db",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Orders API depends on Order Queue",
+              "parentEntityName": "orders-api",
+              "childEntityName": "order-queue",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/orders-api-to-order-queue",
+            "name": "orders-api-to-order-queue",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Orders API depends on Catalog Storage",
+              "parentEntityName": "orders-api",
+              "childEntityName": "catalog-storage",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/relationships/orders-api-to-catalog-storage",
+            "name": "orders-api-to-catalog-storage",
+            "type": "Microsoft.CloudHealth/healthmodels/relationships",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/SignalDefinitions_CreateOrUpdate.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/SignalDefinitions_CreateOrUpdate.json
@@ -1,0 +1,119 @@
+{
+  "title": "SignalDefinitions_CreateOrUpdate",
+  "operationId": "SignalDefinitions_CreateOrUpdate",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "signalDefinitionName": "sql-cpu-percent",
+    "resource": {
+      "properties": {
+        "displayName": "SQL CPU utilization",
+        "signalKind": "AzureResourceMetric",
+        "refreshInterval": "PT1M",
+        "tags": {
+          "environment": "production",
+          "team": "online-store"
+        },
+        "dataUnit": "Percent",
+        "metricNamespace": "Microsoft.Sql/servers/databases",
+        "metricName": "cpu_percent",
+        "timeGrain": "PT5M",
+        "aggregationType": "Average",
+        "evaluationRules": {
+          "degradedRule": {
+            "operator": "GreaterThan",
+            "threshold": 70
+          },
+          "unhealthyRule": {
+            "operator": "Dynamic",
+            "sensitivity": "Medium"
+          }
+        }
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "SQL CPU utilization",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "dataUnit": "Percent",
+          "metricNamespace": "Microsoft.Sql/servers/databases",
+          "metricName": "cpu_percent",
+          "timeGrain": "PT5M",
+          "aggregationType": "Average",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "GreaterThan",
+              "threshold": 70
+            },
+            "unhealthyRule": {
+              "operator": "Dynamic",
+              "sensitivity": "Medium"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/sql-cpu-percent",
+        "name": "sql-cpu-percent",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    },
+    "201": {
+      "body": {
+        "properties": {
+          "displayName": "SQL CPU utilization",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "dataUnit": "Percent",
+          "metricNamespace": "Microsoft.Sql/servers/databases",
+          "metricName": "cpu_percent",
+          "timeGrain": "PT5M",
+          "aggregationType": "Average",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "GreaterThan",
+              "threshold": 70
+            },
+            "unhealthyRule": {
+              "operator": "Dynamic",
+              "sensitivity": "Medium"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/sql-cpu-percent",
+        "name": "sql-cpu-percent",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/SignalDefinitions_Delete.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/SignalDefinitions_Delete.json
@@ -1,0 +1,19 @@
+{
+  "title": "SignalDefinitions_Delete",
+  "operationId": "SignalDefinitions_Delete",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "signalDefinitionName": "sql-cpu-percent"
+  },
+  "responses": {
+    "202": {
+      "headers": {
+        "location": "https://management.azure.com/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/providers/Microsoft.CloudHealth/locations/eastus/operations/d5bae4c3-6f70-8192-a3b4-c5d6e7f8091a?api-version=2026-09-01-preview"
+      }
+    },
+    "204": {}
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/SignalDefinitions_Get.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/SignalDefinitions_Get.json
@@ -1,0 +1,53 @@
+{
+  "title": "SignalDefinitions_Get",
+  "operationId": "SignalDefinitions_Get",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store",
+    "signalDefinitionName": "sql-cpu-percent"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "properties": {
+          "displayName": "SQL CPU utilization",
+          "signalKind": "AzureResourceMetric",
+          "refreshInterval": "PT1M",
+          "tags": {
+            "environment": "production",
+            "team": "online-store"
+          },
+          "dataUnit": "Percent",
+          "metricNamespace": "Microsoft.Sql/servers/databases",
+          "metricName": "cpu_percent",
+          "timeGrain": "PT5M",
+          "aggregationType": "Average",
+          "evaluationRules": {
+            "degradedRule": {
+              "operator": "GreaterThan",
+              "threshold": 70
+            },
+            "unhealthyRule": {
+              "operator": "Dynamic",
+              "sensitivity": "Medium"
+            }
+          },
+          "provisioningState": "Succeeded"
+        },
+        "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/sql-cpu-percent",
+        "name": "sql-cpu-percent",
+        "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+        "systemData": {
+          "createdBy": "admin@contoso.com",
+          "createdByType": "User",
+          "createdAt": "2026-05-04T08:15:00.000Z",
+          "lastModifiedBy": "admin@contoso.com",
+          "lastModifiedByType": "User",
+          "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+        }
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/SignalDefinitions_ListByHealthModel.json
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/preview/2026-09-01-preview/examples/SignalDefinitions_ListByHealthModel.json
@@ -1,0 +1,129 @@
+{
+  "title": "SignalDefinitions_ListByHealthModel",
+  "operationId": "SignalDefinitions_ListByHealthModel",
+  "parameters": {
+    "api-version": "2026-09-01-preview",
+    "subscriptionId": "abcdef12-3456-7890-abcd-ef1234567890",
+    "resourceGroupName": "online-store-rg",
+    "healthModelName": "online-store"
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "value": [
+          {
+            "properties": {
+              "displayName": "SQL CPU utilization",
+              "signalKind": "AzureResourceMetric",
+              "refreshInterval": "PT1M",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "dataUnit": "Percent",
+              "metricNamespace": "Microsoft.Sql/servers/databases",
+              "metricName": "cpu_percent",
+              "timeGrain": "PT5M",
+              "aggregationType": "Average",
+              "evaluationRules": {
+                "degradedRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 70
+                },
+                "unhealthyRule": {
+                  "operator": "Dynamic",
+                  "sensitivity": "Medium"
+                }
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/sql-cpu-percent",
+            "name": "sql-cpu-percent",
+            "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Failed request rate",
+              "signalKind": "LogAnalyticsQuery",
+              "refreshInterval": "PT5M",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "dataUnit": "Percent",
+              "queryText": "requests | where timestamp > ago(5m) | summarize failureRate = 100.0 * countif(success == false) / count()",
+              "timeGrain": "PT5M",
+              "valueColumnName": "failureRate",
+              "evaluationRules": {
+                "degradedRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 1
+                },
+                "unhealthyRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 5
+                }
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/app-failed-requests",
+            "name": "app-failed-requests",
+            "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          },
+          {
+            "properties": {
+              "displayName": "Pod CPU utilization",
+              "signalKind": "PrometheusMetricsQuery",
+              "refreshInterval": "PT1M",
+              "tags": {
+                "environment": "production",
+                "team": "online-store"
+              },
+              "dataUnit": "Percent",
+              "queryText": "sum(rate(container_cpu_usage_seconds_total{namespace=\"online-store\", pod=~\"orders-api-.*\"}[5m])) * 100",
+              "timeGrain": "PT5M",
+              "evaluationRules": {
+                "degradedRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 70
+                },
+                "unhealthyRule": {
+                  "operator": "GreaterThan",
+                  "threshold": 90
+                }
+              },
+              "provisioningState": "Succeeded"
+            },
+            "id": "/subscriptions/abcdef12-3456-7890-abcd-ef1234567890/resourceGroups/online-store-rg/providers/Microsoft.CloudHealth/healthmodels/online-store/signalDefinitions/pod-cpu-usage",
+            "name": "pod-cpu-usage",
+            "type": "Microsoft.CloudHealth/healthmodels/signalDefinitions",
+            "systemData": {
+              "createdBy": "admin@contoso.com",
+              "createdByType": "User",
+              "createdAt": "2026-05-04T08:15:00.000Z",
+              "lastModifiedBy": "admin@contoso.com",
+              "lastModifiedByType": "User",
+              "lastModifiedAt": "2026-05-04T09:30:00.000Z"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/readme.md
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/readme.md
@@ -27,7 +27,22 @@ These are the global settings for the cloudhealth.
 ```yaml
 openapi-type: arm
 openapi-subtype: rpaas
-tag: package-2026-05-01-preview
+tag: package-2026-09-01-preview
+```
+
+### Tag: package-2026-09-01-preview
+
+These settings apply only when `--tag=package-2026-09-01-preview` is specified on the command line.
+
+```yaml $(tag) == 'package-2026-09-01-preview'
+input-file:
+  - preview/2026-09-01-preview/cloudhealth.json
+suppressions:
+  - code: AvoidAdditionalProperties
+    reason: Approved scenario for dynamic annotation key-value properties
+    where:
+      - $.definitions.DataAnnotation.properties.annotationDetails
+      - $.definitions.AddDataAnnotationRequest.properties.annotationDetails
 ```
 
 ### Tag: package-2026-05-01-preview

--- a/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/service.yaml
+++ b/specification/cloudhealth/resource-manager/Microsoft.CloudHealth/CloudHealth/service.yaml
@@ -11,3 +11,7 @@ versions:
     source: typespec
     swagger-files:
       - preview/2026-05-01-preview/cloudhealth.json
+  - version: 2026-09-01-preview
+    source: typespec
+    swagger-files:
+      - preview/2026-09-01-preview/cloudhealth.json


### PR DESCRIPTION
## Summary

Adds the `2026-09-01-preview` API version for `Microsoft.CloudHealth` (Azure Health Models / AHM).

The spec content was developed and merged into the `RPSaaSMaster` branch of `Azure/azure-rest-api-specs-pr` (PRs #28777, #28917), and is now being published to the public repo.

## Changes in this API version

- Add signal aggregation groups on entities: new `SignalAggregationGroup` model and `signalAggregationGroups` property, with an optional `displayName` and optional `aggregationType`.
- Introduce the `AggregationType` union, adding the `BestOf` aggregation strategy.
- Rename `DependenciesAggregationUnit` to `AggregationUnit` (via `@renamedFrom`) and retype `DependenciesSignalGroupV2.aggregationType` / `unit` accordingly.
- Remove `lookBackWindow` from `ThresholdRuleV2`.
- Make `DiscoveryRuleProperties.entityName` optional.

## Files

| Area | Change |
| --- | --- |
| `main.tsp` | Version-gated changes for `2026-09-01-preview` only |
| `preview/2026-09-01-preview/cloudhealth.json` | Generated via `tsp compile` |
| `preview/2026-09-01-preview/examples/` | 33 generated examples |
| `examples/2026-09-01-preview/` | 33 source examples |
| `service.yaml` | New version entry |
| `readme.md` | New `package-2026-09-01-preview` tag, set as default |

## Validation

- `tsp compile` succeeds with no errors or warnings.
- `tsp format` reports no changes.
- Prettier passes on all changed JSON.
- The three previously shipped versions (`2025-05-01-preview`, `2026-01-01-preview`, `2026-05-01-preview`) are **byte-identical** to `main` — this PR adds a new version and does not modify any released API version.

### Note on `RefreshInterval.PT15M`

The `PT15M` refresh interval was added to `main` in #43685 but was never reflected into `RPSaaSMaster`. Rather than copying the swagger from `RPSaaSMaster` (which would have silently dropped `PT15M` from the shipped `2026-05-01-preview`), this branch was created from `main` and the TypeSpec was regenerated, so `PT15M` is correctly retained in both the existing versions and the new one.

## Notes for reviewers

This version is **preview**, not GA. An earlier draft (#43688) modelled it as `stable/2026-09-01`; that was corrected to preview in Azure/azure-rest-api-specs-pr#28917 and this PR reflects the corrected shape. #43688 is superseded by this PR.
