### PR TITLE
Add Voice Live VAD profiles to Foundry Voice Agents

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -90123,6 +90123,11 @@
               "azure_semantic_vad_en"
             ]
           },
+          "profile": {
+            "$ref": "#/components/schemas/VoiceAzureSemanticVadProfile",
+            "description": "The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.",
+            "default": "classic"
+          },
           "threshold": {
             "type": "number",
             "format": "float",
@@ -90201,6 +90206,11 @@
               "azure_semantic_vad_multilingual"
             ]
           },
+          "profile": {
+            "$ref": "#/components/schemas/VoiceAzureSemanticVadProfile",
+            "description": "The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.",
+            "default": "classic"
+          },
           "threshold": {
             "type": "number",
             "format": "float",
@@ -90274,6 +90284,31 @@
           ]
         }
       },
+      "VoiceAzureSemanticVadProfile": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "classic",
+              "eager",
+              "normal",
+              "patient"
+            ]
+          }
+        ],
+        "description": "A bundled Voice Live profile for Azure semantic voice activity detection.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "VoiceAzureSemanticVadTurnDetection": {
         "type": "object",
         "required": [
@@ -90285,6 +90320,11 @@
             "enum": [
               "azure_semantic_vad"
             ]
+          },
+          "profile": {
+            "$ref": "#/components/schemas/VoiceAzureSemanticVadProfile",
+            "description": "The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.",
+            "default": "classic"
           },
           "threshold": {
             "type": "number",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -86337,7 +86337,7 @@
           },
           "session": {
             "$ref": "#/components/schemas/VoiceAgentSessionUpdateConfig",
-            "description": "The stable realtime session fields to update."
+            "description": "The stable realtime session fields to update. Configure an Azure semantic VAD profile through `audio.input.turn_detection.profile`."
           }
         },
         "description": "The `session.update` client event."
@@ -87794,7 +87794,7 @@
             "description": "The ID of the user message item that will be created when speech stops."
           }
         },
-        "description": "The `input_audio_buffer.speech_started` server event."
+        "description": "The `input_audio_buffer.speech_started` server event emitted when turn detection detects speech, including when an Azure semantic VAD profile is configured."
       },
       "VoiceAgentServerEventInputAudioBufferSpeechStopped": {
         "type": "object",
@@ -87826,7 +87826,7 @@
             "description": "The ID of the user message item that will be created."
           }
         },
-        "description": "The `input_audio_buffer.speech_stopped` server event."
+        "description": "The `input_audio_buffer.speech_stopped` server event emitted when turn detection detects the end of speech, including when an Azure semantic VAD profile is configured."
       },
       "VoiceAgentServerEventInputAudioBufferTimeoutTriggered": {
         "type": "object",
@@ -87863,7 +87863,7 @@
             "description": "The ID of the item associated with this segment."
           }
         },
-        "description": "The `input_audio_buffer.timeout_triggered` server event."
+        "description": "The `input_audio_buffer.timeout_triggered` server event emitted when the configured input audio idle timeout ends input, including with an Azure semantic VAD profile."
       },
       "VoiceAgentServerEventMcpListToolsCompleted": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -82033,7 +82033,7 @@ components:
           x-stainless-const: true
         session:
           $ref: '#/components/schemas/VoiceAgentSessionUpdateConfig'
-          description: The stable realtime session fields to update.
+          description: The stable realtime session fields to update. Configure an Azure semantic VAD profile through `audio.input.turn_detection.profile`.
       description: The `session.update` client event.
     VoiceAgentCreateConversationItem:
       anyOf:
@@ -83000,7 +83000,7 @@ components:
         item_id:
           type: string
           description: The ID of the user message item that will be created when speech stops.
-      description: The `input_audio_buffer.speech_started` server event.
+      description: The `input_audio_buffer.speech_started` server event emitted when turn detection detects speech, including when an Azure semantic VAD profile is configured.
     VoiceAgentServerEventInputAudioBufferSpeechStopped:
       type: object
       required:
@@ -83027,7 +83027,7 @@ components:
         item_id:
           type: string
           description: The ID of the user message item that will be created.
-      description: The `input_audio_buffer.speech_stopped` server event.
+      description: The `input_audio_buffer.speech_stopped` server event emitted when turn detection detects the end of speech, including when an Azure semantic VAD profile is configured.
     VoiceAgentServerEventInputAudioBufferTimeoutTriggered:
       type: object
       required:
@@ -83055,7 +83055,7 @@ components:
         item_id:
           type: string
           description: The ID of the item associated with this segment.
-      description: The `input_audio_buffer.timeout_triggered` server event.
+      description: The `input_audio_buffer.timeout_triggered` server event emitted when the configured input audio idle timeout ends input, including with an Azure semantic VAD profile.
     VoiceAgentServerEventMcpListToolsCompleted:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -84662,6 +84662,10 @@ components:
           type: string
           enum:
             - azure_semantic_vad_en
+        profile:
+          $ref: '#/components/schemas/VoiceAzureSemanticVadProfile'
+          description: The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.
+          default: classic
         threshold:
           type: number
           format: float
@@ -84716,6 +84720,10 @@ components:
           type: string
           enum:
             - azure_semantic_vad_multilingual
+        profile:
+          $ref: '#/components/schemas/VoiceAzureSemanticVadProfile'
+          description: The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.
+          default: classic
         threshold:
           type: number
           format: float
@@ -84766,6 +84774,20 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    VoiceAzureSemanticVadProfile:
+      anyOf:
+        - type: string
+        - type: 'null'
+        - type: string
+          enum:
+            - classic
+            - eager
+            - normal
+            - patient
+      description: A bundled Voice Live profile for Azure semantic voice activity detection.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     VoiceAzureSemanticVadTurnDetection:
       type: object
       required:
@@ -84775,6 +84797,10 @@ components:
           type: string
           enum:
             - azure_semantic_vad
+        profile:
+          $ref: '#/components/schemas/VoiceAzureSemanticVadProfile'
+          description: The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.
+          default: classic
         threshold:
           type: number
           format: float

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -93817,6 +93817,11 @@
               "azure_semantic_vad_en"
             ]
           },
+          "profile": {
+            "$ref": "#/components/schemas/VoiceAzureSemanticVadProfile",
+            "description": "The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.",
+            "default": "classic"
+          },
           "threshold": {
             "type": "number",
             "format": "float",
@@ -93895,6 +93900,11 @@
               "azure_semantic_vad_multilingual"
             ]
           },
+          "profile": {
+            "$ref": "#/components/schemas/VoiceAzureSemanticVadProfile",
+            "description": "The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.",
+            "default": "classic"
+          },
           "threshold": {
             "type": "number",
             "format": "float",
@@ -93968,6 +93978,31 @@
           ]
         }
       },
