### PR TITLE
feat(voice-agents): add subagent configuration

### DIFF
--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -12374,12 +12374,6 @@
                 "model": {
                   "contentType": "text/plain"
                 },
-                "languages": {
-                  "contentType": "application/json"
-                },
-                "keywords": {
-                  "contentType": "application/json"
-                },
                 "response_format": {
                   "contentType": "application/json"
                 },
@@ -19087,24 +19081,16 @@
                       "deprecated": true
                     },
                     "safety_identifier": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
+                      "type": "string",
+                      "maxLength": 64,
+                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                     },
                     "prompt_cache_key": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
+                      "type": "string",
+                      "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                    },
+                    "service_tier": {
+                      "$ref": "#/components/schemas/OpenAI.ServiceTier"
                     },
                     "prompt_cache_retention": {
                       "anyOf": [
@@ -19173,9 +19159,6 @@
                     },
                     "prompt": {
                       "$ref": "#/components/schemas/OpenAI.Prompt"
-                    },
-                    "service_tier": {
-                      "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                     },
                     "truncation": {
                       "anyOf": [
@@ -19321,7 +19304,7 @@
                     "conversation": {
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/OpenAI.ResponseConversation"
+                          "$ref": "#/components/schemas/OpenAI.ConversationReference"
                         },
                         {
                           "type": "null"
@@ -19460,24 +19443,16 @@
                     "deprecated": true
                   },
                   "safety_identifier": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "type": "string",
+                    "maxLength": 64,
+                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                   },
                   "prompt_cache_key": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "type": "string",
+                    "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                  },
+                  "service_tier": {
+                    "$ref": "#/components/schemas/OpenAI.ServiceTier"
                   },
                   "prompt_cache_retention": {
                     "anyOf": [
@@ -19549,9 +19524,6 @@
                   },
                   "prompt": {
                     "$ref": "#/components/schemas/OpenAI.Prompt"
-                  },
-                  "service_tier": {
-                    "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                   },
                   "truncation": {
                     "anyOf": [
@@ -40815,8 +40787,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
-                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -40825,26 +40795,11 @@
                 ]
               }
             ],
-            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
+            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -40875,8 +40830,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
-                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -40885,19 +40838,11 @@
                 ]
               }
             ],
-            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
+            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format."
           },
           "prompt": {
             "type": "string",
@@ -43291,9 +43236,6 @@
           "reasoning_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
-          "text_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
           "rejected_prediction_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           }
@@ -43306,12 +43248,6 @@
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cached_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "text_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "image_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cache_write_tokens": {
@@ -44908,6 +44844,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -44927,14 +44864,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -45351,8 +45280,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -45816,6 +45744,20 @@
         "description": "The conversation that this response belongs to.",
         "title": "Conversation object"
       },
+      "OpenAI.ConversationReference": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the conversation that this response was associated with."
+          }
+        },
+        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
+        "title": "Conversation"
+      },
       "OpenAI.ConversationResource": {
         "type": "object",
         "required": [
@@ -46217,24 +46159,16 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "maxLength": 64,
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -46265,9 +46199,6 @@
           "model": {
             "type": "string",
             "description": "The model deployment to use for this chat completion."
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "modalities": {
             "$ref": "#/components/schemas/OpenAI.ResponseModalities"
@@ -46697,16 +46628,6 @@
           "model": {
             "type": "string",
             "description": "The model deployment used for the creation of this chat completion."
-          },
-          "metadata": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "service_tier": {
             "$ref": "#/components/schemas/OpenAI.ServiceTier"
@@ -48112,7 +48033,7 @@
                 }
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
           },
           "prompt": {
             "type": "string",
@@ -48135,7 +48056,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`."
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`."
           },
           "model": {
             "anyOf": [
@@ -48146,8 +48067,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
@@ -48158,7 +48077,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -48307,8 +48226,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "dall-e-3",
                   "gpt-image-1",
@@ -48319,7 +48236,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
             "x-oaiTypeLabel": "string",
             "default": "dall-e-2"
           },
@@ -48471,7 +48388,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`.",
             "default": "auto"
           },
           "style": {
@@ -49825,7 +49742,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n  The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
+            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -49837,7 +49754,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
                   "gpt-4o-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
@@ -49845,26 +49761,12 @@
                 ]
               }
             ],
-            "description": "ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
+            "description": "ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
             "x-oaiTypeLabel": "string"
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -49992,13 +49894,6 @@
             "type": "string",
             "description": "The transcribed text."
           },
-          "languages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.TranscriptionLanguage"
-            },
-            "description": "The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected."
-          },
           "logprobs": {
             "type": "array",
             "items": {
@@ -50118,7 +50013,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
+            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -51227,8 +51122,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "gpt-image-1",
                   "gpt-image-1-mini",
                   "chatgpt-image-latest"
@@ -51238,7 +51131,7 @@
                 "type": "null"
               }
             ],
-            "description": "The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.",
+            "description": "The model to use for image editing.",
             "x-oaiTypeLabel": "string",
             "default": "gpt-image-1.5"
           },
@@ -51385,7 +51278,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Background behavior for generated image output.",
             "default": "auto"
           },
           "stream": {
@@ -54927,9 +54820,7 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21"
+                  "gpt-image-1.5"
                 ]
               }
             ],
@@ -54997,7 +54888,7 @@
               "opaque",
               "auto"
             ],
-            "description": "Set the background of the generated image. One of `transparent`,\n  `opaque`, or `auto`. Transparent backgrounds are available for\n  supported GPT Image models. For `gpt-image-2` and\n  `gpt-image-2-2026-04-21`, this support is in preview. When using\n  `transparent`, set the output format to `png` or `webp`. Default: `auto`.",
+            "description": "Background type for the generated image. One of `transparent`,\n  `opaque`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "input_fidelity": {
@@ -56067,7 +55958,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -56381,6 +56272,7 @@
       "OpenAI.InputItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
+          "call_id",
           "type",
           "output"
         ],
@@ -56396,14 +56288,10 @@
             ]
           },
           "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "The unique ID of the function tool call generated by the model."
           },
           "type": {
             "type": "string",
@@ -56437,26 +56325,6 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "namespace": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "caller": {
             "anyOf": [
@@ -57040,8 +56908,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -57824,7 +57691,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -58896,6 +58763,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -58915,14 +58783,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -59292,8 +59152,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -59796,6 +59655,7 @@
       "OpenAI.ItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
+          "call_id",
           "type",
           "output"
         ],
@@ -59811,14 +59671,10 @@
             ]
           },
           "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "The unique ID of the function tool call generated by the model."
           },
           "type": {
             "type": "string",
@@ -59852,26 +59708,6 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "namespace": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "caller": {
             "anyOf": [
@@ -60508,8 +60344,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -61528,6 +61363,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -61547,14 +61383,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -61977,8 +61805,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -63853,7 +63680,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -64464,25 +64293,13 @@
           "owned_by": {
             "type": "string",
             "description": "The organization that owns the model."
-          },
-          "shutdown_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The date when the model will shut down, or null if not announced."
           }
         },
         "description": "Describes an OpenAI model offering that can be used with the API.",
         "title": "Model",
         "x-oaiMeta": {
           "name": "The model object",
-          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\",\n  \"shutdown_date\": \"2026-10-23\"\n}\n"
+          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
         }
       },
       "OpenAI.Moderation": {
@@ -65094,6 +64911,7 @@
           },
           "description": {
             "type": "string",
+            "minLength": 1,
             "description": "A description of the namespace shown to the model."
           },
           "tools": {
@@ -65260,7 +65078,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -66240,6 +66060,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -66259,14 +66080,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -66636,8 +66449,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -67130,7 +66942,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -67642,7 +67456,6 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.RealtimeConversationItemMessage",
             "function_call": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall",
             "function_call_output": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput",
             "mcp_approval_response": "#/components/schemas/OpenAI.RealtimeMCPApprovalResponse",
@@ -67804,351 +67617,6 @@
           ]
         }
       },
-      "OpenAI.RealtimeConversationItemMessage": {
-        "type": "object",
-        "required": [
-          "role",
-          "type"
-        ],
-        "properties": {
-          "role": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageType"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ]
-          }
-        },
-        "discriminator": {
-          "propertyName": "role",
-          "mapping": {
-            "system": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem",
-            "user": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUser",
-            "assistant": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItem"
-          }
-        ]
-      },
-      "OpenAI.RealtimeConversationItemMessageAssistant": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "assistant"
-            ],
-            "description": "The role of the message sender. Always `assistant`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "An assistant message item in a Realtime conversation.",
-        "title": "Realtime assistant message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageAssistantContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "output_text",
-              "output_audio"
-            ]
-          },
-          "text": {
-            "type": "string"
-          },
-          "audio": {
-            "type": "string"
-          },
-          "transcript": {
-            "type": "string"
-          }
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageSystem": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "system"
-            ],
-            "description": "The role of the message sender. Always `system`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. \"the user is now asking about a different topic\"), use system messages.",
-        "title": "Realtime system message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageSystemContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "input_text"
-            ],
-            "x-stainless-const": true
-          },
-          "text": {
-            "type": "string"
-          }
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "system",
-              "user",
-              "assistant"
-            ]
-          }
-        ]
-      },
-      "OpenAI.RealtimeConversationItemMessageUser": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user"
-            ],
-            "description": "The role of the message sender. Always `user`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "A user message item in a Realtime conversation.",
-        "title": "Realtime user message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageUserContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "input_text",
-              "input_audio",
-              "input_image"
-            ]
-          },
-          "text": {
-            "type": "string"
-          },
-          "audio": {
-            "type": "string"
-          },
-          "image_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "detail": {
-            "type": "string",
-            "enum": [
-              "auto",
-              "low",
-              "high"
-            ],
-            "default": "auto"
-          },
-          "transcript": {
-            "type": "string"
-          }
-        }
-      },
       "OpenAI.RealtimeConversationItemType": {
         "anyOf": [
           {
@@ -68162,8 +67630,7 @@
               "mcp_approval_response",
               "mcp_list_tools",
               "mcp_call",
-              "mcp_approval_request",
-              "message"
+              "mcp_approval_request"
             ]
           }
         ]
@@ -70287,24 +69754,16 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "maxLength": 64,
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -70373,9 +69832,6 @@
           },
           "prompt": {
             "$ref": "#/components/schemas/OpenAI.Prompt"
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
           },
           "truncation": {
             "anyOf": [
@@ -70521,7 +69977,7 @@
           "conversation": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.ResponseConversation"
+                "$ref": "#/components/schemas/OpenAI.ConversationReference"
               },
               {
                 "type": "null"
@@ -71063,20 +70519,6 @@
           "example": "{\n  \"type\": \"response.content_part.done\",\n  \"item_id\": \"msg_123\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"sequence_number\": 1,\n  \"part\": {\n    \"type\": \"output_text\",\n    \"text\": \"In a shimmering forest under a sky full of stars, a lonely unicorn named Lila discovered a hidden pond that glowed with moonlight. Every night, she would leave sparkling, magical flowers by the water's edge, hoping to share her beauty with others. One enchanting evening, she woke to find a group of friendly animals gathered around, eager to be friends and share in her magic.\",\n    \"annotations\": []\n  }\n}\n"
         }
       },
-      "OpenAI.ResponseConversation": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the conversation that this response was associated with."
-          }
-        },
-        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
-        "title": "Conversation"
-      },
       "OpenAI.ResponseCreatedEvent": {
         "type": "object",
         "required": [
@@ -71233,7 +70675,6 @@
           "server_error",
           "rate_limit_exceeded",
           "invalid_prompt",
-          "data_residency_mismatch",
           "bio_policy",
           "vector_store_timeout",
           "invalid_image",
@@ -71838,22 +71279,6 @@
           "partial_image_b64": {
             "type": "string",
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
-          },
-          "size": {
-            "type": "string",
-            "description": "The image size that was used."
-          },
-          "quality": {
-            "type": "string",
-            "description": "The image quality that was used."
-          },
-          "background": {
-            "type": "string",
-            "description": "The background setting that was used."
-          },
-          "output_format": {
-            "type": "string",
-            "description": "The output format that was used."
           }
         },
         "allOf": [
@@ -72390,7 +71815,7 @@
           },
           "item": {
             "$ref": "#/components/schemas/OpenAI.OutputItem",
-            "description": "The output item that was added. For reasoning items, `encrypted_content`\n  may be incomplete while the item is in progress. Use the reasoning item\n  from the corresponding `response.output_item.done` event when passing it\n  as input to a subsequent request."
+            "description": "The output item that was added."
           }
         },
         "allOf": [
@@ -72502,7 +71927,7 @@
         "x-oaiMeta": {
           "name": "response.output_text.annotation.added",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"file_citation\",\n    \"file_id\": \"file-abc\",\n    \"index\": 0,\n    \"filename\": \"example.txt\"\n  },\n  \"sequence_number\": 1\n}\n"
+          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"text_annotation\",\n    \"text\": \"This is a test annotation\",\n    \"start\": 0,\n    \"end\": 10\n  },\n  \"sequence_number\": 1\n}\n"
         }
       },
       "OpenAI.ResponsePromptVariables": {
@@ -73027,238 +72452,6 @@
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
       },
-      "OpenAI.ResponseShellCallCommandAddedStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "command"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.added"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.added`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was added."
-          },
-          "command": {
-            "type": "string",
-            "description": "The shell command that was added."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was added to a tool call.",
-        "title": "Response shell command added event"
-      },
-      "OpenAI.ResponseShellCallCommandDeltaStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "delta"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.delta"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.delta`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was updated."
-          },
-          "delta": {
-            "type": "string",
-            "description": "The shell command delta that was appended."
-          },
-          "obfuscation": {
-            "type": "string",
-            "description": "An obfuscation string that was added to pad the event payload."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was incrementally updated.",
-        "title": "Response shell command delta event"
-      },
-      "OpenAI.ResponseShellCallCommandDoneStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "command"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.done"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.done`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was completed."
-          },
-          "command": {
-            "type": "string",
-            "description": "The final shell command that was emitted."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was completed.",
-        "title": "Response shell command done event"
-      },
-      "OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "item_id",
-          "output_index",
-          "command_index",
-          "delta"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_output_content.delta"
-            ],
-            "description": "The type of the event, always `response.shell_call_output_content.delta`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "item_id": {
-            "type": "string",
-            "description": "The ID of the output item that was updated."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that produced output."
-          },
-          "delta": {
-            "$ref": "#/components/schemas/OpenAI.ShellCallOutputDelta",
-            "description": "The stdout/stderr delta that was emitted."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated shell call output was incrementally added.",
-        "title": "Response shell call output content delta event"
-      },
-      "OpenAI.ResponseShellCallOutputContentDoneStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "item_id",
-          "output_index",
-          "command_index",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_output_content.done"
-            ],
-            "description": "The type of the event, always `response.shell_call_output_content.done`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "item_id": {
-            "type": "string",
-            "description": "The ID of the output item that was updated."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that produced output."
-          },
-          "output": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputContent"
-            },
-            "description": "The output contents emitted for the shell command."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated shell call output was completed.",
-        "title": "Response shell call output content done event"
-      },
       "OpenAI.ResponseStreamEvent": {
         "type": "object",
         "required": [
@@ -73319,11 +72512,6 @@
             "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
             "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
             "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
-            "response.shell_call_command.added": "#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent",
-            "response.shell_call_command.delta": "#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent",
-            "response.shell_call_command.done": "#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent",
-            "response.shell_call_output_content.delta": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent",
-            "response.shell_call_output_content.done": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent",
             "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
             "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
             "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
@@ -73331,8 +72519,7 @@
             "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
             "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
           }
-        },
-        "description": "Event emitted while a response is streamed."
+        }
       },
       "OpenAI.ResponseStreamEventType": {
         "anyOf": [
@@ -73361,11 +72548,6 @@
               "response.file_search_call.searching",
               "response.function_call_arguments.delta",
               "response.function_call_arguments.done",
-              "response.shell_call_command.added",
-              "response.shell_call_command.delta",
-              "response.shell_call_command.done",
-              "response.shell_call_output_content.delta",
-              "response.shell_call_output_content.done",
               "response.in_progress",
               "response.failed",
               "response.incomplete",
@@ -75033,60 +74215,23 @@
               "default",
               "flex",
               "scale",
-              "priority",
-              "fast"
+              "priority"
             ]
           },
           {
             "type": "null"
           }
         ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
+        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
       },
       "OpenAI.ServiceTierEnum": {
         "type": "string",
         "enum": [
           "auto",
           "default",
-          "fast",
           "flex",
           "priority"
         ]
-      },
-      "OpenAI.ServiceTierResponses": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "auto",
-              "default",
-              "flex",
-              "scale",
-              "priority",
-              "fast",
-              "ultrafast"
-            ]
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
-      },
-      "OpenAI.ShellCallOutputDelta": {
-        "type": "object",
-        "properties": {
-          "stdout": {
-            "type": "string",
-            "description": "The stdout delta that was emitted."
-          },
-          "stderr": {
-            "type": "string",
-            "description": "The stderr delta that was emitted."
-          }
-        },
-        "description": "A delta of stdout/stderr emitted while a shell call was running.",
-        "title": "Shell call output delta"
       },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
