### PR TITLE
Move lease.yaml path

### DIFF
--- a/.github/arm-leases/apicenter/Microsoft.ApiCenter/ApiCenter/lease.yaml
+++ b/.github/arm-leases/apicenter/Microsoft.ApiCenter/ApiCenter/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.ApiCenter
-  startdate: "2026-07-06"
+  startdate: "2026-08-21"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/deviceregistry/Microsoft.DeviceRegistry/DeviceRegistry/lease.yaml
+++ b/.github/arm-leases/deviceregistry/Microsoft.DeviceRegistry/DeviceRegistry/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.DeviceRegistry
-  startdate: "2026-07-06"
+  startdate: "2026-08-21"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/edgemarketplace/Microsoft.EdgeMarketplace/EdgeMarketplace/lease.yaml
+++ b/.github/arm-leases/edgemarketplace/Microsoft.EdgeMarketplace/EdgeMarketplace/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: Microsoft.EdgeMarketplace
-  startdate: "2026-07-06"
+  startdate: "2026-08-21"
   duration: P180D
   reviewer: "@tejaswiminnu"

--- a/.github/arm-leases/liftrmongodb/MongoDB.Atlas/MongoDBAtlas/lease.yaml
+++ b/.github/arm-leases/liftrmongodb/MongoDB.Atlas/MongoDBAtlas/lease.yaml
@@ -1,5 +1,5 @@
 lease:
   resource-provider: MongoDB.Atlas
-  startdate: "2026-07-06"
+  startdate: "2026-08-21"
   duration: P180D
   reviewer: "@vikeshi26"


### PR DESCRIPTION
Updated the startdate for the following resource providers to "2026-08-21" and move folder:
* `.github/arm-leases/apicenter/Microsoft.ApiCenter/ApiCenter/lease.yaml`
* `.github/arm-leases/deviceregistry/Microsoft.DeviceRegistry/DeviceRegistry/lease.yaml`
* `.github/arm-leases/edgemarketplace/Microsoft.EdgeMarketplace/EdgeMarketplac/lease.yaml`
* `.github/arm-leases/liftrmongodb/MongoDB.Atlas/MongoDBAtlas/lease.yaml`