+      "VoiceAzureSemanticVadProfile": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "classic",
+              "eager",
+              "normal",
+              "patient"
+            ]
+          }
+        ],
+        "description": "A bundled Voice Live profile for Azure semantic voice activity detection.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "VoiceAzureSemanticVadTurnDetection": {
         "type": "object",
         "required": [
@@ -93979,6 +94014,11 @@
             "enum": [
               "azure_semantic_vad"
             ]
+          },
+          "profile": {
+            "$ref": "#/components/schemas/VoiceAzureSemanticVadProfile",
+            "description": "The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.",
+            "default": "classic"
           },
           "threshold": {
             "type": "number",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -90031,7 +90031,7 @@
           },
           "session": {
             "$ref": "#/components/schemas/VoiceAgentSessionUpdateConfig",
-            "description": "The stable realtime session fields to update."
+            "description": "The stable realtime session fields to update. Configure an Azure semantic VAD profile through `audio.input.turn_detection.profile`."
           }
         },
         "description": "The `session.update` client event."
@@ -91488,7 +91488,7 @@
             "description": "The ID of the user message item that will be created when speech stops."
           }
         },
-        "description": "The `input_audio_buffer.speech_started` server event."
+        "description": "The `input_audio_buffer.speech_started` server event emitted when turn detection detects speech, including when an Azure semantic VAD profile is configured."
       },
       "VoiceAgentServerEventInputAudioBufferSpeechStopped": {
         "type": "object",
@@ -91520,7 +91520,7 @@
             "description": "The ID of the user message item that will be created."
           }
         },
-        "description": "The `input_audio_buffer.speech_stopped` server event."
+        "description": "The `input_audio_buffer.speech_stopped` server event emitted when turn detection detects the end of speech, including when an Azure semantic VAD profile is configured."
       },
       "VoiceAgentServerEventInputAudioBufferTimeoutTriggered": {
         "type": "object",
@@ -91557,7 +91557,7 @@
             "description": "The ID of the item associated with this segment."
           }
         },
-        "description": "The `input_audio_buffer.timeout_triggered` server event."
+        "description": "The `input_audio_buffer.timeout_triggered` server event emitted when the configured input audio idle timeout ends input, including with an Azure semantic VAD profile."
       },
       "VoiceAgentServerEventMcpListToolsCompleted": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -87167,6 +87167,10 @@ components:
           type: string
           enum:
             - azure_semantic_vad_en
+        profile:
+          $ref: '#/components/schemas/VoiceAzureSemanticVadProfile'
+          description: The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.
+          default: classic
         threshold:
           type: number
           format: float
@@ -87221,6 +87225,10 @@ components:
           type: string
           enum:
             - azure_semantic_vad_multilingual
+        profile:
+          $ref: '#/components/schemas/VoiceAzureSemanticVadProfile'
+          description: The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.
+          default: classic
         threshold:
           type: number
           format: float
@@ -87271,6 +87279,20 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
+    VoiceAzureSemanticVadProfile:
+      anyOf:
+        - type: string
+        - type: 'null'
+        - type: string
+          enum:
+            - classic
+            - eager
+            - normal
+            - patient
+      description: A bundled Voice Live profile for Azure semantic voice activity detection.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     VoiceAzureSemanticVadTurnDetection:
       type: object
       required:
@@ -87280,6 +87302,10 @@ components:
           type: string
           enum:
             - azure_semantic_vad
+        profile:
+          $ref: '#/components/schemas/VoiceAzureSemanticVadProfile'
+          description: The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.
+          default: classic
         threshold:
           type: number
           format: float

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -84538,7 +84538,7 @@ components:
           x-stainless-const: true
         session:
           $ref: '#/components/schemas/VoiceAgentSessionUpdateConfig'
-          description: The stable realtime session fields to update.
+          description: The stable realtime session fields to update. Configure an Azure semantic VAD profile through `audio.input.turn_detection.profile`.
       description: The `session.update` client event.
     VoiceAgentCreateConversationItem:
       anyOf:
@@ -85505,7 +85505,7 @@ components:
         item_id:
           type: string
           description: The ID of the user message item that will be created when speech stops.
-      description: The `input_audio_buffer.speech_started` server event.
+      description: The `input_audio_buffer.speech_started` server event emitted when turn detection detects speech, including when an Azure semantic VAD profile is configured.
     VoiceAgentServerEventInputAudioBufferSpeechStopped:
       type: object
       required:
@@ -85532,7 +85532,7 @@ components:
         item_id:
           type: string
           description: The ID of the user message item that will be created.
-      description: The `input_audio_buffer.speech_stopped` server event.
+      description: The `input_audio_buffer.speech_stopped` server event emitted when turn detection detects the end of speech, including when an Azure semantic VAD profile is configured.
     VoiceAgentServerEventInputAudioBufferTimeoutTriggered:
       type: object
       required:
@@ -85560,7 +85560,7 @@ components:
         item_id:
           type: string
           description: The ID of the item associated with this segment.
-      description: The `input_audio_buffer.timeout_triggered` server event.
+      description: The `input_audio_buffer.timeout_triggered` server event emitted when the configured input audio idle timeout ends input, including with an Azure semantic VAD profile.
     VoiceAgentServerEventMcpListToolsCompleted:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
@@ -558,9 +558,33 @@ model VoiceEndOfUtteranceDetection {
   timeout_ms?: duration;
 }
 