@@ -76364,19 +75509,6 @@
           "logprobs"
         ]
       },
-      "OpenAI.TranscriptionLanguage": {
-        "type": "object",
-        "required": [
-          "code"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "The code of a language detected in the audio."
-          }
-        },
-        "description": "A language detected in transcribed audio."
-      },
       "OpenAI.TranscriptionSegment": {
         "type": "object",
         "required": [
@@ -77451,7 +76583,7 @@
             "type": "null"
           }
         ],
-        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`. The default is\n`medium`."
+        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`."
       },
       "OpenAI.VideoCharacterResource": {
         "type": "object",
@@ -78058,11 +77190,6 @@
               "web_search"
             ],
             "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
-          },
-          "external_web_access": {
-            "type": "boolean",
-            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
-            "default": true
           },
           "filters": {
             "anyOf": [
@@ -79588,6 +78715,47 @@
         "x-ms-foundry-meta": {
           "required_previews": [
             "preview_tool"
+          ]
+        }
+      },
+      "ResponsePolicy": {
+        "type": "object",
+        "properties": {
+          "immediate_ack": {
+            "type": "boolean",
+            "description": "Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent."
+          },
+          "gap_filling_interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 120,
+            "description": "The number of seconds without subagent content or user input before the voice agent provides a gap-filling response."
+          },
+          "ack_instructions": {
+            "type": "string",
+            "description": "Instructions used to generate the immediate acknowledgement."
+          },
+          "gap_filling_instructions": {
+            "type": "string",
+            "description": "Instructions used to generate gap-filling speech while waiting for progress."
+          },
+          "progress_instructions": {
+            "type": "string",
+            "description": "Instructions used to summarize streamed subagent progress for speech."
+          },
+          "progress_update_interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 300,
+            "description": "The minimum number of seconds between spoken progress updates."
+          }
+        },
+        "description": "Policy for delivering responses while a voice agent waits for a subagent.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
           ]
         }
       },
@@ -81163,6 +80331,66 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ]
+      },
+      "SubAgent": {
+        "type": "object",
+        "required": [
+          "agent_name",
+          "agent_capabilities"
+        ],
+        "properties": {
+          "agent_name": {
+            "type": "string",
+            "description": "The name of the subagent. The subagent must be in the same project as the voice agent."
+          },
+          "agent_version": {
+            "type": "string",
+            "description": "The version of the subagent. When omitted, the active version is used."
+          },
+          "agent_capabilities": {
+            "type": "string",
+            "description": "A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query."
+          },
+          "invoke_timeout_seconds": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 1200,
+            "description": "The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used."
+          }
+        },
+        "description": "A sibling Foundry text agent that a voice agent may consult as a background specialist.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "SubAgentConfig": {
+        "type": "object",
+        "required": [
+          "subagents"
+        ],
+        "properties": {
+          "subagents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubAgent"
+            },
+            "minItems": 1,
+            "description": "The sibling Foundry text agents, in the same project, that this voice agent may consult."
+          },
+          "response_policy": {
+            "$ref": "#/components/schemas/ResponsePolicy",
+            "description": "Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response."
+          }
+        },
+        "description": "Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
       },
       "SyntheticDataGenerationPreviewEvalRunDataSource": {
         "type": "object",
@@ -83548,6 +82776,10 @@
             },
             "description": "Set of structured inputs that participate in prompt template substitution, rendered per session before the live session starts."
           },
+          "subagent_config": {
+            "$ref": "#/components/schemas/SubAgentConfig",
+            "description": "Optional configuration for sibling Foundry text agents that this voice agent may consult as background specialists."
+          },
           "store": {
             "type": "boolean",
             "description": "Whether conversations with this agent are persisted. A single, all-or-nothing persistence switch that defaults to\n`false` (privacy-safe: off by default). When `true`, Foundry persists the full conversation — the transcript/event\ntimeline and raw audio. When `false`, nothing is persisted and no conversation is surfaced. There is no separate\naudio-logging control; audio is persisted only as part of this switch. Latency/performance telemetry (e.g.\ntime-to-first-audio, inter-token latency, interruption) is observability-only (customer trace / App Insights) and\nis not part of the persisted conversation content.",
@@ -83741,21 +82973,6 @@
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -85251,11 +84468,6 @@
             "enum": [
               "web_search"
             ]
-          },
-          "external_web_access": {
-            "type": "boolean",
-            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
-            "default": true
           },
           "filters": {
             "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -80351,6 +80351,11 @@
             "type": "string",
             "description": "A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query."
           },
+          "enable_delta_progress": {
+            "type": "boolean",
+            "description": "Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.",
+            "default": false
+          },
           "invoke_timeout_seconds": {
             "type": "integer",
             "format": "int32",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.json
@@ -78718,47 +78718,6 @@
           ]
         }
       },
-      "ResponsePolicy": {
-        "type": "object",
-        "properties": {
-          "immediate_ack": {
-            "type": "boolean",
-            "description": "Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent."
-          },
-          "gap_filling_interval": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 5,
-            "maximum": 120,
-            "description": "The number of seconds without subagent content or user input before the voice agent provides a gap-filling response."
-          },
-          "ack_instructions": {
-            "type": "string",
-            "description": "Instructions used to generate the immediate acknowledgement."
-          },
-          "gap_filling_instructions": {
-            "type": "string",
-            "description": "Instructions used to generate gap-filling speech while waiting for progress."
-          },
-          "progress_instructions": {
-            "type": "string",
-            "description": "Instructions used to summarize streamed subagent progress for speech."
-          },
-          "progress_update_interval": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 5,
-            "maximum": 300,
-            "description": "The minimum number of seconds between spoken progress updates."
-          }
-        },
-        "description": "Policy for delivering responses while a voice agent waits for a subagent.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
       "ResponseRetrievalItemGenerationParams": {
         "type": "object",
         "required": [
@@ -80331,71 +80290,6 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ]
-      },
-      "SubAgent": {
-        "type": "object",
-        "required": [
-          "agent_name",
-          "agent_capabilities"
-        ],
-        "properties": {
-          "agent_name": {
-            "type": "string",
-            "description": "The name of the subagent. The subagent must be in the same project as the voice agent."
-          },
-          "agent_version": {
-            "type": "string",
-            "description": "The version of the subagent. When omitted, the active version is used."
-          },
-          "agent_capabilities": {
-            "type": "string",
-            "description": "A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query."
-          },
-          "enable_delta_progress": {
-            "type": "boolean",
-            "description": "Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.",
-            "default": false
-          },
-          "invoke_timeout_seconds": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 5,
-            "maximum": 1200,
-            "description": "The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used."
-          }
-        },
-        "description": "A sibling Foundry text agent that a voice agent may consult as a background specialist.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "SubAgentConfig": {
-        "type": "object",
-        "required": [
-          "subagents"
-        ],
-        "properties": {
-          "subagents": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SubAgent"
-            },
-            "minItems": 1,
-            "description": "The sibling Foundry text agents, in the same project, that this voice agent may consult."
-          },
-          "response_policy": {
-            "$ref": "#/components/schemas/ResponsePolicy",
-            "description": "Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response."
-          }
-        },
-        "description": "Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
       },
       "SyntheticDataGenerationPreviewEvalRunDataSource": {
         "type": "object",
@@ -82782,7 +82676,7 @@
             "description": "Set of structured inputs that participate in prompt template substitution, rendered per session before the live session starts."
           },
           "subagent_config": {
-            "$ref": "#/components/schemas/SubAgentConfig",
+            "$ref": "#/components/schemas/VoiceAgentSubAgentConfig",
             "description": "Optional configuration for sibling Foundry text agents that this voice agent may consult as background specialists."
           },
           "store": {
@@ -83521,6 +83415,112 @@
           }
         ],
         "description": "A static interim response selected from configured text."
+      },
+      "VoiceAgentSubAgent": {
+        "type": "object",
+        "required": [
+          "agent_name",
+          "agent_capabilities"
+        ],
+        "properties": {
+          "agent_name": {
+            "type": "string",
+            "description": "The name of the subagent. The subagent must be in the same project as the voice agent."
+          },
+          "agent_version": {
+            "type": "string",
+            "description": "The version of the subagent. When omitted, the active version is used."
+          },
+          "agent_capabilities": {
+            "type": "string",
+            "description": "A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query."
+          },
+          "enable_delta_progress": {
+            "type": "boolean",
+            "description": "Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.",
+            "default": false
+          },
+          "invoke_timeout_seconds": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 1200,
+            "description": "The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used."
+          }
+        },
+        "description": "A sibling Foundry text agent that a voice agent may consult as a background specialist.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceAgentSubAgentConfig": {
+        "type": "object",
+        "required": [
+          "subagents"
+        ],
+        "properties": {
+          "subagents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VoiceAgentSubAgent"
+            },
+            "minItems": 1,
+            "description": "The sibling Foundry text agents, in the same project, that this voice agent may consult."
+          },
+          "response_policy": {
+            "$ref": "#/components/schemas/VoiceAgentSubagentResponsePolicy",
+            "description": "Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response."
+          }
+        },
+        "description": "Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceAgentSubagentResponsePolicy": {
+        "type": "object",
+        "properties": {
+          "immediate_ack": {
+            "type": "boolean",
+            "description": "Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent."
+          },
+          "gap_filling_interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 120,
+            "description": "The number of seconds without subagent content or user input before the voice agent provides a gap-filling response."
+          },
+          "ack_instructions": {
+            "type": "string",
+            "description": "Instructions used to generate the immediate acknowledgement."
+          },
+          "gap_filling_instructions": {
+            "type": "string",
+            "description": "Instructions used to generate gap-filling speech while waiting for progress."
+          },
+          "progress_instructions": {
+            "type": "string",
+            "description": "Instructions used to summarize streamed subagent progress for speech."
+          },
+          "progress_update_interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 300,
+            "description": "The minimum number of seconds between spoken progress updates."
+          }
+        },
+        "description": "Policy for delivering responses while a voice agent waits for a subagent.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
       },
       "VoiceAgentSystemTool": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -77030,6 +77030,10 @@ components:
         agent_capabilities:
           type: string
           description: A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query.
+        enable_delta_progress:
+          type: boolean
+          description: Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.
+          default: false
         invoke_timeout_seconds:
           type: integer
           format: int32

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -75885,37 +75885,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - preview_tool
-    ResponsePolicy:
-      type: object
-      properties:
-        immediate_ack:
-          type: boolean
-          description: Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent.
-        gap_filling_interval:
-          type: integer
-          format: int32
-          minimum: 5
-          maximum: 120
-          description: The number of seconds without subagent content or user input before the voice agent provides a gap-filling response.
-        ack_instructions:
-          type: string
-          description: Instructions used to generate the immediate acknowledgement.
-        gap_filling_instructions:
-          type: string
-          description: Instructions used to generate gap-filling speech while waiting for progress.
-        progress_instructions:
-          type: string
-          description: Instructions used to summarize streamed subagent progress for speech.
-        progress_update_interval:
-          type: integer
-          format: int32
-          minimum: 5
-          maximum: 300
-          description: The minimum number of seconds between spoken progress updates.
-      description: Policy for delivering responses while a voice agent waits for a subagent.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
     ResponseRetrievalItemGenerationParams:
       type: object
       required:
@@ -77015,53 +76984,6 @@ components:
           description: The structured output captured during the response.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
-    SubAgent:
-      type: object
-      required:
-        - agent_name
-        - agent_capabilities
-      properties:
-        agent_name:
-          type: string
-          description: The name of the subagent. The subagent must be in the same project as the voice agent.
-        agent_version:
-          type: string
-          description: The version of the subagent. When omitted, the active version is used.
-        agent_capabilities:
-          type: string
-          description: A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query.
-        enable_delta_progress:
-          type: boolean
-          description: Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.
-          default: false
-        invoke_timeout_seconds:
-          type: integer
-          format: int32
-          minimum: 5
-          maximum: 1200
-          description: The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used.
-      description: A sibling Foundry text agent that a voice agent may consult as a background specialist.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    SubAgentConfig:
-      type: object
-      required:
-        - subagents
-      properties:
-        subagents:
-          type: array
-          items:
-            $ref: '#/components/schemas/SubAgent'
-          minItems: 1
-          description: The sibling Foundry text agents, in the same project, that this voice agent may consult.
-        response_policy:
-          $ref: '#/components/schemas/ResponsePolicy'
-          description: Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response.
-      description: Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
     SyntheticDataGenerationPreviewEvalRunDataSource:
       type: object
       required:
@@ -78734,7 +78656,7 @@ components:
             $ref: '#/components/schemas/StructuredInputDefinition'
           description: Set of structured inputs that participate in prompt template substitution, rendered per session before the live session starts.
         subagent_config:
-          $ref: '#/components/schemas/SubAgentConfig'
+          $ref: '#/components/schemas/VoiceAgentSubAgentConfig'
           description: Optional configuration for sibling Foundry text agents that this voice agent may consult as background specialists.
         store:
           type: boolean
@@ -79238,6 +79160,84 @@ components:
       allOf:
         - $ref: '#/components/schemas/VoiceAgentInterimResponseConfig'
       description: A static interim response selected from configured text.
+    VoiceAgentSubAgent:
+      type: object
+      required:
+        - agent_name
+        - agent_capabilities
+      properties:
+        agent_name:
+          type: string
+          description: The name of the subagent. The subagent must be in the same project as the voice agent.
+        agent_version:
+          type: string
+          description: The version of the subagent. When omitted, the active version is used.
+        agent_capabilities:
+          type: string
+          description: A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query.
+        enable_delta_progress:
+          type: boolean
+          description: Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.
+          default: false
+        invoke_timeout_seconds:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 1200
+          description: The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used.
+      description: A sibling Foundry text agent that a voice agent may consult as a background specialist.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceAgentSubAgentConfig:
+      type: object
+      required:
+        - subagents
+      properties:
+        subagents:
+          type: array
+          items:
+            $ref: '#/components/schemas/VoiceAgentSubAgent'
+          minItems: 1
+          description: The sibling Foundry text agents, in the same project, that this voice agent may consult.
+        response_policy:
+          $ref: '#/components/schemas/VoiceAgentSubagentResponsePolicy'
+          description: Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response.
+      description: Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceAgentSubagentResponsePolicy:
+      type: object
+      properties:
+        immediate_ack:
+          type: boolean
+          description: Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent.
+        gap_filling_interval:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 120
+          description: The number of seconds without subagent content or user input before the voice agent provides a gap-filling response.
+        ack_instructions:
+          type: string
+          description: Instructions used to generate the immediate acknowledgement.
+        gap_filling_instructions:
+          type: string
+          description: Instructions used to generate gap-filling speech while waiting for progress.
+        progress_instructions:
+          type: string
+          description: Instructions used to summarize streamed subagent progress for speech.
+        progress_update_interval:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 300
+          description: The minimum number of seconds between spoken progress updates.
+      description: Policy for delivering responses while a voice agent waits for a subagent.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     VoiceAgentSystemTool:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/v1/microsoft-foundry-openapi3.yaml
@@ -9196,10 +9196,6 @@ paths:
             encoding:
               model:
                 contentType: text/plain
-              languages:
-                contentType: application/json
-              keywords:
-                contentType: application/json
               response_format:
                 contentType: application/json
               temperature:
@@ -25169,13 +25165,16 @@ paths:
                         Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                     deprecated: true
                   safety_identifier:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
+                    type: string
+                    maxLength: 64
+                    description: |-
+                      A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   prompt_cache_key:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
+                    type: string
+                    description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                  service_tier:
+                    $ref: '#/components/schemas/OpenAI.ServiceTier'
                   prompt_cache_retention:
                     anyOf:
                       - type: string
@@ -25209,8 +25208,6 @@ paths:
                       - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                   prompt:
                     $ref: '#/components/schemas/OpenAI.Prompt'
-                  service_tier:
-                    $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                   truncation:
                     anyOf:
                       - type: string
@@ -25300,7 +25297,7 @@ paths:
                     default: true
                   conversation:
                     anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ResponseConversation'
+                      - $ref: '#/components/schemas/OpenAI.ConversationReference'
                       - type: 'null'
                   max_output_tokens:
                     anyOf:
@@ -25379,13 +25376,16 @@ paths:
                       Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   deprecated: true
                 safety_identifier:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
+                  type: string
+                  maxLength: 64
+                  description: |-
+                    A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                 prompt_cache_key:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
+                  type: string
+                  description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                service_tier:
+                  $ref: '#/components/schemas/OpenAI.ServiceTier'
                 prompt_cache_retention:
                   anyOf:
                     - type: string
@@ -25421,8 +25421,6 @@ paths:
                     - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                 prompt:
                   $ref: '#/components/schemas/OpenAI.Prompt'
-                service_tier:
-                  $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                 truncation:
                   anyOf:
                     - type: string
@@ -48333,31 +48331,18 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
-                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
+          description: The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
         language:
           type: string
           description: |-
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -48387,23 +48372,15 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
-                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
+          description: The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
         language:
           type: string
           description: The language of the input audio.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format.
         prompt:
           type: string
           description: The prompt configured for input audio transcription, when present.
@@ -50135,8 +50112,6 @@ components:
           $ref: '#/components/schemas/OpenAI.integer'
         reasoning_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
-        text_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
         rejected_prediction_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
     OpenAI.CompletionUsagePromptTokensDetails:
