### PR TITLE
Use source branch for generated SDK PR state

### DIFF
--- a/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
+++ b/eng/pipelines/templates/stages/archetype-spec-gen-sdk.yml
@@ -318,7 +318,9 @@ stages:
             Write-Host "Branch name is set to: $sdkPrBranchName"
             Write-Host "##vso[task.setvariable variable=SdkPullRequestSourceBranch]$sdkPrBranchName"
 
-            $openAsDraft = ('$(SpecRepoCommit)' -ne 'main') -or $${{ not(endsWith(parameters.TriggerSource, '-release')) }}
+            $specRepoSourceBranch = '$(Build.SourceBranch)'
+            Write-Host "Spec repo source branch: '$specRepoSourceBranch'"
+            $openAsDraft = ($specRepoSourceBranch -ne 'refs/heads/main') -or $${{ not(endsWith(parameters.TriggerSource, '-release')) }}
             Write-Host "Open SDK pull request as draft: $openAsDraft"
             Write-Host "##vso[task.setvariable variable=OpenSdkPullRequestAsDraft]$openAsDraft"
           workingDirectory: $(SdkRepoDirectory)
@@ -380,7 +382,7 @@ stages:
         - ${{ if endsWith(parameters.TriggerSource, '-release') }}:
           - task: PowerShell@2
             displayName: Add auto-release label
-            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['SpecRepoCommit'], 'main'), not(endsWith(variables['SdkRepoName'], '-pr')))
+            condition: and(succeeded(), eq(variables['HasChanges'], 'true'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), not(endsWith(variables['SdkRepoName'], '-pr')))
             inputs:
               pwsh: true
               workingDirectory: $(SdkRepoDirectory)


### PR DESCRIPTION
## Summary
- use `Build.SourceBranch` instead of the commit SHA to determine whether generated SDK PRs should be drafts
- gate the `auto-release` label on `refs/heads/main`
- log the resolved spec repository source branch in the SDK PR branch setup step

## Context
`SpecRepoCommit` is populated from `Build.SourceVersion`, so its runtime value is a commit SHA rather than `main`. This caused release-triggered SDK PRs from `main` to remain drafts.

## Test
[Pipeline Run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6727649&view=ms.vss-build-web.run-extensions-tab)