### PR TITLE
[Quota] Fix .NET AZC0030 on transfer action request models (2026-09-01-preview)

### DIFF
--- a/specification/quota/resource-manager/Microsoft.Quota/Quota/client.tsp
+++ b/specification/quota/resource-manager/Microsoft.Quota/Quota/client.tsp
@@ -71,6 +71,23 @@ using Microsoft.Quota;
 @@clientName(GroupQuotaLimitLists.list, "get", "csharp");
 @@clientName(SubscriptionQuotaAllocationsLists.list, "get", "csharp");
 
+// Avoids .NET analyzer AZC0030, which rejects model names ending in "Request".
+@@clientName(
+  QuotaTransferCancelRequest,
+  "QuotaTransferCancelContent",
+  "csharp"
+);
+@@clientName(
+  IncomingQuotaTransferApproveRequest,
+  "IncomingQuotaTransferApproveContent",
+  "csharp"
+);
+@@clientName(
+  IncomingQuotaTransferRejectRequest,
+  "IncomingQuotaTransferRejectContent",
+  "csharp"
+);
+
 @@usage(QuotaAllocationRequestStatus, Usage.input, "csharp");
 @@usage(QuotaAllocationRequestBase, Usage.input, "csharp");
 @@usage(GroupQuotaSubscriptionRequestStatusProperties, Usage.input, "csharp");

--- a/specification/quota/resource-manager/Microsoft.Quota/Quota/transfer-models.tsp
+++ b/specification/quota/resource-manager/Microsoft.Quota/Quota/transfer-models.tsp
@@ -334,7 +334,6 @@ model IncomingQuotaTransferProperties {
 /**
  * Request body for the donor cancel action.
  */
-#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_09_01_preview)
 model QuotaTransferCancelRequest {
   /**
@@ -347,7 +346,6 @@ model QuotaTransferCancelRequest {
 /**
  * Request body for the recipient approve action.
  */
-#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_09_01_preview)
 model IncomingQuotaTransferApproveRequest {
   /**
@@ -360,7 +358,6 @@ model IncomingQuotaTransferApproveRequest {
 /**
  * Request body for the recipient reject action.
  */
-#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix" "Name kept for backward compatibility"
 @added(Versions.v2026_09_01_preview)
 model IncomingQuotaTransferRejectRequest {
   /**


### PR DESCRIPTION
## Summary

Fixes the `azure-sdk-for-net` PR validation failure for `Azure.ResourceManager.Quota` ([Azure/azure-sdk-for-net#62296](https://github.com/Azure/azure-sdk-for-net/pull/62296)), which failed with 9 `AZC0030` analyzer errors across all matrix legs.

The .NET analyzer rejects model names ending in `Request`. Three transfer action body models added in `2026-09-01-preview` trip it:

- `QuotaTransferCancelRequest`
- `IncomingQuotaTransferApproveRequest`
- `IncomingQuotaTransferRejectRequest`

## Changes

**`client.tsp`** — adds three `csharp`-scoped `@clientName` aliases mapping the models to `*Content` names, following the ~30 existing `@@clientName(..., "csharp")` entries already in this file.

**`transfer-models.tsp`** — removes three `#suppress "@azure-tools/typespec-client-generator-core/csharp-model-suffix"` directives. Their justification was `"Name kept for backward compatibility"`, which is factually wrong: all three models are `@added(Versions.v2026_09_01_preview)`, so there is no prior version to be compatible with. The suppression also never had any effect on `AZC0030`, which runs downstream in the .NET repo, not in TypeSpec.

## Why `@clientName` instead of renaming the models

Renaming the models in `main.tsp` would change the `definitions` keys in `openapi.json`. That would churn all five language SDK PRs — including the three that are currently green — and would edit an already-merged API version.

The `@clientName` approach confines the change to the .NET client surface.

## Verification

`openapi.json` is **byte-identical** after this change. Verified by running `tsp compile .` and confirming the generated swagger does not appear in `git status`:

```
$ npx --no-install tsp compile .
Compilation completed successfully.

$ git status --porcelain
 M specification/quota/resource-manager/Microsoft.Quota/Quota/client.tsp
 M specification/quota/resource-manager/Microsoft.Quota/Quota/transfer-models.tsp
```

Consequences of that invariance:

- The HTTP wire contract is unchanged. Request bodies remain `{"reason": "..."}` / `{"comment": "..."}`; swagger `definitions` keys are not wire-visible.
- The `2025-09-01` stable version is untouched.
- Python, JavaScript, Go, and Java SDKs are unaffected and need no regeneration.
- Only `Azure.ResourceManager.Quota` needs to be regenerated after this merges.

## Related

- Original spec PR: #44066 (merged)
- Release plan: 36140