@@ -50145,10 +50120,6 @@ components:
         audio_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cached_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
-        text_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
-        image_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cache_write_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
@@ -51281,6 +51252,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -51298,12 +51270,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -51591,7 +51557,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -51915,6 +51880,16 @@ components:
           description: The unique ID of the conversation.
       description: The conversation that this response belongs to.
       title: Conversation object
+    OpenAI.ConversationReference:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: The unique ID of the conversation that this response was associated with.
+      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
+      title: Conversation
     OpenAI.ConversationResource:
       type: object
       required:
@@ -52159,13 +52134,16 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          maxLength: 64
+          description: |-
+            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTier'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -52189,8 +52167,6 @@ components:
         model:
           type: string
           description: The model deployment to use for this chat completion.
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTier'
         modalities:
           $ref: '#/components/schemas/OpenAI.ResponseModalities'
         verbosity:
@@ -52517,10 +52493,6 @@ components:
         model:
           type: string
           description: The model deployment used for the creation of this chat completion.
-        metadata:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
         service_tier:
           $ref: '#/components/schemas/OpenAI.ServiceTier'
         system_fingerprint:
@@ -53562,7 +53534,7 @@ components:
                 contentEncoding: base64
           description: |-
             The image(s) to edit. Must be a supported image file or an array of images.
-              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`
+              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`
               file less than 50MB. You can provide up to 16 images.
               `chatgpt-image-latest` follows the same input constraints as GPT image models.
               For `dall-e-2`, you can only provide one image, and it should be a square
@@ -53581,27 +53553,24 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
         model:
           anyOf:
             - type: string
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.
+          description: The model to use for image generation. Defaults to `gpt-image-1.5`.
           x-oaiTypeLabel: string
         'n':
           anyOf:
@@ -53693,14 +53662,12 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - dall-e-3
                 - gpt-image-1
                 - gpt-image-1-mini
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
+          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
           x-oaiTypeLabel: string
           default: dall-e-2
         'n':
@@ -53798,13 +53765,12 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
           default: auto
         style:
           anyOf:
@@ -54698,9 +54664,7 @@ components:
       type: object
       properties:
         file:
-          description: |-
-            The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-              The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
+          description: 'The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -54708,26 +54672,15 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
                 - gpt-4o-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe-diarize
-          description: ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
+          description: ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
           x-oaiTypeLabel: string
         language:
           type: string
           description: The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`.
         prompt:
           type: string
           description: An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text#prompting) should match the audio language. This field is not supported when using `gpt-4o-transcribe-diarize`.
@@ -54845,11 +54798,6 @@ components:
         text:
           type: string
           description: The transcribed text.
-        languages:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.TranscriptionLanguage'
-          description: The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected.
         logprobs:
           type: array
           items:
@@ -54972,7 +54920,7 @@ components:
       type: object
       properties:
         file:
-          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.'
+          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -55729,13 +55677,11 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.
+          description: The model to use for image editing.
           x-oaiTypeLabel: string
           default: gpt-image-1.5
         images:
@@ -55827,7 +55773,7 @@ components:
                 - opaque
                 - auto
             - type: 'null'
-          description: Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.
+          description: Background behavior for generated image output.
           default: auto
         stream:
           anyOf:
@@ -58383,8 +58329,6 @@ components:
                 - gpt-image-1
                 - gpt-image-1-mini
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
           default: gpt-image-1
         quality:
           type: string
@@ -58438,11 +58382,8 @@ components:
             - opaque
             - auto
           description: |-
-            Set the background of the generated image. One of `transparent`,
-              `opaque`, or `auto`. Transparent backgrounds are available for
-              supported GPT Image models. For `gpt-image-2` and
-              `gpt-image-2-2026-04-21`, this support is in preview. When using
-              `transparent`, set the output format to `png` or `webp`. Default: `auto`.
+            Background type for the generated image. One of `transparent`,
+              `opaque`, or `auto`. Default: `auto`.
           default: auto
         input_fidelity:
           anyOf:
@@ -59169,7 +59110,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
@@ -59380,6 +59321,7 @@ components:
     OpenAI.InputItemFunctionCallOutputItemParam:
       type: object
       required:
+        - call_id
         - type
         - output
       properties:
@@ -59388,9 +59330,10 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: The unique ID of the function tool call generated by the model.
         type:
           type: string
           enum:
@@ -59408,14 +59351,6 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
-        name:
-          anyOf:
-            - type: string
-            - type: 'null'
-        namespace:
-          anyOf:
-            - type: string
-            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -59789,7 +59724,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -60313,7 +60247,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
@@ -61049,6 +60983,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -61066,12 +61001,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -61323,7 +61252,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -61678,6 +61606,7 @@ components:
     OpenAI.ItemFunctionCallOutputItemParam:
       type: object
       required:
+        - call_id
         - type
         - output
       properties:
@@ -61686,9 +61615,10 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: The unique ID of the function tool call generated by the model.
         type:
           type: string
           enum:
@@ -61706,14 +61636,6 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
-        name:
-          anyOf:
-            - type: string
-            - type: 'null'
-        namespace:
-          anyOf:
-            - type: string
-            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -62131,7 +62053,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -62845,6 +62766,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -62862,12 +62784,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -63163,7 +63079,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -64522,6 +64437,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -64961,12 +64878,6 @@ components:
         owned_by:
           type: string
           description: The organization that owns the model.
-        shutdown_date:
-          anyOf:
-            - type: string
-              format: date
-            - type: 'null'
-          description: The date when the model will shut down, or null if not announced.
       description: Describes an OpenAI model offering that can be used with the API.
       title: Model
       x-oaiMeta:
@@ -64976,8 +64887,7 @@ components:
             "id": "VAR_chat_model_id",
             "object": "model",
             "created": 1686935002,
-            "owned_by": "openai",
-            "shutdown_date": "2026-10-23"
+            "owned_by": "openai"
           }
     OpenAI.Moderation:
       type: object
@@ -65348,6 +65258,7 @@ components:
           description: The namespace name used in tool calls (for example, `crm`).
         description:
           type: string
+          minLength: 1
           description: A description of the namespace shown to the model.
         tools:
           type: array
@@ -65477,6 +65388,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -66167,6 +66080,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -66184,12 +66098,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -66441,7 +66349,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -66797,6 +66704,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -67151,7 +67060,6 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
           function_call: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall'
           function_call_output: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput'
           mcp_approval_response: '#/components/schemas/OpenAI.RealtimeMCPApprovalResponse'
@@ -67268,248 +67176,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessage:
-      type: object
-      required:
-        - role
-        - type
-      properties:
-        role:
-          $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageType'
-        type:
-          type: string
-          enum:
-            - message
-      discriminator:
-        propertyName: role
-        mapping:
-          system: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem'
-          user: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUser'
-          assistant: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItem'
-    OpenAI.RealtimeConversationItemMessageAssistant:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - assistant
-          description: The role of the message sender. Always `assistant`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: An assistant message item in a Realtime conversation.
-      title: Realtime assistant message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageAssistantContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - output_text
-            - output_audio
-        text:
-          type: string
-        audio:
-          type: string
-        transcript:
-          type: string
-    OpenAI.RealtimeConversationItemMessageSystem:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - system
-          description: The role of the message sender. Always `system`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. "the user is now asking about a different topic"), use system messages.
-      title: Realtime system message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageSystemContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - input_text
-          x-stainless-const: true
-        text:
-          type: string
-    OpenAI.RealtimeConversationItemMessageType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - system
-            - user
-            - assistant
-    OpenAI.RealtimeConversationItemMessageUser:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - user
-          description: The role of the message sender. Always `user`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: A user message item in a Realtime conversation.
-      title: Realtime user message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageUserContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - input_text
-            - input_audio
-            - input_image
-        text:
-          type: string
-        audio:
-          type: string
-        image_url:
-          type: string
-          format: uri
-        detail:
-          type: string
-          enum:
-            - auto
-            - low
-            - high
-          default: auto
-        transcript:
-          type: string
     OpenAI.RealtimeConversationItemType:
       anyOf:
         - type: string
@@ -67521,7 +67187,6 @@ components:
             - mcp_list_tools
             - mcp_call
             - mcp_approval_request
-            - message
     OpenAI.RealtimeCreateClientSecretRequest:
       type: object
       properties:
@@ -69228,13 +68893,16 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          maxLength: 64
+          description: |-
+            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTier'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -69268,8 +68936,6 @@ components:
             - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
         prompt:
           $ref: '#/components/schemas/OpenAI.Prompt'
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
         truncation:
           anyOf:
             - type: string
@@ -69359,7 +69025,7 @@ components:
           default: true
         conversation:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.ResponseConversation'
+            - $ref: '#/components/schemas/OpenAI.ConversationReference'
             - type: 'null'
         max_output_tokens:
           anyOf:
@@ -69868,16 +69534,6 @@ components:
               "annotations": []
             }
           }
-    OpenAI.ResponseConversation:
-      type: object
-      required:
-        - id
-      properties:
-        id:
-          type: string
-          description: The unique ID of the conversation that this response was associated with.
-      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
-      title: Conversation
     OpenAI.ResponseCreatedEvent:
       type: object
       required:
@@ -70041,7 +69697,6 @@ components:
         - server_error
         - rate_limit_exceeded
         - invalid_prompt
-        - data_residency_mismatch
         - bio_policy
         - vector_store_timeout
         - invalid_image
@@ -70573,18 +70228,6 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
-        size:
-          type: string
-          description: The image size that was used.
-        quality:
-          type: string
-          description: The image quality that was used.
-        background:
-          type: string
-          description: The background setting that was used.
-        output_format:
-          type: string
-          description: The output format that was used.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
@@ -71106,11 +70749,7 @@ components:
           description: The sequence number of this event.
         item:
           $ref: '#/components/schemas/OpenAI.OutputItem'
-          description: |-
-            The output item that was added. For reasoning items, `encrypted_content`
-              may be incomplete while the item is in progress. Use the reasoning item
-              from the corresponding `response.output_item.done` event when passing it
-              as input to a subsequent request.
+          description: The output item that was added.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
@@ -71228,10 +70867,10 @@ components:
             "content_index": 0,
             "annotation_index": 0,
             "annotation": {
-              "type": "file_citation",
-              "file_id": "file-abc",
-              "index": 0,
-              "filename": "example.txt"
+              "type": "text_annotation",
+              "text": "This is a test annotation",
+              "start": 0,
+              "end": 10
             },
             "sequence_number": 1
           }
@@ -71700,174 +71339,6 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
-    OpenAI.ResponseShellCallCommandAddedStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - command
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.added
-          description: The type of the event, always `response.shell_call_command.added`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was added.
-        command:
-          type: string
-          description: The shell command that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was added to a tool call.
-      title: Response shell command added event
-    OpenAI.ResponseShellCallCommandDeltaStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - delta
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.delta
-          description: The type of the event, always `response.shell_call_command.delta`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was updated.
-        delta:
-          type: string
-          description: The shell command delta that was appended.
-        obfuscation:
-          type: string
-          description: An obfuscation string that was added to pad the event payload.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was incrementally updated.
-      title: Response shell command delta event
-    OpenAI.ResponseShellCallCommandDoneStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - command
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.done
-          description: The type of the event, always `response.shell_call_command.done`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was completed.
-        command:
-          type: string
-          description: The final shell command that was emitted.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was completed.
-      title: Response shell command done event
-    OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - item_id
-        - output_index
-        - command_index
-        - delta
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_output_content.delta
-          description: The type of the event, always `response.shell_call_output_content.delta`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        item_id:
-          type: string
-          description: The ID of the output item that was updated.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that produced output.
-        delta:
-          $ref: '#/components/schemas/OpenAI.ShellCallOutputDelta'
-          description: The stdout/stderr delta that was emitted.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated shell call output was incrementally added.
-      title: Response shell call output content delta event
-    OpenAI.ResponseShellCallOutputContentDoneStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - item_id
-        - output_index
-        - command_index
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_output_content.done
-          description: The type of the event, always `response.shell_call_output_content.done`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        item_id:
-          type: string
-          description: The ID of the output item that was updated.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that produced output.
-        output:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
-          description: The output contents emitted for the shell command.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated shell call output was completed.
-      title: Response shell call output content done event
     OpenAI.ResponseStreamEvent:
       type: object
       required:
@@ -71925,18 +71396,12 @@ components:
           response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
           response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
           response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
-          response.shell_call_command.added: '#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent'
-          response.shell_call_command.delta: '#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent'
-          response.shell_call_command.done: '#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent'
-          response.shell_call_output_content.delta: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent'
-          response.shell_call_output_content.done: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent'
           response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
           response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
           response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
           response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
           response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
           response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
-      description: Event emitted while a response is streamed.
     OpenAI.ResponseStreamEventType:
       anyOf:
         - type: string
@@ -71961,11 +71426,6 @@ components:
             - response.file_search_call.searching
             - response.function_call_arguments.delta
             - response.function_call_arguments.done
-            - response.shell_call_command.added
-            - response.shell_call_command.delta
-            - response.shell_call_command.done
-            - response.shell_call_output_content.delta
-            - response.shell_call_output_content.done
             - response.in_progress
             - response.failed
             - response.incomplete
@@ -73208,14 +72668,12 @@ components:
             - flex
             - scale
             - priority
-            - fast
         - type: 'null'
       description: |-
         Specifies the processing type used for serving the request.
         - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
         - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
-        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
-        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
+        - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
     OpenAI.ServiceTierEnum:
@@ -73223,41 +72681,8 @@ components:
       enum:
         - auto
         - default
-        - fast
         - flex
         - priority
-    OpenAI.ServiceTierResponses:
-      anyOf:
-        - type: string
-          enum:
-            - auto
-            - default
-            - flex
-            - scale
-            - priority
-            - fast
-            - ultrafast
-        - type: 'null'
-      description: |-
-        Specifies the processing type used for serving the request.
-        - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
-        - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
-        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
-        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
-        - If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.
-        - When not set, the default behavior is 'auto'.
-        When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
-    OpenAI.ShellCallOutputDelta:
-      type: object
-      properties:
-        stdout:
-          type: string
-          description: The stdout delta that was emitted.
-        stderr:
-          type: string
-          description: The stderr delta that was emitted.
-      description: A delta of stdout/stderr emitted while a shell call was running.
-      title: Shell call output delta
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -74193,15 +73618,6 @@ components:
       type: string
       enum:
         - logprobs
-    OpenAI.TranscriptionLanguage:
-      type: object
-      required:
-        - code
-      properties:
-        code:
-          type: string
-          description: The code of a language detected in the audio.
-      description: A language detected in transcribed audio.
     OpenAI.TranscriptionSegment:
       type: object
       required:
@@ -75015,8 +74431,7 @@ components:
       description: |-
         Constrains the verbosity of the model's response. Lower values will result in
         more concise responses, while higher values will result in more verbose responses.
-        Currently supported values are `low`, `medium`, and `high`. The default is
-        `medium`.
+        Currently supported values are `low`, `medium`, and `high`.
     OpenAI.VideoCharacterResource:
       type: object
       required:
@@ -75417,10 +74832,6 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
-        external_web_access:
-          type: boolean
-          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
-          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
@@ -76474,6 +75885,37 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - preview_tool
+    ResponsePolicy:
+      type: object
+      properties:
+        immediate_ack:
+          type: boolean
+          description: Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent.
+        gap_filling_interval:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 120
+          description: The number of seconds without subagent content or user input before the voice agent provides a gap-filling response.
+        ack_instructions:
+          type: string
+          description: Instructions used to generate the immediate acknowledgement.
+        gap_filling_instructions:
+          type: string
+          description: Instructions used to generate gap-filling speech while waiting for progress.
+        progress_instructions:
+          type: string
+          description: Instructions used to summarize streamed subagent progress for speech.
+        progress_update_interval:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 300
+          description: The minimum number of seconds between spoken progress updates.
+      description: Policy for delivering responses while a voice agent waits for a subagent.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     ResponseRetrievalItemGenerationParams:
       type: object
       required:
@@ -77573,6 +77015,49 @@ components:
           description: The structured output captured during the response.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
+    SubAgent:
+      type: object
+      required:
+        - agent_name
+        - agent_capabilities
+      properties:
+        agent_name:
+          type: string
+          description: The name of the subagent. The subagent must be in the same project as the voice agent.
+        agent_version:
+          type: string
+          description: The version of the subagent. When omitted, the active version is used.
+        agent_capabilities:
+          type: string
+          description: A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query.
+        invoke_timeout_seconds:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 1200
+          description: The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used.
+      description: A sibling Foundry text agent that a voice agent may consult as a background specialist.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    SubAgentConfig:
+      type: object
+      required:
+        - subagents
+      properties:
+        subagents:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubAgent'
+          minItems: 1
+          description: The sibling Foundry text agents, in the same project, that this voice agent may consult.
+        response_policy:
+          $ref: '#/components/schemas/ResponsePolicy'
+          description: Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response.
+      description: Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     SyntheticDataGenerationPreviewEvalRunDataSource:
       type: object
       required:
@@ -79244,6 +78729,9 @@ components:
           unevaluatedProperties:
             $ref: '#/components/schemas/StructuredInputDefinition'
           description: Set of structured inputs that participate in prompt template substitution, rendered per session before the live session starts.
+        subagent_config:
+          $ref: '#/components/schemas/SubAgentConfig'
+          description: Optional configuration for sibling Foundry text agents that this voice agent may consult as background specialists.
         store:
           type: boolean
           description: |-
@@ -79389,17 +78877,6 @@ components:
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -80437,10 +79914,6 @@ components:
           type: string
           enum:
             - web_search
-        external_web_access:
-          type: boolean
-          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
-          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -83270,47 +83270,6 @@
           ]
         }
       },
-      "ResponsePolicy": {
-        "type": "object",
-        "properties": {
-          "immediate_ack": {
-            "type": "boolean",
-            "description": "Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent."
-          },
-          "gap_filling_interval": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 5,
-            "maximum": 120,
-            "description": "The number of seconds without subagent content or user input before the voice agent provides a gap-filling response."
-          },
-          "ack_instructions": {
-            "type": "string",
-            "description": "Instructions used to generate the immediate acknowledgement."
-          },
-          "gap_filling_instructions": {
-            "type": "string",
-            "description": "Instructions used to generate gap-filling speech while waiting for progress."
-          },
-          "progress_instructions": {
-            "type": "string",
-            "description": "Instructions used to summarize streamed subagent progress for speech."
-          },
-          "progress_update_interval": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 5,
-            "maximum": 300,
-            "description": "The minimum number of seconds between spoken progress updates."
-          }
-        },
-        "description": "Policy for delivering responses while a voice agent waits for a subagent.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
       "ResponseRetrievalItemGenerationParams": {
         "type": "object",
         "required": [
@@ -84883,71 +84842,6 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ]
-      },
-      "SubAgent": {
-        "type": "object",
-        "required": [
-          "agent_name",
-          "agent_capabilities"
-        ],
-        "properties": {
-          "agent_name": {
-            "type": "string",
-            "description": "The name of the subagent. The subagent must be in the same project as the voice agent."
-          },
-          "agent_version": {
-            "type": "string",
-            "description": "The version of the subagent. When omitted, the active version is used."
-          },
-          "agent_capabilities": {
-            "type": "string",
-            "description": "A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query."
-          },
-          "enable_delta_progress": {
-            "type": "boolean",
-            "description": "Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.",
-            "default": false
-          },
-          "invoke_timeout_seconds": {
-            "type": "integer",
-            "format": "int32",
-            "minimum": 5,
-            "maximum": 1200,
-            "description": "The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used."
-          }
-        },
-        "description": "A sibling Foundry text agent that a voice agent may consult as a background specialist.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "SubAgentConfig": {
-        "type": "object",
-        "required": [
-          "subagents"
-        ],
-        "properties": {
-          "subagents": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SubAgent"
-            },
-            "minItems": 1,
-            "description": "The sibling Foundry text agents, in the same project, that this voice agent may consult."
-          },
-          "response_policy": {
-            "$ref": "#/components/schemas/ResponsePolicy",
-            "description": "Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response."
-          }
-        },
-        "description": "Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
       },
       "SyntheticDataGenerationPreviewEvalRunDataSource": {
         "type": "object",
@@ -87437,7 +87331,7 @@
             "description": "Set of structured inputs that participate in prompt template substitution, rendered per session before the live session starts."
           },
           "subagent_config": {
-            "$ref": "#/components/schemas/SubAgentConfig",
+            "$ref": "#/components/schemas/VoiceAgentSubAgentConfig",
             "description": "Optional configuration for sibling Foundry text agents that this voice agent may consult as background specialists."
           },
           "store": {
@@ -88176,6 +88070,112 @@
           }
         ],
         "description": "A static interim response selected from configured text."
+      },
+      "VoiceAgentSubAgent": {
+        "type": "object",
+        "required": [
+          "agent_name",
+          "agent_capabilities"
+        ],
+        "properties": {
+          "agent_name": {
+            "type": "string",
+            "description": "The name of the subagent. The subagent must be in the same project as the voice agent."
+          },
+          "agent_version": {
+            "type": "string",
+            "description": "The version of the subagent. When omitted, the active version is used."
+          },
+          "agent_capabilities": {
+            "type": "string",
+            "description": "A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query."
+          },
+          "enable_delta_progress": {
+            "type": "boolean",
+            "description": "Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.",
+            "default": false
+          },
+          "invoke_timeout_seconds": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 1200,
+            "description": "The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used."
+          }
+        },
+        "description": "A sibling Foundry text agent that a voice agent may consult as a background specialist.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceAgentSubAgentConfig": {
+        "type": "object",
+        "required": [
+          "subagents"
+        ],
+        "properties": {
+          "subagents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VoiceAgentSubAgent"
+            },
+            "minItems": 1,
+            "description": "The sibling Foundry text agents, in the same project, that this voice agent may consult."
+          },
+          "response_policy": {
+            "$ref": "#/components/schemas/VoiceAgentSubagentResponsePolicy",
+            "description": "Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response."
+          }
+        },
+        "description": "Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "VoiceAgentSubagentResponsePolicy": {
+        "type": "object",
+        "properties": {
+          "immediate_ack": {
+            "type": "boolean",
+            "description": "Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent."
+          },
+          "gap_filling_interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 120,
+            "description": "The number of seconds without subagent content or user input before the voice agent provides a gap-filling response."
+          },
+          "ack_instructions": {
+            "type": "string",
+            "description": "Instructions used to generate the immediate acknowledgement."
+          },
+          "gap_filling_instructions": {
+            "type": "string",
+            "description": "Instructions used to generate gap-filling speech while waiting for progress."
+          },
+          "progress_instructions": {
+            "type": "string",
+            "description": "Instructions used to summarize streamed subagent progress for speech."
+          },
+          "progress_update_interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 300,
+            "description": "The minimum number of seconds between spoken progress updates."
+          }
+        },
+        "description": "Policy for delivering responses while a voice agent waits for a subagent.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
       },
       "VoiceAgentSystemTool": {
         "type": "object",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -84903,6 +84903,11 @@
             "type": "string",
             "description": "A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query."
           },
+          "enable_delta_progress": {
+            "type": "boolean",
+            "description": "Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.",
+            "default": false
+          },
           "invoke_timeout_seconds": {
             "type": "integer",
             "format": "int32",

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.json
@@ -15168,12 +15168,6 @@
                 "model": {
                   "contentType": "text/plain"
                 },
-                "languages": {
-                  "contentType": "application/json"
-                },
-                "keywords": {
-                  "contentType": "application/json"
-                },
                 "response_format": {
                   "contentType": "application/json"
                 },
@@ -21881,24 +21875,16 @@
                       "deprecated": true
                     },
                     "safety_identifier": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
+                      "type": "string",
+                      "maxLength": 64,
+                      "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                     },
                     "prompt_cache_key": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
+                      "type": "string",
+                      "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                    },
+                    "service_tier": {
+                      "$ref": "#/components/schemas/OpenAI.ServiceTier"
                     },
                     "prompt_cache_retention": {
                       "anyOf": [
@@ -21967,9 +21953,6 @@
                     },
                     "prompt": {
                       "$ref": "#/components/schemas/OpenAI.Prompt"
-                    },
-                    "service_tier": {
-                      "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                     },
                     "truncation": {
                       "anyOf": [
@@ -22115,7 +22098,7 @@
                     "conversation": {
                       "anyOf": [
                         {
-                          "$ref": "#/components/schemas/OpenAI.ResponseConversation"
+                          "$ref": "#/components/schemas/OpenAI.ConversationReference"
                         },
                         {
                           "type": "null"
@@ -22262,24 +22245,16 @@
                     "deprecated": true
                   },
                   "safety_identifier": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "type": "string",
+                    "maxLength": 64,
+                    "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
                   },
                   "prompt_cache_key": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "type": "string",
+                    "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+                  },
+                  "service_tier": {
+                    "$ref": "#/components/schemas/OpenAI.ServiceTier"
                   },
                   "prompt_cache_retention": {
                     "anyOf": [
@@ -22351,9 +22326,6 @@
                   },
                   "prompt": {
                     "$ref": "#/components/schemas/OpenAI.Prompt"
-                  },
-                  "service_tier": {
-                    "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
                   },
                   "truncation": {
                     "anyOf": [
@@ -45248,8 +45220,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
-                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -45258,26 +45228,11 @@
                 ]
               }
             ],
-            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
+            "description": "The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -45308,8 +45263,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
-                  "gpt-live-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
                   "gpt-4o-transcribe",
@@ -45318,19 +45271,11 @@
                 ]
               }
             ],
-            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
+            "description": "The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`."
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format."
           },
           "prompt": {
             "type": "string",
@@ -47724,9 +47669,6 @@
           "reasoning_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
-          "text_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
           "rejected_prediction_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           }
@@ -47739,12 +47681,6 @@
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cached_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "text_tokens": {
-            "$ref": "#/components/schemas/OpenAI.integer"
-          },
-          "image_tokens": {
             "$ref": "#/components/schemas/OpenAI.integer"
           },
           "cache_write_tokens": {
@@ -49341,6 +49277,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -49360,14 +49297,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -49784,8 +49713,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -50249,6 +50177,20 @@
         "description": "The conversation that this response belongs to.",
         "title": "Conversation object"
       },
+      "OpenAI.ConversationReference": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the conversation that this response was associated with."
+          }
+        },
+        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
+        "title": "Conversation"
+      },
       "OpenAI.ConversationResource": {
         "type": "object",
         "required": [
@@ -50650,24 +50592,16 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "maxLength": 64,
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -50698,9 +50632,6 @@
           "model": {
             "type": "string",
             "description": "The model deployment to use for this chat completion."
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "modalities": {
             "$ref": "#/components/schemas/OpenAI.ResponseModalities"
@@ -51130,16 +51061,6 @@
           "model": {
             "type": "string",
             "description": "The model deployment used for the creation of this chat completion."
-          },
-          "metadata": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/OpenAI.Metadata"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "service_tier": {
             "$ref": "#/components/schemas/OpenAI.ServiceTier"
@@ -52545,7 +52466,7 @@
                 }
               }
             ],
-            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
+            "description": "The image(s) to edit. Must be a supported image file or an array of images.\n  For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`\n  file less than 50MB. You can provide up to 16 images.\n  `chatgpt-image-latest` follows the same input constraints as GPT image models.\n  For `dall-e-2`, you can only provide one image, and it should be a square\n  `png` file less than 4MB."
           },
           "prompt": {
             "type": "string",
@@ -52568,7 +52489,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`."
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`."
           },
           "model": {
             "anyOf": [
@@ -52579,8 +52500,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "gpt-image-1",
                   "gpt-image-1-mini",
@@ -52591,7 +52510,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.",
+            "description": "The model to use for image generation. Defaults to `gpt-image-1.5`.",
             "x-oaiTypeLabel": "string"
           },
           "n": {
@@ -52740,8 +52659,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "dall-e-2",
                   "dall-e-3",
                   "gpt-image-1",
@@ -52752,7 +52669,7 @@
                 "type": "null"
               }
             ],