+@doc("A bundled Voice Live profile for Azure semantic voice activity detection.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+union VoiceAzureSemanticVadProfile {
+  string,
+
+  @doc("Disables profile expansion and uses explicit turn-detection settings.")
+  none: null,
+
+  @doc("Preserves the current default turn-detection behavior.")
+  classic: "classic",
+
+  @doc("Prioritizes fast turn detection.")
+  eager: "eager",
+
+  @doc("Balances turn-detection latency and tolerance for pauses.")
+  normal: "normal",
+
+  @doc("Prioritizes tolerance for longer pauses.")
+  patient: "patient",
+}
+
 /** Options shared by Azure semantic voice activity detection configurations. */
 #suppress "@azure-tools/typespec-azure-core/known-encoding" "The existing voice-agent wire contract requires integer-millisecond durations."
 alias VoiceAzureSemanticVadOptions = {
+  @doc("The bundled VAD profile. Defaults to classic. Set to null to disable profile expansion.")
+  profile?: VoiceAzureSemanticVadProfile = VoiceAzureSemanticVadProfile.classic;
+
   @doc("Activation threshold for voice activity detection, from 0 to 1.")
   @minValue(0)
   @maxValue(1)

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/protocol.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/protocol.tsp
@@ -400,7 +400,7 @@ model VoiceAgentClientEventResponseCreate {
 model VoiceAgentClientEventSessionUpdate {
   ...OmitProperties<OpenAI.RealtimeClientEventSessionUpdate, "session">;
 
-  @doc("The stable realtime session fields to update.")
+  @doc("The stable realtime session fields to update. Configure an Azure semantic VAD profile through `audio.input.turn_detection.profile`.")
   session: VoiceAgentSessionUpdateConfig;
 }
 
@@ -497,19 +497,19 @@ model VoiceAgentServerEventInputAudioBufferCommitted {
   ...OpenAI.RealtimeServerEventInputAudioBufferCommitted;
 }
 
-@doc("The `input_audio_buffer.speech_started` server event.")
+@doc("The `input_audio_buffer.speech_started` server event emitted when turn detection detects speech, including when an Azure semantic VAD profile is configured.")
 @usage(VoiceAgentServerEventUsage)
 model VoiceAgentServerEventInputAudioBufferSpeechStarted {
   ...OpenAI.RealtimeServerEventInputAudioBufferSpeechStarted;
 }
 
-@doc("The `input_audio_buffer.speech_stopped` server event.")
+@doc("The `input_audio_buffer.speech_stopped` server event emitted when turn detection detects the end of speech, including when an Azure semantic VAD profile is configured.")
 @usage(VoiceAgentServerEventUsage)
 model VoiceAgentServerEventInputAudioBufferSpeechStopped {
   ...OpenAI.RealtimeServerEventInputAudioBufferSpeechStopped;
 }
 
-@doc("The `input_audio_buffer.timeout_triggered` server event.")
+@doc("The `input_audio_buffer.timeout_triggered` server event emitted when the configured input audio idle timeout ends input, including with an Azure semantic VAD profile.")
 @usage(VoiceAgentServerEventUsage)
 model VoiceAgentServerEventInputAudioBufferTimeoutTriggered {
   ...OpenAI.RealtimeServerEventInputAudioBufferTimeoutTriggered;

--- a/specification/ai/data-plane/VoiceLive/client.tsp
+++ b/specification/ai/data-plane/VoiceLive/client.tsp
@@ -90,6 +90,12 @@ using Azure.ClientGenerator.Core;
   Access.public,
   "python"
 );
+@@access(
+  VoiceLive.ServerEventInputAudioBufferTimeoutTriggered,
+  Access.public,
+  "python"
+);
+@@access(VoiceLive.ServerEventInputAudioBufferAllIdle, Access.public, "python");
 @@access(VoiceLive.ServerEventResponseAudioDone, Access.public, "python");
 @@access(
   VoiceLive.ServerEventResponseAudioTranscriptDelta,
@@ -295,6 +301,16 @@ using Azure.ClientGenerator.Core;
 @@clientName(
   VoiceLive.ServerEventInputAudioBufferSpeechStopped,
   "SessionUpdateInputAudioBufferSpeechStopped",
+  "csharp"
+);
+@@clientName(
+  VoiceLive.ServerEventInputAudioBufferTimeoutTriggered,
+  "SessionUpdateInputAudioBufferTimeoutTriggered",
+  "csharp"
+);
+@@clientName(
+  VoiceLive.ServerEventInputAudioBufferAllIdle,
+  "SessionUpdateInputAudioBufferAllIdle",
   "csharp"
 );
 @@clientName(
@@ -703,6 +719,12 @@ using Azure.ClientGenerator.Core;
   Access.public,
   "java"
 );
+@@access(
+  VoiceLive.ServerEventInputAudioBufferTimeoutTriggered,
+  Access.public,
+  "java"
+);
+@@access(VoiceLive.ServerEventInputAudioBufferAllIdle, Access.public, "java");
 @@access(VoiceLive.ServerEventResponseAudioDone, Access.public, "java");
 @@access(
   VoiceLive.ServerEventResponseAudioTranscriptDelta,
@@ -815,6 +837,16 @@ using Azure.ClientGenerator.Core;
 @@clientName(
   VoiceLive.ServerEventInputAudioBufferSpeechStopped,
   "SessionUpdateInputAudioBufferSpeechStopped",
+  "java"
+);
+@@clientName(
+  VoiceLive.ServerEventInputAudioBufferTimeoutTriggered,
+  "SessionUpdateInputAudioBufferTimeoutTriggered",
+  "java"
+);
+@@clientName(
+  VoiceLive.ServerEventInputAudioBufferAllIdle,
+  "SessionUpdateInputAudioBufferAllIdle",
   "java"
 );
 @@clientName(
@@ -1158,6 +1190,11 @@ using Azure.ClientGenerator.Core;
   "silenceDurationInMs",
   "javascript"
 );
+@@clientName(
+  VoiceLive.ServerVad.idle_timeout_ms,
+  "idleTimeoutInMs",
+  "javascript"
+);
 
 @@clientName(
   VoiceLive.AzureSemanticVad.prefix_padding_ms,
@@ -1172,6 +1209,11 @@ using Azure.ClientGenerator.Core;
 @@clientName(
   VoiceLive.AzureSemanticVad.speech_duration_ms,
   "speechDurationInMs",
+  "javascript"
+);
+@@clientName(
+  VoiceLive.AzureSemanticVad.idle_timeout_ms,
+  "idleTimeoutInMs",
   "javascript"
 );
 
@@ -1190,6 +1232,11 @@ using Azure.ClientGenerator.Core;
   "speechDurationInMs",
   "javascript"
 );
+@@clientName(
+  VoiceLive.AzureSemanticVadEn.idle_timeout_ms,
+  "idleTimeoutInMs",
+  "javascript"
+);
 
 @@clientName(
   VoiceLive.AzureSemanticVadMultilingual.prefix_padding_ms,
@@ -1204,6 +1251,11 @@ using Azure.ClientGenerator.Core;
 @@clientName(
   VoiceLive.AzureSemanticVadMultilingual.speech_duration_ms,
   "speechDurationInMs",
+  "javascript"
+);
+@@clientName(
+  VoiceLive.AzureSemanticVadMultilingual.idle_timeout_ms,
+  "idleTimeoutInMs",
   "javascript"
 );
 

--- a/specification/ai/data-plane/VoiceLive/client.tsp
+++ b/specification/ai/data-plane/VoiceLive/client.tsp
@@ -90,12 +90,6 @@ using Azure.ClientGenerator.Core;
   Access.public,
   "python"
 );
-@@access(
-  VoiceLive.ServerEventInputAudioBufferTimeoutTriggered,
-  Access.public,
-  "python"
-);
-@@access(VoiceLive.ServerEventInputAudioBufferAllIdle, Access.public, "python");
 @@access(VoiceLive.ServerEventResponseAudioDone, Access.public, "python");
 @@access(
   VoiceLive.ServerEventResponseAudioTranscriptDelta,
@@ -301,16 +295,6 @@ using Azure.ClientGenerator.Core;
 @@clientName(
   VoiceLive.ServerEventInputAudioBufferSpeechStopped,
   "SessionUpdateInputAudioBufferSpeechStopped",
-  "csharp"
-);
-@@clientName(
-  VoiceLive.ServerEventInputAudioBufferTimeoutTriggered,
-  "SessionUpdateInputAudioBufferTimeoutTriggered",
-  "csharp"
-);
-@@clientName(
-  VoiceLive.ServerEventInputAudioBufferAllIdle,
-  "SessionUpdateInputAudioBufferAllIdle",
   "csharp"
 );
 @@clientName(
@@ -719,12 +703,6 @@ using Azure.ClientGenerator.Core;
   Access.public,
   "java"
 );
-@@access(
-  VoiceLive.ServerEventInputAudioBufferTimeoutTriggered,
-  Access.public,
-  "java"
-);
-@@access(VoiceLive.ServerEventInputAudioBufferAllIdle, Access.public, "java");
 @@access(VoiceLive.ServerEventResponseAudioDone, Access.public, "java");
 @@access(
   VoiceLive.ServerEventResponseAudioTranscriptDelta,
@@ -837,16 +815,6 @@ using Azure.ClientGenerator.Core;
 @@clientName(
   VoiceLive.ServerEventInputAudioBufferSpeechStopped,
   "SessionUpdateInputAudioBufferSpeechStopped",
-  "java"
-);
-@@clientName(
-  VoiceLive.ServerEventInputAudioBufferTimeoutTriggered,
-  "SessionUpdateInputAudioBufferTimeoutTriggered",
-  "java"
-);
-@@clientName(
-  VoiceLive.ServerEventInputAudioBufferAllIdle,
-  "SessionUpdateInputAudioBufferAllIdle",
   "java"
 );
 @@clientName(
@@ -1190,11 +1158,6 @@ using Azure.ClientGenerator.Core;
   "silenceDurationInMs",
   "javascript"
 );
-@@clientName(
-  VoiceLive.ServerVad.idle_timeout_ms,
-  "idleTimeoutInMs",
-  "javascript"
-);
 
 @@clientName(
   VoiceLive.AzureSemanticVad.prefix_padding_ms,
@@ -1209,11 +1172,6 @@ using Azure.ClientGenerator.Core;
 @@clientName(
   VoiceLive.AzureSemanticVad.speech_duration_ms,
   "speechDurationInMs",
-  "javascript"
-);
-@@clientName(
-  VoiceLive.AzureSemanticVad.idle_timeout_ms,
-  "idleTimeoutInMs",
   "javascript"
 );
 
@@ -1232,11 +1190,6 @@ using Azure.ClientGenerator.Core;
   "speechDurationInMs",
   "javascript"
 );
-@@clientName(
-  VoiceLive.AzureSemanticVadEn.idle_timeout_ms,
-  "idleTimeoutInMs",
-  "javascript"
-);
 
 @@clientName(
   VoiceLive.AzureSemanticVadMultilingual.prefix_padding_ms,
@@ -1251,11 +1204,6 @@ using Azure.ClientGenerator.Core;
 @@clientName(
   VoiceLive.AzureSemanticVadMultilingual.speech_duration_ms,
   "speechDurationInMs",
-  "javascript"
-);
-@@clientName(
-  VoiceLive.AzureSemanticVadMultilingual.idle_timeout_ms,
-  "idleTimeoutInMs",
   "javascript"
 );
 

--- a/specification/ai/data-plane/VoiceLive/custom.tsp
+++ b/specification/ai/data-plane/VoiceLive/custom.tsp
@@ -844,27 +844,6 @@ union TurnDetectionType {
   azure_semantic_vad_multilingual: "azure_semantic_vad_multilingual",
 }
 
-/** Profile selectors for Voice Live-managed Azure semantic VAD. */
-@added(Versions.v2026_07_15)
-union AzureSemanticVadProfile {
-  string,
-
-  /** Disables profile expansion and preserves field-by-field VAD configuration. */
-  none: null,
-
-  /** Preserves the current default VAD behavior. */
-  classic: "classic",
-
-  /** Prioritizes fast turn detection. */
-  eager: "eager",
-
-  /** Balances turn-detection latency and tolerance for pauses. */
-  normal: "normal",
-
-  /** Prioritizes tolerance for longer pauses. */
-  patient: "patient",
-}
-
 /** Base model for VAD-based turn detection. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
 @usage(DualUsage)
@@ -900,14 +879,6 @@ model ServerVad extends TurnDetection {
 @usage(DualUsage)
 model AzureSemanticVad extends TurnDetection {
   type: TurnDetectionType.azure_semantic_vad;
-
-  /**
-   * Selects a bundled VAD configuration. Defaults to `classic` when omitted.
-   * Set to `null` to disable profile expansion and use explicit field values.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Explicit null disables profile expansion without disabling turn detection."
-  @added(Versions.v2026_07_15)
-  profile?: AzureSemanticVadProfile = AzureSemanticVadProfile.classic;
 
   /** Activation threshold for VAD detection. Range: 0.0 to 1.0. */
   @minValue(0)
@@ -948,14 +919,6 @@ model AzureSemanticVad extends TurnDetection {
 model AzureSemanticVadEn extends TurnDetection {
   type: TurnDetectionType.azure_semantic_vad_en;
 
-  /**
-   * Selects a bundled VAD configuration. Defaults to `classic` when omitted.
-   * Set to `null` to disable profile expansion and use explicit field values.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Explicit null disables profile expansion without disabling turn detection."
-  @added(Versions.v2026_07_15)
-  profile?: AzureSemanticVadProfile = AzureSemanticVadProfile.classic;
-
   /** Activation threshold for VAD detection. Range: 0.0 to 1.0. */
   @minValue(0)
   @maxValue(1)
@@ -991,14 +954,6 @@ model AzureSemanticVadEn extends TurnDetection {
 @usage(DualUsage)
 model AzureSemanticVadMultilingual extends TurnDetection {
   type: TurnDetectionType.azure_semantic_vad_multilingual;
-
-  /**
-   * Selects a bundled VAD configuration. Defaults to `classic` when omitted.
-   * Set to `null` to disable profile expansion and use explicit field values.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Explicit null disables profile expansion without disabling turn detection."
-  @added(Versions.v2026_07_15)
-  profile?: AzureSemanticVadProfile = AzureSemanticVadProfile.classic;
 
   /** Activation threshold for VAD detection. Range: 0.0 to 1.0. */
   @minValue(0)

--- a/specification/ai/data-plane/VoiceLive/custom.tsp
+++ b/specification/ai/data-plane/VoiceLive/custom.tsp
@@ -882,11 +882,6 @@ model ServerVad extends TurnDetection {
   /** Duration of silence required to end speech detection, in milliseconds. */
   silence_duration_ms?: int32;
 
-  /** Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds. */
-  @added(Versions.v2026_07_15)
-  @minValue(0)
-  idle_timeout_ms?: int32;
-
   /** Configuration for end-of-utterance detection. */
   end_of_utterance_detection?: EouDetection;
 
@@ -924,11 +919,6 @@ model AzureSemanticVad extends TurnDetection {
 
   /** Duration of silence required to end speech detection, in milliseconds. */
   silence_duration_ms?: int32;
-
-  /** Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds. */
-  @added(Versions.v2026_07_15)
-  @minValue(0)
-  idle_timeout_ms?: int32;
 
   /** Configuration for end-of-utterance detection. */
   end_of_utterance_detection?: EouDetection;
@@ -977,11 +967,6 @@ model AzureSemanticVadEn extends TurnDetection {
   /** Duration of silence required to end speech detection, in milliseconds. */
   silence_duration_ms?: int32;
 
-  /** Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds. */
-  @added(Versions.v2026_07_15)
-  @minValue(0)
-  idle_timeout_ms?: int32;
-
   /** Configuration for end-of-utterance detection. */
   end_of_utterance_detection?: EouDetection;
 
@@ -1025,11 +1010,6 @@ model AzureSemanticVadMultilingual extends TurnDetection {
 
   /** Duration of silence required to end speech detection, in milliseconds. */
   silence_duration_ms?: int32;
-
-  /** Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds. */
-  @added(Versions.v2026_07_15)
-  @minValue(0)
-  idle_timeout_ms?: int32;
 
   /** Configuration for end-of-utterance detection. */
   end_of_utterance_detection?: EouDetection;

--- a/specification/ai/data-plane/VoiceLive/custom.tsp
+++ b/specification/ai/data-plane/VoiceLive/custom.tsp
@@ -844,6 +844,27 @@ union TurnDetectionType {
   azure_semantic_vad_multilingual: "azure_semantic_vad_multilingual",
 }
 
+/** Profile selectors for Voice Live-managed Azure semantic VAD. */
+@added(Versions.v2026_07_15)
+union AzureSemanticVadProfile {
+  string,
+
+  /** Disables profile expansion and preserves field-by-field VAD configuration. */
+  none: null,
+
+  /** Preserves the current default VAD behavior. */
+  classic: "classic",
+
+  /** Prioritizes fast turn detection. */
+  eager: "eager",
+
+  /** Balances turn-detection latency and tolerance for pauses. */
+  normal: "normal",
+
+  /** Prioritizes tolerance for longer pauses. */
+  patient: "patient",
+}
+
 /** Base model for VAD-based turn detection. */
 #suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
 @usage(DualUsage)
@@ -860,6 +881,11 @@ model ServerVad extends TurnDetection {
 
   /** Duration of silence required to end speech detection, in milliseconds. */
   silence_duration_ms?: int32;
+
+  /** Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds. */
+  @added(Versions.v2026_07_15)
+  @minValue(0)
+  idle_timeout_ms?: int32;
 
   /** Configuration for end-of-utterance detection. */
   end_of_utterance_detection?: EouDetection;
@@ -880,6 +906,14 @@ model ServerVad extends TurnDetection {
 model AzureSemanticVad extends TurnDetection {
   type: TurnDetectionType.azure_semantic_vad;
 
+  /**
+   * Selects a bundled VAD configuration. Defaults to `classic` when omitted.
+   * Set to `null` to disable profile expansion and use explicit field values.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Explicit null disables profile expansion without disabling turn detection."
+  @added(Versions.v2026_07_15)
+  profile?: AzureSemanticVadProfile = AzureSemanticVadProfile.classic;
+
   /** Activation threshold for VAD detection. Range: 0.0 to 1.0. */
   @minValue(0)
   @maxValue(1)
@@ -890,6 +924,11 @@ model AzureSemanticVad extends TurnDetection {
 
   /** Duration of silence required to end speech detection, in milliseconds. */
   silence_duration_ms?: int32;
+
+  /** Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds. */
+  @added(Versions.v2026_07_15)
+  @minValue(0)
+  idle_timeout_ms?: int32;
 
   /** Configuration for end-of-utterance detection. */
   end_of_utterance_detection?: EouDetection;
@@ -919,6 +958,14 @@ model AzureSemanticVad extends TurnDetection {
 model AzureSemanticVadEn extends TurnDetection {
   type: TurnDetectionType.azure_semantic_vad_en;
 
+  /**
+   * Selects a bundled VAD configuration. Defaults to `classic` when omitted.
+   * Set to `null` to disable profile expansion and use explicit field values.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Explicit null disables profile expansion without disabling turn detection."
+  @added(Versions.v2026_07_15)
+  profile?: AzureSemanticVadProfile = AzureSemanticVadProfile.classic;
+
   /** Activation threshold for VAD detection. Range: 0.0 to 1.0. */
   @minValue(0)
   @maxValue(1)
@@ -929,6 +976,11 @@ model AzureSemanticVadEn extends TurnDetection {
 
   /** Duration of silence required to end speech detection, in milliseconds. */
   silence_duration_ms?: int32;
+
+  /** Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds. */
+  @added(Versions.v2026_07_15)
+  @minValue(0)
+  idle_timeout_ms?: int32;
 
   /** Configuration for end-of-utterance detection. */
   end_of_utterance_detection?: EouDetection;
@@ -955,6 +1007,14 @@ model AzureSemanticVadEn extends TurnDetection {
 model AzureSemanticVadMultilingual extends TurnDetection {
   type: TurnDetectionType.azure_semantic_vad_multilingual;
 
+  /**
+   * Selects a bundled VAD configuration. Defaults to `classic` when omitted.
+   * Set to `null` to disable profile expansion and use explicit field values.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-nullable" "Explicit null disables profile expansion without disabling turn detection."
+  @added(Versions.v2026_07_15)
+  profile?: AzureSemanticVadProfile = AzureSemanticVadProfile.classic;
+
   /** Activation threshold for VAD detection. Range: 0.0 to 1.0. */
   @minValue(0)
   @maxValue(1)
@@ -965,6 +1025,11 @@ model AzureSemanticVadMultilingual extends TurnDetection {
 
   /** Duration of silence required to end speech detection, in milliseconds. */
   silence_duration_ms?: int32;
+
+  /** Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds. */
+  @added(Versions.v2026_07_15)
+  @minValue(0)
+  idle_timeout_ms?: int32;
 
   /** Configuration for end-of-utterance detection. */
   end_of_utterance_detection?: EouDetection;

--- a/specification/ai/data-plane/VoiceLive/events.tsp
+++ b/specification/ai/data-plane/VoiceLive/events.tsp
@@ -65,15 +65,6 @@ union ServerEventType {
   input_audio_buffer_cleared: "input_audio_buffer.cleared",
   input_audio_buffer_speech_started: "input_audio_buffer.speech_started",
   input_audio_buffer_speech_stopped: "input_audio_buffer.speech_stopped",
-
-  /** Sent after the configured input inactivity timeout elapses. */
-  @added(Versions.v2026_07_15)
-  input_audio_buffer_timeout_triggered: "input_audio_buffer.timeout_triggered",
-
-  /** Sent when every input audio channel is idle. */
-  @added(Versions.v2026_07_15)
-  input_audio_buffer_all_idle: "input_audio_buffer.all_idle",
-
   response_created: "response.created",
   response_done: "response.done",
   response_output_item_added: "response.output_item.added",

--- a/specification/ai/data-plane/VoiceLive/events.tsp
+++ b/specification/ai/data-plane/VoiceLive/events.tsp
@@ -65,6 +65,15 @@ union ServerEventType {
   input_audio_buffer_cleared: "input_audio_buffer.cleared",
   input_audio_buffer_speech_started: "input_audio_buffer.speech_started",
   input_audio_buffer_speech_stopped: "input_audio_buffer.speech_stopped",
+
+  /** Sent after the configured input inactivity timeout elapses. */
+  @added(Versions.v2026_07_15)
+  input_audio_buffer_timeout_triggered: "input_audio_buffer.timeout_triggered",
+
+  /** Sent when every input audio channel is idle. */
+  @added(Versions.v2026_07_15)
+  input_audio_buffer_all_idle: "input_audio_buffer.all_idle",
+
   response_created: "response.created",
   response_done: "response.done",
   response_output_item_added: "response.output_item.added",

--- a/specification/ai/data-plane/VoiceLive/models.tsp
+++ b/specification/ai/data-plane/VoiceLive/models.tsp
@@ -667,6 +667,33 @@ model ServerEventInputAudioBufferSpeechStopped extends ServerEvent {
   item_id: string;
 }
 
+/**
+ * Sent when the user has remained silent longer than the configured
+ * `idle_timeout_ms`.
+ */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+@added(Versions.v2026_07_15)
+@usage(ResponseUsage)
+model ServerEventInputAudioBufferTimeoutTriggered extends ServerEvent {
+  /** The event type, must be `input_audio_buffer.timeout_triggered`. */
+  type: ServerEventType.input_audio_buffer_timeout_triggered;
+
+  /** The ID of the user message item associated with the timeout. */
+  item_id: string;
+
+  /** The ID of the preceding conversation item, when available. */
+  previous_item_id?: string;
+}
+
+/** Sent when every input audio channel is idle. */
+#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
+@added(Versions.v2026_07_15)
+@usage(ResponseUsage)
+model ServerEventInputAudioBufferAllIdle extends ServerEvent {
+  /** The event type, must be `input_audio_buffer.all_idle`. */
+  type: ServerEventType.input_audio_buffer_all_idle;
+}
+
 // Tool customization (apply_discriminator): apply discriminated type
 /**
  * Returned when a conversation item is created. There are several scenarios that produce this event:

--- a/specification/ai/data-plane/VoiceLive/models.tsp
+++ b/specification/ai/data-plane/VoiceLive/models.tsp
@@ -667,33 +667,6 @@ model ServerEventInputAudioBufferSpeechStopped extends ServerEvent {
   item_id: string;
 }
 
-/**
- * Sent when the user has remained silent longer than the configured
- * `idle_timeout_ms`.
- */
-#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
-@added(Versions.v2026_07_15)
-@usage(ResponseUsage)
-model ServerEventInputAudioBufferTimeoutTriggered extends ServerEvent {
-  /** The event type, must be `input_audio_buffer.timeout_triggered`. */
-  type: ServerEventType.input_audio_buffer_timeout_triggered;
-
-  /** The ID of the user message item associated with the timeout. */
-  item_id: string;
-
-  /** The ID of the preceding conversation item, when available. */
-  previous_item_id?: string;
-}
-
-/** Sent when every input audio channel is idle. */
-#suppress "@azure-tools/typespec-azure-core/casing-style" // Service message format is snake_case to remain close to OpenAI style.
-@added(Versions.v2026_07_15)
-@usage(ResponseUsage)
-model ServerEventInputAudioBufferAllIdle extends ServerEvent {
-  /** The event type, must be `input_audio_buffer.all_idle`. */
-  type: ServerEventType.input_audio_buffer_all_idle;
-}
-
 // Tool customization (apply_discriminator): apply discriminated type
 /**
  * Returned when a conversation item is created. There are several scenarios that produce this event:

--- a/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
@@ -872,6 +872,44 @@
       "type": "object",
       "description": "Server Speech Detection (Azure semantic VAD, default variant).",
       "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Selects a bundled VAD configuration. Defaults to `classic` when omitted.\nSet to `null` to disable profile expansion and use explicit field values.",
+          "default": "classic",
+          "enum": [
+            "classic",
+            "eager",
+            "normal",
+            "patient"
+          ],
+          "x-ms-enum": {
+            "name": "AzureSemanticVadProfile",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "classic",
+                "value": "classic",
+                "description": "Preserves the current default VAD behavior."
+              },
+              {
+                "name": "eager",
+                "value": "eager",
+                "description": "Prioritizes fast turn detection."
+              },
+              {
+                "name": "normal",
+                "value": "normal",
+                "description": "Balances turn-detection latency and tolerance for pauses."
+              },
+              {
+                "name": "patient",
+                "value": "patient",
+                "description": "Prioritizes tolerance for longer pauses."
+              }
+            ]
+          },
+          "x-nullable": true
+        },
         "threshold": {
           "type": "number",
           "format": "float",
@@ -888,6 +926,12 @@
           "type": "integer",
           "format": "int32",
           "description": "Duration of silence required to end speech detection, in milliseconds."
+        },
+        "idle_timeout_ms": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds.",
+          "minimum": 0
         },
         "end_of_utterance_detection": {
           "$ref": "#/definitions/EouDetection",
@@ -937,6 +981,44 @@
       "type": "object",
       "description": "Server Speech Detection (Azure semantic VAD, English-only).",
       "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Selects a bundled VAD configuration. Defaults to `classic` when omitted.\nSet to `null` to disable profile expansion and use explicit field values.",
+          "default": "classic",
+          "enum": [
+            "classic",
+            "eager",
+            "normal",
+            "patient"
+          ],
+          "x-ms-enum": {
+            "name": "AzureSemanticVadProfile",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "classic",
+                "value": "classic",
+                "description": "Preserves the current default VAD behavior."
+              },
+              {
+                "name": "eager",
+                "value": "eager",
+                "description": "Prioritizes fast turn detection."
+              },
+              {
+                "name": "normal",
+                "value": "normal",
+                "description": "Balances turn-detection latency and tolerance for pauses."
+              },
+              {
+                "name": "patient",
+                "value": "patient",
+                "description": "Prioritizes tolerance for longer pauses."
+              }
+            ]
+          },
+          "x-nullable": true
+        },
         "threshold": {
           "type": "number",
           "format": "float",
@@ -953,6 +1035,12 @@
           "type": "integer",
           "format": "int32",
           "description": "Duration of silence required to end speech detection, in milliseconds."
+        },
+        "idle_timeout_ms": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds.",
+          "minimum": 0
         },
         "end_of_utterance_detection": {
           "$ref": "#/definitions/EouDetection",
@@ -995,6 +1083,44 @@
       "type": "object",
       "description": "Server Speech Detection (Azure semantic VAD).",
       "properties": {
+        "profile": {
+          "type": "string",
+          "description": "Selects a bundled VAD configuration. Defaults to `classic` when omitted.\nSet to `null` to disable profile expansion and use explicit field values.",
+          "default": "classic",
+          "enum": [
+            "classic",
+            "eager",
+            "normal",
+            "patient"
+          ],
+          "x-ms-enum": {
+            "name": "AzureSemanticVadProfile",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "classic",
+                "value": "classic",
+                "description": "Preserves the current default VAD behavior."
+              },
+              {
+                "name": "eager",
+                "value": "eager",
+                "description": "Prioritizes fast turn detection."
+              },
+              {
+                "name": "normal",
+                "value": "normal",
+                "description": "Balances turn-detection latency and tolerance for pauses."
+              },
+              {
+                "name": "patient",
+                "value": "patient",
+                "description": "Prioritizes tolerance for longer pauses."
+              }
+            ]
+          },
+          "x-nullable": true
+        },
         "threshold": {
           "type": "number",
           "format": "float",
@@ -1011,6 +1137,12 @@
           "type": "integer",
           "format": "int32",
           "description": "Duration of silence required to end speech detection, in milliseconds."
+        },
+        "idle_timeout_ms": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds.",
+          "minimum": 0
         },
         "end_of_utterance_detection": {
           "$ref": "#/definitions/EouDetection",
@@ -1055,6 +1187,43 @@
         }
       ],
       "x-ms-discriminator-value": "azure_semantic_vad_multilingual"
+    },
+    "AzureSemanticVadProfile": {
+      "type": "string",
+      "description": "Profile selectors for Voice Live-managed Azure semantic VAD.",
+      "enum": [
+        "classic",
+        "eager",
+        "normal",
+        "patient"
+      ],
+      "x-ms-enum": {
+        "name": "AzureSemanticVadProfile",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "classic",
+            "value": "classic",
+            "description": "Preserves the current default VAD behavior."
+          },
+          {
+            "name": "eager",
+            "value": "eager",
+            "description": "Prioritizes fast turn detection."
+          },
+          {
+            "name": "normal",
+            "value": "normal",
+            "description": "Balances turn-detection latency and tolerance for pauses."
+          },
+          {
+            "name": "patient",
+            "value": "patient",
+            "description": "Prioritizes tolerance for longer pauses."
+          }
+        ]
+      },
+      "x-nullable": true
     },
     "AzureStandardVoice": {
       "type": "object",
@@ -4316,6 +4485,16 @@
         "message"
       ]
     },
+    "ServerEventInputAudioBufferAllIdle": {
+      "type": "object",
+      "description": "Sent when every input audio channel is idle.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "input_audio_buffer.all_idle"
+    },
     "ServerEventInputAudioBufferCleared": {
       "type": "object",
       "description": "Returned when the input audio buffer is cleared by the client with a\n`input_audio_buffer.clear` event.",
@@ -4398,6 +4577,29 @@
         }
       ],
       "x-ms-discriminator-value": "input_audio_buffer.speech_stopped"
+    },
+    "ServerEventInputAudioBufferTimeoutTriggered": {
+      "type": "object",
+      "description": "Sent when the user has remained silent longer than the configured\n`idle_timeout_ms`.",
+      "properties": {
+        "item_id": {
+          "type": "string",
+          "description": "The ID of the user message item associated with the timeout."
+        },
+        "previous_item_id": {
+          "type": "string",
+          "description": "The ID of the preceding conversation item, when available."
+        }
+      },
+      "required": [
+        "item_id"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServerEvent"
+        }
+      ],
+      "x-ms-discriminator-value": "input_audio_buffer.timeout_triggered"
     },
     "ServerEventMcpListToolsCompleted": {
       "type": "object",
@@ -5762,6 +5964,8 @@
         "input_audio_buffer.cleared",
         "input_audio_buffer.speech_started",
         "input_audio_buffer.speech_stopped",
+        "input_audio_buffer.timeout_triggered",
+        "input_audio_buffer.all_idle",
         "response.created",
         "response.done",
         "response.output_item.added",
@@ -5870,6 +6074,16 @@
           {
             "name": "input_audio_buffer_speech_stopped",
             "value": "input_audio_buffer.speech_stopped"
+          },
+          {
+            "name": "input_audio_buffer_timeout_triggered",
+            "value": "input_audio_buffer.timeout_triggered",
+            "description": "Sent after the configured input inactivity timeout elapses."
+          },
+          {
+            "name": "input_audio_buffer_all_idle",
+            "value": "input_audio_buffer.all_idle",
+            "description": "Sent when every input audio channel is idle."
           },
           {
             "name": "response_created",
@@ -6106,6 +6320,12 @@
           "type": "integer",
           "format": "int32",
           "description": "Duration of silence required to end speech detection, in milliseconds."
+        },
+        "idle_timeout_ms": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds.",
+          "minimum": 0
         },
         "end_of_utterance_detection": {
           "$ref": "#/definitions/EouDetection",

--- a/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
@@ -927,12 +927,6 @@
           "format": "int32",
           "description": "Duration of silence required to end speech detection, in milliseconds."
         },
-        "idle_timeout_ms": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds.",
-          "minimum": 0
-        },
         "end_of_utterance_detection": {
           "$ref": "#/definitions/EouDetection",
           "description": "Configuration for end-of-utterance detection."
@@ -1036,12 +1030,6 @@
           "format": "int32",
           "description": "Duration of silence required to end speech detection, in milliseconds."
         },
-        "idle_timeout_ms": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds.",
-          "minimum": 0
-        },
         "end_of_utterance_detection": {
           "$ref": "#/definitions/EouDetection",
           "description": "Configuration for end-of-utterance detection."
@@ -1137,12 +1125,6 @@
           "type": "integer",
           "format": "int32",
           "description": "Duration of silence required to end speech detection, in milliseconds."
-        },
-        "idle_timeout_ms": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds.",
-          "minimum": 0
         },
         "end_of_utterance_detection": {
           "$ref": "#/definitions/EouDetection",
@@ -4485,16 +4467,6 @@
         "message"
       ]
     },
-    "ServerEventInputAudioBufferAllIdle": {
-      "type": "object",
-      "description": "Sent when every input audio channel is idle.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/ServerEvent"
-        }
-      ],
-      "x-ms-discriminator-value": "input_audio_buffer.all_idle"
-    },
     "ServerEventInputAudioBufferCleared": {
       "type": "object",
       "description": "Returned when the input audio buffer is cleared by the client with a\n`input_audio_buffer.clear` event.",
@@ -4577,29 +4549,6 @@
         }
       ],
       "x-ms-discriminator-value": "input_audio_buffer.speech_stopped"
-    },
-    "ServerEventInputAudioBufferTimeoutTriggered": {
-      "type": "object",
-      "description": "Sent when the user has remained silent longer than the configured\n`idle_timeout_ms`.",
-      "properties": {
-        "item_id": {
-          "type": "string",
-          "description": "The ID of the user message item associated with the timeout."
-        },
-        "previous_item_id": {
-          "type": "string",
-          "description": "The ID of the preceding conversation item, when available."
-        }
-      },
-      "required": [
-        "item_id"
-      ],
-      "allOf": [
-        {
-          "$ref": "#/definitions/ServerEvent"
-        }
-      ],
-      "x-ms-discriminator-value": "input_audio_buffer.timeout_triggered"
     },
     "ServerEventMcpListToolsCompleted": {
       "type": "object",
@@ -5964,8 +5913,6 @@
         "input_audio_buffer.cleared",
         "input_audio_buffer.speech_started",
         "input_audio_buffer.speech_stopped",
-        "input_audio_buffer.timeout_triggered",
-        "input_audio_buffer.all_idle",
         "response.created",
         "response.done",
         "response.output_item.added",
@@ -6074,16 +6021,6 @@
           {
             "name": "input_audio_buffer_speech_stopped",
             "value": "input_audio_buffer.speech_stopped"
-          },
-          {
-            "name": "input_audio_buffer_timeout_triggered",
-            "value": "input_audio_buffer.timeout_triggered",
-            "description": "Sent after the configured input inactivity timeout elapses."
-          },
-          {
-            "name": "input_audio_buffer_all_idle",
-            "value": "input_audio_buffer.all_idle",
-            "description": "Sent when every input audio channel is idle."
           },
           {
             "name": "response_created",
@@ -6320,12 +6257,6 @@
           "type": "integer",
           "format": "int32",
           "description": "Duration of silence required to end speech detection, in milliseconds."
-        },
-        "idle_timeout_ms": {
-          "type": "integer",
-          "format": "int32",
-          "description": "Duration of user inactivity before the server sends an input audio buffer timeout event, in milliseconds.",
-          "minimum": 0
         },
         "end_of_utterance_detection": {
           "$ref": "#/definitions/EouDetection",

--- a/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
+++ b/specification/ai/data-plane/VoiceLive/stable/2026-07-15/VoiceLive.json
@@ -872,44 +872,6 @@
       "type": "object",
       "description": "Server Speech Detection (Azure semantic VAD, default variant).",
       "properties": {
-        "profile": {
-          "type": "string",
-          "description": "Selects a bundled VAD configuration. Defaults to `classic` when omitted.\nSet to `null` to disable profile expansion and use explicit field values.",
-          "default": "classic",
-          "enum": [
-            "classic",
-            "eager",
-            "normal",
-            "patient"
-          ],
-          "x-ms-enum": {
-            "name": "AzureSemanticVadProfile",
-            "modelAsString": true,
-            "values": [
-              {
-                "name": "classic",
-                "value": "classic",
-                "description": "Preserves the current default VAD behavior."
-              },
-              {
-                "name": "eager",
-                "value": "eager",
-                "description": "Prioritizes fast turn detection."
-              },
-              {
-                "name": "normal",
-                "value": "normal",
-                "description": "Balances turn-detection latency and tolerance for pauses."
-              },
-              {
-                "name": "patient",
-                "value": "patient",
-                "description": "Prioritizes tolerance for longer pauses."
-              }
-            ]
-          },
-          "x-nullable": true
-        },
         "threshold": {
           "type": "number",
           "format": "float",
@@ -975,44 +937,6 @@
       "type": "object",
       "description": "Server Speech Detection (Azure semantic VAD, English-only).",
       "properties": {
-        "profile": {
-          "type": "string",
-          "description": "Selects a bundled VAD configuration. Defaults to `classic` when omitted.\nSet to `null` to disable profile expansion and use explicit field values.",
-          "default": "classic",
-          "enum": [
-            "classic",
-            "eager",
-            "normal",
-            "patient"
-          ],
-          "x-ms-enum": {
-            "name": "AzureSemanticVadProfile",
-            "modelAsString": true,
-            "values": [
-              {
-                "name": "classic",
-                "value": "classic",
-                "description": "Preserves the current default VAD behavior."
-              },
-              {
-                "name": "eager",
-                "value": "eager",
-                "description": "Prioritizes fast turn detection."
-              },
-              {
-                "name": "normal",
-                "value": "normal",
-                "description": "Balances turn-detection latency and tolerance for pauses."
-              },
-              {
-                "name": "patient",
-                "value": "patient",
-                "description": "Prioritizes tolerance for longer pauses."
-              }
-            ]
-          },
-          "x-nullable": true
-        },
         "threshold": {
           "type": "number",
           "format": "float",
@@ -1071,44 +995,6 @@
       "type": "object",
       "description": "Server Speech Detection (Azure semantic VAD).",
       "properties": {
-        "profile": {
-          "type": "string",
-          "description": "Selects a bundled VAD configuration. Defaults to `classic` when omitted.\nSet to `null` to disable profile expansion and use explicit field values.",
-          "default": "classic",
-          "enum": [
-            "classic",
-            "eager",
-            "normal",
-            "patient"
-          ],
-          "x-ms-enum": {
-            "name": "AzureSemanticVadProfile",
-            "modelAsString": true,
-            "values": [
-              {
-                "name": "classic",
-                "value": "classic",
-                "description": "Preserves the current default VAD behavior."
-              },
-              {
-                "name": "eager",
-                "value": "eager",
-                "description": "Prioritizes fast turn detection."
-              },
-              {
-                "name": "normal",
-                "value": "normal",
-                "description": "Balances turn-detection latency and tolerance for pauses."
-              },
-              {
-                "name": "patient",
-                "value": "patient",
-                "description": "Prioritizes tolerance for longer pauses."
-              }
-            ]
-          },
-          "x-nullable": true
-        },
         "threshold": {
           "type": "number",
           "format": "float",
@@ -1169,43 +1055,6 @@
         }
       ],
       "x-ms-discriminator-value": "azure_semantic_vad_multilingual"
-    },
-    "AzureSemanticVadProfile": {
-      "type": "string",
-      "description": "Profile selectors for Voice Live-managed Azure semantic VAD.",
-      "enum": [
-        "classic",
-        "eager",
-        "normal",
-        "patient"
-      ],
-      "x-ms-enum": {
-        "name": "AzureSemanticVadProfile",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "classic",
-            "value": "classic",
-            "description": "Preserves the current default VAD behavior."
-          },
-          {
-            "name": "eager",
-            "value": "eager",
-            "description": "Prioritizes fast turn detection."
-          },
-          {
-            "name": "normal",
-            "value": "normal",
-            "description": "Balances turn-detection latency and tolerance for pauses."
-          },
-          {
-            "name": "patient",
-            "value": "patient",
-            "description": "Prioritizes tolerance for longer pauses."
-          }
-        ]
-      },
-      "x-nullable": true
     },
     "AzureStandardVoice": {
       "type": "object",


### PR DESCRIPTION
## Summary

- expose the Voice Live Azure semantic VAD `profile` contract in the Foundry Voice Agents TypeSpec
- support `classic`, `eager`, `normal`, and `patient`, with omitted values defaulting to `classic`
- preserve explicit `profile: null` to disable profile expansion without disabling turn detection
- document the profile-bearing `session.update` path and related VAD lifecycle events in `src/voice-agents/protocol.tsp`
- regenerate the Foundry v1 and virtual-public-preview OpenAPI documents

## Scope

The profile is inherited only by the Voice Live-managed Azure semantic VAD variants:

- `azure_semantic_vad`
- `azure_semantic_vad_en`
- `azure_semantic_vad_multilingual`

`protocol.tsp` explicitly documents `audio.input.turn_detection.profile` on `session.update` and the existing `input_audio_buffer.speech_started`, `input_audio_buffer.speech_stopped`, and `input_audio_buffer.timeout_triggered` server events. Event payloads remain unchanged. Assistant-speaking and TTS-conditioned VAD tuning remains private and is not included in the SDK contract.

## Validation

- `npx tsp format -c specification/ai-foundry/data-plane/Foundry/src/voice-agents/{agents,protocol}.tsp`
- `npx tsp compile specification/ai-foundry/data-plane/Foundry`