### PR TITLE
Fix stale TypeSpec suppression results

### DIFF
--- a/.github/workflows/src/typespec-suppressions/post-results.js
+++ b/.github/workflows/src/typespec-suppressions/post-results.js
@@ -35,6 +35,16 @@ export default async function postSuppressionsResults({ github, context, core })
     repo,
     pull_number: issue_number,
   });
+
+  // A workflow for an older commit can finish after a newer synchronize event.
+  // Never let that stale run overwrite the sticky comment for the current PR head.
+  if (pr.head.sha !== head_sha) {
+    core.info(
+      `Skipping stale TypeSpec suppressions result for ${head_sha}; current PR head is ${pr.head.sha}.`,
+    );
+    return;
+  }
+
   /** @type {string[]} */
   const labelNames = pr.labels.map((/** @type {{ name?: string }} */ label) => label.name ?? "");
 

--- a/.github/workflows/test/typespec-suppressions/post-results.test.js
+++ b/.github/workflows/test/typespec-suppressions/post-results.test.js
@@ -58,12 +58,13 @@ describe("post-results", () => {
 
   /**
    * @param {string[]} labels
+   * @param {string} [headSha]
    * @returns {import("../mocks.js").GitHub}
    */
-  function githubWithLabels(labels) {
+  function githubWithLabels(labels, headSha = "abc123") {
     const github = createMockGithub();
     github.rest.pulls.get.mockResolvedValue({
-      data: { labels: labels.map((name) => ({ name })) },
+      data: { head: { sha: headSha }, labels: labels.map((name) => ({ name })) },
     });
     return github;
   }
@@ -130,6 +131,15 @@ describe("post-results", () => {
 
     await postSuppressionsResults(args(github));
 
+    expect(commentOrUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does not overwrite the comment with results from an older PR commit", async () => {
+    const github = githubWithLabels([], "newer456");
+
+    await postSuppressionsResults(args(github));
+
+    expect(buildSuppressionsComment).not.toHaveBeenCalled();
     expect(commentOrUpdate).not.toHaveBeenCalled();
   });
 });

--- a/.github/workflows/typespec-suppressions-code.yaml
+++ b/.github/workflows/typespec-suppressions-code.yaml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: typespec-suppressions-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   typespec-suppressions:
     name: "TypeSpec Suppressions - Analyze Code"
@@ -30,7 +34,7 @@ jobs:
           $ignoreCoreFiles = -not (@('main', 'RPSaaSMaster') -contains $Env:GITHUB_BASE_REF)
           $typespecFolders, $checkedAll = & "./eng/scripts/Get-TypeSpec-Folders.ps1" `
             -BaseCommitish:"${{ github.event.pull_request.base.sha }}" `
-            -HeadCommitish:"HEAD" `
+            -HeadCommitish:"${{ github.event.pull_request.head.sha }}" `
             -IgnoreCoreFiles:$ignoreCoreFiles
 
           $typespecFolders | Set-Content -Path typespec-folders.txt
@@ -66,7 +70,7 @@ jobs:
               '{' \
               '  "repoRoot": "'"$GITHUB_WORKSPACE"'",' \
               '  "baseRevision": "'"${{ github.event.pull_request.base.sha }}"'",' \
-              '  "headRevision": "HEAD",' \
+              '  "headRevision": "'"${{ github.event.pull_request.head.sha }}"'",' \
               '  "specPaths": [],' \
               '  "requiresApproval": false,' \
               '  "counts": {' \
@@ -94,7 +98,7 @@ jobs:
 
           npm exec --no -- typespec-suppressions \
             --base "${{ github.event.pull_request.base.sha }}" \
-            --head HEAD \
+            --head "${{ github.event.pull_request.head.sha }}" \
             --json-output "typespec-suppressions-report.json" \
             --markdown-output "$GITHUB_STEP_SUMMARY" \
             --check-rules-file "eng/tools/typespec-suppressions/check-rules.json" \


### PR DESCRIPTION
## Summary

- compare every suppression run using the PR event's explicit base and head SHAs
- cancel obsolete analysis runs when a newer commit is pushed
- prevent completed runs for older commits from overwriting the current sticky PR comment

## Validation

- targeted TypeSpec suppression workflow tests
- workflow schema validation
- ESLint, TypeScript, and Prettier checks