-            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
+            "description": "The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.",
             "x-oaiTypeLabel": "string",
             "default": "dall-e-2"
           },
@@ -52904,7 +52821,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image(s). This parameter is only\n  supported for the GPT image models. Must be one of `transparent`, `opaque`,\n  or `auto` (default value). When `auto` is used, the model will automatically\n  determine the best background for the image.\n  Transparent backgrounds are available for supported GPT Image models. For\n  `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When\n  using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Allows to set transparency for the background of the generated image(s).\n  This parameter is only supported for the GPT image models. Must be one of\n  `transparent`, `opaque` or `auto` (default value). When `auto` is used, the\n  model will automatically determine the best background for the image.\n  If `transparent`, the output format needs to support transparency, so it\n  should be set to either `png` (default value) or `webp`.",
             "default": "auto"
           },
           "style": {
@@ -54258,7 +54175,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.\n  The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
+            "description": "The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -54270,7 +54187,6 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
-                  "gpt-transcribe",
                   "gpt-4o-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
@@ -54278,26 +54194,12 @@
                 ]
               }
             ],
-            "description": "ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
+            "description": "ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.",
             "x-oaiTypeLabel": "string"
           },
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -54425,13 +54327,6 @@
             "type": "string",
             "description": "The transcribed text."
           },
-          "languages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.TranscriptionLanguage"
-            },
-            "description": "The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected."
-          },
           "logprobs": {
             "type": "array",
             "items": {
@@ -54551,7 +54446,7 @@
         "type": "object",
         "properties": {
           "file": {
-            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.",
+            "description": "The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.",
             "x-oaiTypeLabel": "file"
           },
           "model": {
@@ -55660,8 +55555,6 @@
                 "type": "string",
                 "enum": [
                   "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21",
                   "gpt-image-1",
                   "gpt-image-1-mini",
                   "chatgpt-image-latest"
@@ -55671,7 +55564,7 @@
                 "type": "null"
               }
             ],
-            "description": "The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.",
+            "description": "The model to use for image editing.",
             "x-oaiTypeLabel": "string",
             "default": "gpt-image-1.5"
           },
@@ -55818,7 +55711,7 @@
                 "type": "null"
               }
             ],
-            "description": "Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.",
+            "description": "Background behavior for generated image output.",
             "default": "auto"
           },
           "stream": {
@@ -59360,9 +59253,7 @@
                 "enum": [
                   "gpt-image-1",
                   "gpt-image-1-mini",
-                  "gpt-image-1.5",
-                  "gpt-image-2",
-                  "gpt-image-2-2026-04-21"
+                  "gpt-image-1.5"
                 ]
               }
             ],
@@ -59430,7 +59321,7 @@
               "opaque",
               "auto"
             ],
-            "description": "Set the background of the generated image. One of `transparent`,\n  `opaque`, or `auto`. Transparent backgrounds are available for\n  supported GPT Image models. For `gpt-image-2` and\n  `gpt-image-2-2026-04-21`, this support is in preview. When using\n  `transparent`, set the output format to `png` or `webp`. Default: `auto`.",
+            "description": "Background type for the generated image. One of `transparent`,\n  `opaque`, or `auto`. Default: `auto`.",
             "default": "auto"
           },
           "input_fidelity": {
@@ -60500,7 +60391,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -60814,6 +60705,7 @@
       "OpenAI.InputItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
+          "call_id",
           "type",
           "output"
         ],
@@ -60829,14 +60721,10 @@
             ]
           },
           "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "The unique ID of the function tool call generated by the model."
           },
           "type": {
             "type": "string",
@@ -60870,26 +60758,6 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "namespace": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "caller": {
             "anyOf": [
@@ -61473,8 +61341,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -62257,7 +62124,7 @@
           },
           "encrypted_content": {
             "type": "string",
-            "maxLength": 20971520,
+            "maxLength": 10485760,
             "description": "The encrypted content of the compaction summary."
           }
         },
@@ -63329,6 +63196,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -63348,14 +63216,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -63725,8 +63585,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -64229,6 +64088,7 @@
       "OpenAI.ItemFunctionCallOutputItemParam": {
         "type": "object",
         "required": [
+          "call_id",
           "type",
           "output"
         ],
@@ -64244,14 +64104,10 @@
             ]
           },
           "call_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "description": "The unique ID of the function tool call generated by the model."
           },
           "type": {
             "type": "string",
@@ -64285,26 +64141,6 @@
               }
             ],
             "description": "Text, image, or file output of the function tool call."
-          },
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "namespace": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "caller": {
             "anyOf": [
@@ -64941,8 +64777,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -65961,6 +65796,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -65980,14 +65816,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -66410,8 +66238,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -68286,7 +68113,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -68897,25 +68726,13 @@
           "owned_by": {
             "type": "string",
             "description": "The organization that owns the model."
-          },
-          "shutdown_date": {
-            "anyOf": [
-              {
-                "type": "string",
-                "format": "date"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "The date when the model will shut down, or null if not announced."
           }
         },
         "description": "Describes an OpenAI model offering that can be used with the API.",
         "title": "Model",
         "x-oaiMeta": {
           "name": "The model object",
-          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\",\n  \"shutdown_date\": \"2026-10-23\"\n}\n"
+          "example": "{\n  \"id\": \"VAR_chat_model_id\",\n  \"object\": \"model\",\n  \"created\": 1686935002,\n  \"owned_by\": \"openai\"\n}\n"
         }
       },
       "OpenAI.Moderation": {
@@ -69527,6 +69344,7 @@
           },
           "description": {
             "type": "string",
+            "minLength": 1,
             "description": "A description of the namespace shown to the model."
           },
           "tools": {
@@ -69693,7 +69511,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -70684,6 +70504,7 @@
         "required": [
           "id",
           "type",
+          "call_id",
           "output"
         ],
         "properties": {
@@ -70703,14 +70524,6 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model."
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the tool that produced the output."
-          },
-          "namespace": {
-            "type": "string",
-            "description": "The namespace of the tool that produced the output."
           },
           "caller": {
             "anyOf": [
@@ -71080,8 +70893,7 @@
           },
           "error": {
             "type": "object",
-            "unevaluatedProperties": {},
-            "description": "The error from the tool call, if any."
+            "unevaluatedProperties": {}
           },
           "status": {
             "$ref": "#/components/schemas/OpenAI.MCPToolCallStatus",
@@ -71574,7 +71386,9 @@
         "type": "object",
         "required": [
           "type",
-          "text"
+          "text",
+          "annotations",
+          "logprobs"
         ],
         "properties": {
           "type": {
@@ -72086,7 +71900,6 @@
         "discriminator": {
           "propertyName": "type",
           "mapping": {
-            "message": "#/components/schemas/OpenAI.RealtimeConversationItemMessage",
             "function_call": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall",
             "function_call_output": "#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput",
             "mcp_approval_response": "#/components/schemas/OpenAI.RealtimeMCPApprovalResponse",
@@ -72248,351 +72061,6 @@
           ]
         }
       },
-      "OpenAI.RealtimeConversationItemMessage": {
-        "type": "object",
-        "required": [
-          "role",
-          "type"
-        ],
-        "properties": {
-          "role": {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageType"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ]
-          }
-        },
-        "discriminator": {
-          "propertyName": "role",
-          "mapping": {
-            "system": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem",
-            "user": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUser",
-            "assistant": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant"
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItem"
-          }
-        ]
-      },
-      "OpenAI.RealtimeConversationItemMessageAssistant": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "assistant"
-            ],
-            "description": "The role of the message sender. Always `assistant`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "An assistant message item in a Realtime conversation.",
-        "title": "Realtime assistant message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageAssistantContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "output_text",
-              "output_audio"
-            ]
-          },
-          "text": {
-            "type": "string"
-          },
-          "audio": {
-            "type": "string"
-          },
-          "transcript": {
-            "type": "string"
-          }
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageSystem": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "system"
-            ],
-            "description": "The role of the message sender. Always `system`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. \"the user is now asking about a different topic\"), use system messages.",
-        "title": "Realtime system message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageSystemContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "input_text"
-            ],
-            "x-stainless-const": true
-          },
-          "text": {
-            "type": "string"
-          }
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageType": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "string",
-            "enum": [
-              "system",
-              "user",
-              "assistant"
-            ]
-          }
-        ]
-      },
-      "OpenAI.RealtimeConversationItemMessageUser": {
-        "type": "object",
-        "required": [
-          "type",
-          "role",
-          "content"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the item. This may be provided by the client or generated by the server."
-          },
-          "object": {
-            "type": "string",
-            "enum": [
-              "realtime.item"
-            ],
-            "description": "Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.",
-            "x-stainless-const": true
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "message"
-            ],
-            "description": "The type of the item. Always `message`.",
-            "x-stainless-const": true
-          },
-          "status": {
-            "type": "string",
-            "enum": [
-              "completed",
-              "incomplete",
-              "in_progress"
-            ],
-            "description": "The status of the item. Has no effect on the conversation."
-          },
-          "role": {
-            "type": "string",
-            "enum": [
-              "user"
-            ],
-            "description": "The role of the message sender. Always `user`.",
-            "x-stainless-const": true
-          },
-          "content": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent"
-            },
-            "description": "The content of the message."
-          },
-          "created_at": {
-            "$ref": "#/components/schemas/FoundryTimestamp",
-            "description": "The Unix timestamp (in seconds) for when the item was persisted.",
-            "readOnly": true
-          },
-          "response_id": {
-            "type": "string",
-            "description": "The id of the response that produced this item, when applicable.",
-            "readOnly": true
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.RealtimeConversationItemMessage"
-          }
-        ],
-        "description": "A user message item in a Realtime conversation.",
-        "title": "Realtime user message item",
-        "x-ms-foundry-meta": {
-          "required_previews": [
-            "VoiceAgents=V1Preview"
-          ]
-        }
-      },
-      "OpenAI.RealtimeConversationItemMessageUserContent": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "input_text",
-              "input_audio",
-              "input_image"
-            ]
-          },
-          "text": {
-            "type": "string"
-          },
-          "audio": {
-            "type": "string"
-          },
-          "image_url": {
-            "type": "string",
-            "format": "uri"
-          },
-          "detail": {
-            "type": "string",
-            "enum": [
-              "auto",
-              "low",
-              "high"
-            ],
-            "default": "auto"
-          },
-          "transcript": {
-            "type": "string"
-          }
-        }
-      },
       "OpenAI.RealtimeConversationItemType": {
         "anyOf": [
           {
@@ -72606,8 +72074,7 @@
               "mcp_approval_response",
               "mcp_list_tools",
               "mcp_call",
-              "mcp_approval_request",
-              "message"
+              "mcp_approval_request"
             ]
           }
         ]
@@ -74731,24 +74198,16 @@
             "deprecated": true
           },
           "safety_identifier": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "maxLength": 64,
+            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\n  The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers)."
           },
           "prompt_cache_key": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "type": "string",
+            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching)."
+          },
+          "service_tier": {
+            "$ref": "#/components/schemas/OpenAI.ServiceTier"
           },
           "prompt_cache_retention": {
             "anyOf": [
@@ -74817,9 +74276,6 @@
           },
           "prompt": {
             "$ref": "#/components/schemas/OpenAI.Prompt"
-          },
-          "service_tier": {
-            "$ref": "#/components/schemas/OpenAI.ServiceTierResponses"
           },
           "truncation": {
             "anyOf": [
@@ -74965,7 +74421,7 @@
           "conversation": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/OpenAI.ResponseConversation"
+                "$ref": "#/components/schemas/OpenAI.ConversationReference"
               },
               {
                 "type": "null"
@@ -75515,20 +74971,6 @@
           "example": "{\n  \"type\": \"response.content_part.done\",\n  \"item_id\": \"msg_123\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"sequence_number\": 1,\n  \"part\": {\n    \"type\": \"output_text\",\n    \"text\": \"In a shimmering forest under a sky full of stars, a lonely unicorn named Lila discovered a hidden pond that glowed with moonlight. Every night, she would leave sparkling, magical flowers by the water's edge, hoping to share her beauty with others. One enchanting evening, she woke to find a group of friendly animals gathered around, eager to be friends and share in her magic.\",\n    \"annotations\": []\n  }\n}\n"
         }
       },
-      "OpenAI.ResponseConversation": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "description": "The unique ID of the conversation that this response was associated with."
-          }
-        },
-        "description": "The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.",
-        "title": "Conversation"
-      },
       "OpenAI.ResponseCreatedEvent": {
         "type": "object",
         "required": [
@@ -75685,7 +75127,6 @@
           "server_error",
           "rate_limit_exceeded",
           "invalid_prompt",
-          "data_residency_mismatch",
           "bio_policy",
           "vector_store_timeout",
           "invalid_image",
@@ -76290,22 +75731,6 @@
           "partial_image_b64": {
             "type": "string",
             "description": "Base64-encoded partial image data, suitable for rendering as an image."
-          },
-          "size": {
-            "type": "string",
-            "description": "The image size that was used."
-          },
-          "quality": {
-            "type": "string",
-            "description": "The image quality that was used."
-          },
-          "background": {
-            "type": "string",
-            "description": "The background setting that was used."
-          },
-          "output_format": {
-            "type": "string",
-            "description": "The output format that was used."
           }
         },
         "allOf": [
@@ -76842,7 +76267,7 @@
           },
           "item": {
             "$ref": "#/components/schemas/OpenAI.OutputItem",
-            "description": "The output item that was added. For reasoning items, `encrypted_content`\n  may be incomplete while the item is in progress. Use the reasoning item\n  from the corresponding `response.output_item.done` event when passing it\n  as input to a subsequent request."
+            "description": "The output item that was added."
           }
         },
         "allOf": [
@@ -76954,7 +76379,7 @@
         "x-oaiMeta": {
           "name": "response.output_text.annotation.added",
           "group": "responses",
-          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"file_citation\",\n    \"file_id\": \"file-abc\",\n    \"index\": 0,\n    \"filename\": \"example.txt\"\n  },\n  \"sequence_number\": 1\n}\n"
+          "example": "{\n  \"type\": \"response.output_text.annotation.added\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 0,\n  \"content_index\": 0,\n  \"annotation_index\": 0,\n  \"annotation\": {\n    \"type\": \"text_annotation\",\n    \"text\": \"This is a test annotation\",\n    \"start\": 0,\n    \"end\": 10\n  },\n  \"sequence_number\": 1\n}\n"
         }
       },
       "OpenAI.ResponsePromptVariables": {
@@ -77479,238 +76904,6 @@
           "example": "{\n  \"type\": \"response.refusal.done\",\n  \"item_id\": \"item-abc\",\n  \"output_index\": 1,\n  \"content_index\": 2,\n  \"refusal\": \"final refusal text\",\n  \"sequence_number\": 1\n}\n"
         }
       },
-      "OpenAI.ResponseShellCallCommandAddedStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "command"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.added"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.added`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was added."
-          },
-          "command": {
-            "type": "string",
-            "description": "The shell command that was added."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was added to a tool call.",
-        "title": "Response shell command added event"
-      },
-      "OpenAI.ResponseShellCallCommandDeltaStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "delta"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.delta"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.delta`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was updated."
-          },
-          "delta": {
-            "type": "string",
-            "description": "The shell command delta that was appended."
-          },
-          "obfuscation": {
-            "type": "string",
-            "description": "An obfuscation string that was added to pad the event payload."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was incrementally updated.",
-        "title": "Response shell command delta event"
-      },
-      "OpenAI.ResponseShellCallCommandDoneStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "output_index",
-          "command_index",
-          "command"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_command.done"
-            ],
-            "description": "The type of the event, always `response.shell_call_command.done`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that was completed."
-          },
-          "command": {
-            "type": "string",
-            "description": "The final shell command that was emitted."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated a shell command was completed.",
-        "title": "Response shell command done event"
-      },
-      "OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "item_id",
-          "output_index",
-          "command_index",
-          "delta"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_output_content.delta"
-            ],
-            "description": "The type of the event, always `response.shell_call_output_content.delta`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "item_id": {
-            "type": "string",
-            "description": "The ID of the output item that was updated."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that produced output."
-          },
-          "delta": {
-            "$ref": "#/components/schemas/OpenAI.ShellCallOutputDelta",
-            "description": "The stdout/stderr delta that was emitted."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated shell call output was incrementally added.",
-        "title": "Response shell call output content delta event"
-      },
-      "OpenAI.ResponseShellCallOutputContentDoneStreamingEvent": {
-        "type": "object",
-        "required": [
-          "type",
-          "sequence_number",
-          "item_id",
-          "output_index",
-          "command_index",
-          "output"
-        ],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "response.shell_call_output_content.done"
-            ],
-            "description": "The type of the event, always `response.shell_call_output_content.done`.",
-            "x-stainless-const": true
-          },
-          "sequence_number": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The sequence number of the event that was emitted."
-          },
-          "item_id": {
-            "type": "string",
-            "description": "The ID of the output item that was updated."
-          },
-          "output_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the output item that was updated."
-          },
-          "command_index": {
-            "$ref": "#/components/schemas/OpenAI.integer",
-            "description": "The index of the shell command that produced output."
-          },
-          "output": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OpenAI.FunctionShellCallOutputContent"
-            },
-            "description": "The output contents emitted for the shell command."
-          }
-        },
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/OpenAI.ResponseStreamEvent"
-          }
-        ],
-        "description": "A streaming event that indicated shell call output was completed.",
-        "title": "Response shell call output content done event"
-      },
       "OpenAI.ResponseStreamEvent": {
         "type": "object",
         "required": [
@@ -77771,11 +76964,6 @@
             "response.reasoning_text.done": "#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent",
             "response.refusal.delta": "#/components/schemas/OpenAI.ResponseRefusalDeltaEvent",
             "response.refusal.done": "#/components/schemas/OpenAI.ResponseRefusalDoneEvent",
-            "response.shell_call_command.added": "#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent",
-            "response.shell_call_command.delta": "#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent",
-            "response.shell_call_command.done": "#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent",
-            "response.shell_call_output_content.delta": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent",
-            "response.shell_call_output_content.done": "#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent",
             "response.output_text.delta": "#/components/schemas/OpenAI.ResponseTextDeltaEvent",
             "response.output_text.done": "#/components/schemas/OpenAI.ResponseTextDoneEvent",
             "response.web_search_call.completed": "#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent",
@@ -77783,8 +76971,7 @@
             "response.web_search_call.searching": "#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent",
             "response.audio.delta": "#/components/schemas/OpenAI.ResponseAudioDeltaEvent"
           }
-        },
-        "description": "Event emitted while a response is streamed."
+        }
       },
       "OpenAI.ResponseStreamEventType": {
         "anyOf": [
@@ -77813,11 +77000,6 @@
               "response.file_search_call.searching",
               "response.function_call_arguments.delta",
               "response.function_call_arguments.done",
-              "response.shell_call_command.added",
-              "response.shell_call_command.delta",
-              "response.shell_call_command.done",
-              "response.shell_call_output_content.delta",
-              "response.shell_call_output_content.done",
               "response.in_progress",
               "response.failed",
               "response.incomplete",
@@ -79485,60 +78667,23 @@
               "default",
               "flex",
               "scale",
-              "priority",
-              "fast"
+              "priority"
             ]
           },
           {
             "type": "null"
           }
         ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
+        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
       },
       "OpenAI.ServiceTierEnum": {
         "type": "string",
         "enum": [
           "auto",
           "default",
-          "fast",
           "flex",
           "priority"
         ]
-      },
-      "OpenAI.ServiceTierResponses": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": [
-              "auto",
-              "default",
-              "flex",
-              "scale",
-              "priority",
-              "fast",
-              "ultrafast"
-            ]
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "description": "Specifies the processing type used for serving the request.\n- If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n- If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n- If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n- To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n- If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.\n- When not set, the default behavior is 'auto'.\nWhen the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter."
-      },
-      "OpenAI.ShellCallOutputDelta": {
-        "type": "object",
-        "properties": {
-          "stdout": {
-            "type": "string",
-            "description": "The stdout delta that was emitted."
-          },
-          "stderr": {
-            "type": "string",
-            "description": "The stderr delta that was emitted."
-          }
-        },
-        "description": "A delta of stdout/stderr emitted while a shell call was running.",
-        "title": "Shell call output delta"
       },
       "OpenAI.SkillReferenceParam": {
         "type": "object",
@@ -80818,19 +79963,6 @@
           "logprobs"
         ]
       },
-      "OpenAI.TranscriptionLanguage": {
-        "type": "object",
-        "required": [
-          "code"
-        ],
-        "properties": {
-          "code": {
-            "type": "string",
-            "description": "The code of a language detected in the audio."
-          }
-        },
-        "description": "A language detected in transcribed audio."
-      },
       "OpenAI.TranscriptionSegment": {
         "type": "object",
         "required": [
@@ -81905,7 +81037,7 @@
             "type": "null"
           }
         ],
-        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`. The default is\n`medium`."
+        "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`."
       },
       "OpenAI.VideoCharacterResource": {
         "type": "object",
@@ -82512,11 +81644,6 @@
               "web_search"
             ],
             "description": "The type of the web search tool. One of `web_search` or `web_search_2025_08_26`."
-          },
-          "external_web_access": {
-            "type": "boolean",
-            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
-            "default": true
           },
           "filters": {
             "anyOf": [
@@ -84143,6 +83270,47 @@
           ]
         }
       },
+      "ResponsePolicy": {
+        "type": "object",
+        "properties": {
+          "immediate_ack": {
+            "type": "boolean",
+            "description": "Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent."
+          },
+          "gap_filling_interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 120,
+            "description": "The number of seconds without subagent content or user input before the voice agent provides a gap-filling response."
+          },
+          "ack_instructions": {
+            "type": "string",
+            "description": "Instructions used to generate the immediate acknowledgement."
+          },
+          "gap_filling_instructions": {
+            "type": "string",
+            "description": "Instructions used to generate gap-filling speech while waiting for progress."
+          },
+          "progress_instructions": {
+            "type": "string",
+            "description": "Instructions used to summarize streamed subagent progress for speech."
+          },
+          "progress_update_interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 300,
+            "description": "The minimum number of seconds between spoken progress updates."
+          }
+        },
+        "description": "Policy for delivering responses while a voice agent waits for a subagent.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
       "ResponseRetrievalItemGenerationParams": {
         "type": "object",
         "required": [
@@ -85715,6 +84883,66 @@
             "$ref": "#/components/schemas/OpenAI.OutputItem"
           }
         ]
+      },
+      "SubAgent": {
+        "type": "object",
+        "required": [
+          "agent_name",
+          "agent_capabilities"
+        ],
+        "properties": {
+          "agent_name": {
+            "type": "string",
+            "description": "The name of the subagent. The subagent must be in the same project as the voice agent."
+          },
+          "agent_version": {
+            "type": "string",
+            "description": "The version of the subagent. When omitted, the active version is used."
+          },
+          "agent_capabilities": {
+            "type": "string",
+            "description": "A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query."
+          },
+          "invoke_timeout_seconds": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 5,
+            "maximum": 1200,
+            "description": "The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used."
+          }
+        },
+        "description": "A sibling Foundry text agent that a voice agent may consult as a background specialist.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
+      },
+      "SubAgentConfig": {
+        "type": "object",
+        "required": [
+          "subagents"
+        ],
+        "properties": {
+          "subagents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubAgent"
+            },
+            "minItems": 1,
+            "description": "The sibling Foundry text agents, in the same project, that this voice agent may consult."
+          },
+          "response_policy": {
+            "$ref": "#/components/schemas/ResponsePolicy",
+            "description": "Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response."
+          }
+        },
+        "description": "Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.",
+        "x-ms-foundry-meta": {
+          "required_previews": [
+            "VoiceAgents=V1Preview"
+          ]
+        }
       },
       "SyntheticDataGenerationPreviewEvalRunDataSource": {
         "type": "object",
@@ -88203,6 +87431,10 @@
             },
             "description": "Set of structured inputs that participate in prompt template substitution, rendered per session before the live session starts."
           },
+          "subagent_config": {
+            "$ref": "#/components/schemas/SubAgentConfig",
+            "description": "Optional configuration for sibling Foundry text agents that this voice agent may consult as background specialists."
+          },
           "store": {
             "type": "boolean",
             "description": "Whether conversations with this agent are persisted. A single, all-or-nothing persistence switch that defaults to\n`false` (privacy-safe: off by default). When `true`, Foundry persists the full conversation — the transcript/event\ntimeline and raw audio. When `false`, nothing is persisted and no conversation is surfaced. There is no separate\naudio-logging control; audio is persisted only as part of this switch. Latency/performance telemetry (e.g.\ntime-to-first-audio, inter-token latency, interruption) is observability-only (customer trace / App Insights) and\nis not part of the persisted conversation content.",
@@ -88396,21 +87628,6 @@
           "language": {
             "type": "string",
             "description": "The language of the input audio. Supplying the input language in\n  [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format\n  will improve accuracy and latency."
-          },
-          "languages": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "minItems": 1,
-            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
-          },
-          "keywords": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`."
           },
           "prompt": {
             "type": "string",
@@ -89906,11 +89123,6 @@
             "enum": [
               "web_search"
             ]
-          },
-          "external_web_access": {
-            "type": "boolean",
-            "description": "Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.",
-            "default": true
           },
           "filters": {
             "anyOf": [

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -11037,10 +11037,6 @@ paths:
             encoding:
               model:
                 contentType: text/plain
-              languages:
-                contentType: application/json
-              keywords:
-                contentType: application/json
               response_format:
                 contentType: application/json
               temperature:
@@ -27010,13 +27006,16 @@ paths:
                         Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                     deprecated: true
                   safety_identifier:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
+                    type: string
+                    maxLength: 64
+                    description: |-
+                      A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                        The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   prompt_cache_key:
-                    anyOf:
-                      - type: string
-                      - type: 'null'
+                    type: string
+                    description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                  service_tier:
+                    $ref: '#/components/schemas/OpenAI.ServiceTier'
                   prompt_cache_retention:
                     anyOf:
                       - type: string
@@ -27050,8 +27049,6 @@ paths:
                       - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                   prompt:
                     $ref: '#/components/schemas/OpenAI.Prompt'
-                  service_tier:
-                    $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                   truncation:
                     anyOf:
                       - type: string
@@ -27141,7 +27138,7 @@ paths:
                     default: true
                   conversation:
                     anyOf:
-                      - $ref: '#/components/schemas/OpenAI.ResponseConversation'
+                      - $ref: '#/components/schemas/OpenAI.ConversationReference'
                       - type: 'null'
                   max_output_tokens:
                     anyOf:
@@ -27232,13 +27229,16 @@ paths:
                       Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                   deprecated: true
                 safety_identifier:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
+                  type: string
+                  maxLength: 64
+                  description: |-
+                    A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+                      The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
                 prompt_cache_key:
-                  anyOf:
-                    - type: string
-                    - type: 'null'
+                  type: string
+                  description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+                service_tier:
+                  $ref: '#/components/schemas/OpenAI.ServiceTier'
                 prompt_cache_retention:
                   anyOf:
                     - type: string
@@ -27274,8 +27274,6 @@ paths:
                     - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
                 prompt:
                   $ref: '#/components/schemas/OpenAI.Prompt'
-                service_tier:
-                  $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
                 truncation:
                   anyOf:
                     - type: string
@@ -51381,31 +51379,18 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
-                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model to use for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
+          description: The model to use for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`. Use `gpt-4o-transcribe-diarize` when you need diarization with speaker labels.
         language:
           type: string
           description: |-
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -51435,23 +51420,15 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
-                - gpt-live-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe
                 - gpt-4o-transcribe-diarize
                 - gpt-realtime-whisper
-          description: The model used for transcription. Current options are `whisper-1`, `gpt-transcribe`, `gpt-live-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
+          description: The model used for transcription. Current options are `whisper-1`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `gpt-4o-transcribe`, `gpt-4o-transcribe-diarize`, and `gpt-realtime-whisper`.
         language:
           type: string
           description: The language of the input audio.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: The possible input audio languages configured for transcription, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format.
         prompt:
           type: string
           description: The prompt configured for input audio transcription, when present.
@@ -53183,8 +53160,6 @@ components:
           $ref: '#/components/schemas/OpenAI.integer'
         reasoning_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
-        text_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
         rejected_prediction_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
     OpenAI.CompletionUsagePromptTokensDetails:
@@ -53193,10 +53168,6 @@ components:
         audio_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cached_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
-        text_tokens:
-          $ref: '#/components/schemas/OpenAI.integer'
-        image_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
         cache_write_tokens:
           $ref: '#/components/schemas/OpenAI.integer'
@@ -54329,6 +54300,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -54346,12 +54318,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -54639,7 +54605,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -54963,6 +54928,16 @@ components:
           description: The unique ID of the conversation.
       description: The conversation that this response belongs to.
       title: Conversation object
+    OpenAI.ConversationReference:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+          description: The unique ID of the conversation that this response was associated with.
+      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
+      title: Conversation
     OpenAI.ConversationResource:
       type: object
       required:
@@ -55207,13 +55182,16 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          maxLength: 64
+          description: |-
+            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTier'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -55237,8 +55215,6 @@ components:
         model:
           type: string
           description: The model deployment to use for this chat completion.
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTier'
         modalities:
           $ref: '#/components/schemas/OpenAI.ResponseModalities'
         verbosity:
@@ -55565,10 +55541,6 @@ components:
         model:
           type: string
           description: The model deployment used for the creation of this chat completion.
-        metadata:
-          anyOf:
-            - $ref: '#/components/schemas/OpenAI.Metadata'
-            - type: 'null'
         service_tier:
           $ref: '#/components/schemas/OpenAI.ServiceTier'
         system_fingerprint:
@@ -56610,7 +56582,7 @@ components:
                 contentEncoding: base64
           description: |-
             The image(s) to edit. Must be a supported image file or an array of images.
-              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, and `gpt-image-2-2026-04-21`), each image should be a `png`, `webp`, or `jpg`
+              For the GPT image models (`gpt-image-1`, `gpt-image-1-mini`, and `gpt-image-1.5`), each image should be a `png`, `webp`, or `jpg`
               file less than 50MB. You can provide up to 16 images.
               `chatgpt-image-latest` follows the same input constraints as GPT image models.
               For `dall-e-2`, you can only provide one image, and it should be a square
@@ -56629,27 +56601,24 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
         model:
           anyOf:
             - type: string
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2` or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`, or `chatgpt-image-latest`). Defaults to `gpt-image-1.5`.
+          description: The model to use for image generation. Defaults to `gpt-image-1.5`.
           x-oaiTypeLabel: string
         'n':
           anyOf:
@@ -56741,14 +56710,12 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - dall-e-2
                 - dall-e-3
                 - gpt-image-1
                 - gpt-image-1-mini
             - type: 'null'
-          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`, `gpt-image-2`, `gpt-image-2-2026-04-21`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
+          description: The model to use for image generation. One of `dall-e-2`, `dall-e-3`, or a GPT image model (`gpt-image-1`, `gpt-image-1-mini`, `gpt-image-1.5`). Defaults to `dall-e-2` unless a parameter specific to the GPT image models is used.
           x-oaiTypeLabel: string
           default: dall-e-2
         'n':
@@ -56846,13 +56813,12 @@ components:
                 - auto
             - type: 'null'
           description: |-
-            Set the background of the generated image(s). This parameter is only
-              supported for the GPT image models. Must be one of `transparent`, `opaque`,
-              or `auto` (default value). When `auto` is used, the model will automatically
-              determine the best background for the image.
-              Transparent backgrounds are available for supported GPT Image models. For
-              `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When
-              using `transparent`, set the output format to `png` or `webp`.
+            Allows to set transparency for the background of the generated image(s).
+              This parameter is only supported for the GPT image models. Must be one of
+              `transparent`, `opaque` or `auto` (default value). When `auto` is used, the
+              model will automatically determine the best background for the image.
+              If `transparent`, the output format needs to support transparency, so it
+              should be set to either `png` (default value) or `webp`.
           default: auto
         style:
           anyOf:
@@ -57746,9 +57712,7 @@ components:
       type: object
       properties:
         file:
-          description: |-
-            The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.
-              The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.
+          description: 'The audio file object (not file name) to transcribe, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -57756,26 +57720,15 @@ components:
             - type: string
               enum:
                 - whisper-1
-                - gpt-transcribe
                 - gpt-4o-transcribe
                 - gpt-4o-mini-transcribe
                 - gpt-4o-mini-transcribe-2025-12-15
                 - gpt-4o-transcribe-diarize
-          description: ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
+          description: ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.
           x-oaiTypeLabel: string
         language:
           type: string
           description: The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`.
         prompt:
           type: string
           description: An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text#prompting) should match the audio language. This field is not supported when using `gpt-4o-transcribe-diarize`.
@@ -57893,11 +57846,6 @@ components:
         text:
           type: string
           description: The transcribed text.
-        languages:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.TranscriptionLanguage'
-          description: The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected.
         logprobs:
           type: array
           items:
@@ -58020,7 +57968,7 @@ components:
       type: object
       properties:
         file:
-          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm. The request must include enough format metadata for the file to be identified. We recommend an extension-bearing filename and an appropriate content type.'
+          description: 'The audio file object (not file name) translate, in one of these formats: flac, mp3, mp4, mpeg, mpga, m4a, ogg, wav, or webm.'
           x-oaiTypeLabel: file
         model:
           anyOf:
@@ -58777,13 +58725,11 @@ components:
             - type: string
               enum:
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
                 - gpt-image-1
                 - gpt-image-1-mini
                 - chatgpt-image-latest
             - type: 'null'
-          description: The GPT image model to use for image editing, including `gpt-image-2` and its dated snapshot `gpt-image-2-2026-04-21`.
+          description: The model to use for image editing.
           x-oaiTypeLabel: string
           default: gpt-image-1.5
         images:
@@ -58875,7 +58821,7 @@ components:
                 - opaque
                 - auto
             - type: 'null'
-          description: Set the background of the generated image output. Transparent backgrounds are available for supported GPT Image models. For `gpt-image-2` and `gpt-image-2-2026-04-21`, this support is in preview. When using `transparent`, set the output format to `png` or `webp`.
+          description: Background behavior for generated image output.
           default: auto
         stream:
           anyOf:
@@ -61431,8 +61377,6 @@ components:
                 - gpt-image-1
                 - gpt-image-1-mini
                 - gpt-image-1.5
-                - gpt-image-2
-                - gpt-image-2-2026-04-21
           default: gpt-image-1
         quality:
           type: string
@@ -61486,11 +61430,8 @@ components:
             - opaque
             - auto
           description: |-
-            Set the background of the generated image. One of `transparent`,
-              `opaque`, or `auto`. Transparent backgrounds are available for
-              supported GPT Image models. For `gpt-image-2` and
-              `gpt-image-2-2026-04-21`, this support is in preview. When using
-              `transparent`, set the output format to `png` or `webp`. Default: `auto`.
+            Background type for the generated image. One of `transparent`,
+              `opaque`, or `auto`. Default: `auto`.
           default: auto
         input_fidelity:
           anyOf:
@@ -62217,7 +62158,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.InputItem'
@@ -62428,6 +62369,7 @@ components:
     OpenAI.InputItemFunctionCallOutputItemParam:
       type: object
       required:
+        - call_id
         - type
         - output
       properties:
@@ -62436,9 +62378,10 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: The unique ID of the function tool call generated by the model.
         type:
           type: string
           enum:
@@ -62456,14 +62399,6 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
-        name:
-          anyOf:
-            - type: string
-            - type: 'null'
-        namespace:
-          anyOf:
-            - type: string
-            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -62837,7 +62772,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -63361,7 +63295,7 @@ components:
           default: compaction
         encrypted_content:
           type: string
-          maxLength: 20971520
+          maxLength: 10485760
           description: The encrypted content of the compaction summary.
       allOf:
         - $ref: '#/components/schemas/OpenAI.Item'
@@ -64097,6 +64031,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -64114,12 +64049,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -64371,7 +64300,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -64726,6 +64654,7 @@ components:
     OpenAI.ItemFunctionCallOutputItemParam:
       type: object
       required:
+        - call_id
         - type
         - output
       properties:
@@ -64734,9 +64663,10 @@ components:
             - type: string
             - type: 'null'
         call_id:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          minLength: 1
+          maxLength: 64
+          description: The unique ID of the function tool call generated by the model.
         type:
           type: string
           enum:
@@ -64754,14 +64684,6 @@ components:
                   - $ref: '#/components/schemas/OpenAI.InputImageContentParamAutoParam'
                   - $ref: '#/components/schemas/OpenAI.InputFileContentParam'
           description: Text, image, or file output of the function tool call.
-        name:
-          anyOf:
-            - type: string
-            - type: 'null'
-        namespace:
-          anyOf:
-            - type: string
-            - type: 'null'
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -65179,7 +65101,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -65893,6 +65814,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -65910,12 +65832,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -66211,7 +66127,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -67570,6 +67485,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -68009,12 +67926,6 @@ components:
         owned_by:
           type: string
           description: The organization that owns the model.
-        shutdown_date:
-          anyOf:
-            - type: string
-              format: date
-            - type: 'null'
-          description: The date when the model will shut down, or null if not announced.
       description: Describes an OpenAI model offering that can be used with the API.
       title: Model
       x-oaiMeta:
@@ -68024,8 +67935,7 @@ components:
             "id": "VAR_chat_model_id",
             "object": "model",
             "created": 1686935002,
-            "owned_by": "openai",
-            "shutdown_date": "2026-10-23"
+            "owned_by": "openai"
           }
     OpenAI.Moderation:
       type: object
@@ -68396,6 +68306,7 @@ components:
           description: The namespace name used in tool calls (for example, `crm`).
         description:
           type: string
+          minLength: 1
           description: A description of the namespace shown to the model.
         tools:
           type: array
@@ -68525,6 +68436,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -69220,6 +69133,7 @@ components:
       required:
         - id
         - type
+        - call_id
         - output
       properties:
         id:
@@ -69237,12 +69151,6 @@ components:
         call_id:
           type: string
           description: The unique ID of the function tool call generated by the model.
-        name:
-          type: string
-          description: The name of the tool that produced the output.
-        namespace:
-          type: string
-          description: The namespace of the tool that produced the output.
         caller:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.ToolCallCallerParam'
@@ -69494,7 +69402,6 @@ components:
         error:
           type: object
           unevaluatedProperties: {}
-          description: The error from the tool call, if any.
         status:
           $ref: '#/components/schemas/OpenAI.MCPToolCallStatus'
           description: The status of the tool call. One of `in_progress`, `completed`, `incomplete`, `calling`, or `failed`.
@@ -69850,6 +69757,8 @@ components:
       required:
         - type
         - text
+        - annotations
+        - logprobs
       properties:
         type:
           type: string
@@ -70204,7 +70113,6 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          message: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
           function_call: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCall'
           function_call_output: '#/components/schemas/OpenAI.RealtimeConversationItemFunctionCallOutput'
           mcp_approval_response: '#/components/schemas/OpenAI.RealtimeMCPApprovalResponse'
@@ -70321,248 +70229,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessage:
-      type: object
-      required:
-        - role
-        - type
-      properties:
-        role:
-          $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageType'
-        type:
-          type: string
-          enum:
-            - message
-      discriminator:
-        propertyName: role
-        mapping:
-          system: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystem'
-          user: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUser'
-          assistant: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistant'
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItem'
-    OpenAI.RealtimeConversationItemMessageAssistant:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - assistant
-          description: The role of the message sender. Always `assistant`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageAssistantContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: An assistant message item in a Realtime conversation.
-      title: Realtime assistant message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageAssistantContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - output_text
-            - output_audio
-        text:
-          type: string
-        audio:
-          type: string
-        transcript:
-          type: string
-    OpenAI.RealtimeConversationItemMessageSystem:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - system
-          description: The role of the message sender. Always `system`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageSystemContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: A system message in a Realtime conversation can be used to provide additional context or instructions to the model. This is similar but distinct from the instruction prompt provided at the start of a conversation, as system messages can be added at any point in the conversation. For major changes to the conversation's behavior, use instructions, but for smaller updates (e.g. "the user is now asking about a different topic"), use system messages.
-      title: Realtime system message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageSystemContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - input_text
-          x-stainless-const: true
-        text:
-          type: string
-    OpenAI.RealtimeConversationItemMessageType:
-      anyOf:
-        - type: string
-        - type: string
-          enum:
-            - system
-            - user
-            - assistant
-    OpenAI.RealtimeConversationItemMessageUser:
-      type: object
-      required:
-        - type
-        - role
-        - content
-      properties:
-        id:
-          type: string
-          description: The unique ID of the item. This may be provided by the client or generated by the server.
-        object:
-          type: string
-          enum:
-            - realtime.item
-          description: Identifier for the API object being returned - always `realtime.item`. Optional when creating a new item.
-          x-stainless-const: true
-        type:
-          type: string
-          enum:
-            - message
-          description: The type of the item. Always `message`.
-          x-stainless-const: true
-        status:
-          type: string
-          enum:
-            - completed
-            - incomplete
-            - in_progress
-          description: The status of the item. Has no effect on the conversation.
-        role:
-          type: string
-          enum:
-            - user
-          description: The role of the message sender. Always `user`.
-          x-stainless-const: true
-        content:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessageUserContent'
-          description: The content of the message.
-        created_at:
-          $ref: '#/components/schemas/FoundryTimestamp'
-          description: The Unix timestamp (in seconds) for when the item was persisted.
-          readOnly: true
-        response_id:
-          type: string
-          description: The id of the response that produced this item, when applicable.
-          readOnly: true
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.RealtimeConversationItemMessage'
-      description: A user message item in a Realtime conversation.
-      title: Realtime user message item
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    OpenAI.RealtimeConversationItemMessageUserContent:
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - input_text
-            - input_audio
-            - input_image
-        text:
-          type: string
-        audio:
-          type: string
-        image_url:
-          type: string
-          format: uri
-        detail:
-          type: string
-          enum:
-            - auto
-            - low
-            - high
-          default: auto
-        transcript:
-          type: string
     OpenAI.RealtimeConversationItemType:
       anyOf:
         - type: string
@@ -70574,7 +70240,6 @@ components:
             - mcp_list_tools
             - mcp_call
             - mcp_approval_request
-            - message
     OpenAI.RealtimeCreateClientSecretRequest:
       type: object
       properties:
@@ -72281,13 +71946,16 @@ components:
               Used to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
           deprecated: true
         safety_identifier:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          maxLength: 64
+          description: |-
+            A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.
+              The IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).
         prompt_cache_key:
-          anyOf:
-            - type: string
-            - type: 'null'
+          type: string
+          description: Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).
+        service_tier:
+          $ref: '#/components/schemas/OpenAI.ServiceTier'
         prompt_cache_retention:
           anyOf:
             - type: string
@@ -72321,8 +71989,6 @@ components:
             - $ref: '#/components/schemas/OpenAI.ToolChoiceParam'
         prompt:
           $ref: '#/components/schemas/OpenAI.Prompt'
-        service_tier:
-          $ref: '#/components/schemas/OpenAI.ServiceTierResponses'
         truncation:
           anyOf:
             - type: string
@@ -72412,7 +72078,7 @@ components:
           default: true
         conversation:
           anyOf:
-            - $ref: '#/components/schemas/OpenAI.ResponseConversation'
+            - $ref: '#/components/schemas/OpenAI.ConversationReference'
             - type: 'null'
         max_output_tokens:
           anyOf:
@@ -72933,16 +72599,6 @@ components:
               "annotations": []
             }
           }
-    OpenAI.ResponseConversation:
-      type: object
-      required:
-        - id
-      properties:
-        id:
-          type: string
-          description: The unique ID of the conversation that this response was associated with.
-      description: The conversation that this response belonged to. Input items and output items from this response were automatically added to this conversation.
-      title: Conversation
     OpenAI.ResponseCreatedEvent:
       type: object
       required:
@@ -73106,7 +72762,6 @@ components:
         - server_error
         - rate_limit_exceeded
         - invalid_prompt
-        - data_residency_mismatch
         - bio_policy
         - vector_store_timeout
         - invalid_image
@@ -73638,18 +73293,6 @@ components:
         partial_image_b64:
           type: string
           description: Base64-encoded partial image data, suitable for rendering as an image.
-        size:
-          type: string
-          description: The image size that was used.
-        quality:
-          type: string
-          description: The image quality that was used.
-        background:
-          type: string
-          description: The background setting that was used.
-        output_format:
-          type: string
-          description: The output format that was used.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a partial image is available during image generation streaming.
@@ -74171,11 +73814,7 @@ components:
           description: The sequence number of this event.
         item:
           $ref: '#/components/schemas/OpenAI.OutputItem'
-          description: |-
-            The output item that was added. For reasoning items, `encrypted_content`
-              may be incomplete while the item is in progress. Use the reasoning item
-              from the corresponding `response.output_item.done` event when passing it
-              as input to a subsequent request.
+          description: The output item that was added.
       allOf:
         - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
       description: Emitted when a new output item is added.
@@ -74293,10 +73932,10 @@ components:
             "content_index": 0,
             "annotation_index": 0,
             "annotation": {
-              "type": "file_citation",
-              "file_id": "file-abc",
-              "index": 0,
-              "filename": "example.txt"
+              "type": "text_annotation",
+              "text": "This is a test annotation",
+              "start": 0,
+              "end": 10
             },
             "sequence_number": 1
           }
@@ -74765,174 +74404,6 @@ components:
             "refusal": "final refusal text",
             "sequence_number": 1
           }
-    OpenAI.ResponseShellCallCommandAddedStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - command
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.added
-          description: The type of the event, always `response.shell_call_command.added`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was added.
-        command:
-          type: string
-          description: The shell command that was added.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was added to a tool call.
-      title: Response shell command added event
-    OpenAI.ResponseShellCallCommandDeltaStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - delta
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.delta
-          description: The type of the event, always `response.shell_call_command.delta`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was updated.
-        delta:
-          type: string
-          description: The shell command delta that was appended.
-        obfuscation:
-          type: string
-          description: An obfuscation string that was added to pad the event payload.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was incrementally updated.
-      title: Response shell command delta event
-    OpenAI.ResponseShellCallCommandDoneStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - output_index
-        - command_index
-        - command
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_command.done
-          description: The type of the event, always `response.shell_call_command.done`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that was completed.
-        command:
-          type: string
-          description: The final shell command that was emitted.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated a shell command was completed.
-      title: Response shell command done event
-    OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - item_id
-        - output_index
-        - command_index
-        - delta
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_output_content.delta
-          description: The type of the event, always `response.shell_call_output_content.delta`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        item_id:
-          type: string
-          description: The ID of the output item that was updated.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that produced output.
-        delta:
-          $ref: '#/components/schemas/OpenAI.ShellCallOutputDelta'
-          description: The stdout/stderr delta that was emitted.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated shell call output was incrementally added.
-      title: Response shell call output content delta event
-    OpenAI.ResponseShellCallOutputContentDoneStreamingEvent:
-      type: object
-      required:
-        - type
-        - sequence_number
-        - item_id
-        - output_index
-        - command_index
-        - output
-      properties:
-        type:
-          type: string
-          enum:
-            - response.shell_call_output_content.done
-          description: The type of the event, always `response.shell_call_output_content.done`.
-          x-stainless-const: true
-        sequence_number:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The sequence number of the event that was emitted.
-        item_id:
-          type: string
-          description: The ID of the output item that was updated.
-        output_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the output item that was updated.
-        command_index:
-          $ref: '#/components/schemas/OpenAI.integer'
-          description: The index of the shell command that produced output.
-        output:
-          type: array
-          items:
-            $ref: '#/components/schemas/OpenAI.FunctionShellCallOutputContent'
-          description: The output contents emitted for the shell command.
-      allOf:
-        - $ref: '#/components/schemas/OpenAI.ResponseStreamEvent'
-      description: A streaming event that indicated shell call output was completed.
-      title: Response shell call output content done event
     OpenAI.ResponseStreamEvent:
       type: object
       required:
@@ -74990,18 +74461,12 @@ components:
           response.reasoning_text.done: '#/components/schemas/OpenAI.ResponseReasoningTextDoneEvent'
           response.refusal.delta: '#/components/schemas/OpenAI.ResponseRefusalDeltaEvent'
           response.refusal.done: '#/components/schemas/OpenAI.ResponseRefusalDoneEvent'
-          response.shell_call_command.added: '#/components/schemas/OpenAI.ResponseShellCallCommandAddedStreamingEvent'
-          response.shell_call_command.delta: '#/components/schemas/OpenAI.ResponseShellCallCommandDeltaStreamingEvent'
-          response.shell_call_command.done: '#/components/schemas/OpenAI.ResponseShellCallCommandDoneStreamingEvent'
-          response.shell_call_output_content.delta: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDeltaStreamingEvent'
-          response.shell_call_output_content.done: '#/components/schemas/OpenAI.ResponseShellCallOutputContentDoneStreamingEvent'
           response.output_text.delta: '#/components/schemas/OpenAI.ResponseTextDeltaEvent'
           response.output_text.done: '#/components/schemas/OpenAI.ResponseTextDoneEvent'
           response.web_search_call.completed: '#/components/schemas/OpenAI.ResponseWebSearchCallCompletedEvent'
           response.web_search_call.in_progress: '#/components/schemas/OpenAI.ResponseWebSearchCallInProgressEvent'
           response.web_search_call.searching: '#/components/schemas/OpenAI.ResponseWebSearchCallSearchingEvent'
           response.audio.delta: '#/components/schemas/OpenAI.ResponseAudioDeltaEvent'
-      description: Event emitted while a response is streamed.
     OpenAI.ResponseStreamEventType:
       anyOf:
         - type: string
@@ -75026,11 +74491,6 @@ components:
             - response.file_search_call.searching
             - response.function_call_arguments.delta
             - response.function_call_arguments.done
-            - response.shell_call_command.added
-            - response.shell_call_command.delta
-            - response.shell_call_command.done
-            - response.shell_call_output_content.delta
-            - response.shell_call_output_content.done
             - response.in_progress
             - response.failed
             - response.incomplete
@@ -76273,14 +75733,12 @@ components:
             - flex
             - scale
             - priority
-            - fast
         - type: 'null'
       description: |-
         Specifies the processing type used for serving the request.
         - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
         - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
-        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
-        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
+        - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.
         - When not set, the default behavior is 'auto'.
         When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
     OpenAI.ServiceTierEnum:
@@ -76288,41 +75746,8 @@ components:
       enum:
         - auto
         - default
-        - fast
         - flex
         - priority
-    OpenAI.ServiceTierResponses:
-      anyOf:
-        - type: string
-          enum:
-            - auto
-            - default
-            - flex
-            - scale
-            - priority
-            - fast
-            - ultrafast
-        - type: 'null'
-      description: |-
-        Specifies the processing type used for serving the request.
-        - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.
-        - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.
-        - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.
-        - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.
-        - If set to 'ultrafast', then the request will be processed with the access-controlled Ultrafast Processing service tier. This tier is currently available for `gpt-5.6-sol`; a response served through it will show `service_tier=ultrafast`.
-        - When not set, the default behavior is 'auto'.
-        When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.
-    OpenAI.ShellCallOutputDelta:
-      type: object
-      properties:
-        stdout:
-          type: string
-          description: The stdout delta that was emitted.
-        stderr:
-          type: string
-          description: The stderr delta that was emitted.
-      description: A delta of stdout/stderr emitted while a shell call was running.
-      title: Shell call output delta
     OpenAI.SkillReferenceParam:
       type: object
       required:
@@ -77260,15 +76685,6 @@ components:
       type: string
       enum:
         - logprobs
-    OpenAI.TranscriptionLanguage:
-      type: object
-      required:
-        - code
-      properties:
-        code:
-          type: string
-          description: The code of a language detected in the audio.
-      description: A language detected in transcribed audio.
     OpenAI.TranscriptionSegment:
       type: object
       required:
@@ -78082,8 +77498,7 @@ components:
       description: |-
         Constrains the verbosity of the model's response. Lower values will result in
         more concise responses, while higher values will result in more verbose responses.
-        Currently supported values are `low`, `medium`, and `high`. The default is
-        `medium`.
+        Currently supported values are `low`, `medium`, and `high`.
     OpenAI.VideoCharacterResource:
       type: object
       required:
@@ -78484,10 +77899,6 @@ components:
           enum:
             - web_search
           description: The type of the web search tool. One of `web_search` or `web_search_2025_08_26`.
-        external_web_access:
-          type: boolean
-          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
-          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'
@@ -79609,6 +79020,37 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - preview_tool
+    ResponsePolicy:
+      type: object
+      properties:
+        immediate_ack:
+          type: boolean
+          description: Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent.
+        gap_filling_interval:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 120
+          description: The number of seconds without subagent content or user input before the voice agent provides a gap-filling response.
+        ack_instructions:
+          type: string
+          description: Instructions used to generate the immediate acknowledgement.
+        gap_filling_instructions:
+          type: string
+          description: Instructions used to generate gap-filling speech while waiting for progress.
+        progress_instructions:
+          type: string
+          description: Instructions used to summarize streamed subagent progress for speech.
+        progress_update_interval:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 300
+          description: The minimum number of seconds between spoken progress updates.
+      description: Policy for delivering responses while a voice agent waits for a subagent.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     ResponseRetrievalItemGenerationParams:
       type: object
       required:
@@ -80708,6 +80150,49 @@ components:
           description: The structured output captured during the response.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
+    SubAgent:
+      type: object
+      required:
+        - agent_name
+        - agent_capabilities
+      properties:
+        agent_name:
+          type: string
+          description: The name of the subagent. The subagent must be in the same project as the voice agent.
+        agent_version:
+          type: string
+          description: The version of the subagent. When omitted, the active version is used.
+        agent_capabilities:
+          type: string
+          description: A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query.
+        invoke_timeout_seconds:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 1200
+          description: The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used.
+      description: A sibling Foundry text agent that a voice agent may consult as a background specialist.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    SubAgentConfig:
+      type: object
+      required:
+        - subagents
+      properties:
+        subagents:
+          type: array
+          items:
+            $ref: '#/components/schemas/SubAgent'
+          minItems: 1
+          description: The sibling Foundry text agents, in the same project, that this voice agent may consult.
+        response_policy:
+          $ref: '#/components/schemas/ResponsePolicy'
+          description: Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response.
+      description: Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     SyntheticDataGenerationPreviewEvalRunDataSource:
       type: object
       required:
@@ -82448,6 +81933,9 @@ components:
           unevaluatedProperties:
             $ref: '#/components/schemas/StructuredInputDefinition'
           description: Set of structured inputs that participate in prompt template substitution, rendered per session before the live session starts.
+        subagent_config:
+          $ref: '#/components/schemas/SubAgentConfig'
+          description: Optional configuration for sibling Foundry text agents that this voice agent may consult as background specialists.
         store:
           type: boolean
           description: |-
@@ -82593,17 +82081,6 @@ components:
             The language of the input audio. Supplying the input language in
               [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format
               will improve accuracy and latency.
-        languages:
-          type: array
-          items:
-            type: string
-          minItems: 1
-          description: Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
-        keywords:
-          type: array
-          items:
-            type: string
-          description: Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe` and `gpt-live-transcribe`.
         prompt:
           type: string
           description: |-
@@ -83641,10 +83118,6 @@ components:
           type: string
           enum:
             - web_search
-        external_web_access:
-          type: boolean
-          description: Allow live internet access for web search. Defaults to true when omitted. When false, the web search tool runs in offline/cache-only mode and will not fetch new external content.
-          default: true
         filters:
           anyOf:
             - $ref: '#/components/schemas/OpenAI.WebSearchToolFilters'

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -80165,6 +80165,10 @@ components:
         agent_capabilities:
           type: string
           description: A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query.
+        enable_delta_progress:
+          type: boolean
+          description: Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.
+          default: false
         invoke_timeout_seconds:
           type: integer
           format: int32

--- a/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
+++ b/specification/ai-foundry/data-plane/Foundry/openapi3/virtual-public-preview/microsoft-foundry-openapi3.yaml
@@ -79020,37 +79020,6 @@ components:
       x-ms-foundry-meta:
         required_previews:
           - preview_tool
-    ResponsePolicy:
-      type: object
-      properties:
-        immediate_ack:
-          type: boolean
-          description: Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent.
-        gap_filling_interval:
-          type: integer
-          format: int32
-          minimum: 5
-          maximum: 120
-          description: The number of seconds without subagent content or user input before the voice agent provides a gap-filling response.
-        ack_instructions:
-          type: string
-          description: Instructions used to generate the immediate acknowledgement.
-        gap_filling_instructions:
-          type: string
-          description: Instructions used to generate gap-filling speech while waiting for progress.
-        progress_instructions:
-          type: string
-          description: Instructions used to summarize streamed subagent progress for speech.
-        progress_update_interval:
-          type: integer
-          format: int32
-          minimum: 5
-          maximum: 300
-          description: The minimum number of seconds between spoken progress updates.
-      description: Policy for delivering responses while a voice agent waits for a subagent.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
     ResponseRetrievalItemGenerationParams:
       type: object
       required:
@@ -80150,53 +80119,6 @@ components:
           description: The structured output captured during the response.
       allOf:
         - $ref: '#/components/schemas/OpenAI.OutputItem'
-    SubAgent:
-      type: object
-      required:
-        - agent_name
-        - agent_capabilities
-      properties:
-        agent_name:
-          type: string
-          description: The name of the subagent. The subagent must be in the same project as the voice agent.
-        agent_version:
-          type: string
-          description: The version of the subagent. When omitted, the active version is used.
-        agent_capabilities:
-          type: string
-          description: A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query.
-        enable_delta_progress:
-          type: boolean
-          description: Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.
-          default: false
-        invoke_timeout_seconds:
-          type: integer
-          format: int32
-          minimum: 5
-          maximum: 1200
-          description: The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used.
-      description: A sibling Foundry text agent that a voice agent may consult as a background specialist.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
-    SubAgentConfig:
-      type: object
-      required:
-        - subagents
-      properties:
-        subagents:
-          type: array
-          items:
-            $ref: '#/components/schemas/SubAgent'
-          minItems: 1
-          description: The sibling Foundry text agents, in the same project, that this voice agent may consult.
-        response_policy:
-          $ref: '#/components/schemas/ResponsePolicy'
-          description: Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response.
-      description: Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.
-      x-ms-foundry-meta:
-        required_previews:
-          - VoiceAgents=V1Preview
     SyntheticDataGenerationPreviewEvalRunDataSource:
       type: object
       required:
@@ -81938,7 +81860,7 @@ components:
             $ref: '#/components/schemas/StructuredInputDefinition'
           description: Set of structured inputs that participate in prompt template substitution, rendered per session before the live session starts.
         subagent_config:
-          $ref: '#/components/schemas/SubAgentConfig'
+          $ref: '#/components/schemas/VoiceAgentSubAgentConfig'
           description: Optional configuration for sibling Foundry text agents that this voice agent may consult as background specialists.
         store:
           type: boolean
@@ -82442,6 +82364,84 @@ components:
       allOf:
         - $ref: '#/components/schemas/VoiceAgentInterimResponseConfig'
       description: A static interim response selected from configured text.
+    VoiceAgentSubAgent:
+      type: object
+      required:
+        - agent_name
+        - agent_capabilities
+      properties:
+        agent_name:
+          type: string
+          description: The name of the subagent. The subagent must be in the same project as the voice agent.
+        agent_version:
+          type: string
+          description: The version of the subagent. When omitted, the active version is used.
+        agent_capabilities:
+          type: string
+          description: A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query.
+        enable_delta_progress:
+          type: boolean
+          description: Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.
+          default: false
+        invoke_timeout_seconds:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 1200
+          description: The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used.
+      description: A sibling Foundry text agent that a voice agent may consult as a background specialist.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceAgentSubAgentConfig:
+      type: object
+      required:
+        - subagents
+      properties:
+        subagents:
+          type: array
+          items:
+            $ref: '#/components/schemas/VoiceAgentSubAgent'
+          minItems: 1
+          description: The sibling Foundry text agents, in the same project, that this voice agent may consult.
+        response_policy:
+          $ref: '#/components/schemas/VoiceAgentSubagentResponsePolicy'
+          description: Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response.
+      description: Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
+    VoiceAgentSubagentResponsePolicy:
+      type: object
+      properties:
+        immediate_ack:
+          type: boolean
+          description: Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent.
+        gap_filling_interval:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 120
+          description: The number of seconds without subagent content or user input before the voice agent provides a gap-filling response.
+        ack_instructions:
+          type: string
+          description: Instructions used to generate the immediate acknowledgement.
+        gap_filling_instructions:
+          type: string
+          description: Instructions used to generate gap-filling speech while waiting for progress.
+        progress_instructions:
+          type: string
+          description: Instructions used to summarize streamed subagent progress for speech.
+        progress_update_interval:
+          type: integer
+          format: int32
+          minimum: 5
+          maximum: 300
+          description: The minimum number of seconds between spoken progress updates.
+      description: Policy for delivering responses while a voice agent waits for a subagent.
+      x-ms-foundry-meta:
+        required_previews:
+          - VoiceAgents=V1Preview
     VoiceAgentSystemTool:
       type: object
       required:

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
@@ -190,9 +190,10 @@ model SubAgent {
   agent_capabilities: string;
 
   @doc("The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used.")
-  @minValue(5)
-  @maxValue(1200)
-  invoke_timeout_seconds?: int32;
+  @encode(DurationKnownEncoding.seconds, int32)
+  @minValue(duration.fromISO("PT5S"))
+  @maxValue(duration.fromISO("PT20M"))
+  invoke_timeout_seconds?: duration;
 }
 
 @doc("Policy for delivering responses while a voice agent waits for a subagent.")
@@ -202,9 +203,10 @@ model ResponsePolicy {
   immediate_ack?: boolean;
 
   @doc("The number of seconds without subagent content or user input before the voice agent provides a gap-filling response.")
-  @minValue(5)
-  @maxValue(120)
-  gap_filling_interval?: int32;
+  @encode(DurationKnownEncoding.seconds, int32)
+  @minValue(duration.fromISO("PT5S"))
+  @maxValue(duration.fromISO("PT2M"))
+  gap_filling_interval?: duration;
 
   @doc("Instructions used to generate the immediate acknowledgement.")
   ack_instructions?: string;
@@ -216,9 +218,10 @@ model ResponsePolicy {
   progress_instructions?: string;
 
   @doc("The minimum number of seconds between spoken progress updates.")
-  @minValue(5)
-  @maxValue(300)
-  progress_update_interval?: int32;
+  @encode(DurationKnownEncoding.seconds, int32)
+  @minValue(duration.fromISO("PT5S"))
+  @maxValue(duration.fromISO("PT5M"))
+  progress_update_interval?: duration;
 }
 
 @doc("Session-start greeting configuration for a voice agent.")

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
@@ -152,6 +152,9 @@ model VoiceAgentDefinition extends AgentDefinition {
   @doc("Set of structured inputs that participate in prompt template substitution, rendered per session before the live session starts.")
   structured_inputs?: Record<StructuredInputDefinition>;
 
+  @doc("Optional configuration for sibling Foundry text agents that this voice agent may consult as background specialists.")
+  subagent_config?: SubAgentConfig;
+
   @doc("""
     Whether conversations with this agent are persisted. A single, all-or-nothing persistence switch that defaults to
     `false` (privacy-safe: off by default). When `true`, Foundry persists the full conversation — the transcript/event
@@ -161,6 +164,61 @@ model VoiceAgentDefinition extends AgentDefinition {
     is not part of the persisted conversation content.
     """)
   store?: boolean = false;
+}
+
+@doc("Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model SubAgentConfig {
+  @doc("The sibling Foundry text agents, in the same project, that this voice agent may consult.")
+  @minItems(1)
+  subagents: SubAgent[];
+
+  @doc("Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response.")
+  response_policy?: ResponsePolicy;
+}
+
+@doc("A sibling Foundry text agent that a voice agent may consult as a background specialist.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model SubAgent {
+  @doc("The name of the subagent. The subagent must be in the same project as the voice agent.")
+  agent_name: string;
+
+  @doc("The version of the subagent. When omitted, the active version is used.")
+  agent_version?: string;
+
+  @doc("A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query.")
+  agent_capabilities: string;
+
+  @doc("The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used.")
+  @minValue(5)
+  @maxValue(1200)
+  invoke_timeout_seconds?: int32;
+}
+
+@doc("Policy for delivering responses while a voice agent waits for a subagent.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model ResponsePolicy {
+  @doc("Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent.")
+  immediate_ack?: boolean;
+
+  @doc("The number of seconds without subagent content or user input before the voice agent provides a gap-filling response.")
+  @minValue(5)
+  @maxValue(120)
+  gap_filling_interval?: int32;
+
+  @doc("Instructions used to generate the immediate acknowledgement.")
+  ack_instructions?: string;
+
+  @doc("Instructions used to generate gap-filling speech while waiting for progress.")
+  gap_filling_instructions?: string;
+
+  @doc("Instructions used to summarize streamed subagent progress for speech.")
+  progress_instructions?: string;
+
+  @doc("The minimum number of seconds between spoken progress updates.")
+  @minValue(5)
+  @maxValue(300)
+  progress_update_interval?: int32;
 }
 
 @doc("Session-start greeting configuration for a voice agent.")

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
@@ -189,6 +189,9 @@ model SubAgent {
   @doc("A description of the subagent's capabilities, used by the voice agent to decide whether to forward a query.")
   agent_capabilities: string;
 
+  @doc("Whether progress updates are emitted incrementally instead of only when the subagent invocation completes. Defaults to `false`.")
+  enable_delta_progress?: boolean = false;
+
   @doc("The wall-clock timeout, in seconds, for each invocation of this subagent. When omitted, the service timeout is used.")
   @encode(DurationKnownEncoding.seconds, int32)
   @minValue(duration.fromISO("PT5S"))

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/agents.tsp
@@ -153,7 +153,7 @@ model VoiceAgentDefinition extends AgentDefinition {
   structured_inputs?: Record<StructuredInputDefinition>;
 
   @doc("Optional configuration for sibling Foundry text agents that this voice agent may consult as background specialists.")
-  subagent_config?: SubAgentConfig;
+  subagent_config?: VoiceAgentSubAgentConfig;
 
   @doc("""
     Whether conversations with this agent are persisted. A single, all-or-nothing persistence switch that defaults to
@@ -168,18 +168,18 @@ model VoiceAgentDefinition extends AgentDefinition {
 
 @doc("Configuration for sibling Foundry text agents that a voice agent may consult, and for delivery of their responses.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model SubAgentConfig {
+model VoiceAgentSubAgentConfig {
   @doc("The sibling Foundry text agents, in the same project, that this voice agent may consult.")
   @minItems(1)
-  subagents: SubAgent[];
+  subagents: VoiceAgentSubAgent[];
 
   @doc("Policy for acknowledging forwarded requests and filling gaps while waiting for a subagent response.")
-  response_policy?: ResponsePolicy;
+  response_policy?: VoiceAgentSubagentResponsePolicy;
 }
 
 @doc("A sibling Foundry text agent that a voice agent may consult as a background specialist.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model SubAgent {
+model VoiceAgentSubAgent {
   @doc("The name of the subagent. The subagent must be in the same project as the voice agent.")
   agent_name: string;
 
@@ -201,7 +201,7 @@ model SubAgent {
 
 @doc("Policy for delivering responses while a voice agent waits for a subagent.")
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model ResponsePolicy {
+model VoiceAgentSubagentResponsePolicy {
   @doc("Whether the voice agent provides an immediate acknowledgement before forwarding a request to a subagent.")
   immediate_ack?: boolean;
 

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/protocol.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/protocol.tsp
@@ -23,6 +23,9 @@ union VoiceAgentClientEventTypeExtension {
 
 union VoiceAgentServerEventTypeExtension {
   warning: "warning",
+  session_subagent_started: "session.subagent.started",
+  session_subagent_completed: "session.subagent.completed",
+  session_subagent_aborted: "session.subagent.aborted",
   session_avatar_connecting: "session.avatar.connecting",
   session_avatar_switch_to_speaking: "session.avatar.switch_to_speaking",
   session_avatar_switch_to_idle: "session.avatar.switch_to_idle",
@@ -446,7 +449,8 @@ union VoiceAgentSubagentAbortReason {
 @doc("The `session.subagent.started` server event.")
 @usage(VoiceAgentServerEventUsage)
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model VoiceAgentServerEventSessionSubagentStarted {
+model VoiceAgentServerEventSessionSubagentStarted
+  extends OpenAI.RealtimeServerEvent {
   @doc("The event type. Always `session.subagent.started`.")
   type: "session.subagent.started";
 
@@ -456,7 +460,8 @@ model VoiceAgentServerEventSessionSubagentStarted {
 @doc("The `session.subagent.completed` server event.")
 @usage(VoiceAgentServerEventUsage)
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model VoiceAgentServerEventSessionSubagentCompleted {
+model VoiceAgentServerEventSessionSubagentCompleted
+  extends OpenAI.RealtimeServerEvent {
   @doc("The event type. Always `session.subagent.completed`.")
   type: "session.subagent.completed";
 
@@ -466,7 +471,8 @@ model VoiceAgentServerEventSessionSubagentCompleted {
 @doc("The `session.subagent.aborted` server event.")
 @usage(VoiceAgentServerEventUsage)
 @extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
-model VoiceAgentServerEventSessionSubagentAborted {
+model VoiceAgentServerEventSessionSubagentAborted
+  extends OpenAI.RealtimeServerEvent {
   @doc("The event type. Always `session.subagent.aborted`.")
   type: "session.subagent.aborted";
 

--- a/specification/ai-foundry/data-plane/Foundry/src/voice-agents/protocol.tsp
+++ b/specification/ai-foundry/data-plane/Foundry/src/voice-agents/protocol.tsp
@@ -126,6 +126,9 @@ union VoiceAgentServerEvent {
   response_output_text_delta: OpenAI.RealtimeServerEventResponseTextDelta,
   response_output_text_done: OpenAI.RealtimeServerEventResponseTextDone,
   session_created: OpenAI.RealtimeServerEventSessionCreated,
+  session_subagent_started: VoiceAgentServerEventSessionSubagentStarted,
+  session_subagent_completed: VoiceAgentServerEventSessionSubagentCompleted,
+  session_subagent_aborted: VoiceAgentServerEventSessionSubagentAborted,
   session_updated: OpenAI.RealtimeServerEventSessionUpdated,
   error: OpenAI.RealtimeServerEventError,
   warning: VoiceAgentServerEventWarning,
@@ -400,6 +403,78 @@ model VoiceAgentClientEventSessionUpdate {
   OpenAI.RealtimeServerEventSessionUpdated.session,
   VoiceAgentSessionResponse
 );
+
+@doc("Fields shared by server events that report the lifecycle of a subagent consultation.")
+model VoiceAgentServerEventSessionSubagentLifecycle {
+  @doc("The server-generated event identifier.")
+  event_id: string;
+
+  @doc("The identifier of the subagent consultation.")
+  consultation_id: string;
+
+  @doc("The identifier of the function call that initiated the consultation.")
+  call_id: string;
+
+  @doc("The name of the consulted subagent.")
+  subagent_name: string;
+}
+
+@doc("The reason a subagent consultation was aborted.")
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+union VoiceAgentSubagentAbortReason {
+  string,
+
+  @doc("The requested subagent was not configured for the voice agent.")
+  unknown_target: "unknown_target",
+
+  @doc("The subagent invocation exceeded its configured timeout.")
+  timeout: "timeout",
+
+  @doc("The consultation was cancelled because the voice session ended.")
+  cancelled: "cancelled",
+
+  @doc("The consultation was stopped at the user's request.")
+  stopped_by_user: "stopped_by_user",
+
+  @doc("The consultation was replaced by a newer request.")
+  superseded: "superseded",
+
+  @doc("The consultation failed.")
+  failed: "failed",
+}
+
+@doc("The `session.subagent.started` server event.")
+@usage(VoiceAgentServerEventUsage)
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model VoiceAgentServerEventSessionSubagentStarted {
+  @doc("The event type. Always `session.subagent.started`.")
+  type: "session.subagent.started";
+
+  ...VoiceAgentServerEventSessionSubagentLifecycle;
+}
+
+@doc("The `session.subagent.completed` server event.")
+@usage(VoiceAgentServerEventUsage)
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model VoiceAgentServerEventSessionSubagentCompleted {
+  @doc("The event type. Always `session.subagent.completed`.")
+  type: "session.subagent.completed";
+
+  ...VoiceAgentServerEventSessionSubagentLifecycle;
+}
+
+@doc("The `session.subagent.aborted` server event.")
+@usage(VoiceAgentServerEventUsage)
+@extension("x-ms-foundry-meta", VoiceAgentRequiredPreview)
+model VoiceAgentServerEventSessionSubagentAborted {
+  @doc("The event type. Always `session.subagent.aborted`.")
+  type: "session.subagent.aborted";
+
+  ...VoiceAgentServerEventSessionSubagentLifecycle;
+
+  @doc("The reason the consultation was aborted.")
+  reason: VoiceAgentSubagentAbortReason;
+}
 
 @doc("The `session.avatar.connect` client event.")
 @usage(VoiceAgentClientEventUsage)


### PR DESCRIPTION
## Summary

Adds the new `subagent_config` property to the feature-gated Voice Agent v1 data-plane contract. It allows a voice agent to consult same-project text agents and configure acknowledgement, gap-filling, and progress responses.

```json
{
  "subagent_config": {
    "subagents": [
      {
        "agent_name": "my-text-agent",
        "agent_version": "3",
        "agent_capabilities": "Answers product support questions.",
        "enable_delta_progress": true,
        "invoke_timeout_seconds": 120
      }
    ],
    "response_policy": {
      "immediate_ack": true,
      "ack_instructions": "Tell the user you are checking.",
      "gap_filling_interval": 15,
      "gap_filling_instructions": "Provide a brief waiting update.",
      "progress_instructions": "Summarize relevant progress.",
      "progress_update_interval": 30
    }
  }
}
```

Adds WebSocket lifecycle events so clients can track subagent consultations:

- `session.subagent.started`
- `session.subagent.completed`
- `session.subagent.aborted`

Each event includes `event_id`, `consultation_id`, `call_id`, and `subagent_name`. Aborted events also include a reason such as `unknown_target`, `timeout`, `cancelled`, `stopped_by_user`, `superseded`, or `failed`.

Regenerates OpenAPI for `v1` and `virtual-public-preview`.

## Validation

- TypeSpec compilation and formatting passed.
- Generated schemas, validation bounds, event payloads, and union references verified.